### PR TITLE
pkgconfig: don't report missing packages on stderr

### DIFF
--- a/share/wake/lib/system/pkgconfig.wake
+++ b/share/wake/lib/system/pkgconfig.wake
@@ -38,6 +38,7 @@ target pkgConfigImp args =
     | setPlanLocalOnly True
     | setPlanEcho Verbose
     | setPlanStdout logNever
+    | setPlanStderr logVerbose
     | editPlanEnvironment addenv
     | runJob
   def output = result.getJobStdout | getWhenFail "" | tokenize `\n` | head


### PR DESCRIPTION
This was causing people to worry unnecessarily.
Fixes #197.