### PR TITLE
Detect when an old re2 library is combined with a large string input

### DIFF
--- a/src/regexp.cpp
+++ b/src/regexp.cpp
@@ -20,6 +20,7 @@
 #include "heap.h"
 #include "hash.h"
 #include "type.h"
+#include "sfinae.h"
 #include <iostream>
 #include <string>
 #include <iosfwd>
@@ -53,10 +54,15 @@ static PRIMTYPE(type_re2str) {
     out->unify(String::typeVar);
 }
 
+TEST_MEMBER(set_dot_nl);
+
 static PRIMFN(prim_re2str) {
   EXPECT(1);
   REGEXP(arg0, 0);
-  auto out = std::make_shared<String>(arg0->exp.pattern().substr(4)); // skip the (?s)
+  auto out =
+    has_set_dot_nl<RE2::Options>::value
+    ? std::make_shared<String>(arg0->exp.pattern())
+    : std::make_shared<String>(arg0->exp.pattern().substr(4)); // skip the (?s)
   RETURN(out);
 }
 

--- a/src/sfinae.h
+++ b/src/sfinae.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SFINAE_H
+#define SFINAE_H
+
+#define TEST_MEMBER(member)						\
+  template <typename T>							\
+  struct has_##member {							\
+    typedef char yes;							\
+    struct no { char x[2]; };						\
+    template <typename C> static yes test(decltype(&C::member));	\
+    template <typename C> static no  test(...); 			\
+    static bool const value = sizeof(test<T>(0)) == sizeof(yes);	\
+  }
+
+template <bool C, typename T>
+struct enable_if {
+  typedef T type;
+};
+
+template <typename T>
+struct enable_if<false, T> { };
+
+#endif

--- a/src/value.h
+++ b/src/value.h
@@ -130,7 +130,7 @@ struct RegExp : public Value {
   RE2 exp;
   static const TypeDescriptor type;
   static TypeVar typeVar;
-  RegExp(const std::string &regexp, const RE2::Options &opts) : Value(&type), exp(re2::StringPiece(regexp), opts) { }
+  RegExp(const std::string &regexp, const RE2::Options &opts);
   RegExp(const std::string &regexp);
 
   void format(std::ostream &os, FormatState &state) const;


### PR DESCRIPTION
This situation causes wake to crash.