### PR TITLE
Fix globals stack overflow

### DIFF
--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -97,7 +97,3 @@ void prim_register_exception(PrimMap &pmap) {
   prim_register(pmap, "use",      prim_id,    type_id,    PRIM_IMPURE);
   prim_register(pmap, "true",     prim_true,  type_true,  PRIM_PURE);
 }
-
-Expr *force_use(Expr *expr) {
-  return new App(LOCATION, new Lambda(LOCATION, "_", new Prim(LOCATION, "use")), expr);
-}

--- a/src/prim.h
+++ b/src/prim.h
@@ -85,7 +85,6 @@ size_t reserve_hash();
 Work *claim_hash(Heap &h, Value *value, Continuation *continuation);
 
 void dont_report_future_targets();
-Expr *force_use(Expr *expr);
 
 /* The evaluation order of wake makes two guarantees:
  *   [1] Exactly the effects of straight-line execution are produced.


### PR DESCRIPTION
On sufficiently large projects, `wake -g` runs out of stack space.
This was caused by a now unnecessary code path which nested all symbols.
That code has been removed.