### PR TITLE
job: forbid absolute paths in visible list

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -143,6 +143,13 @@ global def makePlan cmd visible =
 
 def defaultUsage = Usage 0 0.0 1.0 0 0 0
 
+def validateVisible vis =
+  def check = match _
+    BadPath e = Some e
+    Path x if matches `/.*` x = Some (makeError "visible Path not relative: {x}")
+    _ = None
+  findSomeFn check vis
+
 # This runner does not detect inputs/outputs on it's own
 # You must use Fn{Inputs,Outputs} to fill in this information
 global def localRunner =
@@ -152,7 +159,7 @@ global def localRunner =
     Fail e =
       def _ = badlaunch job e
       Fail e
-    Pass (RunnerInput cmd vis env dir stdin _ _ predict) = match (findSomeFn getPathError vis)
+    Pass (RunnerInput cmd vis env dir stdin _ _ predict) = match vis.validateVisible
       Some e =
         def _ = badlaunch job e
         Fail e
@@ -173,7 +180,7 @@ global def virtualRunner =
     Fail e =
       def _ = badlaunch job e
       Fail e
-    Pass (RunnerInput _ vis _ _ _ _ _ predict) = match (findSomeFn getPathError vis)
+    Pass (RunnerInput _ vis _ _ _ _ _ predict) = match vis.validateVisible
       Some e =
         def _ = badlaunch job e
         Fail e
@@ -405,7 +412,7 @@ global def makeJSONRunner rawScript score estimate =
   def pre = match _
     Fail f = Pair (Fail f) ""
     _ if ! ok = Pair (Fail (makeError "Runner {script} is not executable")) ""
-    Pass (RunnerInput command visible environment directory stdin res prefix record) = match (findSomeFn getPathError visible)
+    Pass (RunnerInput command visible environment directory stdin res prefix record) = match visible.validateVisible
       Some e = Pair (Fail e) ""
       None =
         def pmkdir m p = prim "mkdir"


### PR DESCRIPTION
Previously, the fuse runner ignored these and the preload runner died.

I can only imagine how horribly wrong things would go with a slurm runner.