### PR TITLE
add file name to hash failed message

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -59,7 +59,7 @@ global def hashpair f = memoize 0 ( # Pair file hash
     def job = launch "." "." "" Nil ("<hash>", f, Nil)
     def final _ = finish job Nil Nil
     def _ = waitOne final job.status
-    if job.status == 0 then add f (head (extract '(.{32}).*' job.stdout)) else raise "Hashing failed"
+    if job.status == 0 then add f (head (extract '(.{32}).*' job.stdout)) else raise "Failed to hash file {f}"
 )
 global def hashname f = (hashpair f).first  # just the filename
 global def hashcode f = (hashpair f).second # just the hashcode


### PR DESCRIPTION
`Hashing failed` is a pretty common error, but It's hard to tell where the error originates from when there are a lot of files being hashed. Adding the file name to the exception message would help debugging.