### PR TITLE
installAs: check for BAD PATH before running

### DIFF
--- a/share/wake/lib/system/cp.wake
+++ b/share/wake/lib/system/cp.wake
@@ -13,17 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-global def installAs dest file =
-  def sdest = simplify dest
-  def cmd = which "cp", file.getPathName, sdest, Nil
-  def inputs = mkdir "{dest}/..", file, Nil
-  def foutputs _ = sdest, Nil
-  makePlan cmd inputs
-  | setPlanEnvironment Nil
-  | setPlanLocalOnly True
-  | setPlanFnOutputs foutputs
-  | runJob
-  | getJobOutput
+global def installAs dest file = match file.getPathResult
+  Fail e = makeBadPath e
+  Pass _ =
+    def sdest = simplify dest
+    def cmd = which "cp", file.getPathName, sdest, Nil
+    def inputs = mkdir "{dest}/..", file, Nil
+    def foutputs _ = sdest, Nil
+    makePlan cmd inputs
+    | setPlanEnvironment Nil
+    | setPlanLocalOnly True
+    | setPlanFnOutputs foutputs
+    | runJob
+    | getJobOutput
 
 global def installIn dir file =
   installAs "{dir}/{file.getPathName}" file


### PR DESCRIPTION
running the command `wake 'installIn "asdf" "asdf".makeError.makeBadPath, installIn "asdf" "lkj".makeError.makeBadPath, Nil'` gives the following error
```
ERROR: Target subkey mismatch for share/wake/lib/system/job.wake:247:[8-78]
To debug, rerun your wake command with these additional options:
  --debug-target=15313308315147462255 to see the unique target arguments (before the '\')
  --debug-target=179846794147169920 to see the first invocation's extra arguments
  --debug-target=3543282263022983498 to see the second invocation's extra arguments
```
running with `--debug-target=15313308315147462255` shows
```
Debug-target hash input was: ("/bin/cp", "BADPATH", "asdf/BADPATH", Nil), Nil, ".", "", Nil
```

This makes change makes it so that `installAs` and `installIn` will propagate the bad paths rather than failing with subkey mismatch.