### PR TITLE
wake: fix an inlining bug that consumed exponential memory

### DIFF
--- a/src/cse.cpp
+++ b/src/cse.cpp
@@ -77,7 +77,6 @@ static void cse_reduce(PassCSE &p, Hash hash, std::unique_ptr<Term> self) {
     p.stream.transfer(std::move(self));
   } else {
     size_t prior = ins.first->second;
-    p.stream[prior]->set(SSA_SINGLETON, false);
     p.stream.discard(prior);
   }
 }


### PR DESCRIPTION
A very important inlining optimization is the singleton-exemption.

This allows inlining of a function to proceed (no matter how large the
function is) if there is only one use of that function.

A prominant example would be 'map (someFnHere) list'.
We want to always transform that code into a loop with someFnHere inside it.

The wake parser also implements pattern matching using large functions that
are invoked only once.  It is very important to inline these in order to
expose further inlining opportunities in the inner clauses.

However, wake had a bug (fixed by this PR) whereby some functions were
erroneously retaining their singleton status even after transformations (in
this case inlinling itself) added additional references.

Futhermore, when we inlined a singleton function, we left it's old instance behind.

The net result of these two bugs was that we could potentially grow the SSA,
doubling the size every time a singleton inlining occured.