### PR TITLE
Better SSA output

### DIFF
--- a/src/inline.cpp
+++ b/src/inline.cpp
@@ -131,6 +131,8 @@ static void rapp_inline(PassInline &p, std::unique_ptr<RApp> self) {
         x->pass_inline(q, std::move(x));
       }
       fun->update(q.stream.map());
+      // Keep the result label, if possible
+      if (!self->label.empty()) q.stream[fun->output]->label = std::move(self->label);
       p.stream.discard(fun->output, self->get(SSA_SINGLETON)); // replace App with function output
       if (singleton) {
         fun->output = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -530,13 +530,15 @@ int main(int argc, char **argv) {
   // Convert AST to optimized SSA
   std::unique_ptr<Term> ssa = Term::fromExpr(std::move(root));
   if (optim) ssa = Term::optimize(std::move(ssa), runtime);
-  ssa = Term::scope(std::move(ssa), runtime);
 
   // Upon request, dump out the SSA
   if (dumpssa) {
-    TermFormat format(true);
+    TermFormat format;
     ssa->format(std::cout, format);
   }
+
+  // Implement scope
+  ssa = Term::scope(std::move(ssa), runtime);
 
   // Exit without execution for these arguments
   if (noexecute) return 0;

--- a/src/ssa.cpp
+++ b/src/ssa.cpp
@@ -173,7 +173,22 @@ void RFun::format(std::ostream &os, TermFormat &format) const {
       os << ++format.id;
     }
     if (!x->label.empty()) os << " (" << x->label << ")";
-    os << " [" << x->flags << "," << x->meta << "] = ";
+    os << " [";
+    if ((x->flags & SSA_RECURSIVE) != 0) {
+      os << "R"; // recursive
+      // only functions can be recursive => not E or O
+    } else if ((x->flags & SSA_EFFECT) != 0) {
+      os << "E"; // effects
+      // if effects are produced, must also be ordered
+    } else if ((x->flags & SSA_ORDERED) != 0) {
+      os << "O"; // ordered
+    } else if ((x->flags & SSA_USED) == 0) {
+      os << "U"; // unused, and not an effect!
+    } else {
+      // nothing interesting
+      os << "-";
+    }
+    os << "," << x->meta << "] = ";
     x->format(os, format);
   }
   format.id -= terms.size();


### PR DESCRIPTION
When trying to debug what code was compiled to, the pre-scoped form of SSA is a lot easier to read.

You can see this output when you use the secret developer --stop-after-ssa option. This shows what the wake files got compiled into after applying optimization.