### PR TITLE
inline: fix a case of infinite recursion

### DIFF
--- a/src/inline.cpp
+++ b/src/inline.cpp
@@ -116,6 +116,8 @@ static void rapp_inline(PassInline &p, std::unique_ptr<RApp> self) {
         // We will move the original; preventing exponwntial growth
         fun = static_cast<RFun*>(term);
       } else {
+        // Temporarily mark this term recursive in case it gets closed by a Y-combinator
+        term->set(SSA_RECURSIVE, true);
         copy = static_unique_pointer_cast<RFun>(term->clone(p.stream.scope(), fnid));
         fun = copy.get();
       }
@@ -134,6 +136,8 @@ static void rapp_inline(PassInline &p, std::unique_ptr<RApp> self) {
         fun->output = 0;
         fun->terms.resize(fargs.size());
         fun->set(SSA_MOVED, true);
+      } else {
+        term->set(SSA_RECURSIVE, false);
       }
     } else {
       // Combine App() but don't inline


### PR DESCRIPTION
Normally, wake does not inline recursive functions.
However, using a Y combinator can hide this from wake.

For example:
````
  data Foo = Foo (Foo => Integer => Integer)
  def foo (Foo self) x = if x == 0 then 1 else x * self (Foo self) (x-1)
  def bar x = foo (Foo foo) x
````

In this definition, 'foo' does not look like a recursive function to wake's
front-end.  However, 'bar' closes foo over itself.  This now creates a
situation where the inliner can inline foo over and over again forever.

The fix?: mark an inlined function recursive for the duration of inlining.