### PR TITLE
make: install now installs to /usr/local by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CC	:= cc -std=c99
 CXX	:= c++ -std=c++11
 CFLAGS	:= -Wall -O2 -DVERSION=$(VERSION)
 LDFLAGS	:=
+DESTDIR ?= /usr/local
 
 LOCAL_CFLAGS :=	-Iutf8proc -Igopt -Icommon
 FUSE_CFLAGS  :=	$(shell pkg-config --silence-errors --cflags fuse)
@@ -38,7 +39,7 @@ wake.db:	bin/wake lib/wake/fuse-wake lib/wake/fuse-waked lib/wake/shim-wake $(EX
 	test -f $@ || ./bin/wake --init .
 
 install:	all
-	$(WAKE_ENV) ./bin/wake install '"install"'
+	$(WAKE_ENV) ./bin/wake install '"$(DESTDIR)"'
 
 tarball:	wake.db
 	$(WAKE_ENV) ./bin/wake tarball Unit

--- a/wake.spec.in
+++ b/wake.spec.in
@@ -24,8 +24,7 @@ or that your colleagues already built, you might appreciate wake.
 USE_FUSE_WAKE=0 make all
 
 %install
-USE_FUSE_WAKE=0 make install
-mv install "%{buildroot}/usr"
+USE_FUSE_WAKE=0 make DESTDIR=%{buildroot}/usr install
 
 %files
 /usr/bin/wake


### PR DESCRIPTION
Installing into the working directory leads to problems with duplicated
symbols which can surprise new users.

Now, 'make DESTDIR=/wherever install' acts as people expect.

Fixes #256.