### PR TITLE
wake: expose cwd where wake was invoked

### DIFF
--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -37,6 +37,7 @@ export target whichIn path exec =
 
 export def which exec = whichIn path exec
 export def workspace = prim "workspace"
+export def cwd = prim "prefix"
 
 def mkdirRunner =
   def imp m p = prim "mkdir"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -391,7 +391,7 @@ int main(int argc, char **argv) {
 
   /* Primitives */
   JobTable jobtable(&db, percent, verbose, quiet, check, !tty);
-  StringInfo info(verbose, debug, quiet, VERSION_STR);
+  StringInfo info(verbose, debug, quiet, VERSION_STR, make_canonical(prefix));
   PrimMap pmap = prim_register_all(&info, &jobtable);
 
   if (!flatten_exports(*top)) ok = false;

--- a/src/prim.h
+++ b/src/prim.h
@@ -157,8 +157,10 @@ struct StringInfo {
   bool verbose;
   bool debug;
   bool quiet;
-  const char *version;
-  StringInfo(bool v, bool d, bool q, const char *x) : verbose(v), debug(d), quiet(q), version(x) { }
+  std::string version;
+  std::string prefix;
+  StringInfo(bool v, bool d, bool q, const std::string &version_, const std::string &prefix_)
+   : verbose(v), debug(d), quiet(q), version(version_), prefix(prefix_) { }
 };
 
 void prim_register(PrimMap &pmap, const char *key, PrimFn fn, PrimType type, int flags, void *data = 0);

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -559,6 +559,17 @@ static PRIMFN(prim_str2bin) {
   RETURN(Integer::alloc(runtime.heap, out));
 }
 
+static PRIMTYPE(type_prefix) {
+  return args.size() == 0 &&
+    out->unify(String::typeVar);
+}
+
+static PRIMFN(prim_prefix) {
+  EXPECT(0);
+  StringInfo *info = static_cast<StringInfo*>(data);
+  RETURN(String::alloc(runtime.heap, info->prefix));
+}
+
 static PRIMTYPE(type_uname) {
   TypeVar pair;
   Data::typePair.clone(pair);
@@ -607,6 +618,7 @@ void prim_register_string(PrimMap &pmap, StringInfo *info) {
   prim_register(pmap, "format",   prim_format,   type_format,    PRIM_PURE);
   prim_register(pmap, "version",  prim_version,  type_version,   PRIM_PURE, (void*)info);
   prim_register(pmap, "level",    prim_level,    type_level,     PRIM_PURE, (void*)info);
+  prim_register(pmap, "prefix",   prim_prefix,   type_prefix,    PRIM_PURE, (void*)info);
   prim_register(pmap, "scmp",     prim_scmp,     type_scmp,      PRIM_PURE);
   prim_register(pmap, "sNFC",     prim_sNFC,     type_normalize, PRIM_PURE);
   prim_register(pmap, "sNFKC",    prim_sNFKC,    type_normalize, PRIM_PURE);


### PR DESCRIPTION
This is necessary to be able to process file names passed to wake functions from the command line.