### PR TITLE
Bump MAX_JSON to 128 MiB.

### DIFF
--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -24,7 +24,7 @@
 #define _XOPEN_SOURCE 700
 #endif
 
-#define MAX_JSON (1024*1024)
+#define MAX_JSON (128*1024*1024)
 
 #include <fuse.h>
 #include <stdio.h>


### PR DESCRIPTION
Increase the size of the JSON string. The old value, 1Mib, results in I/O error messages from wake. The increase in MAX_JSON is already part of master - this PR back ports it to v0.17.

Note we will also need to create and distribute a 0.17.1 release of wake.

Update: Will need the same change in the 0.15 release.  