### PR TITLE
Set release date and committer for v0.15.3 release.

### DIFF
--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -1,8 +1,8 @@
 wake (@VERSION@-1) unstable; urgency=medium
 
-  * New upstream release.
+  * Increase maximum size of JSON files to 128 MiB.
 
- -- Wesley W. Terpstra <terpstra@debian.org>  Fri, 13 Sep 2019 11:45:14 -0700
+ -- Richard Xia <richardxia@richardxia.com>  Mon, 11 Nov 2019 09:57:15 -0700
 
 wake (0.15.2-1) unstable; urgency=medium
 


### PR DESCRIPTION
Since @terpstra is out for a couple weeks, I'm going to take charge of getting the max JSON file size change backported and included in a new release.

Since the change was already backported onto the `v0.15` branch, I believe all I need to do is update the Debian changelog file with the latest release info. After this is merged in and the release tag is created, I'll create another entry in the changelog.in file for the "next" release.

My understanding of the process for cutting a release is the following:

1. Update the `@VERSION@` release information in `debian/changelog.in` to match the actual release info and release date, since the previous information is just a placeholder. (e.g. https://github.com/sifive/wake/commit/bea16cdeda1fea61e36b476f1b29994e87b205ba)
2. Merge that into the release branch (e.g. `v0.15`).
3. Create a tag on the commit which updated the release information (e.g. `v0.15.3`). This I believe should automatically trigger a Circle CI build to build the artifacts and upload them to GitHub.
4. Create a GitHub release from that tag, filling out more detailed release information.
5. Make a create the placeholder release version in `debian/changelog.in` by "freezing" the previous info as the actual release. (e.g. https://github.com/sifive/wake/commit/a11dc3fc3b3c15fa6e36b73ad70cf082de77a38c).

Once I confirm that these are actually the correct instructions, I'll submit a PR against master documenting this process.