### PR TITLE
Stop scan at wake db

### DIFF
--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -170,6 +170,7 @@ static bool scan(std::vector<std::string> &out) {
 }
 
 static bool push_files(std::vector<std::string> &out, const std::string &path, int dirfd, const RE2 &re, size_t skip) {
+  size_t len = out.size();
   auto dir = fdopendir(dirfd);
   if (!dir) {
     close(dirfd);
@@ -180,6 +181,10 @@ static bool push_files(std::vector<std::string> &out, const std::string &path, i
   bool failed = false;
   for (errno = 0; !failed && (f = readdir(dir)); errno = 0) {
     if (f->d_name[0] == '.' && (f->d_name[1] == 0 || (f->d_name[1] == '.' && f->d_name[2] == 0))) continue;
+    if (path != "." && !strcmp(&f->d_name[0], "wake.db")) {
+      out.resize(len);
+      return false;
+    }
     bool recurse;
     struct stat sbuf;
 #ifdef DT_DIR

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -406,6 +406,8 @@ static PRIMFN(prim_files) {
   bool fail = push_files(match, root, *arg1->exp, skip);
   if (fail) match.clear(); // !!! There's a hole in the API
 
+  std::sort(match.begin(), match.end());
+
   size_t need = reserve_list(match.size());
   for (auto &x : match) need += String::reserve(x.size());
   runtime.heap.reserve(need);


### PR DESCRIPTION
This affects which .wake-files are processed.
As a consequence, we can now have tests of wake itself.