### PR TITLE
Detect and report any unused definitions, topics, or arguments

### DIFF
--- a/share/wake/lib/core/list.wake
+++ b/share/wake/lib/core/list.wake
@@ -116,7 +116,7 @@ export def take i l =
 export def drop i l =
   if i <= 0 then l else match l
     Nil = Nil
-    h, t = drop (i-1) t
+    _, t = drop (i-1) t
 
 export def at i l =
   if i < 0 then None else head (drop i l)

--- a/share/wake/lib/core/tree.wake
+++ b/share/wake/lib/core/tree.wake
@@ -78,7 +78,7 @@ export def tinsert y (Tree cmp root) =
 export def tinsertReplace y (Tree cmp root) =
   def helper t = match t
     Tip         = Bin 1 Tip y Tip
-    Bin s l x r = match (cmp x y)
+    Bin _ l x r = match (cmp x y)
       GT = join3 (helper l) x r
       EQ = join3 (delete cmp y l) y (delete cmp y r)
       LT = join3 l x (helper r)
@@ -385,7 +385,7 @@ export def x ∌ y = y ∉ x
 
 export def tcontains y t =
   match t (tupperLE y t)
-    (Tree cmp _) None              = False
+    (Tree _   _) None              = False
     (Tree cmp _) (Some (Pair x _)) = match (cmp x y)
       EQ = True
       _  = False

--- a/share/wake/lib/system/incremental.wake
+++ b/share/wake/lib/system/incremental.wake
@@ -81,7 +81,7 @@ export def runIncrementalJob stateFileLabel reusedOutputFilterFn plan =
     | editPlanVisible  (stateFiles ++ _)
     | setPlanFnInputs  (\_ plan.getPlanVisible | map getPathName)
     | runJob
-  def postTar =
+  def _postTar = # ignored, but executed
     job
     | getJobOutputs
     | filter reusedOutputFilterFn

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -406,10 +406,10 @@ export def preloadRunner =
   makeJSONRunnerPlan preload score
   | makeJSONRunner
 
-def rOK = 0
-def wOK = 1
-def xOK = 2
-def access file mode = prim "access"
+export def rOK = 0
+export def wOK = 1
+export def xOK = 2
+export def access file mode = prim "access"
 
 export def defaultRunner = match sysname
   "Darwin" = fuseRunner

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -179,7 +179,7 @@ export def localRunner =
     Fail e =
       def _ = badlaunch job e
       Fail e
-    Pass (RunnerInput label cmd vis env dir stdin _ _ predict) = match (findSomeFn getPathError vis)
+    Pass (RunnerInput _ cmd vis env dir stdin _ _ predict) = match (findSomeFn getPathError vis)
       Some e =
         def _ = badlaunch job e
         Fail e
@@ -290,7 +290,7 @@ data RunnerOption =
 
 # Run the job!
 export def runJob p = match p
-  Plan label cmd vis env dir stdin stdout stderr echo pers lo res rf usage finputs foutputs =
+  Plan label cmd vis env dir stdin stdout stderr echo pers _lo res rf usage finputs foutputs =
     # Transform the 'List Runner' into 'List RunnerOption'
     def qualify runner = match runner
       Runner name _ _ if ! rf runner = Reject "{name}: rejected by Plan"
@@ -301,7 +301,7 @@ export def runJob p = match p
     def opts = subscribe runner | map qualify
     def best acc = match _ acc
       (Reject _) _ = acc
-      (Accept score fn) (Pair bests bestr) =
+      (Accept score fn) (Pair bests _bestr) =
         if score >. bests then Pair score (Some fn) else acc
     def log = jobLog stdout stderr echo
     match (opts | foldl best (Pair 0.0 None) | getPairSecond)
@@ -488,7 +488,7 @@ export def makeJSONRunner plan =
     Pair (Fail f) _ = Fail f
     Pair (Pass (RunnerOutput _ _ (Usage x _ _ _ _ _))) inFile if x != 0 =
       Fail (makeError "Non-zero exit status ({str x}) for JSON runner {script} on {inFile}")
-    Pair (Pass output) inFile =
+    Pair (Pass _) inFile =
       def unlink f = prim "unlink"
       def outFile = replace `\.in\.json$` ".out.json" inFile
       def json = parseJSONFile (Path outFile)

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -768,7 +768,7 @@ static std::vector<Symbols*> process_import(Top &top, Imports &imports, Location
   for (auto &p : imports.import_all) {
     auto it = top.packages.find(p);
     if (it == top.packages.end()) {
-      ++warnings; // !!! segfaults
+      ++warnings;
       std::cerr << "(warning) Full import from non-existent package '" << p
         << "' at " << location.text() << std::endl;
     } else {
@@ -1025,8 +1025,11 @@ static std::unique_ptr<Expr> fracture(Top &top, bool anon, const std::string &na
     for (auto &file : defp.files)
       for (auto &bulk : file.content->imports.import_all)
         imports.insert(bulk);
-    for (auto &imp : imports)
-      ibinding.symbols.push_back(&top.packages[imp]->exports);
+    for (auto &imp : imports) {
+      auto it = top.packages.find(imp);
+      if (it != top.packages.end())
+        ibinding.symbols.push_back(&it->second->exports);
+    }
 
     std::unique_ptr<Expr> body = fracture(top, true, name, std::move(top.body), &dbinding);
 

--- a/src/bind.h
+++ b/src/bind.h
@@ -25,6 +25,7 @@ struct Top;
 struct Expr;
 
 // Eliminate DefMap + Top + Subscribe expressions
+extern int warnings;
 std::unique_ptr<Expr> bind_refs(std::unique_ptr<Top> top, const PrimMap &pmap);
 bool flatten_exports(Top &top);
 

--- a/src/expr.h
+++ b/src/expr.h
@@ -36,7 +36,8 @@ struct Continuation;
 
 #define FLAG_TOUCHED   0x01 // already explored for _
 #define FLAG_AST       0x02 // useful to include in AST
-#define FLAG_RECURSIVE 0x04
+#define FLAG_RECURSIVE 0x04 // recursive function
+#define FLAG_SYNTHETIC 0x08 // sugar-generated function
 
 /* Expression AST */
 struct Expr {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,7 @@ void print_help(const char *argv0) {
     << "    --no-tty         Surpress interactive build progress interface"              << std::endl
     << "    --no-wait        Do not wait to obtain database lock; fail immediately"      << std::endl
     << "    --no-workspace   Do not open a database or scan for sources files"           << std::endl
+    << "    --fatal-warnings Do not execute if there are any warnings"                   << std::endl
     << "    --heap-factor X  Heap-size is X * live data after the last GC (default 4.0)" << std::endl
     << "    --profile-heap   Report memory consumption on every garbage collection"      << std::endl
     << "    --profile  FILE  Report runtime breakdown by stack trace to HTML/JSON file"  << std::endl
@@ -105,6 +106,7 @@ int main(int argc, char **argv) {
     { 0,   "no-wait",               GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "no-workspace",          GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "no-tty",                GOPT_ARGUMENT_FORBIDDEN },
+    { 0,   "fatal-warnings",        GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "heap-factor",           GOPT_ARGUMENT_REQUIRED  | GOPT_ARGUMENT_NO_HYPHEN },
     { 0,   "profile-heap",          GOPT_ARGUMENT_FORBIDDEN | GOPT_REPEATABLE },
     { 0,   "profile",               GOPT_ARGUMENT_REQUIRED  },
@@ -141,6 +143,7 @@ int main(int argc, char **argv) {
   bool wait    =!arg(options, "no-wait" )->count;
   bool workspace=!arg(options, "no-workspace")->count;
   bool tty     =!arg(options, "no-tty"  )->count;
+  bool fwarning= arg(options, "fatal-warnings")->count;
   int  profileh= arg(options, "profile-heap")->count;
   bool input   = arg(options, "input"   )->count;
   bool output  = arg(options, "output"  )->count;
@@ -449,7 +452,7 @@ int main(int argc, char **argv) {
   if (!root) ok = false;
   ok = ok && sums_ok();
 
-  if (!ok) {
+  if (!ok || (fwarning && warnings)) {
     std::cerr << ">>> Aborting without execution <<<" << std::endl;
     return 1;
   }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -470,7 +470,7 @@ struct Definition {
 };
 
 static void extract_def(std::vector<Definition> &out, long index, AST &&ast, Expr *body) {
-  std::string key = "extract " + std::to_string(++index);
+  std::string key = "_ extract " + std::to_string(++index);
   out.emplace_back(key, ast.token, body);
   for (auto &m : ast.args) {
     AST pattern(m.token, std::string(ast.name));
@@ -1053,7 +1053,7 @@ static void parse_tuple(Lexer &lex, Package &package, Symbols *exports, Symbols 
               new Lambda(memberToken, "_", select),
               new VarRef(memberToken, "_ x")));
       std::string x = std::to_string(members.size()-inner);
-      std::string name = std::string(4 - x.size(), '0') + x;
+      std::string name = "_ a" + std::string(4 - x.size(), '0') + x;
       editmap->defs.insert(std::make_pair(name,
         DefValue(memberToken, std::unique_ptr<Expr>(select))));
     }
@@ -1070,7 +1070,7 @@ static void parse_tuple(Lexer &lex, Package &package, Symbols *exports, Symbols 
     setmap->body = std::unique_ptr<Expr>(new Construct(memberToken, sump, &c));
     for (size_t inner = 0; inner < members.size(); ++inner) {
       std::string x = std::to_string(members.size()-inner);
-      std::string name = std::string(4 - x.size(), '0') + x;
+      std::string name = "_ a" + std::string(4 - x.size(), '0') + x;
       setmap->defs.insert(std::make_pair(name,
         DefValue(memberToken, std::unique_ptr<Expr>(
           (inner == outer)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1038,6 +1038,7 @@ static void parse_tuple(Lexer &lex, Package &package, Symbols *exports, Symbols 
     // Implement get methods
     std::string get = "get" + name + mname;
     Expr *getfn = new Lambda(memberToken, "_", new Get(memberToken, sump, &c, i));
+    getfn->flags |= FLAG_SYNTHETIC;
     bind_def(lex, map, Definition(get, memberToken, getfn), exportb?exports:nullptr, globalb?globals:nullptr);
 
     // Implement edit methods
@@ -1063,6 +1064,7 @@ static void parse_tuple(Lexer &lex, Package &package, Symbols *exports, Symbols 
       new Lambda(memberToken, "fn" + mname,
         new Lambda(memberToken, "_ x", editmap));
 
+    editfn->flags |= FLAG_SYNTHETIC;
     bind_def(lex, map, Definition(edit, memberToken, editfn), exportb?exports:nullptr, globalb?globals:nullptr);
 
     // Implement set methods
@@ -1083,6 +1085,7 @@ static void parse_tuple(Lexer &lex, Package &package, Symbols *exports, Symbols 
       new Lambda(memberToken, mname,
         new Lambda(memberToken, "_ x", setmap));
 
+    setfn->flags |= FLAG_SYNTHETIC;
     bind_def(lex, map, Definition(set, memberToken, setfn), exportb?exports:nullptr, globalb?globals:nullptr);
 
     ++outer;


### PR DESCRIPTION
This PR detects and warns on any unused definitions, topics, or arguments.
This PR adds a `--fatal-warnings` option, which prevents execution if there are any warnings.

Fixes #432.