### PR TITLE
FUSE: prevent overwrite of visible files

### DIFF
--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -1085,12 +1085,14 @@ static int wakefuse_write(const char *path, const char *buf, size_t size,
 		if (it == context.jobs.end())
 			return -ENOENT;
 
+		if (!it->second.is_writeable(key.second))
+			return -EACCES;
+
 		int res = pwrite(fi->fh, buf, size, offset);
 		if (res == -1)
 			res = -errno;
 
 		it->second.obytes += res;
-		it->second.files_wrote.insert(std::move(key.second));
 		return res;
 	}
 

--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -84,7 +84,6 @@ struct Job {
 
 	bool is_writeable(const std::string &path);
 	bool is_readable(const std::string &path);
-protected:
 	bool is_visible(const std::string &path);
 };
 
@@ -715,7 +714,10 @@ static int wakefuse_rename(const char *from, const char *to)
 	if (!it->second.is_writeable(keyf.second))
 		return -EACCES;
 
-	if (!it->second.is_readable(keyt.second))
+	if (it->second.is_visible(keyt.second))
+		return -EACCES;
+
+	if (!it->second.is_writeable(keyt.second))
 		(void)deep_unlink(context.rootfd, keyt.second.c_str());
 
 	int res = renameat(context.rootfd, keyf.second.c_str(), context.rootfd, keyt.second.c_str());

--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -923,7 +923,7 @@ template <typename T>
 struct has_utimensat {
 	typedef char no;
 	template <typename C>
-	static auto test(C c) -> decltype(utimensat(c, nullptr));
+	static auto test(C c) -> decltype(utimensat(c, nullptr, nullptr, 0));
 	template <typename>
 	static no test(...);
 	static const bool value = sizeof(test<int>(0)) != sizeof(no);

--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -938,7 +938,7 @@ maybe_utimensat(T dirfd, const char *path, const struct timespec timens[2]) {
 template <typename T>
 static typename enable_if<!has_utimensat<T>::value, int>::type
 maybe_utimensat(T dirfd, const char *path, const struct timespec timens[2]) {
-	int fd = openat(dirfd, path, O_RDWR | O_NOFOLLOW);
+	int fd = openat(dirfd, path, O_RDONLY | O_NOFOLLOW);
 	struct timeval times[2];
 	times[0].tv_sec = timens[0].tv_sec;
 	times[1].tv_sec = timens[1].tv_sec;


### PR DESCRIPTION
This PR protects visible files from being the target of rename()