### PR TITLE
fuse: adjust timeouts for better restart

### DIFF
--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -1263,7 +1263,7 @@ static void handle_exit(int sig)
 		while (WIFSTOPPED(status));
 	}
 
-	if (exit_attempts == 4) {
+	if (exit_attempts == 3) {
 		fprintf(stderr, "Unable to cleanly exit after 4 unmount attempts\n");
 		exit(1);
 	} else if ((pid = fork()) == 0) {

--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 
 	int ffd = -1;
 	useconds_t wait = 10000; /* 10ms */
-	for (int retry = 0; (ffd = open(fpath.c_str(), O_RDONLY)) == -1 && retry < 10; ++retry) {
+	for (int retry = 0; (ffd = open(fpath.c_str(), O_RDONLY)) == -1 && retry < 12; ++retry) {
 		pid_t pid = fork();
 		if (pid == 0) {
 			ofs.close();


### PR DESCRIPTION
daemon quits after: 2+4+8+16 = 30 seconds of retry
client aborts after: 10ms*(1+2+...+2048) = 40 seconds of retry.