### PR TITLE
Set release date and committer for v0.15.3 release.

### DIFF
--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -1,8 +1,8 @@
 wake (@VERSION@-1) unstable; urgency=medium
 
-  * New upstream release.
+  * Increase maximum size of JSON files to 128 MiB.
 
- -- Wesley W. Terpstra <terpstra@debian.org>  Fri, 13 Sep 2019 11:45:14 -0700
+ -- Richard Xia <richardxia@richardxia.com>  Mon, 11 Nov 2019 09:57:15 -0700
 
 wake (0.15.2-1) unstable; urgency=medium
 


### PR DESCRIPTION
Exact same thing as https://github.com/sifive/wake/pull/333 except this time I've created the `v0.15.3` tag pointing to this commit first. This in fact points to the exact same commit hash as in #333.