### PR TITLE
User-controlled Plan Usage

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -13,13 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-tuple Usage =
+tuple Usage = # Unknown quantities are 0
   global Status:   Integer
   global Runtime:  Double
   global CPUtime:  Double
   global MemBytes: Integer
   global InBytes:  Integer
   global OutBytes: Integer
+
+global def getUsageThreads (Usage _ run cpu _ _ _) =
+  if run ==. 0.0 then cpu else cpu /. run
 
 # RunnerInput is a subset of the fields supplied in the execution Plan
 tuple RunnerInput =
@@ -30,7 +33,7 @@ tuple RunnerInput =
   global Stdin:       String
   global Resources:   List String
   global Prefix:      String        # a unique prefix for this job
-  global Record:      Option Usage  # previous resource usage, if known
+  global Record:      Usage         # previous resource usage
 
 tuple RunnerOutput =
   global Inputs:  List String
@@ -83,6 +86,7 @@ tuple Plan =
   global LocalOnly:    Boolean      # Must run directly in the local workspace; no output detection performed
   global Resources:    List String  # The resources a runner must provide to the job (licenses/etc)
   global RunnerFilter: Runner => Boolean # Reject from consideration Runners which the Plan deems inappropriate
+  global Usage:        Usage        # User-supplied usage prediction; overruled by database statistics (if any)
   global FnInputs:     (List String => List String) # Modify the Runner's reported inputs  (files read)
   global FnOutputs:    (List String => List String) # Modify the Runner's reported outputs (files created)
 
@@ -149,7 +153,7 @@ global def editPlanShare f =
 # Set reasonable defaults for all Plan arguments
 def id x = x
 global def makePlan cmd visible =
-  Plan cmd visible environment "." "" logVerbose logWarn Normal Share False Nil (\_ True) id id
+  Plan cmd visible environment "." "" logVerbose logWarn Normal Share False Nil (\_ True) defaultUsage id id
 
 global def makeShellPlan script visible =
   makePlan (which "dash", "-c", script, Nil) visible
@@ -169,13 +173,13 @@ global def localRunner =
       Some e =
         def _ = badlaunch job e
         Fail e
-      None = match (getOrElse defaultUsage predict)
+      None = match predict
         Usage status runtime cputime mem in out =
           def _ = launch job dir stdin env.implode cmd.implode status runtime cputime mem in out
           match (getJobReality job)
             Pass reality = Pass (RunnerOutput (map getPathName vis) Nil reality)
             Fail f = Fail f
-  def score (Plan _ _ _ _ _ _ _ _ _ lo _ _ _ _) =
+  def score (Plan _ _ _ _ _ _ _ _ _ lo _ _ _ _ _) =
     if lo then Pass 1.0 else Fail "cannot detect outputs"
   Runner "local" score doit
 
@@ -190,7 +194,7 @@ global def virtualRunner =
       Some e =
         def _ = badlaunch job e
         Fail e
-      None = match (getOrElse defaultUsage predict)
+      None = match predict
         Usage status runtime cputime mem in out =
           def _ = virtual job "" "" status runtime cputime mem in out # sets predict+reality
           match (getJobReality job)
@@ -201,7 +205,7 @@ global def virtualRunner =
 def pid = prim "pid"
 
 def implode l = cat (foldr (_, "\0", _) Nil l)
-def runAlways cmd env dir stdin res finputs foutputs vis keep run log =
+def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run log =
   def create dir stdin env cmd visible keep log = prim "job_create"
   def finish job inputs outputs status runtime cputime membytes ibytes obytes = prim "job_finish"
   def badfinish job error = prim "job_fail_finish"
@@ -212,7 +216,7 @@ def runAlways cmd env dir stdin res finputs foutputs vis keep run log =
       BadPath _ = None
     def job = create dir stdin env.implode cmd.implode (mapPartial getPathOpt vis).implode (if keep then 1 else 0) log
     def prefix = "{str pid}.{str (getJobId job)}"
-    def usage = getJobRecord job
+    def usage = getJobRecord job | getOrElse uusage
     def output = run job (Pass (RunnerInput cmd vis env dir stdin res prefix usage))
     def final _ = match output
       Fail e =
@@ -239,16 +243,16 @@ def runAlways cmd env dir stdin res finputs foutputs vis keep run log =
       Pair Nil      last = confirm False last (build Unit)
 
 # Only run if the first four arguments differ
-target runOnce cmd env dir stdin \ res finputs foutputs vis keep run log =
-  runAlways cmd env dir stdin res finputs foutputs vis keep run log
+target runOnce cmd env dir stdin \ res usage finputs foutputs vis keep run log =
+  runAlways cmd env dir stdin res usage finputs foutputs vis keep run log
 
 # Default runners provided by wake
 publish runner = localRunner, defaultRunner, Nil
 
-def runJobImp cmd env dir stdin res finputs foutputs vis pers run log =
+def runJobImp cmd env dir stdin res usage finputs foutputs vis pers run log =
   if isOnce pers
-  then runOnce   cmd env dir stdin res finputs foutputs vis (isKeep pers) run log
-  else runAlways cmd env dir stdin res finputs foutputs vis (isKeep pers) run log
+  then runOnce   cmd env dir stdin res usage finputs foutputs vis (isKeep pers) run log
+  else runAlways cmd env dir stdin res usage finputs foutputs vis (isKeep pers) run log
 
 def logLevelRaw = prim "level"
 def logLevel = match logLevelRaw
@@ -270,8 +274,8 @@ def jobLog stdout stderr echo =
   def bit = if thresh <= logLevelRaw then 1 else 0
   (bit << 4) + (num (stderr logLevel) << 2) + num (stdout logLevel)
 
-global def runJobWith (Runner _ _ run) (Plan cmd vis env dir stdin stdout stderr echo pers _ res _ finputs foutputs) =
-  runJobImp cmd env dir stdin res finputs foutputs vis pers run (jobLog stdout stderr echo)
+global def runJobWith (Runner _ _ run) (Plan cmd vis env dir stdin stdout stderr echo pers _ res _ usage finputs foutputs) =
+  runJobImp cmd env dir stdin res usage finputs foutputs vis pers run (jobLog stdout stderr echo)
 
 data RunnerOption =
   Accept (score: Double) (runnerFn: Job => Result RunnerInput Error => Result RunnerOutput Error)
@@ -279,7 +283,7 @@ data RunnerOption =
 
 # Run the job!
 global def runJob p = match p
-  Plan cmd vis env dir stdin stdout stderr echo pers lo res rf finputs foutputs =
+  Plan cmd vis env dir stdin stdout stderr echo pers lo res rf usage finputs foutputs =
     # Transform the 'List Runner' into 'List RunnerOption'
     def qualify runner = match runner
       Runner name _ _ if ! rf runner = Reject "{name}: rejected by Plan"
@@ -294,7 +298,7 @@ global def runJob p = match p
         if score >. bests then Pair score (Some fn) else acc
     def log = jobLog stdout stderr echo
     match (opts | foldl best (Pair 0.0 None) | getPairSecond)
-      Some r = runJobImp cmd env dir stdin res finputs foutputs vis pers r log
+      Some r = runJobImp cmd env dir stdin res usage finputs foutputs vis pers r log
       None =
         def create dir stdin env cmd visible keep log = prim "job_create"
         def badfinish job e = prim "job_fail_finish"
@@ -385,13 +389,13 @@ global def getJobStatus job = match (getJobReport job)
 def wakePath = prim "execpath" # location of the wake executable
 global def fuseRunner =
   def fuse = "{wakePath}/../lib/wake/fuse-wake"
-  def score (Plan _ _ _ _ _ _ _ _ _ lo _ _ _ _) =
+  def score (Plan _ _ _ _ _ _ _ _ _ lo _ _ _ _ _) =
     if lo then Fail "would hide workspace" else Pass 1.0
   makeJSONRunner fuse score (_)
 
 global def preloadRunner =
   def preload = "{wakePath}/../lib/wake/preload-wake"
-  def score (Plan _ _ _ _ _ _ _ _ _ lo _ _ _ _) =
+  def score (Plan _ _ _ _ _ _ _ _ _ lo _ _ _ _ _) =
     if lo then Fail "would hide workspace" else Pass 1.0
   makeJSONRunner preload score (_)
 
@@ -432,8 +436,7 @@ global def makeJSONRunner rawScript score estimate =
           "resources"   → res | map JString | JArray,
           "version"     → JString version,
           match record
-            None = Nil
-            Some (Usage status runtime cputime membytes inbytes outbytes) =
+            Usage status runtime cputime membytes inbytes outbytes =
               "usage" → JObject (
                 "status"   → JInteger status,
                 "runtime"  → JDouble  runtime,
@@ -515,12 +518,13 @@ def addhash f =
   def add f h = prim "add_hash"
   add p (hashcode p)
 
+def hashUsage = defaultUsage | setUsageCPUtime 0.1
 target hashcode f =
   def get f = prim "get_hash"
   def reuse = get f
   if reuse !=* "" then reuse else
     def hashPlan cmd  =
-      Plan cmd Nil Nil "." "" logNever logError Verbose ReRun True Nil (\_ True) id id
+      Plan cmd Nil Nil "." "" logNever logError Verbose ReRun True Nil (\_ True) hashUsage id id
     def job = hashPlan ("<hash>", f, Nil) | runJobWith localRunner
     def hash =
       job.getJobStdout

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -296,7 +296,7 @@ bool JobTable::exit_now() {
   return exit_asap;
 }
 
-JobTable::JobTable(Database *db, int max_jobs, bool verbose, bool quiet, bool check) : imp(new JobTable::detail) {
+JobTable::JobTable(Database *db, double max_jobs, bool verbose, bool quiet, bool check) : imp(new JobTable::detail) {
   imp->verbose = verbose;
   imp->quiet = quiet;
   imp->check = check;

--- a/src/job.h
+++ b/src/job.h
@@ -27,7 +27,7 @@ struct JobTable {
   struct detail;
   std::unique_ptr<detail> imp;
 
-  JobTable(Database *db, int max_jobs, bool verbose, bool quiet, bool check);
+  JobTable(Database *db, double max_jobs, bool verbose, bool quiet, bool check);
   ~JobTable();
 
   // Wait for a job to complete; false -> no more active jobs

--- a/src/job.h
+++ b/src/job.h
@@ -27,7 +27,7 @@ struct JobTable {
   struct detail;
   std::unique_ptr<detail> imp;
 
-  JobTable(Database *db, double max_jobs, bool verbose, bool quiet, bool check);
+  JobTable(Database *db, double percent, bool verbose, bool quiet, bool check);
   ~JobTable();
 
   // Wait for a job to complete; false -> no more active jobs

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,6 @@
 #define VERSION_STR TOSTRING(VERSION)
 
 #include <iostream>
-#include <thread>
 #include <sstream>
 #include <random>
 #include <inttypes.h>
@@ -175,8 +174,6 @@ int main(int argc, char **argv) {
     }
   }
 
-  double njobs = std::thread::hardware_concurrency() * percent;
-
   double heap_factor = 4.0;
   if (heapf) {
     char *tail;
@@ -319,7 +316,7 @@ int main(int argc, char **argv) {
   top->body = std::unique_ptr<Expr>(body);
 
   /* Primitives */
-  JobTable jobtable(&db, njobs, verbose, quiet, check);
+  JobTable jobtable(&db, percent, verbose, quiet, check);
   StringInfo info(verbose, debug, quiet, VERSION_STR);
   PrimMap pmap = prim_register_all(&info, &jobtable);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,6 +163,10 @@ int main(int argc, char **argv) {
 
   term_init(tty);
 
+  if (!percents) {
+    percents = getenv("WAKE_PERCENT");
+  }
+
   double percent = 0.9;
   if (percents) {
     char *tail;


### PR DESCRIPTION
This is now possible:
```
editPlanUsage (setUsageMemBytes XXX _)
```

wake -p50 will limit wake to using only 50% of memory+cpu+etc, guided by:
1. the database-statistics-based predicted usage
2. the user supplied predict usage
3. the default guess (1 thread, 2MiB)