### PR TITLE
preload: don't fail in runner when conflicting outputs races

### DIFF
--- a/preload/wrap.cpp
+++ b/preload/wrap.cpp
@@ -223,8 +223,9 @@ static void relink_shadow_tree(const std::string &root, const svec &outputs) {
       std::string target = roots + x;
       unlink(x.c_str());
       if (link(target.c_str(), x.c_str()) != 0) {
+        bool die = errno != EEXIST;
         std::cerr << "link " << x << ": " << strerror(errno) << std::endl;
-        exit(1);
+        if (die) exit(1);
       }
     }
   }


### PR DESCRIPTION
Fixes #207.

Obviously, if a build does this (output the same file from two different
Jobs), it is buggy.  However, we should fail later and with a better error
message.