### PR TITLE
C++ sources can also end in .c++ extension

### DIFF
--- a/share/wake/lib/system/gcc.wake
+++ b/share/wake/lib/system/gcc.wake
@@ -21,7 +21,7 @@ def releaseCFlags = ("-Wall", "-O2", "-flto", Nil)
 def releaseLFlags = ("-flto", Nil)
 
 def doCompileC variant gcc flags headers cfile =
-  def obj = replace `\.c(pp)?$` ".{variant}.o" cfile.getPathName
+  def obj = replace `\.c(pp|\+\+)?$` ".{variant}.o" cfile.getPathName
   def cmdline = gcc, distinctBy scmp flags ++ ("-c", cfile.getPathName, "-frandom-seed={obj}", "-o", obj, Nil)
   def result = job cmdline (cfile, headers)
   result.getJobOutput


### PR DESCRIPTION
compileC expects C++ sources to be named `.cpp`, but .`c++` is also a recognized extension