### PR TITLE
runtime: remove upper-limits on vector and integer sizes

### DIFF
--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -72,10 +72,6 @@ static PRIMFN(prim_##name) {					\
   EXPECT(2);							\
   INTEGER_MPZ(arg0, 0);						\
   INTEGER_MPZ(arg1, 1);						\
-  bool MB_size_shift =						\
-    mpz_cmp_si(arg1,  (1<<20)) >= 0 ||				\
-    mpz_cmp_si(arg1, -(1<<20)) <= 0;				\
-  REQUIRE(!MB_size_shift);					\
   MPZ out;							\
   if (mpz_sgn(arg1) >= 0) {					\
     fn1(out.value, arg0, mpz_get_si(arg1));			\
@@ -93,8 +89,6 @@ static PRIMFN(prim_##name) {					\
   EXPECT(2);							\
   INTEGER_MPZ(arg0, 0);						\
   INTEGER_MPZ(arg1, 1);						\
-  bool MB_size_shift =	mpz_cmp_si(arg1, (1<<20)) >= 0;		\
-  REQUIRE(!MB_size_shift);					\
   MPZ out;							\
   if (mpz_sgn(arg1) >= 0) {					\
     fn(out.value, arg0, mpz_get_si(arg1));			\

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -37,7 +37,6 @@ static PRIMFN(prim_vnew) {
   EXPECT(1);
   INTEGER_MPZ(arg0, 0);
   REQUIRE(mpz_cmp_si(arg0, 0) >= 0);
-  REQUIRE(mpz_cmp_si(arg0, 1024*1024*1024) < 0);
   RETURN(Record::alloc(runtime.heap, &Constructor::array, mpz_get_si(arg0)));
 }
 


### PR DESCRIPTION
If a person asks for a multi-megabyte Integer, let them have it.
Likewise, there should be no limit on Vector sizes.

If you run out of memory, fine.