### PR TITLE
fuse: allow up 128MiB JSON Job descriptions

### DIFF
--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -24,7 +24,7 @@
 #define _XOPEN_SOURCE 700
 #endif
 
-#define MAX_JSON (1024*1024)
+#define MAX_JSON (128*1024*1024)
 
 #include <fuse.h>
 #include <stdio.h>


### PR DESCRIPTION
Fixes #311.
It turns out 1MiB was not enough for some tools.