### PR TITLE
Add tap (aka Kestrel combinator) for debugging pipe chains

### DIFF
--- a/share/wake/lib/core/syntax.wake
+++ b/share/wake/lib/core/syntax.wake
@@ -23,3 +23,7 @@ global def argument | pipeFn = pipeFn argument # bash-style pipe operator
 global def dollarFn $ argument = dollarFn argument
 global def f ∘ g = \x f (g x)
 global def flip f x y = f y x
+# Insert a debugging function
+global def tap tapFn argument =
+  def _ = tapFn argument
+  argument


### PR DESCRIPTION
Requested by @richardxia

This allows you to insert debugging into chains of pipes:

eg.
```
global def tapExample =
  makePlan (which "echo", "$FOO", Nil) Nil
  | tap (getPlanEnvironment _ | (println "tap1: {format _}"))
  | editPlanEnvironment ("FOO=hi", _)
  | tap (getPlanEnvironment _ | (println "tap2: {format _}"))
  | runJob
  | getJobStdout
```