### PR TITLE
respect USE_FUSE_WAKE on mac os

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -387,14 +387,13 @@ def wOK = 1
 def xOK = 2
 def access file mode = prim "access"
 
-global def defaultRunner = match sysname
-  "Darwin" = fuseRunner
-  _ = match (getenv "USE_FUSE_WAKE")
-    Some "0" = preloadRunner
-    Some _ = fuseRunner
-    None =
-      def fuse = access "/dev/fuse" wOK
-      if fuse then fuseRunner else preloadRunner
+global def defaultRunner = match sysname "USE_FUSE_WAKE".getenv
+  _        (Some "0") = preloadRunner
+  "Darwin" _          = fuseRunner
+  _        (Some _)   = fuseRunner
+  _        None =
+    def fuse = access "/dev/fuse" wOK
+    if fuse then fuseRunner else preloadRunner
 
 # Make a Runner that runs a named script to run jobs
 # score: Plan => Double; runJob chooses the runner with the largest score for a Plan


### PR DESCRIPTION
Fixes bug where `fuseRunner` is always used on mac os even if `USE_FUSE_WAKE` is set to `0`.