### PR TITLE
Reuse objects rather than reconstructing them

### DIFF
--- a/src/cases.cpp
+++ b/src/cases.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ssa.h"
+#include "prim.h"
+
+struct PassCases {
+  ScopeAnalysis scope;
+  PassCases() { }
+};
+
+static uintptr_t tometa(Constructor *con) {
+  return reinterpret_cast<uintptr_t>(static_cast<void*>(con));
+}
+
+void RArg::pass_cases(PassCases &p) {
+  // These get filled in by RDes
+  meta = 0;
+}
+
+void RLit::pass_cases(PassCases &p) {
+  meta = 0;
+}
+
+void RApp::pass_cases(PassCases &p) {
+  meta = 0;
+}
+
+void RPrim::pass_cases(PassCases &p) {
+  meta = 0;
+}
+
+void RGet::pass_cases(PassCases &p) {
+  meta = 0;
+}
+
+void RDes::pass_cases(PassCases &p) {
+  for (size_t i = 0, num = args.size()-1; i < num; ++i) {
+    RFun *fun = static_cast<RFun*>(p.scope[args[i]]);
+    Term *arg = fun->terms[0].get();
+    if (arg->meta) {
+      arg->meta = ~static_cast<uintptr_t>(0);
+    } else {
+      arg->meta = tometa(&sum->members[i]);
+    }
+  }
+  meta = 0;
+}
+
+void RCon::pass_cases(PassCases &p) {
+  meta = tometa(kind.get());
+}
+
+void RFun::pass_cases(PassCases &p) {
+  for (auto &x : terms) {
+    p.scope.push(x.get());
+    x->pass_cases(p);
+  }
+  meta = 0;
+  p.scope.pop(terms.size());
+}
+
+std::unique_ptr<Term> Term::pass_cases(std::unique_ptr<Term> term) {
+  PassCases pass;
+  pass.scope.push(term.get());
+  term->pass_cases(pass);
+  return term;
+}

--- a/src/decon.cpp
+++ b/src/decon.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ssa.h"
+#include "prim.h"
+#include <algorithm>
+#include <unordered_map>
+
+struct PassDecon {
+  TermStream stream;
+
+  PassDecon(TargetScope &scope) : stream(scope) { }
+};
+
+static uintptr_t tometa(Constructor *con) {
+  return reinterpret_cast<uintptr_t>(static_cast<void*>(con));
+}
+
+void RArg::pass_decon(PassDecon &p, std::unique_ptr<Term> self) {
+  p.stream.transfer(std::move(self));
+}
+
+void RLit::pass_decon(PassDecon &p, std::unique_ptr<Term> self) {
+  p.stream.transfer(std::move(self));
+}
+
+void RApp::pass_decon(PassDecon &p, std::unique_ptr<Term> self) {
+  update(p.stream.map());
+  p.stream.transfer(std::move(self));
+}
+
+void RPrim::pass_decon(PassDecon &p, std::unique_ptr<Term> self) {
+  update(p.stream.map());
+  p.stream.transfer(std::move(self));
+}
+
+void RGet::pass_decon(PassDecon &p, std::unique_ptr<Term> self) {
+  update(p.stream.map());
+  p.stream.transfer(std::move(self));
+}
+
+void RDes::pass_decon(PassDecon &p, std::unique_ptr<Term> self) {
+  update(p.stream.map());
+  p.stream.transfer(std::move(self));
+}
+
+void RCon::pass_decon(PassDecon &p, std::unique_ptr<Term> self) {
+  update(p.stream.map());
+  if (args.empty()) {
+    p.stream.transfer(std::move(self));
+  } else if (p.stream[args[0]]->id() != typeid(RGet)) {
+    p.stream.transfer(std::move(self));
+  } else {
+    size_t candidate = static_cast<RGet*>(p.stream[args[0]])->args[0];
+    bool optimize = p.stream[candidate]->meta == tometa(kind.get());
+    for (size_t i = 0; optimize && i < args.size(); ++i) {
+      Term *term = p.stream[args[i]];
+      if (term->id() != typeid(RGet)) {
+        optimize = false;
+      } else {
+        RGet *get = static_cast<RGet*>(term);
+        if (get->index != i || get->args[0] != candidate)
+          optimize = false;
+      }
+    }
+    if (optimize) {
+      p.stream.discard(candidate);
+    } else {
+      p.stream.transfer(std::move(self));
+    }
+  }
+}
+
+void RFun::pass_decon(PassDecon &p, std::unique_ptr<Term> self) {
+  p.stream.transfer(std::move(self));
+  CheckPoint body = p.stream.begin();
+
+  for (auto &x : terms)
+    x->pass_decon(p, std::move(x));
+
+  update(p.stream.map());
+
+  // Detect returns of a RCon equal to our first argument
+  // This is helpful because it makes it possible collapse cases in an RDes
+  Term *out = p.stream[output];
+  if (out->id() == typeid(RCon)) {
+    RCon *con = static_cast<RCon*>(out);
+    if (con->args.empty() && p.stream[body.target]->meta == tometa(con->kind.get()))
+      output = body.target;
+  }
+
+  terms = p.stream.end(body);
+}
+
+std::unique_ptr<Term> Term::pass_decon(std::unique_ptr<Term> term) {
+  TargetScope scope;
+  PassDecon pass(scope);
+  term->pass_decon(pass, std::move(term));
+  return scope.finish();
+}

--- a/src/inline.cpp
+++ b/src/inline.cpp
@@ -223,7 +223,7 @@ void RDes::pass_inline(PassInline &p, std::unique_ptr<Term> self) {
           cargs.back() = fnid+2;
           f->terms.emplace_back(new RArg());
           f->terms.emplace_back(new RApp(des->args[i], fnid+1));
-          f->terms.emplace_back(new RDes(std::move(cargs)));
+          f->terms.emplace_back(new RDes(sum, std::move(cargs)));
           PassInline q(p.common, fnid); // refs up to fun are unmodified
           f->pass_inline(q, std::unique_ptr<Term>(f));
         }

--- a/src/ssa.cpp
+++ b/src/ssa.cpp
@@ -213,6 +213,8 @@ std::unique_ptr<Term> Term::optimize(std::unique_ptr<Term> term, Runtime &runtim
   term = Term::pass_usage (std::move(term));
   term = Term::pass_sweep (std::move(term));
   term = Term::pass_inline(std::move(term), 20, runtime);
+  term = Term::pass_cases (std::move(term));
+  term = Term::pass_decon (std::move(term));
   term = Term::pass_purity(std::move(term), PRIM_EFFECT,  SSA_EFFECT);
   term = Term::pass_purity(std::move(term), PRIM_ORDERED, SSA_ORDERED);
   term = Term::pass_usage (std::move(term));

--- a/src/ssa.cpp
+++ b/src/ssa.cpp
@@ -102,7 +102,7 @@ std::unique_ptr<Term> RGet::clone(TargetScope &scope, size_t id) const {
 }
 
 void RDes::format(std::ostream &os, TermFormat &format) const {
-  os << "Des(";
+  os << "Des:" << sum->name << "(";
   format_args(os, format);
   os << ")\n";
 }

--- a/src/ssa.h
+++ b/src/ssa.h
@@ -212,8 +212,11 @@ struct RGet final : public Redux {
 };
 
 struct RDes final : public Redux {
+  std::shared_ptr<Sum> sum;
+
   // args = handlers for cases, then obj
-  RDes(std::vector<size_t> &&args_, const char *label_ = "") : Redux(label_, std::move(args_)) { }
+  RDes(const std::shared_ptr<Sum> &sum_, std::vector<size_t> &&args_, const char *label_ = "")
+   : Redux(label_, std::move(args_)), sum(sum_) { }
 
   std::unique_ptr<Term> clone(TargetScope &scope, size_t id) const override;
   void format(std::ostream &os, TermFormat &format) const override;

--- a/src/ssa.h
+++ b/src/ssa.h
@@ -31,6 +31,8 @@
 struct Value;
 struct Expr;
 struct SourceMap;
+struct PassCases;
+struct PassDecon;
 struct PassPurity;
 struct PassUsage;
 struct PassSweep;
@@ -75,6 +77,8 @@ struct Term {
   virtual bool tailCallOk() const = 0;
 
   // All terms must implement their pass behaviour
+  virtual void pass_cases (PassCases  &p) = 0;
+  virtual void pass_decon (PassDecon  &p, std::unique_ptr<Term> self) = 0;
   virtual void pass_purity(PassPurity &p) = 0;
   virtual void pass_usage (PassUsage  &p) = 0;
   virtual void pass_sweep (PassSweep  &p) = 0;
@@ -83,6 +87,8 @@ struct Term {
   virtual void pass_scope (PassScope  &p) = 0;
 
   // The top-level pass invocations
+  static std::unique_ptr<Term> pass_cases (std::unique_ptr<Term> term);
+  static std::unique_ptr<Term> pass_decon (std::unique_ptr<Term> term);
   static std::unique_ptr<Term> pass_purity(std::unique_ptr<Term> term, int pflag, size_t sflag);
   static std::unique_ptr<Term> pass_usage (std::unique_ptr<Term> term);
   static std::unique_ptr<Term> pass_sweep (std::unique_ptr<Term> term);
@@ -127,6 +133,8 @@ struct RArg final : public Leaf {
   void interpret(InterpretContext &context) override;
   bool tailCallOk() const override;
 
+  void pass_cases (PassCases  &p) override;
+  void pass_decon (PassDecon  &p, std::unique_ptr<Term> self) override;
   void pass_purity(PassPurity &p) override;
   void pass_usage (PassUsage  &p) override;
   void pass_sweep (PassSweep  &p) override;
@@ -145,6 +153,8 @@ struct RLit final : public Leaf {
   void interpret(InterpretContext &context) override;
   bool tailCallOk() const override;
 
+  void pass_cases (PassCases  &p) override;
+  void pass_decon (PassDecon  &p, std::unique_ptr<Term> self) override;
   void pass_purity(PassPurity &p) override;
   void pass_usage (PassUsage  &p) override;
   void pass_sweep (PassSweep  &p) override;
@@ -162,6 +172,8 @@ struct RApp final : public Redux {
   void interpret(InterpretContext &context) override;
   bool tailCallOk() const override;
 
+  void pass_cases (PassCases  &p) override;
+  void pass_decon (PassDecon  &p, std::unique_ptr<Term> self) override;
   void pass_purity(PassPurity &p) override;
   void pass_usage (PassUsage  &p) override;
   void pass_sweep (PassSweep  &p) override;
@@ -184,6 +196,8 @@ struct RPrim final : public Redux {
   void interpret(InterpretContext &context) override;
   bool tailCallOk() const override;
 
+  void pass_cases (PassCases  &p) override;
+  void pass_decon (PassDecon  &p, std::unique_ptr<Term> self) override;
   void pass_purity(PassPurity &p) override;
   void pass_usage (PassUsage  &p) override;
   void pass_sweep (PassSweep  &p) override;
@@ -203,6 +217,8 @@ struct RGet final : public Redux {
   void interpret(InterpretContext &context) override;
   bool tailCallOk() const override;
 
+  void pass_cases (PassCases  &p) override;
+  void pass_decon (PassDecon  &p, std::unique_ptr<Term> self) override;
   void pass_purity(PassPurity &p) override;
   void pass_usage (PassUsage  &p) override;
   void pass_sweep (PassSweep  &p) override;
@@ -223,6 +239,8 @@ struct RDes final : public Redux {
   void interpret(InterpretContext &context) override;
   bool tailCallOk() const override;
 
+  void pass_cases (PassCases  &p) override;
+  void pass_decon (PassDecon  &p, std::unique_ptr<Term> self) override;
   void pass_purity(PassPurity &p) override;
   void pass_usage (PassUsage  &p) override;
   void pass_sweep (PassSweep  &p) override;
@@ -243,6 +261,8 @@ struct RCon final : public Redux {
   void interpret(InterpretContext &context) override;
   bool tailCallOk() const override;
 
+  void pass_cases (PassCases  &p) override;
+  void pass_decon (PassDecon  &p, std::unique_ptr<Term> self) override;
   void pass_purity(PassPurity &p) override;
   void pass_usage (PassUsage  &p) override;
   void pass_sweep (PassSweep  &p) override;
@@ -270,6 +290,8 @@ struct RFun final : public Term {
   void interpret(InterpretContext &context) override;
   bool tailCallOk() const override;
 
+  void pass_cases (PassCases  &p) override;
+  void pass_decon (PassDecon  &p, std::unique_ptr<Term> self) override;
   void pass_purity(PassPurity &p) override;
   void pass_usage (PassUsage  &p) override;
   void pass_sweep (PassSweep  &p) override;

--- a/src/tossa.cpp
+++ b/src/tossa.cpp
@@ -136,7 +136,7 @@ static void doit(TargetScope &scope, TermStack *stack, Expr *expr) {
     }
     doit(scope, stack, des->arg.get());
     args.push_back(des->arg->meta);
-    des->meta = scope.append(new RDes(std::move(args)));
+    des->meta = scope.append(new RDes(des->sum, std::move(args)));
   } else if (expr->type == &Prim::type) {
     Prim *prim = static_cast<Prim*>(expr);
     std::vector<size_t> args;


### PR DESCRIPTION
For example,
```
export def orElse alt = match _
  Some a = Some a
  None   = alt
```

is optimized to
```
export def orElse alt x = match x
  Some _ = x
  None   = alt
```

This also makes it possible to completely elide some destructuring.

For example,
```
export def orElse = match _ _
  _ (Some a) = Some a
  (Some a) _ = Some a
  None None  = None
```
gets optimized to the exact same thing as the other two examples.

This is because the inner case-analysis of the first argument ends up with
two cases, both the identity function.