### PR TITLE
Value: format is no longer recursive

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -144,8 +144,7 @@ Hash DefMap::hash() {
 }
 
 void Literal::format(std::ostream &os, int depth) const {
-  os << pad(depth) << "Literal: " << typeVar << " @ " << location << " = ";
-  value->format(os, -1-depth);
+  os << pad(depth) << "Literal: " << typeVar << " @ " << location << " = " << value.get() << std::endl;
 }
 
 Hash Literal::hash() {

--- a/src/heap.h
+++ b/src/heap.h
@@ -86,7 +86,6 @@ struct Binding {
   static std::unique_ptr<Receiver> make_completer(const std::shared_ptr<Binding> &binding, int arg);
 
   std::vector<Location> stack_trace() const;
-  void format(std::ostream &os, int depth) const;
 
   static void wait(Binding *iter, WorkQueue &queue, std::unique_ptr<Finisher> finisher);
   Hash hash() const; // call only after 'wait'

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -63,7 +63,7 @@ struct Job : public Value {
   static TypeVar typeVar;
   Job(Database *db_, const std::string &dir, const std::string &stdin, const std::string &environ, const std::string &cmdline, bool keep);
 
-  void format(std::ostream &os, int depth) const;
+  void format(std::ostream &os, FormatState &state) const;
   TypeVar &getType();
   Hash hash() const;
 
@@ -72,11 +72,10 @@ struct Job : public Value {
 
 const TypeDescriptor Job::type("Job");
 
-void Job::format(std::ostream &os, int p) const {
-  if (APP_PRECEDENCE < p) os << "(";
+void Job::format(std::ostream &os, FormatState &state) const {
+  if (APP_PRECEDENCE < state.p()) os << "(";
   os << "Job " << job;
-  if (APP_PRECEDENCE < p) os << ")";
-  if (p < 0) os << std::endl;
+  if (APP_PRECEDENCE < state.p()) os << ")";
 }
 
 TypeVar Job::typeVar("Job", 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -497,17 +497,9 @@ int main(int argc, const char **argv) {
       (*types)[0].format(std::cout, body->typeVar);
       types = &(*types)[1];
       std::cout << " = ";
-      if (v) {
-        if (v->type == &Exception::type) pass = false;
-        if (args["debug"]) {
-          v->format(std::cout, -1);
-        } else {
-          std::cout << v << std::endl;
-        }
-      } else {
-        pass = false;
-        std::cout << "MISSING FUTURE" << std::endl;
-      }
+      Value::format(std::cout, v, debug, verbose?0:-1);
+      std::cout << std::endl;
+      if (!v || v->type == &Exception::type) pass = false;
     }
   }
 

--- a/src/regexp.cpp
+++ b/src/regexp.cpp
@@ -14,18 +14,18 @@ struct RegExp : public Value {
   static TypeVar typeVar;
   RegExp(const std::string &regexp, const RE2::Options &opts) : Value(&type), exp(re2::StringPiece(regexp), opts) { }
 
-  void format(std::ostream &os, int depth) const;
+  void format(std::ostream &os, FormatState &state) const;
   TypeVar &getType();
   Hash hash() const;
 };
 
 const TypeDescriptor RegExp::type("RegExp");
 
-void RegExp::format(std::ostream &os, int p) const {
-  if (APP_PRECEDENCE < p) os << "(";
+void RegExp::format(std::ostream &os, FormatState &state) const {
+  if (APP_PRECEDENCE < state.p()) os << "(";
   os << "RegExp ";
-  String(exp.pattern()).format(os, p);
-  if (APP_PRECEDENCE < p) os << ")";
+  String(exp.pattern()).format(os, state);
+  if (APP_PRECEDENCE < state.p()) os << ")";
 }
 
 TypeVar RegExp::typeVar("RegExp", 0);

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -23,18 +23,18 @@ struct CatStream : public Value {
   static TypeVar typeVar;
   CatStream() : Value(&type) { }
 
-  void format(std::ostream &os, int depth) const;
+  void format(std::ostream &os, FormatState &state) const;
   TypeVar &getType();
   Hash hash() const;
 };
 
 const TypeDescriptor CatStream::type("CatStream");
 
-void CatStream::format(std::ostream &os, int p) const {
-  if (APP_PRECEDENCE < p) os << "(";
+void CatStream::format(std::ostream &os, FormatState &state) const {
+  if (APP_PRECEDENCE < state.p()) os << "(";
   os << "CatStream ";
-  String(str.str()).format(os, p);
-  if (APP_PRECEDENCE < p) os << ")";
+  String(str.str()).format(os, state);
+  if (APP_PRECEDENCE < state.p()) os << ")";
 }
 
 TypeVar CatStream::typeVar("CatStream", 0);
@@ -222,7 +222,7 @@ static PRIMFN(prim_format) {
   REQUIRE(args.size() == 1, "prim_format expects 1 argument");
   (void)data;
   std::stringstream buffer;
-  args[0]->format(buffer, 0);
+  buffer << args[0].get();
   auto out = std::make_shared<String>(buffer.str());
   RETURN(out);
 }


### PR DESCRIPTION
This prevents segfault due to stack overflow when printing wake large data
structures from C++. I've punted on the issue of printing closures for now.

The plan for 0.13 is to finally print only the free variables used by a closure.
This will also provide us with more stable hashing of methods.