### PR TITLE
main: allow any expression as the first argument to wake

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -431,11 +431,10 @@ int main(int argc, char **argv) {
     cmdline = argv+2;
     Lexer lex(runtime.heap, command, "<target-argument>");
     std::unique_ptr<Expr> var(parse_command(lex));
-    if (var->type == &VarRef::type) {
+    if (var) {
       top->body = std::unique_ptr<Expr>(new App(LOCATION, var.release(), new Prim(LOCATION, "cmdline")));
     } else {
       top->body = std::unique_ptr<Expr>(new Prim(LOCATION, "cmdline"));
-      std::cerr << "Specified target '" << argv[1] << "' is not a legal identifier" << std::endl;
       ok = false;
     }
   } else {


### PR DESCRIPTION
This makes it possible to do stuff like:
```
   wake defaultScalaContext.getScalaCompiler a b c d
```
... and have the expression work as expected.

As discussed on slack.