### PR TITLE
re2c: it is acceptable to fail; don't log it

### DIFF
--- a/re2c/re2c.wake
+++ b/re2c/re2c.wake
@@ -18,6 +18,7 @@ def re2cOk Unit =
   def ver =
     makePlan (which "re2c", "--version", Nil) Nil
     | setPlanStdout logNever
+    | setPlanStderr logNever
     | setPlanEcho Verbose
     | runJob
     | getJobStdout


### PR DESCRIPTION
CircleCI showed 'execve: re2c' in red.