### PR TITLE
Simplify orElse

### DIFF
--- a/share/wake/lib/core/option.wake
+++ b/share/wake/lib/core/option.wake
@@ -35,10 +35,9 @@ export def getOrElse b = match _
  
 # Inteded use: ``int "x" | orElse (int "z") | getOrElse 4``
 # In this case, returns ``x`` if it exists, otherwise ``z``.  Returns ``None`` if both are empty.
-export def orElse = match _ _
-  _ (Some a) = Some a
-  (Some a) _ = Some a
-  None None  = None
+export def orElse alt = match _
+  Some a = a
+  None   = alt
 
 # Returns the Option's value if Some, otherwise returns the result of fn
 # (fn: Unit => a) => Option a => a


### PR DESCRIPTION
Alternatively could do:
```
export def orElse alt x = match x
  Some _ = x
  None   = alt
```
That saves an object allocation but this optimization could also be performed by the compiler.

I opted for what I PRed to keep it consistent with the other option functions (eg. `getOrElse`)
