### PR TITLE
wake: generalize both sides of mutual recursion

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -754,8 +754,9 @@ static bool explore(Expr *expr, const PrimMap &pmap, NameBinding *binding) {
     for (auto &i : def->val)
       ok = explore(i.get(), pmap, binding) && ok;
     for (int i = 0; i < (int)def->fun.size(); ++i) {
-      for (int j = i; j < (int)def->fun.size() && i == def->scc[j]; ++j)
-        if (def->fun[j]) def->fun[j]->typeVar.setDOB();
+      def->fun[i]->typeVar.setDOB();
+      for (int j = i+1; j < (int)def->fun.size() && i == def->scc[j]; ++j)
+        if (def->fun[j]) def->fun[j]->typeVar.setDOB(def->fun[i]->typeVar);
       bind.generalized = def->val.size() + def->scc[i];
       ok = explore(def->fun[i].get(), pmap, &bind) && ok;
     }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -45,6 +45,13 @@ void TypeVar::setDOB() {
   }
 }
 
+void TypeVar::setDOB(const TypeVar &other) {
+  if (!var_dob) {
+    assert (!parent && isFree());
+    free_dob = var_dob = other.var_dob;
+  }
+}
+
 void TypeVar::setTag(int i, const char *tag) {
   TypeVar *a = find();
   if (!a->cargs[i].tag) a->cargs[i].tag = tag;

--- a/src/type.h
+++ b/src/type.h
@@ -63,6 +63,7 @@ public:
   const char *getTag(int i) const;
 
   void setDOB();
+  void setDOB(const TypeVar &other);
   void setTag(int i, const char *tag);
   bool unify(TypeVar &other,  const TypeErrorMessage *message);
   bool unify(TypeVar &&other, const TypeErrorMessage *message) { return unify(other, message); }


### PR DESCRIPTION
This should now type-check:

global def gz x = int (fz x) + 1
global def fz x = str (gz x)

global def fz0 x = fz 44
global def fz1 x = fz "x"
global def gz0 x = gz 44
global def gz1 x = gz "x"