### PR TITLE
wake: move Literals to a shared constant pool

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -38,8 +38,8 @@ const TypeDescriptor Top       ::type("Top");
 const TypeDescriptor VarDef    ::type("VarDef");
 const TypeDescriptor VarArg    ::type("VarArg");
 
-Literal::Literal(const Location &location_, RootPointer<HeapObject> &&value_, TypeVar *litType_)
- : Expr(&type, location_), value(std::move(value_)), litType(litType_) { }
+Literal::Literal(const Location &location_, RootPointer<Value> &&value_, TypeVar *litType_)
+ : Expr(&type, location_), value(std::make_shared<RootPointer<Value> >(std::move(value_))), litType(litType_) { }
 
 static std::string pad(int depth) {
   return std::string(depth, ' ');
@@ -172,11 +172,11 @@ void DefMap::interpret(Runtime &runtime, Scope *scope, Continuation *cont) {
 }
 
 void Literal::format(std::ostream &os, int depth) const {
-  os << pad(depth) << "Literal: " << typeVar << " @ " << location.file() << " = " << value.get() << std::endl;
+  os << pad(depth) << "Literal: " << typeVar << " @ " << location.file() << " = " << value->get() << std::endl;
 }
 
 Hash Literal::hash() {
-  return hashcode = value->hash() + type.hashcode;
+  return hashcode = (*value)->hash() + type.hashcode;
 }
 
 void Prim::format(std::ostream &os, int depth) const {

--- a/src/expr.h
+++ b/src/expr.h
@@ -125,11 +125,11 @@ struct VarRef : public Expr {
 };
 
 struct Literal : public Expr {
-  RootPointer<HeapObject> value;
+  std::shared_ptr<RootPointer<Value> > value;
   TypeVar *litType;
 
   static const TypeDescriptor type;
-  Literal(const Location &location_, RootPointer<HeapObject> &&value_, TypeVar *litType_);
+  Literal(const Location &location_, RootPointer<Value> &&value_, TypeVar *litType_);
 
   void format(std::ostream &os, int depth) const override;
   Hash hash() override;

--- a/src/gc.h
+++ b/src/gc.h
@@ -381,7 +381,21 @@ const char *GCObject<T, B>::type() const {
 
 struct Value : public HeapObject {
   Category category() const override;
+  size_t hashid() const;
+  virtual bool operator == (const Value &x) const;
 };
+
+inline bool operator == (const std::shared_ptr<RootPointer<Value> > &x, const std::shared_ptr<RootPointer<Value> > &y) {
+  return **x == **y;
+}
+
+namespace std {
+  template <> struct hash<std::shared_ptr<RootPointer<Value> > > {
+    size_t operator () (const std::shared_ptr<RootPointer<Value> > &x) const {
+      return (*x)->hashid();
+    }
+  };
+}
 
 struct DestroyableObject : public Value {
   DestroyableObject(Heap &h);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -56,7 +56,7 @@ static bool expectString(Lexer &lex) {
   if (expect(LITERAL, lex)) {
     if (lex.next.expr->type == &Literal::type) {
       Literal *lit = static_cast<Literal*>(lex.next.expr.get());
-      HeapObject *obj = lit->value.get();
+      HeapObject *obj = lit->value->get();
       if (typeid(*obj) == typeid(String)) {
         return true;
       } else {
@@ -216,7 +216,7 @@ static Expr *parse_match(int p, Lexer &lex) {
       std::string comparison("scmp");
       if (e->type == &Literal::type) {
         Literal *lit = static_cast<Literal*>(e);
-        HeapObject *obj = lit->value.get();
+        HeapObject *obj = lit->value->get();
         if (typeid(*obj) == typeid(Integer)) comparison = "icmp";
         if (typeid(*obj) == typeid(Double)) comparison = "dcmp";
       }
@@ -320,7 +320,7 @@ static Expr *parse_unary(int p, Lexer &lex, bool multiline) {
       lex.consume();
       if (expectString(lex)) {
         Literal *lit = static_cast<Literal*>(lex.next.expr.get());
-        name = static_cast<String*>(lit->value.get())->as_str();
+        name = static_cast<String*>(lit->value->get())->as_str();
         location.end = lex.next.location.end;
         lex.consume();
       } else {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -217,7 +217,7 @@ void DefBinding::interpret(Runtime &runtime, Scope *scope, Continuation *cont) {
 }
 
 void Literal::interpret(Runtime &runtime, Scope *scope, Continuation *cont) {
-  cont->resume(runtime, value.get());
+  cont->resume(runtime, value->get());
 }
 
 struct CPrim final : public GCObject<CPrim, Continuation> {

--- a/src/value.h
+++ b/src/value.h
@@ -82,6 +82,7 @@ struct String final : public GCObject<String, Value> {
   template <typename T> bool operator >  (T&& x) const { return compare(std::forward<T>(x)) >  0; }
 
   Hash hash() const override;
+  bool operator == (const Value &x) const override;
   void format(std::ostream &os, FormatState &state) const override;
   static void cstr_format(std::ostream &os, const char *s, size_t len);
 
@@ -123,6 +124,7 @@ struct Integer final : public GCObject<Integer, Value> {
   std::string str(int base = 10) const;
   void format(std::ostream &os, FormatState &state) const override;
   Hash hash() const override;
+  bool operator == (const Value &x) const override;
 
   PadObject *objend() { return Parent::objend() + (abs(length)*sizeof(mp_limb_t) + sizeof(PadObject) - 1) / sizeof(PadObject); }
   static size_t reserve(const MPZ &mpz) { return sizeof(Integer)/sizeof(PadObject) + (abs(mpz.value[0]._mp_size)*sizeof(mp_limb_t) + sizeof(PadObject) - 1) / sizeof(PadObject); }
@@ -159,6 +161,7 @@ struct Double final : public GCObject<Double, Value> {
   std::string str(int format = DEFAULTFLOAT, int precision = limits::max_digits10) const;
   void format(std::ostream &os, FormatState &state) const override;
   Hash hash() const override;
+  bool operator == (const Value &x) const override;
 
   // Never call this during runtime! It can invalidate the heap.
   static RootPointer<Double> literal(Heap &h, const char *str);
@@ -175,6 +178,7 @@ struct RegExp final : public GCObject<RegExp, DestroyableObject> {
 
   void format(std::ostream &os, FormatState &state) const override;
   Hash hash() const override;
+  bool operator == (const Value &x) const override;
 
   // Never call this during runtime! It can invalidate the heap.
   static RootPointer<RegExp> literal(Heap &h, const std::string &value);


### PR DESCRIPTION
This also makes inlining constants free.