### PR TITLE
database: return outputs in the same order they are saved

### DIFF
--- a/bin/digraph
+++ b/bin/digraph
@@ -1,0 +1,36 @@
+#! /bin/sh
+
+# Copyright 2019 SiFive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You should have received a copy of LICENSE.Apache2 along with
+# this software. If not, you may obtain a copy at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sqlite3 wake.db <<EOF | dot -Tsvg > wake.svg
+with
+  jv(id, label) as (select job_id, substr(commandline, 0, instr(commandline, x'00'))
+    from jobs where use_id=(select max(run_id) from runs)),
+  fv(id, label) as (select t.file_id, f.path from jv j, filetree t, files f where j.id=t.job_id and f.file_id=t.file_id),
+  ei(fid, jid) as (select t.file_id, j.id from jv j, filetree t where j.id=t.job_id and t.access=1),
+  eo(jid, fid) as (select j.id, t.file_id from jv j, filetree t where j.id=t.job_id and t.access=2),
+  header(str) as (values('digraph {')),
+  footer(str) as (values('}')),
+  out(str, row) as (
+    select str, 1 as row from header union
+    select '  j' || id || ' [label="' || label || '"];', 2 as row from jv union
+    select '  f' || id || ' [label="' || label || '"];', 3 as row from fv union
+    select '  f' || fid || ' -> j' || jid || ';', 4 as row from ei union
+    select '  j' || jid || ' -> f' || fid || ';', 5 as row from eo union
+    select str, 6 as row from footer
+    order by row)
+select group_concat(str,x'0a') from out;
+EOF

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -322,8 +322,8 @@ global def fuseRunner =
   def post (Pair output fuse) =
     def _ = killJob fuse 14 # SIGALRM
     def result = extract "(.*\0)?\0(.*)" fuse.getJobStdout
-    def inputs  = result | at 0 | tokenize "\0" | reverse | tail
-    def outputs = result | at 1 | tokenize "\0" | reverse | tail
+    def inputs  = result | at 0 | tokenize "\0" | filter (_!=*"")
+    def outputs = result | at 1 | tokenize "\0" | filter (_!=*"")
     def usage (Usage ps pr pc pm pi po) = match fuse.getJobReport
       Usage fs _ fc fm fi fo =
         Usage (if fs == 0 then ps else fs) pr (fc +. pc) (fm + pm) (fi + pi) (fo + po)

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -130,14 +130,14 @@ std::string Database::open(bool wait, bool memory) {
     "  stat_id     integer references stats(stat_id)," // null if unmerged
     "  endtime     text    not null default '',"
     "  keep        integer not null default 0);"       // 0=false, 1=true
-    "create index if not exists job on jobs(directory, commandline, environment, stdin);"
+    "create index if not exists job on jobs(directory, commandline, environment, stdin, keep, job_id, stat_id);"
     "create table if not exists filetree("
     "  tree_id  integer primary key autoincrement,"
     "  access   integer not null," // 0=visible, 1=input, 2=output, 3=indexes
     "  job_id   integer not null references jobs(job_id) on delete cascade,"
     "  file_id  integer not null references files(file_id),"
     "  unique(job_id, access, file_id) on conflict ignore);"
-    "create index if not exists filesearch on filetree(file_id, access);"
+    "create index if not exists filesearch on filetree(file_id, access, job_id);"
     "create table if not exists log("
     "  log_id     integer primary key autoincrement,"
     "  job_id     integer not null references jobs(job_id) on delete cascade,"

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -132,10 +132,11 @@ std::string Database::open(bool wait, bool memory) {
     "  keep        integer not null default 0);"       // 0=false, 1=true
     "create index if not exists job on jobs(directory, commandline, environment, stdin);"
     "create table if not exists filetree("
-    "  access  integer not null," // 0=visible, 1=input, 2=output, 3=indexes
-    "  job_id  integer not null references jobs(job_id) on delete cascade,"
-    "  file_id integer not null references files(file_id),"
-    "  primary key(job_id, access, file_id) on conflict ignore);"
+    "  tree_id  integer primary key autoincrement,"
+    "  access   integer not null," // 0=visible, 1=input, 2=output, 3=indexes
+    "  job_id   integer not null references jobs(job_id) on delete cascade,"
+    "  file_id  integer not null references files(file_id),"
+    "  unique(job_id, access, file_id) on conflict ignore);"
     "create index if not exists filesearch on filetree(file_id, access);"
     "create table if not exists log("
     "  log_id     integer primary key autoincrement,"
@@ -196,7 +197,7 @@ std::string Database::open(bool wait, bool memory) {
     "select output from log where job_id=? and descriptor=? order by log_id";
   const char *sql_get_tree =
     "select f.path, f.hash from filetree t, files f"
-    " where t.job_id=? and t.access=? and f.file_id=t.file_id";
+    " where t.job_id=? and t.access=? and f.file_id=t.file_id order by t.tree_id";
   const char *sql_add_stats =
     "insert into stats(hashcode, status, runtime, cputime, membytes, ibytes, obytes)"
     " values(?, ?, ?, ?, ?, ?, ?)";


### PR DESCRIPTION
Also, have the fuse runner save output jobs in sorted order.
This makes most output of 'wake -o ...' sorted, yet preserves
unusual order if the runner decides to do that.

Fixes #105