### PR TITLE
debian: start release cycle for 0.16-alpha

### DIFF
--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -2,6 +2,12 @@ wake (@VERSION@-1) unstable; urgency=medium
 
   * Auto-generated release package.
 
+ -- Wesley W. Terpstra <terpstra@debian.org>  Tue, 04 Jun 2019 21:17:36 -0700
+
+wake (0.15-1) unstable; urgency=medium
+
+  * Auto-generated release package.
+
  -- Wesley W. Terpstra <terpstra@debian.org>  Tue, 04 Jun 2019 20:54:22 -0700
 
 wake (0.1-1) unstable; urgency=medium


### PR DESCRIPTION
Bump the changelog to start accumulating changes for 0.16.