### PR TITLE
Wake command-line subcommands now controlled by package exports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           debuild -us -uc
           cd ..
           apt-get install -y ./wake_*.deb
-          wake --no-workspace 'shellJob "ls /" Nil | getJobStdout'
+          wake --no-workspace -x 'shellJob "ls /" Nil | getJobStdout'
           mkdir -p release/debian_testing
           mv *.deb *.xz *.changes *.dsc release/debian_testing
       - persist_to_workspace:
@@ -82,7 +82,7 @@ jobs:
           cp /tmp/workspace/wake.spec .
           /usr/bin/scl enable devtoolset-6 'rpmbuild -ba wake.spec'
           yum -y install /root/rpmbuild/RPMS/x86_64/wake-*.rpm
-          wake --no-workspace 'shellJob "ls /" Nil | getJobStdout'
+          wake --no-workspace -x 'shellJob "ls /" Nil | getJobStdout'
           mkdir -p release/centos_6_6
           cp /root/rpmbuild/RPMS/x86_64/*.rpm /root/rpmbuild/SRPMS/*.rpm release/centos_6_6
       - persist_to_workspace:
@@ -107,7 +107,7 @@ jobs:
           cp /tmp/workspace/wake.spec .
           rpmbuild -ba wake.spec
           yum -y install /root/rpmbuild/RPMS/x86_64/wake-*.rpm
-          wake --no-workspace 'shellJob "ls /" Nil | getJobStdout'
+          wake --no-workspace -x 'shellJob "ls /" Nil | getJobStdout'
           mkdir -p release/centos_7_6
           cp /root/rpmbuild/RPMS/x86_64/*.rpm /root/rpmbuild/SRPMS/*.rpm release/centos_7_6
       - persist_to_workspace:
@@ -154,7 +154,7 @@ jobs:
           debuild -us -uc
           cd ..
           apt-get install -y ./wake_*.deb
-          wake --no-workspace 'shellJob "ls /" Nil | getJobStdout'
+          wake --no-workspace -x 'shellJob "ls /" Nil | getJobStdout'
           mkdir -p release/ubuntu_16_04
           mv *.deb *.xz *.changes *.dsc release/ubuntu_16_04
       - persist_to_workspace:
@@ -177,7 +177,7 @@ jobs:
           debuild -us -uc
           cd ..
           apt-get install -y ./wake_*.deb
-          wake --no-workspace 'shellJob "ls /" Nil | getJobStdout'
+          wake --no-workspace -x 'shellJob "ls /" Nil | getJobStdout'
           mkdir -p release/ubuntu_18_04
           mv *.deb *.xz *.changes *.dsc release/ubuntu_18_04
       - persist_to_workspace:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ EXTRA := lib/wake/libpreload-wake.so lib/wake/preload-wake
 endif
 
 all:		wake.db
-	$(WAKE_ENV) ./bin/wake all default
+	$(WAKE_ENV) ./bin/wake build default
 
 clean:
 	rm -f bin/* lib/wake/* */*.o common/jlexer.cpp src/symbol.cpp src/version.h wake.db
@@ -39,10 +39,10 @@ wake.db:	bin/wake lib/wake/fuse-wake lib/wake/fuse-waked lib/wake/shim-wake $(EX
 	test -f $@ || ./bin/wake --init .
 
 install:	all
-	$(WAKE_ENV) ./bin/wake install '"$(DESTDIR)"'
+	$(WAKE_ENV) ./bin/wake install $(DESTDIR)
 
 tarball:	wake.db
-	$(WAKE_ENV) ./bin/wake tarball Unit
+	$(WAKE_ENV) ./bin/wake build tarball
 
 bin/wake:	src/symbol.o $(COMMON)				\
 		$(patsubst %.cpp,%.o,$(wildcard src/*.cpp))	\

--- a/build.wake
+++ b/build.wake
@@ -26,6 +26,10 @@ export def build = match _
   "tarball", Nil = tarball Unit
   _ = Fail "no target specified (try: build default/debug/tarball)".makeError
 
+export def install = match _
+  dest, Nil = doInstall (in cwd dest)
+  _ = Fail "no directory specified (try: install /opt/local)".makeError
+
 # Build all wake targets
 def targets = buildWake, buildFuse, buildFuseDaemon, buildShim, buildPreload, buildPrelib, Nil
 def allOut variant = map (_ variant) targets
@@ -35,7 +39,7 @@ def all variant =
   | getOrPass "BUILT"
 
 # Install wake into a target location
-def install dest =
+def doInstall dest =
   def datfiles = sources "{here}/share" `.*`
   def binfiles = allOut default
   def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe

--- a/build.wake
+++ b/build.wake
@@ -20,6 +20,12 @@ from wake import _
 def default = Pair "native-cpp11-release" "native-c99-release"
 def debug   = Pair "native-cpp11-debug" "native-c99-debug"
 
+export def build = match _
+  "default", Nil = all default
+  "debug",   Nil = all debug
+  "tarball", Nil = tarball Unit
+  _ = Fail "no target specified (try: build default/debug/tarball)".makeError
+
 # Build all wake targets
 def targets = buildWake, buildFuse, buildFuseDaemon, buildShim, buildPreload, buildPrelib, Nil
 def allOut variant = map (_ variant) targets

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@
 
 override_dh_auto_build-arch:
 	USE_FUSE_WAKE=0 make wake.db
-	USE_FUSE_WAKE=0 ./bin/wake all default
+	USE_FUSE_WAKE=0 ./bin/wake build default
 
 override_dh_auto_install-arch:
-	USE_FUSE_WAKE=0 ./bin/wake 'install "{here}/debian/wake/usr"'
+	USE_FUSE_WAKE=0 ./bin/wake install "debian/wake/usr"

--- a/share/doc/wake/tour/packages.adoc
+++ b/share/doc/wake/tour/packages.adoc
@@ -253,7 +253,7 @@ A same-package export must be used in file which declares the identifier.
 == Command-line
 
 When wake is invoked from the command-line,
-it can be used to evaluate an expression or invoke a `main` function.
+it can be used to evaluate an expression or invoke a subcommand.
 In both cases, a package scope must be selected to produce useful work.
 
 First, wake progressively searches from the current directory
@@ -264,12 +264,12 @@ Otherwise, the `wake` package is selected,
 though this many be manually overridden using the '--in' command-line option.
 
 By default, when evaluating the command-line,
-wake passes all non-options to the selected package's `main` function.
+wake passes all non-options to the selected subcommand function.
 This function can then trigger the appropriate build.
 If an appropriate wake file is placed in the workspace root,
-this can make invoking the build as simple as running `wake` with no options.
+this can make invoking the build as simple as running `wake all` with no options.
 
-When invoked with `wake -r '5 + 6'`,
+When invoked with `wake -x '5 + 6'`,
 wake will evaluate the next argument as an expression.
 That expression is evaluated within the scope of the selected package.
 Thus, it has access to even unexported package-level identifiers.

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -27,7 +27,19 @@ export def read path =
 # Simplify away the ..s and .s in a String
 export def simplify path = prim "simplify"
 
+# Concatenate two paths
+#  join "foo"  "bar"    => "foo/bar"
+#  join "foo"  "/bar "  => "/bar"
+#  join "/foo" "bar"    => "/foo/bar"
+#  join "foo"  "../bar" => "bar"
+export def in dir path =
+  if matches `/.*` path then path else simplify "{dir}/{path}"
+
 # Reframe path into a form accesible relative to dir
+# For example:
+#  relative "bin" "bin/usr" => "usr"
+#  relative "bin" "bin"     => "."
+#  relative "bin" "hax"     => "../hax"
 export def relative dir path = prim "relative"
 
 # Locate an executable in the search path
@@ -36,7 +48,13 @@ export target whichIn path exec =
   imp path exec
 
 export def which exec = whichIn path exec
+
+# Absolute path to the workspace root.
+# All paths in wake are relative to the workspace root; you probably just want "."
+# The absolute path should rarely be used because it breaks build relocatability
 export def workspace = prim "workspace"
+
+# The directory within which wake was invoked (relative to the workspace root)
 export def cwd = prim "prefix"
 
 def mkdirRunner =

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -892,10 +892,10 @@ static std::unique_ptr<Expr> fracture(Top &top, bool anon, const std::string &na
           if (at != std::string::npos) {
             def.expr = fracture(top, false, trim(def.name), std::move(def.expr), &dbinding);
             ResolveDef &topicdef = gbinding.defs[gbinding.index.find("topic " + qualified)->second];
-            Location &l = def.expr->location;
+            Location &l = topicdef.expr->location;
             topicdef.expr = std::unique_ptr<Expr>(new App(l, new App(l,
               new VarRef(l, "binary ++@wake"),
-              new VarRef(l, def.name)),
+              new VarRef(def.expr->location, def.name)),
               topicdef.expr.release()));
           } else {
             fail = true;
@@ -925,12 +925,12 @@ static std::unique_ptr<Expr> fracture(Top &top, bool anon, const std::string &na
           for (Expr *iter = def.expr.get(); iter->type == &App::type; iter = next) {
             App *app1 = static_cast<App*>(iter);
             App *app2 = static_cast<App*>(app1->fn.get());
-            app2->val = std::unique_ptr<Expr>(new Ascribe(LOCATION, AST(signature), app2->val.release()));
+            app2->val = std::unique_ptr<Expr>(new Ascribe(def.expr->location, AST(signature), app2->val.release()));
             next = app1->val.get();
           }
 
           // If the topic is empty, still force the type
-          if (!next) def.expr = std::unique_ptr<Expr>(new Ascribe(LOCATION, AST(signature), def.expr.release()));
+          if (!next) def.expr = std::unique_ptr<Expr>(new Ascribe(def.expr->location, AST(signature), def.expr.release()));
         }
       }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -384,6 +384,8 @@ int main(int argc, char **argv) {
 
   TypeVar type = body->typeVar;
   std::string command;
+  char *none = nullptr;
+  char **cmdline = &none;
   if (exec) {
     command = exec;
     Lexer lex(runtime.heap, command, "<execute-argument>");
@@ -391,8 +393,9 @@ int main(int argc, char **argv) {
     if (lex.fail) ok = false;
   } else if (argc > 1) {
     command = argv[1];
+    cmdline = argv+2;
     body = new App(LOCATION, body, force_use(
-      new App(LOCATION, new VarRef(LOCATION, argv[1]), new VarRef(LOCATION, "Nil@wake"))));
+      new App(LOCATION, new VarRef(LOCATION, argv[1]), new Prim(LOCATION, "cmdline"))));
   } else {
     body = new App(LOCATION, body, force_use(new VarRef(LOCATION, "Nil@wake")));
   }
@@ -407,7 +410,7 @@ int main(int argc, char **argv) {
 
   /* Primitives */
   JobTable jobtable(&db, percent, verbose, quiet, check, !tty);
-  StringInfo info(verbose, debug, quiet, VERSION_STR, make_canonical(prefix));
+  StringInfo info(verbose, debug, quiet, VERSION_STR, make_canonical(prefix), cmdline);
   PrimMap pmap = prim_register_all(&info, &jobtable);
 
   std::unique_ptr<Expr> root = bind_refs(std::move(top), pmap);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,10 +47,10 @@
 
 void print_help(const char *argv0) {
   std::cout << std::endl
-    << "Usage: " << argv0 << " [-cvdqiolfdsgh] [-p PERCENT] [--] [arg0 ...]" << std::endl
+    << "Usage: " << argv0 << " [-cvdqiolfdsgh] [-p PERCENT] [--] [subcommand ...]" << std::endl
     << std::endl
     << "  Flags affecting build execution:" << std::endl
-    << "    -pPERCENT        Schedule local jobs for <= PERCENT of system (default 90)"  << std::endl
+    << "    -p PERCENT       Schedule local jobs for <= PERCENT of system (default 90)"  << std::endl
     << "    --check    -c    Rerun all jobs and confirm their output is reproducible"    << std::endl
     << "    --verbose  -v    Report hash progress and result expression types"           << std::endl
     << "    --debug    -d    Report stack frame information for exceptions and closures" << std::endl
@@ -62,6 +62,7 @@ void print_help(const char *argv0) {
     << "    --profile-heap   Report memory consumption on every garbage collection"      << std::endl
     << "    --profile FILE   Report runtime breakdown by stack trace to HTML/JSON file"  << std::endl
     << "    --in      PKG    Use PKG as the select package (default: current directory)" << std::endl
+    << "    --exec -x EXPR   Execute expression EXPR instead of subcommand function"     << std::endl
     << std::endl
     << "  Database commands:" << std::endl
     << "    --init      DIR  Create or replace a wake.db in the specified directory"     << std::endl
@@ -106,6 +107,7 @@ int main(int argc, char **argv) {
     { 0,   "profile-heap",          GOPT_ARGUMENT_FORBIDDEN | GOPT_REPEATABLE },
     { 0,   "profile",               GOPT_ARGUMENT_REQUIRED  },
     { 0,   "in",                    GOPT_ARGUMENT_REQUIRED  },
+    { 'x', "exec",                  GOPT_ARGUMENT_REQUIRED  },
     { 'i', "input",                 GOPT_ARGUMENT_FORBIDDEN },
     { 'o', "output",                GOPT_ARGUMENT_FORBIDDEN },
     { 'l', "last",                  GOPT_ARGUMENT_FORBIDDEN },
@@ -158,6 +160,7 @@ int main(int argc, char **argv) {
   const char *hash    = arg(options, "debug-target")->argument;
   const char *exports = arg(options, "exports")->argument;
   const char *in      = arg(options, "in")->argument;
+  const char *exec    = arg(options, "exec")->argument;
 
   if (help) {
     print_help(argv[0]);
@@ -206,12 +209,16 @@ int main(int argc, char **argv) {
     }
   }
 
+  // Arguments are forbidden with these options
+  bool noargs = init || last || failed || html || global || exports || exec;
+  bool targets = argc == 1 && !noargs;
+
   bool nodb = init;
   bool noparse = nodb || output || input || last || failed;
   bool notype = noparse || parse;
-  bool noexecute = notype || html || tcheck || dumpssa || global || exports;
+  bool noexecute = notype || html || tcheck || dumpssa || global || exports || targets;
 
-  if (noparse && argc < 1) {
+  if (noargs && argc > 1) {
     std::cerr << "Unexpected positional arguments on the command-line!" << std::endl;
     return 1;
   }
@@ -336,6 +343,7 @@ int main(int argc, char **argv) {
 
   // No wake files in the path from workspace to the current directory
   if (!top->def_package) top->def_package = "wake";
+  if (!flatten_exports(*top)) ok = false;
 
   std::vector<std::pair<std::string, std::string> > defs;
   std::set<std::string> types;
@@ -361,43 +369,47 @@ int main(int argc, char **argv) {
     }
   }
 
-  std::string command;
-  if (argc > 1) {
-    std::stringstream expr;
-    for (int i = 1; i < argc; ++i) {
-      if (i != 1) expr << " ";
-      expr << argv[i];
+  if (targets) {
+    auto it = top->packages.find(top->def_package);
+    if (it != top->packages.end()) {
+      for (auto &e : it->second->exports.defs)
+        defs.emplace_back(e.first, e.second.qualified);
     }
-    command = expr.str();
-  } else {
-    command = "Pass \"no command supplied\"";
   }
 
-  // Read all wake targets
   Expr *body = new Lambda(LOCATION, "_", new Literal(LOCATION, String::literal(runtime.heap, "top"), &String::typeVar));
   for (size_t i = 0; i <= defs.size(); ++i) {
     body = new Lambda(LOCATION, "_", body);
   }
+
   TypeVar type = body->typeVar;
-  {
-    Lexer lex(runtime.heap, command, "<command-line>");
+  std::string command;
+  if (exec) {
+    command = exec;
+    Lexer lex(runtime.heap, command, "<execute-argument>");
     body = new App(LOCATION, body, force_use(parse_command(lex)));
     if (lex.fail) ok = false;
+  } else if (argc > 1) {
+    command = argv[1];
+    body = new App(LOCATION, body, force_use(
+      new App(LOCATION, new VarRef(LOCATION, argv[1]), new VarRef(LOCATION, "Nil@wake"))));
+  } else {
+    body = new App(LOCATION, body, force_use(new VarRef(LOCATION, "Nil@wake")));
   }
+
   for (auto &d : defs)
     body = new App(LOCATION, body, force_use(new VarRef(LOCATION, d.second)));
 
   top->body = std::unique_ptr<Expr>(body);
+
+  if (parse) std::cout << top.get();
+  if (notype) return ok?0:1;
 
   /* Primitives */
   JobTable jobtable(&db, percent, verbose, quiet, check, !tty);
   StringInfo info(verbose, debug, quiet, VERSION_STR, make_canonical(prefix));
   PrimMap pmap = prim_register_all(&info, &jobtable);
 
-  if (!flatten_exports(*top)) ok = false;
-  if (parse) std::cout << top.get();
-
-  if (notype) return ok?0:1;
   std::unique_ptr<Expr> root = bind_refs(std::move(top), pmap);
   if (!root) ok = false;
   ok = ok && sums_ok();
@@ -425,6 +437,8 @@ int main(int argc, char **argv) {
     std::cout << std::endl;
   }
 
+  if (targets) std::cout << "Available wake subcommands:" << std::endl;
+
   for (auto &g : defs) {
     Expr *e = root.get();
     while (e && e->type == &DefBinding::type) {
@@ -434,9 +448,17 @@ int main(int argc, char **argv) {
       if (i != d->order.end()) {
         int idx = i->second.index;
         Expr *v = idx < (int)d->val.size() ? d->val[idx].get() : d->fun[idx-d->val.size()].get();
-        std::cout << g.first << ": ";
-        v->typeVar.format(std::cout, v->typeVar);
-        std::cout << " = <" << v->location.file() << ">" << std::endl;
+        if (targets) {
+          if (strcmp(v->typeVar      .getName(), FN))               continue;
+          if (strcmp(v->typeVar[0]   .getName(), "List@wake"))      continue;
+          if (strcmp(v->typeVar[0][0].getName(), "String@builtin")) continue;
+          if (strcmp(v->typeVar[1]   .getName(), "Result@wake"))    continue;
+          std::cout << "  " << g.first << std::endl;
+        } else {
+          std::cout << g.first << ": ";
+          v->typeVar.format(std::cout, v->typeVar);
+          std::cout << " = <" << v->location.file() << ">" << std::endl;
+        }
       }
     }
   }

--- a/src/prim.h
+++ b/src/prim.h
@@ -159,8 +159,9 @@ struct StringInfo {
   bool quiet;
   std::string version;
   std::string prefix;
-  StringInfo(bool v, bool d, bool q, const std::string &version_, const std::string &prefix_)
-   : verbose(v), debug(d), quiet(q), version(version_), prefix(prefix_) { }
+  char **cmdline;
+  StringInfo(bool v, bool d, bool q, const std::string &version_, const std::string &prefix_, char **cmdline_)
+   : verbose(v), debug(d), quiet(q), version(version_), prefix(prefix_), cmdline(cmdline_) { }
 };
 
 void prim_register(PrimMap &pmap, const char *key, PrimFn fn, PrimType type, int flags, void *data = 0);

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -570,6 +570,32 @@ static PRIMFN(prim_prefix) {
   RETURN(String::alloc(runtime.heap, info->prefix));
 }
 
+static PRIMTYPE(type_cmdline) {
+  TypeVar list;
+  Data::typeList.clone(list);
+  list[0].unify(String::typeVar);
+  return args.size() == 0 &&
+    out->unify(list);
+}
+
+static PRIMFN(prim_cmdline) {
+  EXPECT(0);
+  StringInfo *info = static_cast<StringInfo*>(data);
+
+  size_t need = 0, len = 0;
+  for (char **arg = info->cmdline; *arg; ++arg) {
+    need += String::reserve(strlen(*arg));
+    ++len;
+  }
+  need += reserve_list(len);
+  runtime.heap.reserve(need);
+
+  std::vector<Value*> vals;
+  for (char **arg = info->cmdline; *arg; ++arg)
+    vals.push_back(String::claim(runtime.heap, *arg));
+  RETURN(claim_list(runtime.heap, vals.size(), vals.data()));
+}
+
 static PRIMTYPE(type_uname) {
   TypeVar pair;
   Data::typePair.clone(pair);
@@ -619,6 +645,7 @@ void prim_register_string(PrimMap &pmap, StringInfo *info) {
   prim_register(pmap, "version",  prim_version,  type_version,   PRIM_PURE, (void*)info);
   prim_register(pmap, "level",    prim_level,    type_level,     PRIM_PURE, (void*)info);
   prim_register(pmap, "prefix",   prim_prefix,   type_prefix,    PRIM_PURE, (void*)info);
+  prim_register(pmap, "cmdline",  prim_cmdline,  type_cmdline,   PRIM_PURE, (void*)info);
   prim_register(pmap, "scmp",     prim_scmp,     type_scmp,      PRIM_PURE);
   prim_register(pmap, "sNFC",     prim_sNFC,     type_normalize, PRIM_PURE);
   prim_register(pmap, "sNFKC",    prim_sNFKC,    type_normalize, PRIM_PURE);


### PR DESCRIPTION
Invoking wake now lists subcommands exported by a package.

For example:
```
terpstra@peach:~/wake$ ./bin/wake
Available wake subcommands:
  build
  install
```

Subcommands are functions that accept List String and return Result.

Running 'wake build default' from the command-line will result in evaluation of 'build ("default", Nil)'.

This PR also adds two new functions to make coping with files provided by the command-line:
  'in dir path' - combines dir and path
  'cwd' - the directory where wake was invoked