### PR TITLE
database: don't allow job reuse when inputs go missing

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -17,6 +17,7 @@
 
 #include "database.h"
 #include "status.h"
+#include <unordered_set>
 #include <iostream>
 #include <sstream>
 #include <sqlite3.h>
@@ -617,6 +618,27 @@ Usage Database::reuse_job(
   }
   finish_stmt(why, imp->stats_job, imp->debugdb);
 
+  // Create a hash table of visible files
+  std::unordered_set<std::string> vis;
+  const char *tok = visible.c_str();
+  const char *end = tok + visible.size();
+  for (const char *scan = tok; scan != end; ++scan) {
+    if (*scan == 0 && scan != tok) {
+      vis.emplace(tok, scan-tok);
+      tok = scan+1;
+    }
+  }
+
+  // Confirm all inputs are still visible
+  bind_integer(why, imp->get_tree, 1, job);
+  bind_integer(why, imp->get_tree, 2, INPUT);
+  while (sqlite3_step(imp->get_tree) == SQLITE_ROW) {
+    std::string path = rip_column(imp->get_tree, 0);
+    if (vis.find(rip_column(imp->get_tree, 0)) == vis.end()) out.found = false;
+  }
+  finish_stmt(why, imp->get_tree, imp->debugdb);
+
+  // Confirm all outputs still exist, and report their old hashes
   bind_integer(why, imp->get_tree, 1, job);
   bind_integer(why, imp->get_tree, 2, OUTPUT);
   while (sqlite3_step(imp->get_tree) == SQLITE_ROW) {

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -633,7 +633,6 @@ Usage Database::reuse_job(
   bind_integer(why, imp->get_tree, 1, job);
   bind_integer(why, imp->get_tree, 2, INPUT);
   while (sqlite3_step(imp->get_tree) == SQLITE_ROW) {
-    std::string path = rip_column(imp->get_tree, 0);
     if (vis.find(rip_column(imp->get_tree, 0)) == vis.end()) out.found = false;
   }
   finish_stmt(why, imp->get_tree, imp->debugdb);


### PR DESCRIPTION
If you try to run a job with identical command-line/etc, but reduced visible files, it does not rerun. That is a problem is one of the visible files you removed was an input to that job, since presumably the job will have been affected.