### PR TITLE
Fix parser segfault

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -815,7 +815,7 @@ static std::unique_ptr<Expr> fracture(Top &top, bool anon, const std::string &na
     dbinding.current_index = -1;
     std::unique_ptr<Expr> body = fracture(top, true, name, std::move(def->body), &dbinding);
     auto out = fracture_binding(def->location, dbinding.defs, std::move(body));
-    if ((def->flags & FLAG_AST) != 0)
+    if (out && (def->flags & FLAG_AST) != 0)
       out->flags |= FLAG_AST;
     return out;
   } else if (expr->type == &Construct::type) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -488,6 +488,7 @@ static std::vector<Definition> parse_def(Lexer &lex, long index, bool target, bo
 
   ASTState state(false, false);
   AST ast = parse_ast(0, lex, state);
+  if (ast.name.empty()) ast.name = "undef";
   std::string name = std::move(ast.name);
   ast.name.clear();
   if (check_constructors(ast)) lex.fail = true;


### PR DESCRIPTION
Segfaults, even on bad input, leave a bad taste in people's mouths.
Example: `global def`
