### PR TITLE
Improve Vim syntax highlighting

### DIFF
--- a/share/doc/wake/syntax/vim/syntax/wake.vim
+++ b/share/doc/wake/syntax/vim/syntax/wake.vim
@@ -34,6 +34,16 @@ syn match wakeStringEscape "\\[nrfvb\\\"]" contained
 syn region wakeRawString start=/\v'/ skip=/\v\\./ end=/\v'/
 syn region wakeRegexString start=/\v`/ skip=/\v\\./ end=/\v`/
 
+" Numeric literals
+syn match wakeDecNumber /\<[1-9][0-9]*\>/
+syn match wakeBinNumber /\<0b[01_]\+\>/
+syn match wakeOctNumber /\<0[0-7_]*\>/
+syn match wakeHexNumber /\<0x[0-9a-fA-F_]\+\>/
+syn match wakeDecFloatNumber /\<\([1-9][0-9_]*\|0\)\.[0-9]\+\([eE][+-]\?[0-9_]\+\)\?\>/
+syn match wakeDecFloatNumber /\<\([1-9][0-9_]*\|0\)[eE][+-]\?[0-9_]\+\>/
+syn match wakeHexFloatNumber /\<0x[0-9a-fA-F_]\+\.[0-9a-fA-F_]\+\([pP][+-]\?[0-9a-fA-F_]\+\)\?\>/
+syn match wakeHexFloatNumber /\<0x[0-9a-fA-F_]\+[pP][+-]\?[0-9a-fA-F_]\+\>/
+
 "===== Links =====
 hi link wakeKeyword Keyword
 
@@ -50,4 +60,12 @@ hi link wakeString String
 hi link wakeStringEscape Special
 hi link wakeRawString String
 hi link wakeRegexString String
+hi link wakeDecNumber wakeNumber
+hi link wakeBinNumber wakeNumber
+hi link wakeOctNumber wakeNumber
+hi link wakeHexNumber wakeNumber
+hi link wakeNumber Number
+hi link wakeDecFloatNumber wakeFloatNumber
+hi link wakeHexFloatNumber wakeFloatNumber
+hi link wakeFloatNumber Float
 

--- a/share/doc/wake/syntax/vim/syntax/wake.vim
+++ b/share/doc/wake/syntax/vim/syntax/wake.vim
@@ -17,11 +17,11 @@ syn match lineComment "#.*"
 
 " Keywords
 " TODO Should important globals from prim.wake we marked keywords?
-syn keyword wakeKeyword if then else here global subscribe match data
+syn keyword wakeKeyword if then else here global subscribe match data tuple
 
 " definitions
 " TODO How can we handle `def x + y` = syntax?
-syn keyword wakeDef def publish nextgroup=wakeOperator,wakeLowerIdentifier skipwhite
+syn keyword wakeDef def publish target nextgroup=wakeOperator,wakeLowerIdentifier skipwhite
 syn match wakeDefName "[^ =:;()[]\+" contained skipwhite
 syn match wakeOperator "[+-=$]\+" contained
 syn match wakeLowerIdentifier "[a-z][A-Za-z0-9_]*" contained


### PR DESCRIPTION
This adds a few things to the Vim syntax highlighting rules that have been bugging me for a little while.

https://github.com/sifive/wake/commit/ef9893b335ce6b22c1821afb7e624efb7a75e434 - Adding the `tuple` and `target` keywords
https://github.com/sifive/wake/commit/ddbbc981fcfae51ca9d3f436fdb64a9b2428c456 - Adding numeric literals, based on my attempt at translating the [regexes from the Wake parser](https://github.com/sifive/wake/blob/5f67a1e4b9e26b83a31f9c1dbdb22348c141b54e/src/symbol.re#L501-L521) to Vim's regex syntax.