### PR TITLE
Replace state files with runIncrementalJob

### DIFF
--- a/share/wake/lib/system/incremental.wake
+++ b/share/wake/lib/system/incremental.wake
@@ -1,0 +1,84 @@
+# Copyright 2019 SiFive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You should have received a copy of LICENSE.Apache2 along with
+# this software. If not, you may obtain a copy at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This API makes it possible to include a non-source file into a wake build.
+# Generally, one should obtain Paths from sources or as the output of Jobs.
+# This API is useful for things like a comannd-line-supplied input file.
+global def claimFileAsPath existingFile desiredWorkspacePath =
+  def get_modtime file = prim "get_modtime"
+  def time = get_modtime existingFile
+  if time == -1
+  then makeBadPath (makeError "{existingFile}: claimed file does not exist")
+  else
+    makePlan (which "ln", "-f", existingFile, desiredWorkspacePath, Nil) Nil
+    | setPlanLocalOnly   True
+    | setPlanPersistence ReRun
+    | setPlanEcho        Verbose
+    | setPlanStdout      logNever
+    | setPlanStderr      logNever
+    | setPlanFnOutputs   (\_ desiredWorkspacePath, Nil)
+    | runJobWith localRunner
+    | getJobOutput
+
+target tarExe Unit =
+  def gnutar = which "gnutar"
+  if gnutar ==* "gnutar" then which "tar" else gnutar
+
+def tar output paths =
+  def cmd =
+    # Intentionally record mtime => needed for incremental builds
+    tarExe Unit, "--numeric-owner", "--owner=0", "--group=0", "-cf",
+    output, map getPathName paths | sortBy (_<*_)
+  makePlan cmd paths
+  | setPlanLocalOnly True
+  | setPlanEcho      Verbose
+  | setPlanFnOutputs (\_ output, Nil)
+  | runJobWith       localRunner
+  | getJobOutput
+
+# This API allows a Job to access those outputs from its last invocation
+# which are accepted by reusedOutputFilterFn. To use this method, you must
+# guarantee that all output contents will be the same whether or not the
+# previous outputs were made available or not.
+global def runIncrementalJob stateFileLabel reusedOutputFilterFn plan =
+  def pre  = "{stateFileLabel}-pre-{plan.getPlanHash.str}.tar"
+  def post = "{stateFileLabel}-post-{plan.getPlanHash.str}.tar"
+  def escape s = prim "shell_str"
+  def preTar = claimFileAsPath post pre
+  def untar = match preTar.getPathError
+    None   = "tar -xf {escape pre}\n"
+    Some _ = ""
+  def stateFiles = match preTar.getPathError
+    None   = preTar, Nil
+    Some _ = Nil
+  def cd =
+    if plan.getPlanDirectory ==* "."
+    then ""
+    else "cd {plan.getPlanDirectory}\n"
+  def orig = plan.getPlanCommand | map escape | catWith " "
+  def script = "{untar}{cd}{orig}"
+  def job =
+    plan
+    | setPlanDirectory "."
+    | setPlanCommand   (which "dash", "-c", script, Nil)
+    | editPlanVisible  (stateFiles ++ _)
+    | setPlanFnInputs  (\_ plan.getPlanVisible | map getPathName)
+    | runJob
+  def postTar =
+    job
+    | getJobOutputs
+    | filter reusedOutputFilterFn
+    | tar post
+  job

--- a/share/wake/lib/system/incremental.wake
+++ b/share/wake/lib/system/incremental.wake
@@ -51,10 +51,13 @@ def tar output paths =
 # This API allows a Job to access those outputs from its last invocation
 # which are accepted by reusedOutputFilterFn. To use this method, you must
 # guarantee that all output contents will be the same whether or not the
-# previous outputs were made available or not.
+# previous outputs were made available or not. Also, for incremental jobs,
+# all visible files are considered as inputs, since the job might not read
+# all inputs on each run, based on (for example) timestamps.
 global def runIncrementalJob stateFileLabel reusedOutputFilterFn plan =
-  def pre  = "{stateFileLabel}-pre-{plan.getPlanHash.str}.tar"
-  def post = "{stateFileLabel}-post-{plan.getPlanHash.str}.tar"
+  def code = plan | getPlanHash | strbase 62
+  def pre  = "{stateFileLabel}-pre-{code}.tar"
+  def post = "{stateFileLabel}-post-{code}.tar"
   def escape s = prim "shell_str"
   def preTar = claimFileAsPath post pre
   def untar = match preTar.getPathError

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -138,6 +138,12 @@ global def editPlanShare f =
     x                  = x
   editPlanPersistence helper
 
+# Get a unique hash-code for the job
+global def getPlanHash plan =
+  def signature cmd env dir stdin = prim "hash"
+  def Plan cmd _ env dir stdin _ _ _ _ _ _ _ _ _ _ = plan
+  signature cmd env dir stdin
+
 # The criteria which determine if Job execution can be skipped:
 #   Once  is True and a matching job was run by this wake invocation
 #   Keep  is True and there is matching output in the workspace

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -560,30 +560,6 @@ target hashcode f =
       True (x, Nil) = x
       _ _ = "BadHash"
 
-def stateRunner =
-  def add f h = prim "add_hash"
-  def hash = "0000000000000000000000000000000000000000000000000000000000000000"
-  def pre = match _
-    Fail f = Pair (Fail f) ""
-    Pass input = match input.getRunnerInputCommand
-      _, file, Nil = Pair (Pass input) file
-      _ = panic "stateRunner: invalid command-line"
-  def post = match _
-    Pair (Fail f) _ = Fail f
-    Pair (Pass output) file =
-      Pass (editRunnerOutputOutputs (add file hash, _) output)
-  makeRunner "state" (\_ Pass 0.0) pre post virtualRunner
-
-# Mark a file whose contents must not be tracked
-global def makeStatePath file =
-  makePlan ("<state>", file, Nil) Nil
-  | setPlanKeep        False
-  | setPlanEcho        Debug
-  | setPlanEnvironment Nil
-  | setPlanFnOutputs   (file, _)
-  | runJobWith stateRunner
-  | getJobOutput
-
 # Whenever possible, use 'job' if:
 #   cmd can run under FUSE
 #   cmd guarantees to produce the same outputs given the same inputs

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -21,6 +21,7 @@
 #include "status.h"
 #include "utf8.h"
 #include "gc.h"
+#include "shell.h"
 #include <sstream>
 #include <fstream>
 #include <iostream>
@@ -585,6 +586,18 @@ static PRIMFN(prim_uname) {
   RETURN(out);
 }
 
+static PRIMTYPE(type_shell_str) {
+  return args.size() == 1 &&
+    args[0]->unify(String::typeVar) &&
+    out->unify(String::typeVar);
+}
+
+static PRIMFN(prim_shell_str) {
+  EXPECT(1);
+  STRING(str, 0);
+  RETURN(String::alloc(runtime.heap, shell_escape(str->c_str())));
+}
+
 void prim_register_string(PrimMap &pmap, StringInfo *info) {
   prim_register(pmap, "strlen",   prim_strlen,   type_strlen,    PRIM_PURE);
   prim_register(pmap, "vcat",     prim_vcat,     type_vcat,      PRIM_PURE);
@@ -603,6 +616,7 @@ void prim_register_string(PrimMap &pmap, StringInfo *info) {
   prim_register(pmap, "str2code", prim_str2code, type_str2code,  PRIM_PURE);
   prim_register(pmap, "str2bin",  prim_str2bin,  type_str2code,  PRIM_PURE);
   prim_register(pmap, "uname",    prim_uname,    type_uname,     PRIM_PURE);
+  prim_register(pmap, "shell_str",prim_shell_str,type_shell_str, PRIM_PURE);
   prim_register(pmap, "print",    prim_print,    type_print,     PRIM_IMPURE);
   prim_register(pmap, "mkdir",    prim_mkdir,    type_mkdir,     PRIM_IMPURE);
   prim_register(pmap, "unlink",   prim_unlink,   type_unlink,    PRIM_IMPURE);


### PR DESCRIPTION
This works!:
```
global def make Unit =
  makePlan (which "make", "foo", Nil) (sources "x" `.*`)
  | setPlanDirectory "x"
  | runIncrementalJob "foo" (\_ True)
  | getJobOutputs
```

Fixes #65. As State files no longer exist!
Fixes #319. Visible files are now strictly read-only, but that's ok, because we now have a better way to run incremental jobs.