### PR TITLE
shellJob: don't try to escape scripts to one line

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -142,7 +142,7 @@ global def makePlan cmd visible =
   Plan cmd visible environment "." "" logVerbose logWarn Normal Share False Nil (\_ True) id id
 
 global def makeShellPlan script visible =
-  makePlan (which "dash", "-c", replace `\n` '; ' script, Nil) visible
+  makePlan (which "dash", "-c", script, Nil) visible
 
 def defaultUsage = Usage 0 0.0 1.0 0 0 0
 


### PR DESCRIPTION
To do this correctly would require really parsing shell code.
A simple regexp will fail due to comments and strings.