### PR TITLE
Increase MAX_JSON in v0.15.2

### DIFF
--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -24,7 +24,7 @@
 #define _XOPEN_SOURCE 700
 #endif
 
-#define MAX_JSON (1024*1024)
+#define MAX_JSON (128*1024*1024)
 
 #include <fuse.h>
 #include <stdio.h>


### PR DESCRIPTION
Increase the size of the JSON buffer to deal with more "visible" files.  

This is already part of the master branch, but requesting a back port.
Expecting a new release 0.15.3.