### PR TITLE
Lazy recursion

### DIFF
--- a/share/wake/lib/core/string.wake
+++ b/share/wake/lib/core/string.wake
@@ -17,7 +17,9 @@
 
 global def strlen string = prim "strlen"
 
-global def cat listString = prim "lcat"
+global def cat listString =
+  def imp size listString = prim "lcat"
+  imp (foldl (_ + strlen _) 0 listString) listString
 
 global def catWith separator strings =
   if strings.empty then "" else

--- a/src/gc.h
+++ b/src/gc.h
@@ -52,7 +52,7 @@ struct HeapStep {
   HeapObject **found;
 };
 
-enum Category { VALUE, WORK };
+enum Category { VALUE, WORK, DEFERRAL };
 
 struct HeapObject {
   virtual Placement moveto(PadObject *free) = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,6 +102,7 @@ int main(int argc, char **argv) {
     { 0,   "no-tty",                GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "heap-factor",           GOPT_ARGUMENT_REQUIRED  | GOPT_ARGUMENT_NO_HYPHEN },
     { 0,   "profile-heap",          GOPT_ARGUMENT_FORBIDDEN | GOPT_REPEATABLE },
+    { 0,   "lazy",                  GOPT_ARGUMENT_FORBIDDEN },
     { 'i', "input",                 GOPT_ARGUMENT_FORBIDDEN },
     { 'o', "output",                GOPT_ARGUMENT_FORBIDDEN },
     { 's', "script",                GOPT_ARGUMENT_FORBIDDEN },
@@ -129,6 +130,7 @@ int main(int argc, char **argv) {
   bool workspace=!arg(options, "no-workspace")->count;
   bool tty     =!arg(options, "no-tty"  )->count;
   int  profile = arg(options, "profile-heap")->count;
+  bool lazy    = arg(options, "lazy"    )->count;
   bool input   = arg(options, "input"   )->count;
   bool output  = arg(options, "output"  )->count;
   bool script  = arg(options, "script"  )->count;
@@ -275,7 +277,7 @@ int main(int argc, char **argv) {
   auto wakefiles = find_all_wakefiles(ok, workspace);
   if (!ok) std::cerr << "Workspace wake file enumeration failed" << std::endl;
 
-  Runtime runtime(profile, heap_factor);
+  Runtime runtime(profile, heap_factor, !lazy);
   bool sources = find_all_sources(runtime, workspace);
   if (!sources) std::cerr << "Source file enumeration failed" << std::endl;
   ok &= sources;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -39,7 +39,7 @@ Category Work::category() const {
 }
 
 void Continuation::consider(Runtime &runtime, Deferral *def) {
-  def->demand(runtime);
+  def->demand(runtime, this);
 }
 
 Category Deferral::category() const {
@@ -48,6 +48,9 @@ Category Deferral::category() const {
 
 void Deferral::execute(Runtime &runtime) {
   Continuation *c = static_cast<Continuation*>(uses.get());
+#ifdef DEBUG_GC
+  assert(c);
+#endif
   while (c->next) {
     c->value = value;
     c = static_cast<Continuation*>(c->next.get());
@@ -172,7 +175,6 @@ struct CApp final : public GCObject<CApp, Continuation> {
       clo->lambda->body.get(), bind.get(), cont.get());
     if ((clo->lambda->flags & FLAG_RECURSIVE)) {
       Deferral *def = Deferral::claim(runtime.heap);
-      def->uses = cont;
       def->work = work;
       work->cont = def;
       cont->consider(runtime, def);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -38,6 +38,10 @@ Category Work::category() const {
   return WORK;
 }
 
+void Continuation::demand(Runtime &runtime, Deferral *def) {
+  def->demand(runtime);
+}
+
 Category Deferral::category() const {
   return DEFERRAL;
 }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -38,6 +38,22 @@ Category Work::category() const {
   return WORK;
 }
 
+Category Deferral::category() const {
+  return DEFERRAL;
+}
+
+void Deferral::execute(Runtime &runtime) {
+  Continuation *c = static_cast<Continuation*>(uses.get());
+  while (c->next) {
+    c->value = value;
+    c = static_cast<Continuation*>(c->next.get());
+  }
+  c->value = value;
+  c->next = runtime.stack;
+  runtime.stack = uses;
+  uses = nullptr;
+}
+
 Runtime::Runtime(int profile_heap, double heap_factor)
  : abort(false), heap(profile_heap, heap_factor),
    stack(heap.root<Work>(nullptr)),

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -178,6 +178,9 @@ struct CApp final : public GCObject<CApp, Continuation> {
       def->work = work;
       work->cont = def;
       cont->consider(runtime, def);
+      // If already demanded, remove the Deferral
+      // This case is important for tail recursion
+      if (!def->work) work->cont = cont.get();
     } else {
       runtime.schedule(work);
     }

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -44,14 +44,15 @@ struct Work : public HeapObject {
 };
 
 struct Runtime {
-  bool abort;
+  bool abort, strict;
   Heap heap;
   RootPointer<Work> stack;
   RootPointer<Work> lazy;
+  RootPointer<Deferral> deferred;
   RootPointer<HeapObject> output;
   RootPointer<Record> sources; // Vector String
 
-  Runtime(int profile_heap, double heap_factor);
+  Runtime(int profile_heap, double heap_factor, bool strict_);
   void run();
 
   void schedule(Work *work) {

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -70,8 +70,8 @@ struct Runtime {
 struct Continuation : public Work {
   HeapPointer<HeapObject> value;
 
-  // Should the deferral be forced?
-  virtual void demand(Runtime &runtime, Deferral *def);
+  // Should the deferral be demanded?
+  virtual void consider(Runtime &runtime, Deferral *def);
 
   void resume(Runtime &runtime, HeapObject *obj) {
     value = obj;

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -47,6 +47,7 @@ struct Runtime {
   bool abort;
   Heap heap;
   RootPointer<Work> stack;
+  RootPointer<Work> lazy;
   RootPointer<HeapObject> output;
   RootPointer<Record> sources; // Vector String
 
@@ -99,8 +100,10 @@ struct Deferral final : public GCObject<Deferral, Continuation> {
   void demand(Runtime &runtime) {
 #ifdef DEBUG_GC
     assert (work);
+    assert (!work->next);
 #endif
-    runtime.schedule(work.get());
+    work->next = runtime.lazy;
+    runtime.lazy = work;
     work = nullptr;
   }
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -92,6 +92,8 @@ static PRIMFN(prim_lcat) {
 
   size = 0;
   for (Record *scan = list; scan->size() == 2; scan = scan->at(1)->coerce<Record>()) {
+    scan->at(0)->force(runtime);
+    scan->at(1)->force(runtime);
     String *s = scan->at(0)->coerce<String>();
     memcpy(out->c_str() + size, s->c_str(), s->size());
     size += s->size();

--- a/src/tuple.cpp
+++ b/src/tuple.cpp
@@ -17,6 +17,7 @@
 
 #include "tuple.h"
 #include "expr.h"
+#include <cassert>
 
 void Promise::awaken(Runtime &runtime, HeapObject *obj) {
   if (value->category() == DEFERRAL) return;
@@ -28,6 +29,19 @@ void Promise::awaken(Runtime &runtime, HeapObject *obj) {
   c->value = obj;
   c->next = runtime.stack;
   runtime.stack = value;
+}
+
+void Deferral::format(std::ostream &os, FormatState &state) const {
+  os << "Deferral";
+}
+
+Hash Deferral::hash() const {
+  assert(0 /* unreachable */);
+  return Hash();
+}
+
+Category Deferral::category() const {
+  return DEFERRAL;
 }
 
 struct FulFiller final : public GCObject<FulFiller, Continuation> {

--- a/src/tuple.cpp
+++ b/src/tuple.cpp
@@ -47,7 +47,7 @@ struct FulFiller final : public GCObject<FulFiller, Continuation> {
     tuple->at(i)->fulfill(runtime, value.get());
   }
 
-  void demand(Runtime &runtime, Deferral *def) override {
+  void consider(Runtime &runtime, Deferral *def) override {
     Promise *p = tuple->at(i);
     if (p->fresh()) {
       p->defer(def);

--- a/src/tuple.cpp
+++ b/src/tuple.cpp
@@ -52,7 +52,7 @@ struct FulFiller final : public GCObject<FulFiller, Continuation> {
     if (p->fresh()) {
       p->defer(def);
     } else {
-      def->demand(runtime);
+      def->demand(runtime, this);
     }
   }
 };

--- a/src/tuple.h
+++ b/src/tuple.h
@@ -50,12 +50,11 @@ struct alignas(PadObject) Promise {
         break;
       case DEFERRAL:
         Deferral *def = static_cast<Deferral*>(value.get());
-        if (def->work) {
-          c->next = def->uses;
-          def->uses = c;
-          c->consider(runtime, def);
+        if (def->value) {
+          value = def->value;
+          c->resume(runtime, value.get());
         } else {
-          value = c;
+          c->consider(runtime, def);
         }
         break;
     }
@@ -100,9 +99,7 @@ struct alignas(PadObject) Promise {
   void defer(Deferral *defer) {
 #ifdef DEBUG_GC
     assert(!value);
-    assert(!defer->Work::next);
-    assert(defer->work);
-    assert(defer->uses);
+    assert(!defer->value);
 #endif
     value = defer;
   }

--- a/src/tuple.h
+++ b/src/tuple.h
@@ -53,7 +53,7 @@ struct alignas(PadObject) Promise {
         if (def->work) {
           c->next = def->uses;
           def->uses = c;
-          c->demand(runtime, def);
+          c->consider(runtime, def);
         } else {
           value = c;
         }


### PR DESCRIPTION
This PR changes the evaluation order of wake from strict to a hybrid of lazy+strict. This gives us infinite lists and constant-space chaining of list operations. However, it does result in a slight reduction of visible parallelism. It's also possible to slightly tweak this PR to gain the constant-space list operations while maintaining strict evaluation. What's best is TBD. I'll make it a runtime knob for now.