### PR TITLE
write: use target to avoid multiple output errors

### DIFF
--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -74,7 +74,7 @@ global def mkdir path =
     Nil      = panic "impossible"
   path | simplify | tokenize `/` | root
 
-def writeImp inputs mode path content =
+target writeImp inputs mode path content =
   def writeRunner =
     def imp m p c = prim "write"
     def pre input = Pair input Unit


### PR DESCRIPTION
make `writeImp` a target so that calling `write` with the same arguments does not result in an error.
```
$ wake 'write "foo" "bar", write "foo" "bar", Nil'
File output by multiple Jobs: foo
```