### PR TITLE
Add CircleCI build rules for several OSes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,65 @@
+# We pick an arbitrary docker image provided by CircleCI, since all we want is a
+# Docker image that has the Docker client installed within it, and CircleCI
+# preinstalls the Docker client all on their images. We don't need any actual
+# language tools since the entire build happens within Docker.
+version: 2.1
+jobs:
+  centos_7_0:
+    docker:
+      - image: circleci/buildpack-deps:jessie
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: |
+          docker build -f .circleci/dockerfiles/Dockerfile.centos_7_0 .
+
+  centos_7_6:
+    docker:
+      - image: circleci/buildpack-deps:jessie
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: |
+          docker build -f .circleci/dockerfiles/Dockerfile.centos_7_6 .
+
+  debian_10:
+    docker:
+      - image: circleci/buildpack-deps:jessie
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: |
+          docker build -f .circleci/dockerfiles/Dockerfile.debian_10 .
+
+  ubuntu_16_04:
+    docker:
+      - image: circleci/buildpack-deps:jessie
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: |
+          docker build -f .circleci/dockerfiles/Dockerfile.ubuntu_16_04 .
+
+  ubuntu_18_04:
+    docker:
+      - image: circleci/buildpack-deps:jessie
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: |
+          docker build -f .circleci/dockerfiles/Dockerfile.ubuntu_18_04 .
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - centos_7_0
+      - centos_7_6
+      - debian_10
+      - ubuntu_16_04
+      - ubuntu_18_04

--- a/.circleci/dockerfiles/Dockerfile.centos_7_0
+++ b/.circleci/dockerfiles/Dockerfile.centos_7_0
@@ -1,0 +1,25 @@
+FROM centos:7.0.1406
+
+# The Docker CentOS image has a faked out systemd that needs to be replaced in
+# order for us to install some real packages.
+# https://stackoverflow.com/a/36632668/7433423
+RUN yum swap -y -- remove fakesystemd -- install systemd systemd-libs
+# Older versions of CentOS don't have great support for the overlay filesystem
+# that Docker uses, so install a yum plugin that is meant to address this issue.
+# https://github.com/CentOS/sig-cloud-instance-images/issues/15#issuecomment-252563831
+RUN yum --setopt=skip_missing_names_on_install=False install -y yum-plugin-ovl
+RUN yum -y update && yum clean all
+RUN yum --setopt=skip_missing_names_on_install=False install -y \
+  fuse-devel \
+  gcc-c++ \
+  git \
+  gmp-devel \
+  make \
+  ncurses-devel \
+  sqlite-devel
+# re2-devel is not an official CentOS package, so use the EPEL repository.
+RUN yum --setopt=skip_missing_names_on_install=False install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+ yum --setopt=skip_missing_names_on_install=False install -y re2-devel
+WORKDIR /build
+COPY . /build
+RUN make bin/wake

--- a/.circleci/dockerfiles/Dockerfile.centos_7_6
+++ b/.circleci/dockerfiles/Dockerfile.centos_7_6
@@ -1,0 +1,17 @@
+FROM centos:7.6.1810
+
+RUN yum -y update && yum clean all
+RUN yum --setopt=skip_missing_names_on_install=False install -y \
+  fuse-devel \
+  gcc-c++ \
+  git \
+  gmp-devel \
+  make \
+  ncurses-devel \
+  sqlite-devel
+# re2-devel is not an official CentOS package, so use the EPEL repository.
+RUN yum --setopt=skip_missing_names_on_install=False install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+ yum --setopt=skip_missing_names_on_install=False install -y re2-devel
+WORKDIR /build
+COPY . /build
+RUN make bin/wake

--- a/.circleci/dockerfiles/Dockerfile.debian_10
+++ b/.circleci/dockerfiles/Dockerfile.debian_10
@@ -1,0 +1,15 @@
+# Buster (10)
+FROM debian:buster
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  git \
+  libfuse-dev \
+  libgmp-dev \
+  libncurses5-dev \
+  libre2-dev \
+  libsqlite3-dev \
+  pkg-config
+WORKDIR /build
+COPY . /build
+RUN make bin/wake

--- a/.circleci/dockerfiles/Dockerfile.ubuntu_16_04
+++ b/.circleci/dockerfiles/Dockerfile.ubuntu_16_04
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  git \
+  libfuse-dev \
+  libgmp-dev \
+  libncurses5-dev \
+  libre2-dev \
+  libsqlite3-dev \
+  pkg-config
+WORKDIR /build
+COPY . /build
+RUN make bin/wake

--- a/.circleci/dockerfiles/Dockerfile.ubuntu_18_04
+++ b/.circleci/dockerfiles/Dockerfile.ubuntu_18_04
@@ -1,0 +1,14 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  git \
+  libfuse-dev \
+  libgmp-dev \
+  libncurses5-dev \
+  libre2-dev \
+  libsqlite3-dev \
+  pkg-config
+WORKDIR /build
+COPY . /build
+RUN make bin/wake

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.circleci


### PR DESCRIPTION
I set up some CircleCI build rules so that every PR causes a build of wake on several OSes. This is my first time using CircleCI, but I have to say, this is a relatively nice experience compared to Travis CI because of the first-class Docker support.

I have builds running and passing on:

- CentOS 7.6 (I tried building on CentOS 6.x, but gave up after having to work around several oddities/bugs and finally after learning that CentOS 6.8's g++ does not have support for C++ 11)
- Debian 8 (Jessie)
- Debian 9 (Stretch)
- Ubuntu 16.04 (Xenial)
- Ubuntu 18.04 (Bionic)

I did check that this would have caught the bug fixed by https://github.com/sifive/wake/pull/128.