### PR TITLE
circleci: don't include wake's own build rules in reference html

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get update && sudo apt-get install -y build-essential libfuse-dev libsqlite3-dev libgmp-dev libncurses5-dev pkg-config git g++ gcc libre2-dev python3-sphinx
-      - run: USE_FUSE_WAKE=0 make tarball && mkdir www && ./bin/wake --html > www/index.html
+      - run: USE_FUSE_WAKE=0 make tarball && mkdir www && ./bin/wake --no-workspace --html > www/index.html
       - run: PATH=$(pwd)/bin:$PATH PYTHONPATH=$(pwd)/scripts python3 scripts/wake2rst.py
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
           printf 'deb http://archive.debian.org/debian wheezy main\ndeb http://archive.debian.org/debian-security/ wheezy/updates main\n' > /etc/apt/sources.list
       - run: apt-get update -o Acquire::Check-Valid-Until=false && apt-get install -y build-essential devscripts git libfuse-dev libgmp-dev libncurses5-dev libsqlite3-dev pkg-config wget
       - run: |
-          wget -q http://www.terpstra.ca/debian/pool/main/r/re2/libre2-1_20140304+dfsg-2_amd64.deb && dpkg -i libre2-1_20140304+dfsg-2_amd64.deb
-          wget -q http://www.terpstra.ca/debian/pool/main/r/re2/libre2-dev_20140304+dfsg-2_amd64.deb && dpkg -i libre2-dev_20140304+dfsg-2_amd64.deb
+          wget -q https://terpstra.ca/debian/pool/main/r/re2/libre2-1_20140304+dfsg-2_amd64.deb && dpkg -i libre2-1_20140304+dfsg-2_amd64.deb
+          wget -q https://terpstra.ca/debian/pool/main/r/re2/libre2-dev_20140304+dfsg-2_amd64.deb && dpkg -i libre2-dev_20140304+dfsg-2_amd64.deb
       - attach_workspace:
           at: /tmp/workspace
       - run: |
@@ -121,8 +121,8 @@ jobs:
     steps:
       - run: apt-get update && apt-get install -y build-essential debhelper devscripts git libfuse-dev libgmp-dev libncurses5-dev libsqlite3-dev pkg-config wget
       - run: |
-          wget -q http://www.terpstra.ca/debian/pool/main/r/re2/libre2-1_20140304+dfsg-2_amd64.deb && dpkg -i libre2-1_20140304+dfsg-2_amd64.deb
-          wget -q http://www.terpstra.ca/debian/pool/main/r/re2/libre2-dev_20140304+dfsg-2_amd64.deb && dpkg -i libre2-dev_20140304+dfsg-2_amd64.deb
+          wget -q https://terpstra.ca/debian/pool/main/r/re2/libre2-1_20140304+dfsg-2_amd64.deb && dpkg -i libre2-1_20140304+dfsg-2_amd64.deb
+          wget -q https://terpstra.ca/debian/pool/main/r/re2/libre2-dev_20140304+dfsg-2_amd64.deb && dpkg -i libre2-dev_20140304+dfsg-2_amd64.deb
       - attach_workspace:
           at: /tmp/workspace
       - run: |


### PR DESCRIPTION
It's not obvious to people that some of these methods are not part of the public API.