### PR TITLE
Integer: powm _ _ 0 is also division by zero

### DIFF
--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -118,6 +118,8 @@ static PRIMFN(prim_powm) {
   INTEGER_MPZ(arg0, 0);
   INTEGER_MPZ(arg1, 1);
   INTEGER_MPZ(arg2, 2);
+  bool division_by_zero = mpz_cmp_si(arg2, 0) == 0;
+  REQUIRE(!division_by_zero);
   MPZ out;
   mpz_powm(out.value, arg0, arg1, arg2);
   RETURN(Integer::alloc(runtime.heap, out));


### PR DESCRIPTION
Don't fail with "floating point exception" and unclean exit.

Fail with "Requirement !division_by_zero failed" and cleanly exit.