### PR TITLE
vim: Update syntax highlighting for new keywords.

### DIFF
--- a/share/doc/wake/syntax/vim/syntax/wake.vim
+++ b/share/doc/wake/syntax/vim/syntax/wake.vim
@@ -17,11 +17,15 @@ syn match lineComment "#.*"
 
 " Keywords
 " TODO Should important globals from prim.wake we marked keywords?
-syn keyword wakeKeyword if then else here global export import package from type topic binary unary subscribe match require data tuple prim
+syn keyword wakeKeyword if then else here global type topic subscribe match require data tuple prim
+
+syn keyword wakeOperatorModifier binary unary
+syn keyword wakeInclude package export import from
+syn keyword wakeException panic
 
 " definitions
 " TODO How can we handle `def x + y` = syntax?
-syn keyword wakeDef def publish target nextgroup=wakeOperator,wakeLowerIdentifier skipwhite
+syn keyword wakeDef def publish target topic nextgroup=wakeOperatorModifier,wakeOperator,wakeLowerIdentifier skipwhite
 syn match wakeDefName "[^ =:;()[]\+" contained skipwhite
 syn match wakeOperator "[+-=$]\+" contained
 syn match wakeLowerIdentifier "[a-z][A-Za-z0-9_]*" contained
@@ -52,7 +56,10 @@ hi link lineComment Comment
 hi link wakeDef Keyword
 hi link wakeDefName Function
 hi link wakeLowerIdentifier Function
+hi link wakeOperatorModifier Keyword
 hi link wakeOperator Function
+hi link wakeInclude Include
+hi link wakeException Exception
 
 hi link wakeUpperIdentifier Type
 


### PR DESCRIPTION
Highlight topic names as Identifiers.
Highlight package/import/export keywords and Includes.
Highlight panic as Exception.
Correctly highlight unary/binary as keywords and not identifiers.

<img width="455" alt="Screen Shot 2020-04-01 at 11 21 19 PM" src="https://user-images.githubusercontent.com/1002748/78216808-7f0d6e80-746f-11ea-9bdd-8775cd9b9913.png">

I don't really know what I'm doing with vim syntax highlighting, but I think this makes it look better and closer to what I'm used to, at least for my vim color scheme. Yes, I know that any identifier that follows a `def` or `topic` in the import/export list gets incorrectly colored, and, yes, I know that operators are kind of broken, but I don't think I can fix that without spending a lot more time learning how vim syntax highlighting works.