### PR TITLE
Set committer and release notes for v0.17.1.

### DIFF
--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -1,5 +1,11 @@
 wake (@VERSION@-1) unstable; urgency=medium
 
+  * Increase maximum size of JSON files to 128 MiB.
+
+ -- Richard Xia <richardxia@richardxia.com>  Mon, 11 Nov 2019 12:28:14 -0700
+
+wake (0.17.0-1) unstable; urgency=medium
+
   * Auto-generated release package.
 
  -- Wesley W. Terpstra <terpstra@debian.org>  Mon, 30 Sep 2019 13:52:02 -0700


### PR DESCRIPTION
Same as https://github.com/sifive/wake/pull/333 except against the `v0.17` branch.

Also note that we had not created the placeholder section for the next release in the changelog, so I cloned the previous one as `0.17.0-1`.