### PR TITLE
Deep cleaning

### DIFF
--- a/common/unlink.cpp
+++ b/common/unlink.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "unlink.h"
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <errno.h>
+
+int deep_unlink(int parentfd, const char *path) {
+	// Set the directory read-write-execute for removing contents.
+	// However, if this fails, ignore it (later removes will fail).
+	int ignore = fchmodat(parentfd, path, S_IRWXU|S_IRWXG|S_IRWXO, 0);
+	(void)ignore;
+
+	// Capture a persistent handle to the directory
+	int dirfd = openat(parentfd, path, O_RDONLY|O_DIRECTORY);
+	if (dirfd == -1) {
+		if (errno == ENOTDIR) {
+			// The directory became a file between readdir and openat.
+			// This should not count as failure unless we can't remove it.
+			if (unlinkat(parentfd, path, 0)) {
+				return -errno;
+			} else {
+				return 0;
+			}
+		} else {
+			return -errno;
+		}
+	}
+
+	// This could fail due to lack of memory
+	DIR *dir = fdopendir(dirfd);
+	if (!dir) {
+		(void)close(dirfd);
+		return -errno;
+	}
+
+	int out = 0;
+	bool isdir;
+
+	// SUSv3 explicitly notes that it is unspecified whether readdir()
+	// will return a filename that has been added to or removed from
+	// since the last since the last call to opendir() or rewinddir(). 
+	// All filenames that have been neither added nor removed since the
+	// last such call are guaranteed to be returned.
+	for (errno = 0; struct dirent *f = readdir(dir); errno = 0) {
+		if (f->d_name[0] == '.' && (f->d_name[1] == 0 || (f->d_name[1] == '.' && f->d_name[2] == 0)))
+			continue;
+#ifdef DT_DIR
+		if (f->d_type == DT_UNKNOWN) {
+#endif
+			struct stat sbuf;
+			if (fstatat(dirfd, f->d_name, &sbuf, AT_SYMLINK_NOFOLLOW)) {
+				isdir = false;
+			} else {
+				isdir = S_ISDIR(sbuf.st_mode);
+			}
+#ifdef DT_DIR
+		} else {
+			isdir = f->d_type == DT_DIR;
+		}
+#endif
+		if (isdir) {
+			if (int r = deep_unlink(dirfd, f->d_name)) out = r;
+		} else {
+			if (unlinkat(dirfd, f->d_name, 0)) out = -errno;
+		}
+	}
+
+	if (errno) out = -errno;
+	if (closedir(dir)) out = -errno;
+
+	// Remove the (hopefully) now empty directory
+	if (unlinkat(parentfd, path, AT_REMOVEDIR)) out = -errno;
+
+	return out;
+}

--- a/common/unlink.h
+++ b/common/unlink.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UNLINK_H
+#define UNLINK_H
+
+// Remove all files under 'path'.
+// If path is absolute, parentfd is ignored
+// If path is relative and parentfd=AT_FDCWD, relative to current directory
+// Otherwise, path is taken relative to the parentfd directory
+int deep_unlink(int parentfd, const char *path);
+
+#endif

--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -82,7 +82,6 @@ struct Job {
 	void parse();
 	void dump();
 
-	bool is_creatable(const std::string &path);
 	bool is_writeable(const std::string &path);
 	bool is_readable(const std::string &path);
 protected:
@@ -154,11 +153,6 @@ bool Job::is_visible(const std::string &path) {
 		&& i->size() > path.size()
 		&& (*i)[path.size()] == '/'
 		&& 0 == i->compare(0, path.size(), path);
-}
-
-bool Job::is_creatable(const std::string &path) {
-	return true;
-	// is_writeable(path) || faccessat(context.rootfd, path.c_str(), R_OK, 0) != 0;
 }
 
 bool Job::is_writeable(const std::string &path) {
@@ -447,8 +441,8 @@ static int wakefuse_mknod(const char *path, mode_t mode, dev_t rdev)
 	if (key.second == ".")
 		return -EEXIST;
 
-	if (!it->second.is_creatable(key.second))
-		return -EACCES;
+	if (!it->second.is_readable(key.second))
+		(void)deep_unlink(context.rootfd, key.second.c_str());
 
 	int res;
 	if (S_ISREG(mode)) {
@@ -491,6 +485,7 @@ static int wakefuse_mknod(const char *path, mode_t mode, dev_t rdev)
 	if (res == -1)
 		return -errno;
 
+	it->second.files_wrote.insert(std::move(key.second));
 	return 0;
 }
 
@@ -524,10 +519,8 @@ static int wakefuse_create(const char *path, mode_t mode, struct fuse_file_info 
 	if (key.second == ".")
 		return -EEXIST;
 
-	if (!it->second.is_creatable(key.second))
-		return -EACCES;
-
-	(void)unlinkat(context.rootfd, key.second.c_str(), 0);
+	if (!it->second.is_readable(key.second))
+		(void)deep_unlink(context.rootfd, key.second.c_str());
 
 	int fd = openat(context.rootfd, key.second.c_str(), fi->flags, mode);
 	if (fd == -1)
@@ -560,11 +553,11 @@ static int wakefuse_mkdir(const char *path, mode_t mode)
 	if (key.second == ".")
 		return -EEXIST;
 
-	if (!it->second.is_creatable(key.second))
-		return -EACCES;
+	if (!it->second.is_readable(key.second))
+		(void)deep_unlink(context.rootfd, key.second.c_str());
 
 	int res = mkdirat(context.rootfd, key.second.c_str(), mode);
-	if (res == -1 && (errno != EEXIST || it->second.is_readable(key.second)))
+	if (res == -1)
 		return -errno;
 
 	it->second.files_wrote.insert(std::move(key.second));
@@ -659,8 +652,8 @@ static int wakefuse_symlink(const char *from, const char *to)
 	if (key.second == ".")
 		return -EEXIST;
 
-	if (!it->second.is_creatable(key.second))
-		return -EACCES;
+	if (!it->second.is_readable(key.second))
+		(void)deep_unlink(context.rootfd, key.second.c_str());
 
 	int res = symlinkat(from, context.rootfd, key.second.c_str());
 	if (res == -1)
@@ -722,11 +715,8 @@ static int wakefuse_rename(const char *from, const char *to)
 	if (!it->second.is_writeable(keyf.second))
 		return -EACCES;
 
-	if (!it->second.is_creatable(keyt.second))
-		return -EACCES;
-
 	if (!it->second.is_readable(keyt.second))
-		deep_unlink(context.rootfd, keyt.second.c_str());
+		(void)deep_unlink(context.rootfd, keyt.second.c_str());
 
 	int res = renameat(context.rootfd, keyf.second.c_str(), context.rootfd, keyt.second.c_str());
 	if (res == -1)
@@ -781,8 +771,8 @@ static int wakefuse_link(const char *from, const char *to)
 	if (!it->second.is_readable(keyf.second))
 		return -ENOENT;
 
-	if (!it->second.is_creatable(keyt.second))
-		return -EACCES;
+	if (!it->second.is_readable(keyt.second))
+		(void)deep_unlink(context.rootfd, keyt.second.c_str());
 
 	int res = linkat(context.rootfd, keyf.second.c_str(), context.rootfd, keyt.second.c_str(), 0);
 	if (res == -1)

--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -49,6 +49,7 @@
 #include "json5.h"
 #include "execpath.h"
 #include "sfinae.h"
+#include "unlink.h"
 
 #ifdef __APPLE__
 #define st_mtim st_mtimespec
@@ -723,6 +724,9 @@ static int wakefuse_rename(const char *from, const char *to)
 
 	if (!it->second.is_creatable(keyt.second))
 		return -EACCES;
+
+	if (!it->second.is_readable(keyt.second))
+		deep_unlink(context.rootfd, keyt.second.c_str());
 
 	int res = renameat(context.rootfd, keyf.second.c_str(), context.rootfd, keyt.second.c_str());
 	if (res == -1)


### PR DESCRIPTION
Both FUSE and preload runners now use a shared 'rm -rf' helper method, which tries very hard to clean out files. In particular:
- preload runner: clean up even read-only .build/xxx directories
- fuse runner: erase invisible outputs to uphold fiction that nothing was there