### PR TITLE
Improve FUSE quit reliability

### DIFF
--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -861,12 +861,10 @@ int main(int argc, char *argv[])
 
 	// Success! Already unmounted.
 	status = 0;
-	goto destroy;
 
 unmount:
 	// out-of-order completion: unmount THEN destroy
 	fuse_unmount(path.c_str(), fc);
-destroy:
 	if (fh) fuse_destroy(fh);
 freeargs:
 	fuse_opt_free_args(&args);


### PR DESCRIPTION
This doesn't make it bullet-proof, but nearly all of the time the .build/pid directory is unmounted and removed.