### PR TITLE
main: print wake files read when used with -v and -d

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,6 +176,8 @@ int main(int argc, const char **argv) {
   // Read all wake build files
   std::unique_ptr<Top> top(new Top);
   for (auto i : sources(all_sources, ".", "(.*/)?[^/]+\\.wake")) {
+    if (verbose && queue.stack_trace)
+      std::cerr << "Parsing " << i << std::endl;
     Lexer lex(i->value.c_str());
     parse_top(*top.get(), lex);
     if (lex.fail) ok = false;


### PR DESCRIPTION
Let people who ask for too much output know which files wake is reading.

Fixes #17 