### PR TITLE
FreeBSD limits

### DIFF
--- a/src/job.cpp
+++ b/src/job.cpp
@@ -407,7 +407,6 @@ JobTable::JobTable(Database *db, double percent, bool verbose, bool quiet, bool 
   // We want 2 descriptors (stdout+stderr) per job.
   rlim_t requested = imp->max_children * 2 + MAX_SELF_FDS;
   rlim_t maximum = (limit.rlim_max == RLIM_INFINITY) ? OPEN_MAX : limit.rlim_max;
-  if (maximum > OPEN_MAX) maximum = OPEN_MAX;
   if (maximum > FD_SETSIZE) maximum = FD_SETSIZE;
 
   if (maximum < requested) {

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -394,11 +394,15 @@ JobTable::JobTable(Database *db, double percent, bool verbose, bool quiet, bool 
   // Calculate the maximum number of children to ever run
   imp->max_children = imp->limit * 100; // based on minimum 1% CPU utilization in Job::threads
   if (imp->max_children > MAX_CHILDREN) imp->max_children = MAX_CHILDREN; // wake hard cap
-#ifdef CHILD_MAX
-  if (imp->max_children > CHILD_MAX/2) imp->max_children = CHILD_MAX/2;   // limits.h
-#endif
+
   long sys_child_max = sysconf(_SC_CHILD_MAX);
-  if (sys_child_max != -1 && imp->max_children > sys_child_max/2) imp->max_children = sys_child_max/2;
+  if (sys_child_max != -1) {
+    if (imp->max_children > sys_child_max/2) imp->max_children = sys_child_max/2;
+  } else {
+#ifdef CHILD_MAX
+    if (imp->max_children > CHILD_MAX/2) imp->max_children = CHILD_MAX/2;   // limits.h
+#endif
+  }
 
 #ifndef OPEN_MAX
 #define OPEN_MAX 99999


### PR DESCRIPTION
I recently reran wake/master on freeBSD and found a regression when there were more cores on the virtual machine.
These three commits fix the issue.

The symptom was that child processes of wake had a limit of 64 file descriptors, which can cause even reasonable software to break.