### PR TITLE
Improved command line

### DIFF
--- a/gopt/gopt.c
+++ b/gopt/gopt.c
@@ -210,6 +210,7 @@ int gopt (char **argv, struct option *options)
     }
     else
     {
+      doubledash = 1; // added for wake to pass options after target to target commands
       argv[operand_count] = argv[i];
       operand_count++;
     }

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -55,7 +55,7 @@ export def which exec = whichIn path exec
 export def workspace = prim "workspace"
 
 # The directory within which wake was invoked (relative to the workspace root)
-export def cwd = prim "prefix"
+export def cwd = prim "cwd"
 
 def mkdirRunner =
   def imp m p = prim "mkdir"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -484,10 +484,12 @@ int main(int argc, char **argv) {
         int idx = i->second.index;
         Expr *v = idx < (int)d->val.size() ? d->val[idx].get() : d->fun[idx-d->val.size()].get();
         if (targets) {
-          if (strcmp(v->typeVar      .getName(), FN))               continue;
-          if (strcmp(v->typeVar[0]   .getName(), "List@wake"))      continue;
-          if (strcmp(v->typeVar[0][0].getName(), "String@builtin")) continue;
-          if (strcmp(v->typeVar[1]   .getName(), "Result@wake"))    continue;
+          TypeVar fn(FN, 2);
+          TypeVar list;
+          Data::typeList.clone(list);
+          fn[0].unify(list);
+          list[0].unify(String::typeVar);
+          if (!v->typeVar.unify(fn)) continue;
           std::cout << "  " << g.first << std::endl;
         } else {
           std::cout << g.first << ": ";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,8 +77,8 @@ void print_help(const char *argv0) {
     << "  Help functions:" << std::endl
     << "    --version        Print the version of wake on standard output"               << std::endl
     << "    --html           Print all wake source files as cross-referenced HTML"       << std::endl
-    << "    --globals -g     Print all global variables available to the command-line"   << std::endl
-    << "    --exports -e PKG Print all exported symbols for package PKG"                 << std::endl
+    << "    --globals -g     Print global symbols made available to all wake files"      << std::endl
+    << "    --exports -e     Print symbols exported by the selected package (see --in)"  << std::endl
     << "    --help    -h     Print this help message and exit"                           << std::endl
     << std::endl;
     // debug-db, no-optimize, stop-after-* are secret undocumented options
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
     { 0,   "init",                  GOPT_ARGUMENT_REQUIRED  },
     { 0,   "version",               GOPT_ARGUMENT_FORBIDDEN },
     { 'g', "globals",               GOPT_ARGUMENT_FORBIDDEN },
-    { 'e', "exports",               GOPT_ARGUMENT_REQUIRED  },
+    { 'e', "exports",               GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "html",                  GOPT_ARGUMENT_FORBIDDEN },
     { 'h', "help",                  GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "debug-db",              GOPT_ARGUMENT_FORBIDDEN },
@@ -152,13 +152,13 @@ int main(int argc, char **argv) {
   bool tcheck  = arg(options, "stop-after-type-check")->count;
   bool dumpssa = arg(options, "stop-after-ssa")->count;
   bool optim   =!arg(options, "no-optimize")->count;
+  bool exports = arg(options, "exports")->count;
 
   const char *percents= arg(options, "percent")->argument;
   const char *heapf   = arg(options, "heap-factor")->argument;
   const char *profile = arg(options, "profile")->argument;
   const char *init    = arg(options, "init")->argument;
   const char *hash    = arg(options, "debug-target")->argument;
-  const char *exports = arg(options, "exports")->argument;
   const char *in      = arg(options, "in")->argument;
   const char *exec    = arg(options, "exec")->argument;
 
@@ -358,7 +358,7 @@ int main(int argc, char **argv) {
   }
 
   if (exports) {
-    auto it = top->packages.find(exports);
+    auto it = top->packages.find(top->def_package);
     if (it != top->packages.end()) {
       for (auto &e : it->second->exports.defs)
         defs.emplace_back(e.first, e.second.qualified);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@
 
 void print_help(const char *argv0) {
   std::cout << std::endl
-    << "Usage: " << argv0 << " [-cvdqiolfdsgh] [-p PERCENT] [--] [subcommand ...]" << std::endl
+    << "Usage: " << argv0 << " [OPTIONS] [target] [target options ...]" << std::endl
     << std::endl
     << "  Flags affecting build execution:" << std::endl
     << "    -p PERCENT       Schedule local jobs for <= PERCENT of system (default 90)"  << std::endl
@@ -61,8 +61,8 @@ void print_help(const char *argv0) {
     << "    --heap-factor X  Heap-size is X * live data after the last GC (default 4.0)" << std::endl
     << "    --profile-heap   Report memory consumption on every garbage collection"      << std::endl
     << "    --profile FILE   Report runtime breakdown by stack trace to HTML/JSON file"  << std::endl
-    << "    --in      PKG    Use PKG as the select package (default: current directory)" << std::endl
-    << "    --exec -x EXPR   Execute expression EXPR instead of subcommand function"     << std::endl
+    << "    --in      PKG    Evaluate command-line in package PKG (default current dir)" << std::endl
+    << "    --exec -x EXPR   Execute expression EXPR instead of a target function"       << std::endl
     << std::endl
     << "  Database commands:" << std::endl
     << "    --init      DIR  Create or replace a wake.db in the specified directory"     << std::endl
@@ -440,7 +440,7 @@ int main(int argc, char **argv) {
     std::cout << std::endl;
   }
 
-  if (targets) std::cout << "Available wake subcommands:" << std::endl;
+  if (targets) std::cout << "Available wake targets:" << std::endl;
 
   for (auto &g : defs) {
     Expr *e = root.get();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -394,8 +394,15 @@ int main(int argc, char **argv) {
   } else if (argc > 1) {
     command = argv[1];
     cmdline = argv+2;
-    body = new App(LOCATION, body, force_use(
-      new App(LOCATION, new VarRef(LOCATION, argv[1]), new Prim(LOCATION, "cmdline"))));
+    Lexer lex(runtime.heap, command, "<target-argument>");
+    Expr *var = parse_command(lex);
+    if (var->type == &VarRef::type) {
+      body = new App(LOCATION, body, force_use(
+        new App(LOCATION, var, new Prim(LOCATION, "cmdline"))));
+    } else {
+      std::cerr << "Specified target '" << argv[1] << "' is not a legal identifier" << std::endl;
+      ok = false;
+    }
   } else {
     body = new App(LOCATION, body, force_use(new VarRef(LOCATION, "Nil@wake")));
   }

--- a/src/prim.h
+++ b/src/prim.h
@@ -158,10 +158,10 @@ struct StringInfo {
   bool debug;
   bool quiet;
   std::string version;
-  std::string prefix;
+  std::string wake_cwd;
   char **cmdline;
-  StringInfo(bool v, bool d, bool q, const std::string &version_, const std::string &prefix_, char **cmdline_)
-   : verbose(v), debug(d), quiet(q), version(version_), prefix(prefix_), cmdline(cmdline_) { }
+  StringInfo(bool v, bool d, bool q, const std::string &version_, const std::string &wake_cwd_, char **cmdline_)
+   : verbose(v), debug(d), quiet(q), version(version_), wake_cwd(wake_cwd_), cmdline(cmdline_) { }
 };
 
 void prim_register(PrimMap &pmap, const char *key, PrimFn fn, PrimType type, int flags, void *data = 0);

--- a/src/sources.h
+++ b/src/sources.h
@@ -23,7 +23,7 @@
 
 struct Runtime;
 
-bool chdir_workspace(std::string &prefix);
+bool chdir_workspace(const char *chdirto, std::string &wake_cwd, std::string &src_dir);
 bool make_workspace(const std::string &dir);
 std::string make_canonical(const std::string &x);
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -559,15 +559,15 @@ static PRIMFN(prim_str2bin) {
   RETURN(Integer::alloc(runtime.heap, out));
 }
 
-static PRIMTYPE(type_prefix) {
+static PRIMTYPE(type_cwd) {
   return args.size() == 0 &&
     out->unify(String::typeVar);
 }
 
-static PRIMFN(prim_prefix) {
+static PRIMFN(prim_cwd) {
   EXPECT(0);
   StringInfo *info = static_cast<StringInfo*>(data);
-  RETURN(String::alloc(runtime.heap, info->prefix));
+  RETURN(String::alloc(runtime.heap, info->wake_cwd));
 }
 
 static PRIMTYPE(type_cmdline) {
@@ -644,7 +644,7 @@ void prim_register_string(PrimMap &pmap, StringInfo *info) {
   prim_register(pmap, "format",   prim_format,   type_format,    PRIM_PURE);
   prim_register(pmap, "version",  prim_version,  type_version,   PRIM_PURE, (void*)info);
   prim_register(pmap, "level",    prim_level,    type_level,     PRIM_PURE, (void*)info);
-  prim_register(pmap, "prefix",   prim_prefix,   type_prefix,    PRIM_PURE, (void*)info);
+  prim_register(pmap, "cwd",      prim_cwd,      type_cwd,       PRIM_PURE, (void*)info);
   prim_register(pmap, "cmdline",  prim_cmdline,  type_cmdline,   PRIM_PURE, (void*)info);
   prim_register(pmap, "scmp",     prim_scmp,     type_scmp,      PRIM_PURE);
   prim_register(pmap, "sNFC",     prim_sNFC,     type_normalize, PRIM_PURE);


### PR DESCRIPTION
This PR:
- makes it possible to invoke wake as a shell script
- passes options after a target to the target
- removed package name from --exports
- auto-initializes a wake.db where it find a wit-lock.json
- expands the legal list of targets to include non-Results