### PR TITLE
Add functions for turning List of Option|Result to Option|Result of List

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -20,7 +20,7 @@ global def debug   = Pair "native-cpp11-debug" "native-c99-debug"
 def targets = buildWake, buildFuse, buildShim, buildPreload, buildPrelib, Nil
 def allOut variant = map (_ variant) targets
 
-global def all variant = allOut variant | findSome getPathError | getOrPass "BUILT"
+global def all variant = allOut variant | findSomeFn getPathError | getOrPass "BUILT"
 
 global def install dest =
   def libdir = simplify "{here}/share/wake/lib"
@@ -29,4 +29,4 @@ global def install dest =
   def releaseAs exe = cat (dest, "/", take 1 (extract `(.*)\.(.*)` exe))
   def libinstall = map (installIn dest) libfiles
   def bininstall = map (\exe installAs (releaseAs exe.getPathName) exe) binfiles
-  libinstall ++ bininstall | findSome getPathError | getOrPass "INSTALLED"
+  libinstall ++ bininstall | findSomeFn getPathError | getOrPass "INSTALLED"

--- a/share/wake/lib/core/list.wake
+++ b/share/wake/lib/core/list.wake
@@ -34,6 +34,8 @@ global def map f = match _
   Nil  = Nil
   h, t = f h, map f t
 
+# Applies a function to each element of the List and builds a new List from the resulting elements
+# (f: a => List b) => List a => List b
 global def mapFlat f = match _
   Nil  = Nil
   h, t = f h ++ mapFlat f t

--- a/share/wake/lib/core/list.wake
+++ b/share/wake/lib/core/list.wake
@@ -93,14 +93,6 @@ global def find f =
     h, t = if f h then Some (Pair h i) else helper (i+1) t
   helper 0
 
-global def findSome fn =
-  def helper = match _
-    Nil = None
-    h, t = match (fn h)
-      Some x = Some x
-      None = helper t
-  helper
-
 global def exists f l = match (find f l)
   Some _ = True
   None   = False

--- a/share/wake/lib/core/list.wake
+++ b/share/wake/lib/core/list.wake
@@ -34,6 +34,10 @@ global def map f = match _
   Nil  = Nil
   h, t = f h, map f t
 
+global def mapFlat f = match _
+  Nil  = Nil
+  h, t = f h ++ mapFlat f t
+
 global def mapPartial f = match _
   Nil  = Nil
   h, t = match (f h)

--- a/share/wake/lib/core/option.wake
+++ b/share/wake/lib/core/option.wake
@@ -28,6 +28,8 @@ global def getOrElse b = match _
   Some a = a
   None   = b
 
+# Returns the Option's value if Some, otherwise returns the result of fn
+# (fn: Unit => a) => Option a => a
 global def getOrElseFn fn = match _
   Some a = a
   None   = fn Unit
@@ -44,7 +46,12 @@ global def ofilter f = match _
   Some a if f a = Some a
   _ = None
 
+# Finds the first Some in a List of Option or returns None if List is all None
+# List (Option a) => Option a
 global def findSome = findSomeFn (_)
+# Applies a function that returns Option to each element of a List
+#   returning the first Some or a None
+# (fn: a => Option b) => List a => Option b
 global def findSomeFn fn =
   def helper = match _
     Nil = None
@@ -53,7 +60,12 @@ global def findSomeFn fn =
       None = helper t
   helper
 
+# If a List of Options is all Some, returns Some of the elements, otherwise None
+# List (Option a) => Option (List a)
 global def findNone = findNoneFn (_)
+# Applies a function that returns Option to each element of a List
+#   returning None if any result is None, otherwise aggregates the Somes into a List
+# (fn: a => Option b) => List a => Option (List b)
 global def findNoneFn fn =
   def helper = match _
     Nil = Some Nil
@@ -66,12 +78,20 @@ global def findNoneFn fn =
 
 # Promote Option to Result:
 
+# Converts Some to Pass or Fail
+# (f: a) => Option b => Result b a
 global def getOrFail f = getOrFailFn (\_ f)
+# Converts Some to Pass or Fail of output of fn
+# (fn: Unit => a) => Option b => Result b a
 global def getOrFailFn fn = match _
   Some a = Pass a
   None   = Fail (fn Unit)
 
+# Converts Some to Fail or Pass
+# (p: a) => Option b => Result a b
 global def getOrPass p = getOrPassFn (\_ p)
+# Converts Some to Fail or Pass of output of fn
+# (fn: Unit => a) => Option b => Result a b
 global def getOrPassFn fn = match _
   None   = Pass (fn Unit)
   Some f = Fail f

--- a/share/wake/lib/core/option.wake
+++ b/share/wake/lib/core/option.wake
@@ -28,17 +28,9 @@ global def getOrElse b = match _
   Some a = a
   None   = b
 
-global def getOrFail f = match _
-  Some a = Pass a
-  None   = Fail f
-
-global def getOrPass p = match _
-  None   = Pass p
-  Some f = Fail f
-
-global def getOrFailFn fn = match _
-  Some a = Pass a
-  None   = Fail (fn Unit)
+global def getOrElseFn fn = match _
+  Some a = a
+  None   = fn Unit
 
 global def omap f = match _
   Some a = Some (f a)
@@ -51,3 +43,35 @@ global def omapPartial f = match _
 global def ofilter f = match _
   Some a if f a = Some a
   _ = None
+
+global def findSome = findSomeFn (_)
+global def findSomeFn fn =
+  def helper = match _
+    Nil = None
+    h, t = match (fn h)
+      Some x = Some x
+      None = helper t
+  helper
+
+global def findNone = findNoneFn (_)
+global def findNoneFn fn =
+  def helper = match _
+    Nil = Some Nil
+    h, t = match (fn h)
+      None = None
+      Some x = match (helper t)
+       Some t = Some (x, t)
+       n = n
+  helper
+
+# Promote Option to Result:
+
+global def getOrFail f = getOrFailFn (\_ f)
+global def getOrFailFn fn = match _
+  Some a = Pass a
+  None   = Fail (fn Unit)
+
+global def getOrPass p = getOrPassFn (\_ p)
+global def getOrPassFn fn = match _
+  None   = Pass (fn Unit)
+  Some f = Fail f

--- a/share/wake/lib/core/regexp.wake
+++ b/share/wake/lib/core/regexp.wake
@@ -15,8 +15,12 @@
 
 # Regular expressions
 
-# quote: (str: String) => String
-global def quote str = prim "quote"
+# quote: (str: String) => RegExp
+global def quote str =
+  def res str = prim "quote"
+  match (res str).stringToRegExp
+    Pass x = x
+    Fail _ = panic "Quoted String is invalid Regular Expression"
 
 # (str: String) => RegExp
 global def stringToRegExp str = prim "re2"

--- a/share/wake/lib/core/regexp.wake
+++ b/share/wake/lib/core/regexp.wake
@@ -15,6 +15,7 @@
 
 # Regular expressions
 
+# Turns a String into a properly quoted Regular Expression
 # quote: (str: String) => RegExp
 global def quote str =
   def res str = prim "quote"

--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -49,7 +49,12 @@ global def rmapFail fn = match _
   Pass a = Pass a
   Fail f = fn f
 
+# Finds the first Fail in a List of Result or aggregates Passes into a List
+# List (Result a b) => Result (List a) b
 global def findFail = findFailFn (_)
+# Applies a fallible function to each element of a List,
+#   returning the first Fail or aggregates the Passes into a List
+# (fn: a => Result b c) => List a => Result (List b) c
 global def findFailFn fn =
   def helper = match _
     Nil = Pass Nil
@@ -60,7 +65,12 @@ global def findFailFn fn =
         z = z
   helper
 
+# Finds the first Pass in a List of Result or aggregates Fails into a List
+# List (Result a b) => Result a (List b)
 global def findPass = findPassFn (_)
+# Applies a fallible function to each element of a List
+#  returning the first Pass or aggregates the Fails into a List
+# (fn: a => Result b c) => List a => Result b (List c)
 global def findPassFn fn =
   def helper = match _
     Nil = Fail Nil

--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -45,6 +45,28 @@ global def rmapFail fn = match _
   Pass a = Pass a
   Fail f = Fail (fn f)
 
+global def findFail = findFailFn (_)
+global def findFailFn fn =
+  def helper = match _
+    Nil = Pass Nil
+    h, t = match (fn h)
+      Fail y = Fail y
+      Pass x = match (helper t)
+        Pass tt = Pass (x, tt)
+        z = z
+  helper
+
+global def findPass = findPassFn (_)
+global def findPassFn fn =
+  def helper = match _
+    Nil = Fail Nil
+    h, t = match (fn h)
+      Pass y = Pass y
+      Fail x = match (helper t)
+        Fail tt = Fail (x, tt)
+        z = z
+  helper
+
 global def panic s = prim "panic"
 
 global def stack s = prim "stack"

--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -41,9 +41,13 @@ global def rmap fn = match _
   Pass a = Pass (fn a)
   Fail f = Fail f
 
+global def rmapPass fn = match _
+  Pass a = fn a
+  Fail f = Fail f
+
 global def rmapFail fn = match _
   Pass a = Pass a
-  Fail f = Fail (fn f)
+  Fail f = fn f
 
 global def findFail = findFailFn (_)
 global def findFailFn fn =

--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -41,10 +41,14 @@ global def rmap fn = match _
   Pass a = Pass (fn a)
   Fail f = Fail f
 
+# Applies a fallible function to Pass value or propogates Fail
+# (fn: a => Result b c) => Result a c => Result b c
 global def rmapPass fn = match _
   Pass a = fn a
   Fail f = Fail f
 
+# Applies a fallible function to Fail value or propogates Pass
+# (fn: a => Result b c) => Result b a => Result b c
 global def rmapFail fn = match _
   Pass a = Pass a
   Fail f = fn f

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -156,7 +156,7 @@ global def localRunner =
     Fail e =
       def _ = badlaunch job e
       Fail e
-    Pass (RunnerInput cmd vis env dir stdin _ _ predict pool) = match (findSome getPathError vis)
+    Pass (RunnerInput cmd vis env dir stdin _ _ predict pool) = match (findSomeFn getPathError vis)
       Some e =
         def _ = badlaunch job e
         Fail e
@@ -177,7 +177,7 @@ global def virtualRunner =
     Fail e =
       def _ = badlaunch job e
       Fail e
-    Pass (RunnerInput cmd vis env dir stdin _ _ predict pool) = match (findSome getPathError vis)
+    Pass (RunnerInput cmd vis env dir stdin _ _ predict pool) = match (findSomeFn getPathError vis)
       Some e =
         def _ = badlaunch job e
         Fail e
@@ -379,7 +379,7 @@ global def makeJSONRunner rawScript score estimate =
   def pre = match _
     Fail f = Pair (Fail f) ""
     _ if ! ok = Pair (Fail (makeError "Runner {script} is not executable")) ""
-    Pass (RunnerInput command visible environment directory stdin res prefix record _) = match (findSome getPathError visible)
+    Pass (RunnerInput command visible environment directory stdin res prefix record _) = match (findSomeFn getPathError visible)
       Some e = Pair (Fail e) ""
       None =
         def pmkdir m p = prim "mkdir"


### PR DESCRIPTION
h/t @terpstra for most of the work.

The motivating example was to turn `List (Result a b)` -> `Result (List a) b`.

This can be done with `findFail` which finds the first `Fail` in a `List` or returns `Pass (List a)`. There are related functions `findFailFn`, `findPass`, and `findPassFn`.

We already had `findSome` which is similar but for `List (Option a)`, so we also generalized that into `findSome`, `findSomeFn`, `findNone`, and `findNoneFn`. 