### PR TITLE
Search for .wakeignore files

### DIFF
--- a/share/doc/wake/tutorial.md
+++ b/share/doc/wake/tutorial.md
@@ -699,10 +699,19 @@ Examples include testing, where you could exclude some files from regular usage,
 or a directory structure that includes duplicate repository checkouts, where
 duplicate symbol definitions would raise an error.
 
-Wake can look for files named `.wakeignore` containing patterns.
-The pattern language is shell filename globbing with leading directory match.
+Wake looks for files named `.wakeignore` containing patterns.
+The pattern language is shell filename globbing.
 One pattern per line, each relative to the path of the `.wakeignore` file.
-Patterns will only match against files with the `.wake` filename extension.
+
+The concrete syntax is:
+- empty lines are ignored
+- lines starting with a `#` are comments and are ignored
+- `?` matches a single non-slash character
+- `*` matches any number (including zero) of non-slash characters
+- `[a-z]` matches a single lower-case character
+- `/**/` in an expression like `foo/**/bar` stands in for any number of directories (including zero)
+- `foo/**` recursively matches all contents of the directory `foo`
+- `**/bar` matches all files `bar` contained in this directory or any subdirectory
 
 An example:
 
@@ -716,12 +725,13 @@ An example:
                 └── foo.wake
 
 If `repo1` is checked-out out twice like above, then if a `.wakeignore` file
-at path `workspace/repo2` contained `repo1` then `foo.wake` would not
+at path `workspace/repo2` contained `repo1/**` then `foo.wake` would not
 be read twice.
 
 The following patterns in `workspace/repo2/.wakeignore` would all match
-the above `repo2/repo1/foo.wake`:
+the above `foo.wake`:
 
-    repo1
     repo1/foo.wake
-    */*.wake
+    repo1/**
+    repo1/**/foo.wake
+    **/[a-z]?[o].wake

--- a/share/doc/wake/tutorial.md
+++ b/share/doc/wake/tutorial.md
@@ -692,3 +692,36 @@ are also affected by `-v` and `-d`.
 You can construct an `Error` directly, or use `makeError` which simply takes a `String`
 cause and will record the Stack.
 
+### Ignore wake source files
+
+There are occasions where you want wake to ignore wake source files (`*.wake`).
+Examples include testing, where you could exclude some files from regular usage,
+or a directory structure that includes duplicate repository checkouts, where
+duplicate symbol definitions would raise an error.
+
+Wake can look for files named `.wakeignore` containing patterns.
+The pattern language is shell filename globbing with leading directory match.
+One pattern per line, each relative to the path of the `.wakeignore` file.
+Patterns will only match against files with the `.wake` filename extension.
+
+An example:
+
+    workspace
+        ├── wake.db
+        ├── repo1
+        │   └── foo.wake
+        └── repo2
+            ├── .wakeignore
+            └── repo1
+                └── foo.wake
+
+If `repo1` is checked-out out twice like above, then if a `.wakeignore` file
+at path `workspace/repo2` contained `repo1` then `foo.wake` would not
+be read twice.
+
+The following patterns in `workspace/repo2/.wakeignore` would all match
+the above `repo2/repo1/foo.wake`:
+
+    repo1
+    repo1/foo.wake
+    */*.wake

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -306,7 +306,7 @@ int main(int argc, char **argv) {
   if (noparse) return 0;
 
   bool ok = true;
-  auto wakefiles = find_all_wakefiles(ok, workspace);
+  auto wakefiles = find_all_wakefiles(ok, workspace, verbose);
   if (!ok) std::cerr << "Workspace wake file enumeration failed" << std::endl;
 
   uint64_t target_hash = 0;

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -325,7 +325,7 @@ void extract_wakeignore_paths(std::vector<std::string>& paths, std::vector<std::
   RE2::Options options;
   options.set_log_errors(false);
   options.set_one_line(true);
-  RE2 exp("(.*/)*\\.wakeignore", options);
+  RE2 exp("(?s)(.*/)*\\.wakeignore", options);
 
   // erase() provides a new iterator to handle the invalidation
   for (auto p = paths.begin(); p < paths.end(); /**/) {
@@ -420,9 +420,9 @@ std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace) {
   RE2::Options options;
   options.set_log_errors(false);
   options.set_one_line(true);
-  std::string wakefiles = "((?s).*[^/]\\.wake)";
+  std::string wakefiles = "(.*[^/]\\.wake)";
   std::string ignorefiles = "((.*/)*\\.wakeignore)";
-  RE2 exp(wakefiles + "|" + ignorefiles, options);
+  RE2 exp("(?s)" + wakefiles + "|" + ignorefiles, options);
 
   std::string abs_libdir = find_execpath() + "/../share/wake/lib";
   std::string rel_libdir = make_relative(get_cwd(), make_canonical(abs_libdir));

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -35,6 +35,7 @@
 #include <fcntl.h>
 #include <cstring>
 #include <sstream>
+#include <fstream>
 #include <iostream>
 #include <algorithm>
 
@@ -318,6 +319,127 @@ static std::string make_relative(std::string &&dir, std::string &&path) {
   return x;
 }
 
+struct WakeFilter {
+  size_t prefix;
+  std::unique_ptr<RE2> exp;
+  WakeFilter(size_t prefix_, const std::string &exp, const RE2::Options &opts)
+   : prefix(prefix_), exp(new RE2(exp, opts)) { }
+};
+
+static void process_ignorefile(const std::string &path, std::vector<WakeFilter> &filters) {
+  std::ifstream in(path + ".wakeignore");
+  if (!in.is_open()) return;
+
+  RE2::Options options;
+  options.set_log_errors(false);
+  options.set_one_line(true);
+
+  std::string line;
+  while (std::getline(in, line)) {
+    // strip trailing whitespace (including windows CR)
+    size_t found = line.find_last_not_of(" \t\f\v\n\r");
+    if (found != std::string::npos) {
+      line.erase(found+1);
+    } else {
+      line.clear(); // entirely whitespace
+    }
+    // allow empty lines and comments
+    if (line == "" || line[0] == '#') continue;
+    // create a regular expression for .gitignore style syntax
+    std::string exp;
+    size_t s = 0, e;
+    while ((e = line.find_first_of("[?*", s)) != std::string::npos) {
+      re2::StringPiece piece(line.c_str() + s, e - s);
+      exp.append(RE2::QuoteMeta(piece));
+      if (line[e] == '[') {
+        // copy [...] from glob to regexp unmodified
+        size_t c = line.find_first_of("]", e+1);
+        if (c == std::string::npos) { s = e; break; }
+        exp.append(line, e, c-e+1);
+        s = c+1;
+      } else if (line[e] == '?') {
+        // ? can match any non-/ character
+        exp.append("[^/]");
+        s = e+1;
+      } else if (e > 0 && line.size() == e+2 && line[e-1] == '/' && line[e+1] == '*') {
+        // trailing /** -> match everything inside
+        exp.append(".+");
+        s = e+2;
+      } else if (e == 0 && line.size() > 3 && line[1] == '*' && line[2] == '/') {
+        // leading **/ -> any subdirectory
+        exp.append("([^/]*/)*");
+        s = e+3;
+      } else if (e > 0 && line.size() > e+2 && line[e-1] == '/' && line[e+1] == '*' && line[e+2] == '/') {
+        // /**/ somewhere in the string
+        exp.append("([^/]*/)*");
+        s = e+3;
+      } else {
+        // just a normal * -> match any number of non-/ characters
+        exp.append("[^/]*");
+        s = e+1;
+      }
+    }
+    exp.append(RE2::QuoteMeta(line.c_str() + s));
+    filters.emplace_back(path.size(), exp, options);
+  }
+}
+
+static void filter_wakefiles(std::vector<std::string> &wakefiles, bool verbose) {
+  std::string curdir; // Either "" or ".+/"
+  std::vector<WakeFilter> filters;
+
+  process_ignorefile(curdir, filters);
+
+  for (auto p = wakefiles.begin(); p != wakefiles.end(); /**/) {
+    std::string &wakefile = *p;
+
+    // Wake standard library cannot be excluded
+    if (wakefile.compare(0, 3, "../") == 0) { ++p; continue; }
+
+    // Unwind curdir
+    while (!curdir.empty() && wakefile.compare(0, curdir.size(), curdir) != 0) {
+      size_t slash = curdir.find_last_of('/', curdir.size()-2);
+      if (slash == std::string::npos) {
+        curdir.clear();
+      } else {
+        curdir.erase(slash+1);
+      }
+    }
+
+    // Expire any patterns from directories we've left
+    while (!filters.empty() && filters.back().prefix > curdir.size())
+      filters.pop_back();
+
+    // Descend into directory
+    size_t slash;
+    while ((slash = wakefile.find_first_of('/', curdir.size())) != std::string::npos) {
+      curdir.append(wakefile, curdir.size(), slash+1 - curdir.size());
+      process_ignorefile(curdir, filters);
+    }
+
+    // See if any rules exclude this file
+    bool skip = false;
+    for (auto &filter : filters) {
+      re2::StringPiece piece(wakefile.c_str() + filter.prefix, wakefile.size() - filter.prefix);
+      std::cerr << piece << std::endl;
+      if (RE2::FullMatch(piece, *filter.exp)) {
+        if (verbose) {
+          fprintf(stderr, "Skipping %s due to %s.wakeignore\n",
+            wakefile.c_str(), wakefile.substr(0, filter.prefix).c_str());
+        }
+        skip = true;
+        break;
+      }
+    }
+
+    if (skip) {
+      p = wakefiles.erase(p);
+    } else {
+      ++p;
+    }
+  }
+}
+
 std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace) {
   RE2::Options options;
   options.set_log_errors(false);
@@ -335,6 +457,8 @@ std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace) {
   std::sort(acc.begin(), acc.end());
   auto it = std::unique(acc.begin(), acc.end());
   acc.resize(std::distance(acc.begin(), it));
+
+  filter_wakefiles(acc, true);
 
   return acc;
 }

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -372,7 +372,7 @@ bool match(std::string ignore_path, std::string wake_path) {
   for (auto p = patterns.begin(); p != patterns.end(); ++p) {
     auto pattern = p->c_str();
     auto candidate = wake_path.c_str();
-    if (fnmatch(pattern, candidate, FNM_LEADING_DIR) == 0) {
+    if (fnmatch(pattern, candidate, FNM_PATHNAME) == 0) {
       return true;
     }
   }

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -328,7 +328,7 @@ void extract_wakeignore_paths(std::vector<std::string>& paths, std::vector<std::
   RE2 exp("(?s)(.*/)*\\.wakeignore", options);
 
   // erase() provides a new iterator to handle the invalidation
-  for (auto p = paths.begin(); p < paths.end(); /**/) {
+  for (auto p = paths.begin(); p != paths.end(); /**/) {
     auto path = *p;
     if (RE2::FullMatch(path, exp)) {
         ignore_paths.push_back(path);
@@ -360,7 +360,7 @@ bool match(std::string ignore_path, std::string wake_path) {
   get_ignore_patterns(ignore_path, patterns);
 
   // Use fnmatch to implement glob-like patterns
-  for (auto p = patterns.begin(); p < patterns.end(); p++) {
+  for (auto p = patterns.begin(); p != patterns.end(); p++) {
     auto pattern = p->c_str();
     auto candidate = wake_path.c_str();
     if (fnmatch(pattern, candidate, FNM_LEADING_DIR) == 0) {
@@ -378,13 +378,13 @@ void filter_ignore_patterns(std::vector<std::string>& wake_paths) {
   std::vector<std::string> ignore_paths;
   extract_wakeignore_paths(wake_paths, ignore_paths);
 
-  for (auto ip = ignore_paths.begin(); ip < ignore_paths.end(); ip++) {
+  for (auto ip = ignore_paths.begin(); ip != ignore_paths.end(); ip++) {
     // Get the path prefix of the ignore_path.
     // dirname() modifies its argument.
     auto ignore_path = *ip;
     auto ignore_prefix = std::string(dirname(strdup(ignore_path.c_str())));
 
-    for (auto wp = wake_paths.begin(); wp < wake_paths.end(); ) {
+    for (auto wp = wake_paths.begin(); wp != wake_paths.end(); ) {
       std::string wake_path = *wp;
 
       // Only process deeper into the path

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -23,7 +23,6 @@
 #include "execpath.h"
 #include "datatype.h"
 
-#include <libgen.h>
 #include <re2/re2.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -34,11 +33,9 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <fcntl.h>
-#include <fnmatch.h>
 #include <cstring>
 #include <sstream>
 #include <iostream>
-#include <fstream>
 #include <algorithm>
 
 bool make_workspace(const std::string &dir) {
@@ -321,118 +318,11 @@ static std::string make_relative(std::string &&dir, std::string &&path) {
   return x;
 }
 
-void extract_wakeignore_paths(std::vector<std::string>& paths, std::vector<std::string>& ignore_paths) {
-  RE2::Options options;
-  options.set_log_errors(false);
-  options.set_one_line(true);
-  RE2 exp("(?s)(.*/)*\\.wakeignore", options);
-
-  // erase() provides a new iterator to handle the invalidation
-  for (auto p = paths.begin(); p != paths.end(); /**/) {
-    std::string &path = *p;
-    if (RE2::FullMatch(path, exp)) {
-        ignore_paths.emplace_back(std::move(path));
-        p = paths.erase(p);
-    } else {
-        ++p;
-    }
-  }
-}
-
-bool get_ignore_patterns(std::string& file, std::vector<std::string>& patterns) {
-  std::ifstream in(file);
-  std::string line;
-  if (in.is_open()) {
-    while(std::getline(in, line)) {
-      // strip trailing whitespace (including windows CR)
-      size_t found = line.find_last_not_of(" \t\f\v\n\r");
-      if (found != std::string::npos) {
-        line.erase(found+1);
-      } else {
-        line.clear(); // entirely whitespace
-      }
-      // allow empty lines and comments
-      if (line == "" || line[0] == '#') continue;
-      patterns.emplace_back(std::move(line));
-    }
-    in.close();
-  } else {
-    std::cerr << "Failed to read " << file << std::endl;
-    return false;
-  }
-  return true;
-}
-
-bool match(std::string ignore_path, std::string wake_path) {
-  // Extract patterns from the .wakeignore file
-  std::vector<std::string> patterns;
-  get_ignore_patterns(ignore_path, patterns);
-
-  // Use fnmatch to implement glob-like patterns
-  for (auto p = patterns.begin(); p != patterns.end(); ++p) {
-    auto pattern = p->c_str();
-    auto candidate = wake_path.c_str();
-    if (fnmatch(pattern, candidate, FNM_PATHNAME) == 0) {
-      return true;
-    }
-  }
-  return false;
-}
-
-// For each .wakeignore file, check to see if the *.wake source file
-// matches the pattern in the .wakeignore file.
-// For .wakeignore files that are not at the root of the workspace,
-// the relative path is taken into account.
-void filter_ignore_patterns(std::vector<std::string>& wake_paths) {
-  std::vector<std::string> ignore_paths;
-  extract_wakeignore_paths(wake_paths, ignore_paths);
-
-  for (auto ip = ignore_paths.begin(); ip != ignore_paths.end(); ++ip) {
-    // Get the path prefix of the ignore_path.
-    // dirname() modifies its argument.
-    auto ignore_path = *ip;
-    auto ignore_prefix = std::string(dirname(strdup(ignore_path.c_str()))); // this leaks memory
-
-    for (auto wp = wake_paths.begin(); wp != wake_paths.end(); ) {
-      std::string wake_path = *wp;
-
-      // Only process deeper into the path
-      if (wake_path.compare(0, 2, "..") == 0) {
-        ++wp;
-        continue;
-      }
-
-      auto has_common_prefix = wake_path.compare(0, ignore_prefix.length(), ignore_prefix) == 0;
-      auto root_prefix = ignore_prefix.compare(".") == 0;
-      auto relative_wake_path = wake_path;
-
-      if (has_common_prefix && !root_prefix) {
-        // If the prefix is not '.' then it has a '/' to also be removed.
-        std::string no_prefix(wake_path);
-        no_prefix.erase(0, ignore_prefix.length()+1);
-        relative_wake_path = no_prefix;
-      }
-
-      // this re-reads the .wakeignore file over and over
-      if ((has_common_prefix || root_prefix) &&
-          match(ignore_path, relative_wake_path)) {
-
-        std::cerr << "- Not processing wake source '" << wake_path << "' due to '" << ignore_path << "'" << std::endl;
-        wp = wake_paths.erase(wp);
-      } else {
-        ++wp;
-      }
-    }
-  }
-}
-
 std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace) {
   RE2::Options options;
   options.set_log_errors(false);
   options.set_one_line(true);
-  std::string wakefiles = "(.*[^/]\\.wake)";
-  std::string ignorefiles = "((.*/)*\\.wakeignore)";
-  RE2 exp("(?s)" + wakefiles + "|" + ignorefiles, options);
+  RE2 exp("(?s).*[^/]\\.wake", options);
 
   std::string abs_libdir = find_execpath() + "/../share/wake/lib";
   std::string rel_libdir = make_relative(get_cwd(), make_canonical(abs_libdir));
@@ -445,9 +335,6 @@ std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace) {
   std::sort(acc.begin(), acc.end());
   auto it = std::unique(acc.begin(), acc.end());
   acc.resize(std::distance(acc.begin(), it));
-
-  // Remove .wake source files based on patterns in .wakeignore files
-  filter_ignore_patterns(acc);
 
   return acc;
 }

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -426,7 +426,7 @@ static void filter_wakefiles(std::vector<std::string> &wakefiles, bool verbose) 
     size_t prefix = std::string::npos;
     for (auto &filter : filters) {
       re2::StringPiece piece(wakefile.c_str() + filter.prefix, wakefile.size() - filter.prefix);
-      if (RE2::FullMatch(piece, *filter.exp)) {
+      if (skip == filter.allow && RE2::FullMatch(piece, *filter.exp)) {
         skip = !filter.allow;
         prefix = filter.prefix;
       }

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -344,6 +344,15 @@ bool get_ignore_patterns(std::string& file, std::vector<std::string>& patterns) 
   std::string line;
   if (in.is_open()) {
     while(std::getline(in, line)) {
+      // strip trailing whitespace (including windows CR)
+      size_t found = line.find_last_not_of(" \t\f\v\n\r");
+      if (found != std::string::npos) {
+        line.erase(found+1);
+      } else {
+        line.clear(); // entirely whitespace
+      }
+      // allow empty lines and comments
+      if (line == "" || line[0] == '#') continue;
       patterns.emplace_back(std::move(line));
     }
     in.close();

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -334,7 +334,7 @@ void extract_wakeignore_paths(std::vector<std::string>& paths, std::vector<std::
         ignore_paths.emplace_back(std::move(path));
         p = paths.erase(p);
     } else {
-        p++;
+        ++p;
     }
   }
 }
@@ -360,7 +360,7 @@ bool match(std::string ignore_path, std::string wake_path) {
   get_ignore_patterns(ignore_path, patterns);
 
   // Use fnmatch to implement glob-like patterns
-  for (auto p = patterns.begin(); p != patterns.end(); p++) {
+  for (auto p = patterns.begin(); p != patterns.end(); ++p) {
     auto pattern = p->c_str();
     auto candidate = wake_path.c_str();
     if (fnmatch(pattern, candidate, FNM_LEADING_DIR) == 0) {
@@ -378,7 +378,7 @@ void filter_ignore_patterns(std::vector<std::string>& wake_paths) {
   std::vector<std::string> ignore_paths;
   extract_wakeignore_paths(wake_paths, ignore_paths);
 
-  for (auto ip = ignore_paths.begin(); ip != ignore_paths.end(); ip++) {
+  for (auto ip = ignore_paths.begin(); ip != ignore_paths.end(); ++ip) {
     // Get the path prefix of the ignore_path.
     // dirname() modifies its argument.
     auto ignore_path = *ip;
@@ -389,7 +389,7 @@ void filter_ignore_patterns(std::vector<std::string>& wake_paths) {
 
       // Only process deeper into the path
       if (wake_path.compare(0, 2, "..") == 0) {
-        wp++;
+        ++wp;
         continue;
       }
 
@@ -410,7 +410,7 @@ void filter_ignore_patterns(std::vector<std::string>& wake_paths) {
         std::cerr << "- Not processing wake source '" << wake_path << "' due to '" << ignore_path << "'" << std::endl;
         wp = wake_paths.erase(wp);
       } else {
-        wp++;
+        ++wp;
       }
     }
   }

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -391,7 +391,7 @@ void filter_ignore_patterns(std::vector<std::string>& wake_paths) {
     // Get the path prefix of the ignore_path.
     // dirname() modifies its argument.
     auto ignore_path = *ip;
-    auto ignore_prefix = std::string(dirname(strdup(ignore_path.c_str())));
+    auto ignore_prefix = std::string(dirname(strdup(ignore_path.c_str()))); // this leaks memory
 
     for (auto wp = wake_paths.begin(); wp != wake_paths.end(); ) {
       std::string wake_path = *wp;

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -413,6 +413,7 @@ void filter_ignore_patterns(std::vector<std::string>& wake_paths) {
         relative_wake_path = no_prefix;
       }
 
+      // this re-reads the .wakeignore file over and over
       if ((has_common_prefix || root_prefix) &&
           match(ignore_path, relative_wake_path)) {
 

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -329,9 +329,9 @@ void extract_wakeignore_paths(std::vector<std::string>& paths, std::vector<std::
 
   // erase() provides a new iterator to handle the invalidation
   for (auto p = paths.begin(); p != paths.end(); /**/) {
-    auto path = *p;
+    std::string &path = *p;
     if (RE2::FullMatch(path, exp)) {
-        ignore_paths.push_back(path);
+        ignore_paths.emplace_back(std::move(path));
         p = paths.erase(p);
     } else {
         p++;
@@ -344,7 +344,7 @@ bool get_ignore_patterns(std::string& file, std::vector<std::string>& patterns) 
   std::string line;
   if (in.is_open()) {
     while(std::getline(in, line)) {
-      patterns.push_back(line);
+      patterns.emplace_back(std::move(line));
     }
     in.close();
   } else {

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -421,7 +421,6 @@ static void filter_wakefiles(std::vector<std::string> &wakefiles, bool verbose) 
     bool skip = false;
     for (auto &filter : filters) {
       re2::StringPiece piece(wakefile.c_str() + filter.prefix, wakefile.size() - filter.prefix);
-      std::cerr << piece << std::endl;
       if (RE2::FullMatch(piece, *filter.exp)) {
         if (verbose) {
           fprintf(stderr, "Skipping %s due to %s.wakeignore\n",
@@ -440,7 +439,7 @@ static void filter_wakefiles(std::vector<std::string> &wakefiles, bool verbose) 
   }
 }
 
-std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace) {
+std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbose) {
   RE2::Options options;
   options.set_log_errors(false);
   options.set_one_line(true);
@@ -458,7 +457,7 @@ std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace) {
   auto it = std::unique(acc.begin(), acc.end());
   acc.resize(std::distance(acc.begin(), it));
 
-  filter_wakefiles(acc, true);
+  filter_wakefiles(acc, verbose);
 
   return acc;
 }

--- a/src/sources.h
+++ b/src/sources.h
@@ -27,7 +27,7 @@ bool chdir_workspace(std::string &prefix);
 bool make_workspace(const std::string &dir);
 std::string make_canonical(const std::string &x);
 
-std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace);
+std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbose);
 bool find_all_sources(Runtime &runtime, bool workspace);
 
 #endif

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+. $(dirname $0)/test_util.sh
+
+timestamp=`date +'%Y-%m-%dT%H-%M-%S'`
+
+test_dir="$(mktemp -d)/test.${timestamp}"
+echo "Running tests in ${test_dir}"
+mkdir $test_dir
+
+echo Compiling wake
+set -e
+compile_wake $test_dir
+wake_dir="${test_dir}/build/bin"
+export PATH=$wake_dir:$PATH
+echo Using wake executable at $(which wake)
+set +e
+
+declare -A test_results
+pass=0
+fail=0
+for test_path in $test_root/*.t; do
+    cd $test_dir
+    test_file=$(basename $test_path)
+    test_name="${test_file%%.*}"
+
+    echo "Running test [$test_name]"
+    mkdir $test_name
+    cd $test_name
+
+    $test_path
+    if [ $? -eq 0 ]; then
+        test_results["$test_name"]="PASS"
+        touch "PASS"
+        ((pass++))
+    else
+        test_results["$test_name"]="FAIL"
+        touch "FAIL"
+        ((fail++))
+        test_result=1
+    fi
+    echo -e "\033[1K\033[1G${test_results[$test_name]} - ${test_name}";
+done
+
+echo
+echo
+echo "Results:"
+echo "Passing: $pass"
+echo "Failing: $fail"
+
+if [ $fail -ne 0 ]
+then
+    echo "Not removing test dir $test_dir"
+    exit 1
+else
+    echo "Removing test dir $test_dir"
+    rm -rf $test_dir
+    exit 0
+fi

--- a/tests/test_util.sh
+++ b/tests/test_util.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+test_root=$(dirname $(perl -MCwd -e "print Cwd::realpath('$0')"))
+wake_root=$(perl -MCwd -e "print Cwd::realpath('$test_root/..')")
+
+fail=0
+pass=0
+in_prereq=0
+
+check() {
+    check_name=$1
+    shift;
+
+    if $@
+    then echo "PASS - ${check_name}"; pass=$((pass+1))
+    else echo "FAIL - ${check_name}"; fail=$((fail+1))
+    fi
+}
+
+prereq() {
+    if [ "$1" = "off" ]
+    then in_prereq=0; set +e -x
+    else in_prereq=1; set -e +x
+    fi
+}
+
+report() {
+    set +x
+    echo "PASS: $pass"
+    echo "FAIL: $fail"
+}
+
+finish() {
+    if [ $in_prereq -eq 1 ]
+    then fail=$((fail+1))
+    fi
+
+    if [ $pass -eq 0 ] && [ $fail -eq 0 ]
+    then fail=$((fail+1))
+    fi
+
+    if [ $fail -eq 0 ]
+    then echo "Test passed"; exit 0
+    else echo "Test failed"; exit 1
+    fi
+}
+
+compile_wake() {(
+    cd $wake_root                     &&
+    make clean                        &&
+    mkdir -p "${1}/build"             &&
+    make install DESTDIR="${1}/build"
+)}

--- a/tests/wake-ignore.t
+++ b/tests/wake-ignore.t
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+. $(dirname $0)/test_util.sh
+
+prereq on
+
+# Make a repository with a wake file
+mkdir repo1
+(
+  cd repo1
+  git init
+  echo 'global def something = "some text"' > test.wake
+  git add test.wake
+  git commit -m "test wake file"
+)
+
+# Create a second checkout of repo1
+mkdir other_dir
+(
+  cd other_dir
+  git clone ../repo1
+)
+
+wake --init .
+
+prereq off
+
+msg=$(wake)
+check "Wake should raise error for repeated symbol" [ $? -ne 0 ]
+
+echo "repo1" > other_dir/.wakeignore
+msg=$(wake)
+check "Wake should ignore repeated symbol" [ $? -eq 0 ]
+
+
+report
+finish

--- a/tests/wake-ignore.t
+++ b/tests/wake-ignore.t
@@ -27,7 +27,7 @@ prereq off
 msg=$(wake)
 check "Wake should raise error for repeated symbol" [ $? -ne 0 ]
 
-echo "repo1" > other_dir/.wakeignore
+echo "repo1/**" > other_dir/.wakeignore
 msg=$(wake)
 check "Wake should ignore repeated symbol" [ $? -eq 0 ]
 


### PR DESCRIPTION
Files called `.wakeignore` can contain globs to
exclude wake source files from usage.
The exclusions are globs and are relative
to the root of the workspace.

```
workspace
├── wake.db
├── repo1
│   └── foo.wake
└── repo2
    └── repo1
        └── foo.wake
```
If `repo1` is checkout out twice, like above, then if a `.wakeignore` file at path`workspace/repo2` contained `repo2/repo1` then `foo.wake` would not be read twice.

Issue #355 