### PR TITLE
fuse: support unshare isolation for user, host, net, and workspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ all:		wake.db
 
 clean:
 	rm -f bin/* lib/wake/* */*.o common/jlexer.cpp src/symbol.cpp src/version.h wake.db
-	touch bin/stamp lib/wake/stamp
+	touch bin/stamp lib/wake/stamp build/wake/stamp
 
 wake.db:	bin/wake lib/wake/fuse-wake lib/wake/fuse-waked lib/wake/shim-wake $(EXTRA)
 	test -f $@ || ./bin/wake --init .

--- a/build.wake
+++ b/build.wake
@@ -42,7 +42,7 @@ def all variant = map (_ variant) targets | findFailFn getPathResult
 # Install wake into a target location
 def doInstall dest kind =
   require Pass variant = toVariant kind
-  def datfiles = sources "{here}/share" `.*`
+  def datfiles = source "{here}/build/wake/stamp", sources "{here}/share" `.*`
   def binfilesResult = all variant
   def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
   def datinstall = map (installIn dest) datfiles

--- a/debian/rules
+++ b/debian/rules
@@ -9,3 +9,4 @@ override_dh_auto_build-arch:
 
 override_dh_auto_install-arch:
 	./bin/wake install "debian/wake/usr"
+	mkdir -p debian/wake/var/cache/wake

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -391,6 +391,13 @@ export def getJobStatus job = match (getJobReport job)
     else Signaled (-status)
 
 # Implement FUSE-based Runner
+# The FUSE runner on linux supports a few isolation options via resources:
+# - "isolate/user": the Job will appear to run as root
+# - "isolate/host": make the hostname appear to be "build.local"
+# - "isolate/net": disables network access
+# - "isolate/workspace": makes the build appear run in /var/cache/wake
+#    ... if /var/cache/wake does not exist, a directory 'build/wake' is
+#        used relative to where wake has been installed
 def wakePath = prim "execpath" # location of the wake executable
 export def fuseRunner =
   def fuse = "{wakePath}/../lib/wake/fuse-wake"

--- a/wake.spec.in
+++ b/wake.spec.in
@@ -25,11 +25,14 @@ make all
 
 %install
 make DESTDIR=%{buildroot}/usr install
+mkdir -p %{buildroot}/var/cache/wake
 
 %files
 /usr/bin/wake
 /usr/lib/wake
 /usr/share/wake
+/usr/build/wake
+%dir /var/cache/wake
 %doc /usr/share/doc/wake
 
 %changelog


### PR DESCRIPTION
These isolation levels are supported by requesting resources:
- isolate/workspace; makes the workspace appear to be /var/cache/wake
- isolate/user; makes the build user appear to be root
- isolate/host; makes the hostname appear to be build.local
- isolate/net; disables network access