### PR TITLE
main: fix segfault on illegal input

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -434,6 +434,7 @@ int main(int argc, char **argv) {
     if (var->type == &VarRef::type) {
       top->body = std::unique_ptr<Expr>(new App(LOCATION, var.release(), new Prim(LOCATION, "cmdline")));
     } else {
+      top->body = std::unique_ptr<Expr>(new Prim(LOCATION, "cmdline"));
       std::cerr << "Specified target '" << argv[1] << "' is not a legal identifier" << std::endl;
       ok = false;
     }


### PR DESCRIPTION
Previously, `wake foo.kk` would output:
```
  Specified target 'foo.kk' is not a legal identifier
  Segmentation fault
```

Now it outputs:
```
  Specified target 'foo.kk' is not a legal identifier
  >>> Aborting without execution <<<
```