### PR TITLE
Reuse space

### DIFF
--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -176,6 +176,13 @@ size_t Heap::avail() const {
   return (end - free) * sizeof(PadObject);
 }
 
+void *Heap::scratch(size_t bytes) {
+  size_t size = (bytes+sizeof(PadObject)-1)/sizeof(PadObject);
+  Space &idle = imp->spaces[imp->space ^ 1];
+  if (idle.alloc < size) idle.resize(size);
+  return idle.array;
+}
+
 void Heap::report() const {
   if (imp->profile_heap) {
     std::stringstream s;

--- a/src/gc.h
+++ b/src/gc.h
@@ -274,6 +274,9 @@ struct Heap {
   size_t alloc() const;
   size_t avail() const;
 
+  // Grab a large temporary buffer from the GC's unused space
+  void *scratch(size_t bytes);
+
   template <typename T>
   RootPointer<T> root(T *obj) { return RootPointer<T>(roots, obj); }
   template <typename T>

--- a/src/gc.h
+++ b/src/gc.h
@@ -270,9 +270,9 @@ struct Heap {
     return claim(requested_pads);
   }
 
-  size_t used()  const { return (free - begin) * sizeof(PadObject); }
-  size_t alloc() const { return (end - begin) * sizeof(PadObject); }
-  size_t avail() const { return (end - free) * sizeof(PadObject); }
+  size_t used()  const;
+  size_t alloc() const;
+  size_t avail() const;
 
   template <typename T>
   RootPointer<T> root(T *obj) { return RootPointer<T>(roots, obj); }
@@ -283,9 +283,8 @@ private:
   struct Imp;
   std::unique_ptr<Imp> imp;
   RootRing roots;
-  PadObject *begin;
-  PadObject *end;
   PadObject *free;
+  PadObject *end;
 #ifdef DEBUG_GC
   size_t limit;
 #endif

--- a/src/gc.h
+++ b/src/gc.h
@@ -226,12 +226,6 @@ struct GCNeededException {
   GCNeededException(size_t needed_) : needed(needed_) { }
 };
 
-struct HeapStats {
-  const char *type;
-  size_t objects, pads;
-  HeapStats() : type(nullptr), objects(0), pads(0) { }
-};
-
 struct Heap {
   Heap(int profile_heap_, double heap_factor_);
   ~Heap();
@@ -286,16 +280,12 @@ struct Heap {
   RootPointer<T> root(HeapPointer<T> x) { return RootPointer<T>(roots, x.get()); }
 
 private:
-  int profile_heap;
-  double heap_factor;
+  struct Imp;
+  std::unique_ptr<Imp> imp;
+  RootRing roots;
   PadObject *begin;
   PadObject *end;
   PadObject *free;
-  size_t last_pads;
-  size_t most_pads;
-  HeapStats peak[10];
-  RootRing roots;
-  HeapObject *finalize;
 #ifdef DEBUG_GC
   size_t limit;
 #endif


### PR DESCRIPTION
Profiling on linux using 'perf' indicated large pause times when accessing memory in trivial functions. This led me to conclude that we were seeing a lot of page faults. Further investigation revealed the problem was that our GC heap allocations were the problem.

On a large (private) repository, this led to the following performance change:
```
old             new
user    sys     user    sys
11.1    12.6    9.5     1.9
10.4    14.9    9.4     2.0
10.5    14.9    9.8     1.9
```

The big difference is in the "system time" which goes from being the dominant cost (15s) to minor (2s).