### PR TITLE
wake: --no-tty now gathers stdout/stderr of jobs together

### DIFF
--- a/src/database.h
+++ b/src/database.h
@@ -118,6 +118,10 @@ struct Database {
   std::string get_output(
     long job,
     int descriptor);
+  void replay_output(
+    long job,
+    bool stdout,
+    bool stderr);
 
   void add_hash(
     const std::string &file,

--- a/src/job.h
+++ b/src/job.h
@@ -27,7 +27,7 @@ struct JobTable {
   struct detail;
   std::unique_ptr<detail> imp;
 
-  JobTable(Database *db, double percent, bool verbose, bool quiet, bool check);
+  JobTable(Database *db, double percent, bool verbose, bool quiet, bool check, bool batch);
   ~JobTable();
 
   // Wait for a job to complete; false -> no more active jobs

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -334,7 +334,7 @@ int main(int argc, char **argv) {
   top->body = std::unique_ptr<Expr>(body);
 
   /* Primitives */
-  JobTable jobtable(&db, percent, verbose, quiet, check);
+  JobTable jobtable(&db, percent, verbose, quiet, check, !tty);
   StringInfo info(verbose, debug, quiet, VERSION_STR);
   PrimMap pmap = prim_register_all(&info, &jobtable);
 


### PR DESCRIPTION
In interactive mode, you want to see progress immediately, so we pass
stdout/stderr from jobs through as it arrives.

However, in batch mode, we don't have this requirement.  When inspecting
logs from a build it's quite difficult to disentangle which error messages
correspond to which command.

To fix this, wake --no-tty will now defer echoing the command run and it's
stderr/stdout until the job is complete.  Then all of the information is
printed together.