### PR TITLE
Job: changing FnInputs, FnOutputs, Resources, or Keep -> rerun

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -206,15 +206,17 @@ def pid = prim "pid"
 
 def implode l = cat (foldr (_, "\0", _) Nil l)
 def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run log =
-  def create dir stdin env cmd visible keep log = prim "job_create"
+  def create dir stdin env cmd signature visible keep log = prim "job_create"
   def finish job inputs outputs status runtime cputime membytes ibytes obytes = prim "job_finish"
   def badfinish job error = prim "job_fail_finish"
-  def cache dir stdin env cmd visible = prim "job_cache"
+  def cache dir stdin env cmd signature visible = prim "job_cache"
+  def signature cmd res fni fno keep = prim "hash"
+  def hash = signature cmd res finputs foutputs keep
   def build Unit =
     def getPathOpt = match _
       Path name = Some name
       BadPath _ = None
-    def job = create dir stdin env.implode cmd.implode (mapPartial getPathOpt vis).implode (if keep then 1 else 0) log
+    def job = create dir stdin env.implode cmd.implode hash (mapPartial getPathOpt vis).implode (if keep then 1 else 0) log
     def prefix = "{str pid}.{str (getJobId job)}"
     def usage = getJobRecord job | getOrElse uusage
     def output = run job (Pass (RunnerInput cmd vis env dir stdin res prefix usage))
@@ -239,7 +241,7 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run log =
     job
   match keep
     False = build Unit
-    True  = match (cache dir stdin env.implode cmd.implode (map getPathName vis).implode)
+    True  = match (cache dir stdin env.implode cmd.implode hash (map getPathName vis).implode)
       Pair (job, _) last = confirm True  last job
       Pair Nil      last = confirm False last (build Unit)
 
@@ -301,10 +303,10 @@ global def runJob p = match p
     match (opts | foldl best (Pair 0.0 None) | getPairSecond)
       Some r = runJobImp cmd env dir stdin res usage finputs foutputs vis pers r log
       None =
-        def create dir stdin env cmd visible keep log = prim "job_create"
+        def create dir stdin env cmd signature visible keep log = prim "job_create"
         def badfinish job e = prim "job_fail_finish"
         def badlaunch job e = prim "job_fail_launch"
-        def job = create dir stdin env.implode cmd.implode "" 0 log
+        def job = create dir stdin env.implode cmd.implode 0 "" 0 log
         def error =
           def pretty = match _
             Accept _ _ = ""

--- a/src/database.h
+++ b/src/database.h
@@ -80,9 +80,10 @@ struct Database {
 
   Usage reuse_job(
     const std::string &directory,
-    const std::string &stdin, // "" -> /dev/null
     const std::string &environment,
     const std::string &commandline,
+    const std::string &stdin, // "" -> /dev/null
+    uint64_t          signature,
     const std::string &visible,
     bool check,
     long &job,
@@ -93,12 +94,13 @@ struct Database {
     double *pathtime);
   void insert_job( // also wipes out any old runs
     const std::string &directory,
-    const std::string &stdin, // "" -> /dev/null
     const std::string &environment,
     const std::string &commandline,
+    const std::string &stdin, // "" -> /dev/null
     // ^^^ only these matter to identify the job
-    const std::string &visible,
+    uint64_t          signature, // this must match to qualify for reuse
     const std::string &stack,
+    const std::string &visible,
     long   *job); // key used for accesses below
   void finish_job(
     long job,

--- a/src/gc.h
+++ b/src/gc.h
@@ -373,7 +373,7 @@ const char *GCObject<T, B>::type() const {
 
 struct Value : public HeapObject {
   Category category() const override;
-  size_t hashid() const;
+  virtual size_t hashid() const;
   virtual bool operator == (const Value &x) const;
 };
 

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -1114,13 +1114,15 @@ static PRIMFN(prim_job_create) {
   std::stringstream stack;
   for (auto &x : scope->stack_trace()) stack << x << std::endl;
 
+  uint64_t signature = 0;
   out->db->insert_job(
     dir->as_str(),
-    stdin->as_str(),
-    env->as_str(),
     cmd->as_str(),
-    visible->as_str(),
+    env->as_str(),
+    stdin->as_str(),
+    signature,
     stack.str(),
+    visible->as_str(),
     &out->job);
 
   RETURN(out);
@@ -1181,12 +1183,14 @@ static PRIMFN(prim_job_cache) {
   // This function can be rerun; it's side effect has no impact on re-execution of reuse_job.
   long job;
   double pathtime;
+  uint64_t signature = 0;
   std::vector<FileReflection> files;
   Usage reuse = jobtable->imp->db->reuse_job(
     dir->as_str(),
-    stdin->as_str(),
     env->as_str(),
     cmd->as_str(),
+    stdin->as_str(),
+    signature,
     visible->as_str(),
     jobtable->imp->check,
     job,

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -1077,27 +1077,33 @@ static PRIMFN(prim_job_virtual) {
 }
 
 static PRIMTYPE(type_job_create) {
-  return args.size() == 7 &&
+  return args.size() == 8 &&
     args[0]->unify(String::typeVar) &&
     args[1]->unify(String::typeVar) &&
     args[2]->unify(String::typeVar) &&
     args[3]->unify(String::typeVar) &&
-    args[4]->unify(String::typeVar) &&
-    args[5]->unify(Integer::typeVar) &&
+    args[4]->unify(Integer::typeVar) &&
+    args[5]->unify(String::typeVar) &&
     args[6]->unify(Integer::typeVar) &&
+    args[7]->unify(Integer::typeVar) &&
     out->unify(Job::typeVar);
 }
 
 static PRIMFN(prim_job_create) {
   JobTable *jobtable = static_cast<JobTable*>(data);
-  EXPECT(7);
+  EXPECT(8);
   STRING(dir, 0);
   STRING(stdin, 1);
   STRING(env, 2);
   STRING(cmd, 3);
-  STRING(visible, 4);
-  INTEGER_MPZ(keep, 5);
-  INTEGER_MPZ(log, 6);
+  INTEGER_MPZ(signature, 4);
+  STRING(visible, 5);
+  INTEGER_MPZ(keep, 6);
+  INTEGER_MPZ(log, 7);
+
+  Hash hash;
+  REQUIRE(mpz_sizeinbase(signature, 2) <= 8*sizeof(hash.data));
+  mpz_export(&hash.data[0], 0, 1, sizeof(hash.data[0]), 0, 0, signature);
 
   Job *out = Job::alloc(
     runtime.heap,
@@ -1114,13 +1120,12 @@ static PRIMFN(prim_job_create) {
   std::stringstream stack;
   for (auto &x : scope->stack_trace()) stack << x << std::endl;
 
-  uint64_t signature = 0;
   out->db->insert_job(
     dir->as_str(),
     cmd->as_str(),
     env->as_str(),
     stdin->as_str(),
-    signature,
+    hash.data[0],
     stack.str(),
     visible->as_str(),
     &out->job);
@@ -1162,35 +1167,40 @@ static PRIMTYPE(type_job_cache) {
   jlist[0].unify(Job::typeVar);
   pair[0].unify(jlist);
   pair[1].unify(plist);
-  return args.size() == 5 &&
+  return args.size() == 6 &&
     args[0]->unify(String::typeVar) &&
     args[1]->unify(String::typeVar) &&
     args[2]->unify(String::typeVar) &&
     args[3]->unify(String::typeVar) &&
-    args[4]->unify(String::typeVar) &&
+    args[4]->unify(Integer::typeVar) &&
+    args[5]->unify(String::typeVar) &&
     out->unify(pair);
 }
 
 static PRIMFN(prim_job_cache) {
   JobTable *jobtable = static_cast<JobTable*>(data);
-  EXPECT(5);
+  EXPECT(6);
   STRING(dir, 0);
   STRING(stdin, 1);
   STRING(env, 2);
   STRING(cmd, 3);
-  STRING(visible, 4);
+  INTEGER_MPZ(signature, 4);
+  STRING(visible, 5);
+
+  Hash hash;
+  REQUIRE(mpz_sizeinbase(signature, 2) <= 8*sizeof(hash.data));
+  mpz_export(&hash.data[0], 0, 1, sizeof(hash.data[0]), 0, 0, signature);
 
   // This function can be rerun; it's side effect has no impact on re-execution of reuse_job.
   long job;
   double pathtime;
-  uint64_t signature = 0;
   std::vector<FileReflection> files;
   Usage reuse = jobtable->imp->db->reuse_job(
     dir->as_str(),
     env->as_str(),
     cmd->as_str(),
     stdin->as_str(),
-    signature,
+    hash.data[0],
     visible->as_str(),
     jobtable->imp->check,
     job,

--- a/src/ssa.cpp
+++ b/src/ssa.cpp
@@ -138,13 +138,12 @@ void RFun::format(std::ostream &os, TermFormat &format) const {
     for (auto x : escapes)
       os << " " << arg_depth(x) << ":" << arg_offset(x);
     os << "\n";
-    os << pad(format.depth) << "hash: " << hash.data[0] << "\n";
   }
-  os << pad(format.depth) << "returns: ";
   if (format.scoped) {
-    os << arg_depth(output) << ":" << arg_offset(output);
+    os << pad(format.depth) << "hash: " << hash.data[0] << "\n";
+    os << pad(format.depth) << "returns: " << arg_depth(output) << ":" << arg_offset(output);
   } else {
-    os << output;
+    os << pad(format.depth) << "returns: " << output;
     if (output > format.id + terms.size()) os << " !!!";
   }
   os << "\n";

--- a/src/value.h
+++ b/src/value.h
@@ -82,6 +82,7 @@ struct String final : public GCObject<String, Value> {
   template <typename T> bool operator >  (T&& x) const { return compare(std::forward<T>(x)) >  0; }
 
   Hash hash() const override;
+  size_t hashid() const override;
   bool operator == (const Value &x) const override;
   void format(std::ostream &os, FormatState &state) const override;
   static void cstr_format(std::ostream &os, const char *s, size_t len);
@@ -124,6 +125,7 @@ struct Integer final : public GCObject<Integer, Value> {
   std::string str(int base = 10) const;
   void format(std::ostream &os, FormatState &state) const override;
   Hash hash() const override;
+  size_t hashid() const override;
   bool operator == (const Value &x) const override;
 
   PadObject *objend() { return Parent::objend() + (abs(length)*sizeof(mp_limb_t) + sizeof(PadObject) - 1) / sizeof(PadObject); }
@@ -161,6 +163,7 @@ struct Double final : public GCObject<Double, Value> {
   std::string str(int format = DEFAULTFLOAT, int precision = limits::max_digits10) const;
   void format(std::ostream &os, FormatState &state) const override;
   Hash hash() const override;
+  size_t hashid() const override;
   bool operator == (const Value &x) const override;
 
   // Never call this during runtime! It can invalidate the heap.
@@ -178,6 +181,7 @@ struct RegExp final : public GCObject<RegExp, DestroyableObject> {
 
   void format(std::ostream &os, FormatState &state) const override;
   Hash hash() const override;
+  size_t hashid() const override;
   bool operator == (const Value &x) const override;
 
   // Never call this during runtime! It can invalidate the heap.


### PR DESCRIPTION
This is finally possible to fix!

We can now hash functions in a way that is stable enough to only change if a used value or expression differs. ie: the false positive rate is now low enough not to cause builds to waste time.

NOTE: The runner is not included into this test. Otherwise, switching between local/remote build environments would force a rebuild.