### PR TITLE
hash: differently scoped identical functions are identical

### DIFF
--- a/src/cse.cpp
+++ b/src/cse.cpp
@@ -153,12 +153,11 @@ void RFun::pass_cse(PassCSE &p, std::unique_ptr<Term> self) {
     x.push(codes);
     p.table.erase(x);
   }
-  hash = Hash(codes);
 
   p.undo = save;
   auto me = p.stream.end(fun);
   p.starts.pop_back();
-  cse_reduce(p, hash, std::move(me[0]));
+  cse_reduce(p, Hash(codes), std::move(me[0]));
 }
 
 std::unique_ptr<Term> Term::pass_cse(std::unique_ptr<Term> term) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -403,14 +403,7 @@ int main(int argc, char **argv) {
 
   // Convert AST to optimized SSA
   std::unique_ptr<Term> ssa = Term::fromExpr(std::move(root));
-  if (optim) {
-    // Full optimization schedule
-    ssa = Term::optimize(std::move(ssa));
-  } else {
-    // We need at least these two passes to compute function hashes
-    ssa = Term::pass_purity(std::move(ssa), PRIM_ORDERED, SSA_ORDERED);
-    ssa = Term::pass_cse   (std::move(ssa));
-  }
+  if (optim) ssa = Term::optimize(std::move(ssa));
   ssa = Term::scope(std::move(ssa));
 
   // Upon request, dump out the SSA

--- a/src/prim.cpp
+++ b/src/prim.cpp
@@ -97,13 +97,11 @@ HeapStep Closure::explore_escape(HeapStep step) {
       step = it->at(j-1)->recurse<HeapStep, &HeapPointerBase::explore>(step);
     it = it->next.get();
   }
-  size_t depth = 1;
   for (auto x: fun->escapes) {
-    while (arg_depth(x) > depth) {
-      it = it->next.get();
-      ++depth;
-    }
-    step = it->at(arg_offset(x))->recurse<HeapStep, &HeapPointerBase::explore>(step);
+    Scope *s = it;
+    for (size_t depth = 0; depth < arg_depth(x); ++depth)
+      s = s->next.get();
+    step = s->at(arg_offset(x))->recurse<HeapStep, &HeapPointerBase::explore>(step);
   }
   return step;
 }

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -16,56 +16,97 @@
  */
 
 #include "ssa.h"
-#include "prim.h"
-#include <set>
+#include "hash.h"
 
 struct PassScope {
   PassScope *next;
   size_t start;
   size_t index;
-  std::set<size_t> escapes;
+  std::vector<size_t> escapes;
+  std::vector<uint64_t> codes;
   PassScope(PassScope *next_, size_t start_) : next(next_), start(start_), index(start_) { }
 };
 
-static size_t scope_arg(PassScope *top, size_t input) {
-  size_t depth = 0;
-  while (input < top->start) {
-    ++depth;
-    top->escapes.insert(input);
-    top = top->next;
+static size_t scope_arg(PassScope &p, size_t input) {
+  if (input < p.start) {
+    size_t escape;
+    for (escape = 0; escape < p.escapes.size(); ++escape)
+      if (p.escapes[escape] == input)
+        break;
+    if (escape == p.escapes.size())
+      p.escapes.push_back(input);
+    size_t depth = 0;
+    PassScope *top = &p;
+    do {
+      ++depth;
+      top = top->next;
+    } while (input < top->start);
+    size_t offset = input - top->start;
+    p.codes.push_back(make_arg(1, escape));
+    return make_arg(depth, offset);
+  } else {
+    size_t out = make_arg(0, input - p.start);
+    p.codes.push_back(out);
+    return out;
   }
-  return make_arg(depth, input - top->start);
 }
 
-void Leaf::pass_scope(PassScope &p) {
+void RArg::pass_scope(PassScope &p) {
+  p.codes.push_back(typeid(RArg).hash_code());
 }
 
-void Redux::pass_scope(PassScope &p) {
-  for (auto &x : args) x = scope_arg(&p, x);
+void RLit::pass_scope(PassScope &p) {
+  HeapObject *obj = value->get();
+  p.codes.push_back(typeid(RLit).hash_code());
+  p.codes.push_back(typeid(*obj).hash_code());
+  (*value)->hash().push(p.codes);
+}
+
+static void scope_redux(PassScope &p, Redux *redux, size_t type) {
+  p.codes.push_back(type);
+  p.codes.push_back(redux->args.size());
+  for (auto &x : redux->args)
+    x = scope_arg(p, x);
+}
+
+void RApp::pass_scope(PassScope &p) {
+  scope_redux(p, this, typeid(RApp).hash_code());
+}
+
+void RPrim::pass_scope(PassScope &p) {
+  scope_redux(p, this, typeid(RPrim).hash_code());
+  Hash(name).push(p.codes);
+}
+
+void RGet::pass_scope(PassScope &p) {
+  scope_redux(p, this, typeid(RGet).hash_code());
+  p.codes.push_back(index);
+}
+
+void RDes::pass_scope(PassScope &p) {
+  scope_redux(p, this, typeid(RGet).hash_code());
+}
+
+void RCon::pass_scope(PassScope &p) {
+  scope_redux(p, this, typeid(RGet).hash_code());
+  Hash(kind->ast.name).push(p.codes);
 }
 
 void RFun::pass_scope(PassScope &p) {
   PassScope frame(&p, p.index + 1);
 
-  output = scope_arg(&frame, output);
+  output = scope_arg(frame, output);
   for (auto &term : terms) {
     term->pass_scope(frame);
     ++frame.index;
   }
 
-  escapes.reserve(frame.escapes.size());
-  for (auto it = frame.escapes.rbegin(); it != frame.escapes.rend(); ++it)
-    escapes.push_back(*it);
+  hash = Hash(frame.codes);
+  escapes = std::move(frame.escapes);
 
-  size_t depth = 1;
-  PassScope *it = &p;
-  for (auto &x : escapes) {
-    while (x < it->start) {
-      ++depth;
-      it = it->next;
-    }
-    x = make_arg(depth, x - it->start);
-  }
+  p.codes.push_back(typeid(RFun).hash_code());
+  hash.push(p.codes);
+  for (auto &x : escapes) x = scope_arg(p, x);
 }
 
 std::unique_ptr<Term> Term::scope(std::unique_ptr<Term> term) {

--- a/src/ssa.cpp
+++ b/src/ssa.cpp
@@ -138,6 +138,7 @@ void RFun::format(std::ostream &os, TermFormat &format) const {
     for (auto x : escapes)
       os << " " << arg_depth(x) << ":" << arg_offset(x);
     os << "\n";
+    os << pad(format.depth) << "hash: " << hash.data[0] << "\n";
   }
   os << pad(format.depth) << "returns: ";
   if (format.scoped) {

--- a/src/ssa.h
+++ b/src/ssa.h
@@ -102,7 +102,6 @@ std::unique_ptr<T> static_unique_pointer_cast(std::unique_ptr<F>&& x) {
 
 struct Leaf : public Term {
   Leaf(const char *label_) : Term(label_) { }
-  void pass_scope(PassScope &p) override;
 };
 
 // After scope pass, Redux.args is suitable for interpretation
@@ -116,8 +115,6 @@ struct Redux : public Term {
   Redux(const char *label_, std::vector<size_t> &&args_) : Term(label_), args(std::move(args_)) { }
   void update(const SourceMap &map);
   void format_args(std::ostream &os, TermFormat &format) const;
-
-  void pass_scope(PassScope &p) override;
 };
 
 struct RArg final : public Leaf {
@@ -133,6 +130,7 @@ struct RArg final : public Leaf {
   void pass_sweep (PassSweep  &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse   (PassCSE    &p, std::unique_ptr<Term> self) override;
+  void pass_scope (PassScope  &p) override;
 };
 
 struct RLit final : public Leaf {
@@ -150,6 +148,7 @@ struct RLit final : public Leaf {
   void pass_sweep (PassSweep  &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse   (PassCSE    &p, std::unique_ptr<Term> self) override;
+  void pass_scope (PassScope  &p) override;
 };
 
 struct RApp final : public Redux {
@@ -166,6 +165,7 @@ struct RApp final : public Redux {
   void pass_sweep (PassSweep  &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse   (PassCSE    &p, std::unique_ptr<Term> self) override;
+  void pass_scope (PassScope  &p) override;
 };
 
 struct RPrim final : public Redux {
@@ -187,6 +187,7 @@ struct RPrim final : public Redux {
   void pass_sweep (PassSweep  &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse   (PassCSE    &p, std::unique_ptr<Term> self) override;
+  void pass_scope (PassScope  &p) override;
 };
 
 struct RGet final : public Redux {
@@ -205,6 +206,7 @@ struct RGet final : public Redux {
   void pass_sweep (PassSweep  &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse   (PassCSE    &p, std::unique_ptr<Term> self) override;
+  void pass_scope (PassScope  &p) override;
 };
 
 struct RDes final : public Redux {
@@ -221,6 +223,7 @@ struct RDes final : public Redux {
   void pass_sweep (PassSweep  &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse   (PassCSE    &p, std::unique_ptr<Term> self) override;
+  void pass_scope (PassScope  &p) override;
 };
 
 struct RCon final : public Redux {
@@ -240,6 +243,7 @@ struct RCon final : public Redux {
   void pass_sweep (PassSweep  &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse   (PassCSE    &p, std::unique_ptr<Term> self) override;
+  void pass_scope (PassScope  &p) override;
 };
 
 struct RFun final : public Term {


### PR DESCRIPTION
The function '\_ x' is the same, no matter where 'x' is on the stack.
Of course, a closure must also hash the contents of 'x'.