### PR TITLE
Constant space lists

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -692,6 +692,7 @@ struct NameBinding {
       } else {
         auto x = binding->fun[idx-binding->val.size()].get();
         out.var = x?&x->typeVar:0;
+        out.offset = out.def;
         out.lambda = x;
       }
     } else if (next) {

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -46,6 +46,7 @@ struct Runtime {
   bool abort;
   Heap heap;
   RootPointer<Work> stack;
+  RootPointer<Work> recurse;
   RootPointer<HeapObject> output;
   RootPointer<Record> sources; // Vector String
 


### PR DESCRIPTION
I've found an evaluation order which causes many expressions to run in constant space. This PR needs to be a bit more clever about when it runs the recursive calls. Ideally, we would like to run them in demand-order, like lazy languages.