### PR TITLE
wake: remove non-conforming use of reinterpret_cast

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -350,7 +350,7 @@ void Database::close() {
 static int fill_vector(void *data, int cols, char **text, char **colname) {
   (void)colname;
   if (cols >= 1) {
-    std::vector<std::string> *vec = reinterpret_cast<std::vector<std::string>*>(data);
+    std::vector<std::string> *vec = static_cast<std::vector<std::string>*>(data);
     vec->emplace_back(text[0]);
   }
   return 0;
@@ -454,7 +454,7 @@ static void bind_double(const char *why, sqlite3_stmt *stmt, int index, double x
 
 static std::string rip_column(sqlite3_stmt *stmt, int col) {
   return std::string(
-    reinterpret_cast<const char*>(sqlite3_column_blob(stmt, col)),
+    static_cast<const char*>(sqlite3_column_blob(stmt, col)),
     sqlite3_column_bytes(stmt, col));
 }
 
@@ -768,7 +768,7 @@ std::string Database::get_output(long job, int descriptor) {
   bind_integer(why, imp->get_log, 2, descriptor);
   while (sqlite3_step(imp->get_log) == SQLITE_ROW) {
     out.write(
-      reinterpret_cast<const char*>(sqlite3_column_blob(imp->get_log, 0)),
+      static_cast<const char*>(sqlite3_column_blob(imp->get_log, 0)),
       sqlite3_column_bytes(imp->get_log, 0));
   }
   finish_stmt(why, imp->get_log, imp->debugdb);

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -923,7 +923,7 @@ static PRIMTYPE(type_job_launch) {
 }
 
 static PRIMFN(prim_job_launch) {
-  JobTable *jobtable = reinterpret_cast<JobTable*>(data);
+  JobTable *jobtable = static_cast<JobTable*>(data);
   EXPECT(11);
   JOB(job, 0);
   STRING(dir, 1);
@@ -1023,7 +1023,7 @@ static PRIMTYPE(type_job_create) {
 }
 
 static PRIMFN(prim_job_create) {
-  JobTable *jobtable = reinterpret_cast<JobTable*>(data);
+  JobTable *jobtable = static_cast<JobTable*>(data);
   EXPECT(7);
   STRING(dir, 0);
   STRING(stdin, 1);
@@ -1104,7 +1104,7 @@ static PRIMTYPE(type_job_cache) {
 }
 
 static PRIMFN(prim_job_cache) {
-  JobTable *jobtable = reinterpret_cast<JobTable*>(data);
+  JobTable *jobtable = static_cast<JobTable*>(data);
   EXPECT(5);
   STRING(dir, 0);
   STRING(stdin, 1);
@@ -1370,7 +1370,7 @@ static long stat_mod_ns(const char *file) {
 }
 
 static PRIMFN(prim_add_hash) {
-  JobTable *jobtable = reinterpret_cast<JobTable*>(data);
+  JobTable *jobtable = static_cast<JobTable*>(data);
   EXPECT(2);
   STRING(file, 0);
   STRING(hash, 1);
@@ -1385,7 +1385,7 @@ static PRIMTYPE(type_get_hash) {
 }
 
 static PRIMFN(prim_get_hash) {
-  JobTable *jobtable = reinterpret_cast<JobTable*>(data);
+  JobTable *jobtable = static_cast<JobTable*>(data);
   EXPECT(1);
   STRING(file, 0);
   std::string hash = jobtable->imp->db->get_hash(file->as_str(), stat_mod_ns(file->c_str()));

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -382,7 +382,7 @@ static PRIMTYPE(type_version) {
 
 static PRIMFN(prim_version) {
   EXPECT(0);
-  StringInfo *info = reinterpret_cast<StringInfo*>(data);
+  StringInfo *info = static_cast<StringInfo*>(data);
   RETURN(String::alloc(runtime.heap, info->version));
 }
 
@@ -393,7 +393,7 @@ static PRIMTYPE(type_level) {
 
 static PRIMFN(prim_level) {
   EXPECT(0);
-  StringInfo *info = reinterpret_cast<StringInfo*>(data);
+  StringInfo *info = static_cast<StringInfo*>(data);
 
   int x;
   if (info->quiet) {


### PR DESCRIPTION
Conversion to-from void* should be a static_cast.