### PR TITLE
wake: Fix a type checker bug in single arg destructors

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -360,13 +360,9 @@ static std::unique_ptr<Expr> expand_patterns(const Location &location, const std
     for (size_t c = 0; c < sum->members.size(); ++c) {
       Constructor &cons = sum->members[c];
       std::string cname = "_ c" + std::to_string(c);
-      if (sum->members.size() == 1) {
-        map->body = std::unique_ptr<Expr>(new VarRef(location, cname));
-      } else {
-        map->body = std::unique_ptr<Expr>(new App(location,
-          map->body.release(),
-          new VarRef(location, cname)));
-      }
+      map->body = std::unique_ptr<Expr>(new App(location,
+        map->body.release(),
+        new VarRef(location, cname)));
       std::vector<PatternRef> bucket;
       int args = cons.ast.args.size();
       int var = prototype.index;

--- a/src/inline.cpp
+++ b/src/inline.cpp
@@ -160,7 +160,11 @@ void RDes::pass_inline(PassInline &p, std::unique_ptr<Term> self) {
     rapp_inline(p, std::move(app));
   } else {
     Term *input = p.stream[args.back()];
-    if (input->id() == typeid(RCon)) {
+    if (args.size() == 2) {
+      std::unique_ptr<RApp> app(
+        new RApp(args[0], args.back(), label.c_str()));
+      rapp_inline(p, std::move(app));
+    } else if (input->id() == typeid(RCon)) {
       RCon *con = static_cast<RCon*>(input);
       std::unique_ptr<RApp> app(
         new RApp(args[con->kind->index], args.back(), label.c_str()));


### PR DESCRIPTION
global def f Unit = 42

This should not be type: a => Integer
It should be: Unit => Integer

This happened because an inling optimization was applied in the front-end.
Moving it to the backend resolves the type-checker freedom.