### PR TITLE
Database tagging API

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -306,10 +306,13 @@ export def runJob p = match p
         def _ = wait (\_ badfinish job error) (badlaunch job error)
         job
 
-# Job => String => String => Unit
+# SString => String => Job => Job
 # Set the value of a tag on a Job
 # This is useful for post-build reflection into the database
-export def setJobTag job key value = prim "job_tag"
+export def setJobTag key value job =
+  def p job key value = prim "job_tag"
+  def _ = p job key value
+  job
 
 def toUsage (Pair (Pair status runtime) (Pair (Pair cputime membytes) (Pair ibytes obytes))) =
   Usage status runtime cputime membytes ibytes obytes

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -306,6 +306,11 @@ export def runJob p = match p
         def _ = wait (\_ badfinish job error) (badlaunch job error)
         job
 
+# Job => String => Unit
+# Add a tag to a Job
+# This is useful for post-build reflection into the database
+export def tagJob job tag = prim "job_tag"
+
 def toUsage (Pair (Pair status runtime) (Pair (Pair cputime membytes) (Pair ibytes obytes))) =
   Usage status runtime cputime membytes ibytes obytes
 

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -306,10 +306,10 @@ export def runJob p = match p
         def _ = wait (\_ badfinish job error) (badlaunch job error)
         job
 
-# Job => String => Unit
-# Add a tag to a Job
+# Job => String => String => Unit
+# Set the value of a tag on a Job
 # This is useful for post-build reflection into the database
-export def tagJob job tag = prim "job_tag"
+export def setJobTag job key value = prim "job_tag"
 
 def toUsage (Pair (Pair status runtime) (Pair (Pair cputime membytes) (Pair ibytes obytes))) =
   Usage status runtime cputime membytes ibytes obytes

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -189,7 +189,7 @@ std::string Database::open(bool wait, bool memory) {
     "  job_id  integer not null references jobs(job_id) on delete cascade,"
     "  uri     text,"
     "  content text,"
-    "  unique(job_id, uri) on conflict ignore);";
+    "  unique(job_id, uri) on conflict replace);";
 
   while (true) {
     char *fail;

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -68,6 +68,8 @@ struct Database::detail {
   sqlite3_stmt *revtop_order;
   sqlite3_stmt *setcrit_path;
   sqlite3_stmt *tag_job;
+  sqlite3_stmt *get_tags;
+  sqlite3_stmt *get_edges;
 
   long run_id;
   detail(bool debugdb_)
@@ -76,7 +78,7 @@ struct Database::detail {
      wipe_file(0), insert_file(0), update_file(0), get_log(0), replay_log(0), get_tree(0), add_stats(0),
      link_stats(0), detect_overlap(0), delete_overlap(0), find_prior(0), update_prior(0), delete_prior(0),
      find_owner(0), find_last(0), find_failed(0), fetch_hash(0), delete_jobs(0), delete_dups(0),
-     delete_stats(0), revtop_order(0), setcrit_path(0) { }
+     delete_stats(0), revtop_order(0), setcrit_path(0), tag_job(0), get_tags(0), get_edges(0) { }
 };
 
 Database::Database(bool debugdb) : imp(new detail(debugdb)) { }
@@ -298,14 +300,20 @@ std::string Database::open(bool wait, bool memory) {
     "  where stat_id not in (select stat_id from jobs)"
     "  order by stat_id desc limit 9999999 offset 4*(select count(*) from jobs))";
   const char *sql_revtop_order =
-    "select job_id from jobs where use_id=(select max(run_id) from runs) order by job_id desc;";
+    "select job_id from jobs where use_id=(select max(run_id) from runs) order by job_id desc";
   const char *sql_setcrit_path =
     "update stats set pathtime=runtime+("
     "  select coalesce(max(s.pathtime),0) from filetree f1, filetree f2, jobs j, stats s"
     "  where f1.job_id=?1 and f1.access=2 and f1.file_id=f2.file_id and f2.access=1 and f2.job_id=j.job_id and j.stat_id=s.stat_id"
-    ") where stat_id=(select stat_id from jobs where job_id=?1);";
+    ") where stat_id=(select stat_id from jobs where job_id=?1)";
   const char *sql_tag_job =
     "insert into tags(job_id, uri) values(?, ?)";
+  const char *sql_get_tags =
+    "select job_id, uri from tags";
+  const char *sql_get_edges =
+    "select distinct user.job_id as user, used.job_id as used"
+    "  from filetree user, filetree used"
+    "   where user.access=1 and user.file_id=used.file_id and used.access=2";
 
 #define PREPARE(sql, member)										\
   ret = sqlite3_prepare_v2(imp->db, sql, -1, &imp->member, 0);						\
@@ -347,6 +355,8 @@ std::string Database::open(bool wait, bool memory) {
   PREPARE(sql_revtop_order,   revtop_order);
   PREPARE(sql_setcrit_path,   setcrit_path);
   PREPARE(sql_tag_job,        tag_job);
+  PREPARE(sql_get_tags,       get_tags);
+  PREPARE(sql_get_edges,      get_edges);
 
   return "";
 }
@@ -397,6 +407,8 @@ void Database::close() {
   FINALIZE(revtop_order);
   FINALIZE(setcrit_path);
   FINALIZE(tag_job);
+  FINALIZE(get_tags);
+  FINALIZE(get_edges);
 
   if (imp->db) {
     int ret = sqlite3_close(imp->db);
@@ -985,4 +997,26 @@ std::vector<JobReflection> Database::explain(const std::string &file, int use, b
   bind_string (why, imp->find_owner, 1, file);
   bind_integer(why, imp->find_owner, 2, use);
   return find_all(this, imp->find_owner, verbose);
+}
+
+std::vector<JobEdge> Database::get_edges() {
+  std::vector<JobEdge> out;
+  while (sqlite3_step(imp->get_edges) == SQLITE_ROW) {
+    out.emplace_back(
+      sqlite3_column_int64(imp->get_edges, 0),
+      sqlite3_column_int64(imp->get_edges, 1));
+  }
+  finish_stmt("Could not retrieve edges", imp->get_edges, imp->debugdb);
+  return out;
+}
+
+std::vector<JobTag> Database::get_tags() {
+  std::vector<JobTag> out;
+  while (sqlite3_step(imp->get_tags) == SQLITE_ROW) {
+    out.emplace_back(
+      sqlite3_column_int64(imp->get_tags, 0),
+      rip_column(imp->get_tags, 1));
+  }
+  finish_stmt("Could not retrieve tags", imp->get_tags, imp->debugdb);
+  return out;
 }

--- a/src/database.h
+++ b/src/database.h
@@ -57,6 +57,18 @@ struct JobReflection {
   std::vector<FileReflection> outputs;
 };
 
+struct JobTag {
+  long job;
+  std::string uri;
+  JobTag(long job_, std::string &&uri_) : job(job_), uri(std::move(uri_)) { }
+};
+
+struct JobEdge {
+  long user;
+  long used;
+  JobEdge(long user_, long used_) : user(user_), used(used_) { }
+};
+
 struct Database {
   struct detail;
   std::unique_ptr<detail> imp;
@@ -146,6 +158,9 @@ struct Database {
 
   std::vector<JobReflection> last(
     bool verbose);
+
+  std::vector<JobEdge> get_edges();
+  std::vector<JobTag> get_tags();
 };
 
 #endif

--- a/src/database.h
+++ b/src/database.h
@@ -60,7 +60,9 @@ struct JobReflection {
 struct JobTag {
   long job;
   std::string uri;
-  JobTag(long job_, std::string &&uri_) : job(job_), uri(std::move(uri_)) { }
+  std::string content;
+  JobTag(long job_, std::string &&uri_, std::string &&content_)
+   : job(job_), uri(std::move(uri_)), content(std::move(content_)) { }
 };
 
 struct JobEdge {
@@ -123,7 +125,8 @@ struct Database {
 
   void tag_job(
     long job,
-    const std::string &uri);
+    const std::string &uri,
+    const std::string &content);
 
   void save_output( // call only if needs_build -> true
     long job,

--- a/src/database.h
+++ b/src/database.h
@@ -44,6 +44,7 @@ struct JobTag {
   long job;
   std::string uri;
   std::string content;
+  JobTag(JobTag &&o) = default;
   JobTag(long job_, std::string &&uri_, std::string &&content_)
    : job(job_), uri(std::move(uri_)), content(std::move(content_)) { }
 };

--- a/src/database.h
+++ b/src/database.h
@@ -40,6 +40,14 @@ struct Usage {
   Usage() : found(false) { }
 };
 
+struct JobTag {
+  long job;
+  std::string uri;
+  std::string content;
+  JobTag(long job_, std::string &&uri_, std::string &&content_)
+   : job(job_), uri(std::move(uri_)), content(std::move(content_)) { }
+};
+
 struct JobReflection {
   long job;
   std::string label;
@@ -55,14 +63,7 @@ struct JobReflection {
   std::vector<FileReflection> visible;
   std::vector<FileReflection> inputs;
   std::vector<FileReflection> outputs;
-};
-
-struct JobTag {
-  long job;
-  std::string uri;
-  std::string content;
-  JobTag(long job_, std::string &&uri_, std::string &&content_)
-   : job(job_), uri(std::move(uri_)), content(std::move(content_)) { }
+  std::vector<JobTag> tags;
 };
 
 struct JobEdge {

--- a/src/database.h
+++ b/src/database.h
@@ -152,6 +152,10 @@ struct Database {
     long modified);
 
   std::vector<JobReflection> explain(
+    long job,
+    bool verbose);
+
+  std::vector<JobReflection> explain(
     const std::string &file,
     int use,
     bool verbose);

--- a/src/database.h
+++ b/src/database.h
@@ -109,6 +109,10 @@ struct Database {
     Usage reality);
   std::vector<FileReflection> get_tree(int kind, long job);
 
+  void tag_job(
+    long job,
+    const std::string &uri);
+
   void save_output( // call only if needs_build -> true
     long job,
     int descriptor,

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -162,8 +162,13 @@ static void describe_shell(const std::vector<JobReflection> &jobs, bool debug, b
   }
 }
 
-void describe(const std::vector<JobReflection> &jobs, bool script, bool debug, bool verbose) {
-  if (script) {
+void describe(const std::vector<JobReflection> &jobs, bool script, bool debug, bool verbose, const char *taguri) {
+  if (taguri) {
+    for (auto &job : jobs)
+      for (auto &tag : job.tags)
+        if (tag.uri == taguri)
+          std::cout << tag.content << std::endl;
+  } else if (script) {
     describe_shell(jobs, debug, verbose);
   } else {
     describe_human(jobs, debug, verbose);

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -87,6 +87,13 @@ static void describe_human(const std::vector<JobReflection> &jobs, bool debug, b
       std::cout << "Stderr:";
       indent("  ", job.stderr_payload);
     }
+    if (!job.tags.empty()) {
+      std::cout << "Tags:" << std::endl;
+      for (auto &x : job.tags) {
+        std::cout << "  " << x.uri << ": ";
+        indent("    ", x.content);
+      }
+    }
   }
 }
 
@@ -144,6 +151,13 @@ static void describe_shell(const std::vector<JobReflection> &jobs, bool debug, b
     if (!job.stderr_payload.empty()) {
       std::cout << "# Stderr:";
       indent("#   ", job.stderr_payload);
+    }
+    if (!job.tags.empty()) {
+      std::cout << "# Tags:" << std::endl;
+      for (auto &x : job.tags) {
+        std::cout << "   " << x.uri << ": ";
+        indent("#     ", x.content);
+      }
     }
   }
 }

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -21,6 +21,10 @@
 #include "execpath.h"
 #include <iostream>
 #include <string>
+#include <deque>
+#include <unordered_map>
+#include <re2/re2.h>
+#include <assert.h>
 
 #define SHORT_HASH 8
 
@@ -150,4 +154,164 @@ void describe(const std::vector<JobReflection> &jobs, bool script, bool debug, b
   } else {
     describe_human(jobs, debug, verbose);
   }
+}
+
+class BitVector {
+public:
+  BitVector() : imp() { }
+  BitVector(BitVector &&x) : imp(std::move(x.imp)) { }
+
+  bool get(size_t i) const;
+  void toggle(size_t i);
+  long max() const;
+
+  // Bulk operators
+  BitVector& operator |= (const BitVector &o);
+  void clear(const BitVector &o);
+
+private:
+  std::vector<uint64_t> imp;
+};
+
+bool BitVector::get(size_t i) const {
+  size_t j = i / 64, k = i % 64;
+  if (j >= imp.size()) return false;
+  return (imp[j] >> k) & 1;
+}
+
+void BitVector::toggle(size_t i) {
+  size_t j = i / 64, k = i % 64;
+  if (j >= imp.size()) imp.resize(j+1, 0);
+  imp[j] ^= 1 << k;
+}
+
+long BitVector::max() const {
+  size_t i = imp.size();
+  do {
+    uint64_t x = imp[--i];
+    if (x != 0) {
+      // Find the highest set bit
+      int best = 0;
+      for (int i = 0; i < 64; ++i)
+        if (((x >> i) & 1)) best = i;
+      return (i*64) + best;
+    }
+  } while (i != 0);
+  return -1;
+}
+
+BitVector& BitVector::operator |= (const BitVector &o) {
+  size_t both = std::min(imp.size(), o.imp.size());
+  for (size_t i = 0; i < both; ++i)
+    imp[i] |= o.imp[i];
+  if (imp.size() < o.imp.size())
+    imp.insert(imp.end(), o.imp.begin() + both, o.imp.end());
+  return *this;
+}
+
+void BitVector::clear(const BitVector &o) {
+  size_t both = std::min(imp.size(), o.imp.size());
+  for (size_t i = 0; i < both; ++i)
+    imp[i] &= ~o.imp[i];
+}
+
+struct GraphNode {
+  size_t usedUp, usesUp;
+  std::vector<long> usedBy;
+  std::vector<long> uses;
+  BitVector closure;
+  GraphNode() : usedUp(0), usesUp(0) { }
+};
+
+JAST create_tagdag(Database &db, const std::string &tagExpr) {
+  RE2 exp(tagExpr);
+
+  // Pick only those tags that match the RegExp
+  std::unordered_map<long, std::string> relevant;
+  for (auto &tag : db.get_tags())
+    if (RE2::FullMatch(tag.uri, exp))
+      relevant[tag.job] = std::move(tag.uri);
+
+  // Create a bidirectional view of the graph
+  std::unordered_map<long, GraphNode> graph;
+  auto edges = db.get_edges();
+  for (auto &x : edges) {
+    graph[x.user].uses.push_back(x.used);
+    graph[x.used].usedBy.push_back(x.user);
+  }
+
+  // Working queue for Job ids
+  std::deque<long> queue;
+  // Compressed map for URIs
+  std::vector<JobTag> uris;
+
+  // Explore from all nodes which use nothing (ie: build leafs)
+  for (auto &n : graph)
+    if (n.second.uses.empty())
+      queue.push_back(n.first);
+
+  // As we explore, accumulate the transitive closure of relevant nodes via BitVector
+  while (!queue.empty()) {
+    long job = queue.front();
+    queue.pop_front();
+    GraphNode &me = graph[job];
+
+    // Compute the closure over anything relevant we use
+    for (auto usesJob : me.uses)
+      me.closure |= graph[usesJob].closure;
+
+    // If we are relevant, add us to the bitvector, and top-sort the relevant jobs
+    auto rel = relevant.find(job);
+    if (rel != relevant.end()) {
+      me.closure.toggle(uris.size());
+      uris.emplace_back(job, std::move(rel->second));
+    }
+
+    // Enqueue anything for which we are the last dependent
+    for (auto userJob : me.usedBy) {
+      GraphNode &user = graph[userJob];
+      if (++user.usesUp == user.uses.size())
+        queue.push_back(userJob);
+    }
+  }
+
+  // Explore from nodes used by nothing (ie: build targets)
+  for (auto &n : graph)
+    if (n.second.usedBy.empty())
+      queue.push_back(n.first);
+
+  // As we explore, emit those nodes which are relevant to JSON
+  JAST out(JSON_ARRAY);
+  while (!queue.empty()) {
+    long job = queue.front();
+    queue.pop_front();
+    GraphNode &me = graph[job];
+
+    // Enqueue anything for which we are the last user
+    for (auto usesJob : me.uses) {
+      GraphNode &uses = graph[usesJob];
+      if (++uses.usedUp == uses.usedBy.size())
+        queue.push_back(usesJob);
+    }
+
+    // If we are a relevant node, compute the closure
+    if (relevant.find(job) == relevant.end()) continue;
+
+    // Get our own name
+    long max = me.closure.max();
+    assert (max != -1 && me.closure.get(max));
+    me.closure.toggle(max);
+
+    JAST &entry = out.add(JSON_OBJECT);
+    entry.add("uri", std::move(uris[max].uri));
+    JAST &deps = entry.add("deps", JSON_ARRAY);
+
+    while ((max = me.closure.max()) != -1) {
+      deps.add(std::string(uris[max].uri));
+      // Elminate transitively reachable children
+      me.closure.clear(graph[uris[max].job].closure);
+    }
+  }
+
+  return out;
 }

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -264,7 +264,7 @@ JAST create_tagdag(Database &db, const std::string &tagExpr) {
     auto rel = relevant.find(job);
     if (rel != relevant.end()) {
       me.closure.toggle(uris.size());
-      uris.emplace_back(job, std::move(rel->second));
+      uris.emplace_back(job, std::move(rel->second), "");
     }
 
     // Enqueue anything for which we are the last dependent

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -189,7 +189,7 @@ public:
   void clear(const BitVector &o);
 
 private:
-  std::vector<uint64_t> imp;
+  mutable std::vector<uint64_t> imp;
 };
 
 bool BitVector::get(size_t i) const {
@@ -205,17 +205,18 @@ void BitVector::toggle(size_t i) {
 }
 
 long BitVector::max() const {
-  size_t i = imp.size();
-  do {
-    uint64_t x = imp[--i];
+  while (!imp.empty()) {
+    uint64_t x = imp.back();
     if (x != 0) {
       // Find the highest set bit
       int best = 0;
       for (int i = 0; i < 64; ++i)
         if (((x >> i) & 1)) best = i;
-      return (i*64) + best;
+      return ((imp.size()-1)*64) + best;
+    } else {
+      imp.pop_back();
     }
-  } while (i != 0);
+  }
   return -1;
 }
 

--- a/src/describe.h
+++ b/src/describe.h
@@ -22,7 +22,7 @@
 #include "json5.h"
 #include <vector>
 
-void describe(const std::vector<JobReflection> &jobs, bool script, bool debug, bool verbose);
+void describe(const std::vector<JobReflection> &jobs, bool script, bool debug, bool verbose, const char *tag);
 JAST create_tagdag(Database &db, const std::string &tag);
 
 #endif

--- a/src/describe.h
+++ b/src/describe.h
@@ -19,8 +19,10 @@
 #define DESCRIBE
 
 #include "database.h"
+#include "json5.h"
 #include <vector>
 
 void describe(const std::vector<JobReflection> &jobs, bool script, bool debug, bool verbose);
+JAST create_tagdag(Database &db, const std::string &tag);
 
 #endif

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -1444,19 +1444,21 @@ static PRIMFN(prim_job_finish) {
 }
 
 static PRIMTYPE(type_job_tag) {
-  return args.size() == 2 &&
+  return args.size() == 3 &&
     args[0]->unify(Job::typeVar) &&
     args[1]->unify(String::typeVar) &&
+    args[2]->unify(String::typeVar) &&
     out->unify(Data::typeUnit);
 }
 
 static PRIMFN(prim_job_tag) {
-  EXPECT(2);
+  EXPECT(3);
   JOB(job, 0);
-  STRING(tag, 1);
+  STRING(uri, 1);
+  STRING(content, 2);
 
   runtime.heap.reserve(reserve_unit());
-  job->db->tag_job(job->job, tag->as_str());
+  job->db->tag_job(job->job, uri->as_str(), content->as_str());
   RETURN(claim_unit(runtime.heap));
 }
 

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -1443,6 +1443,23 @@ static PRIMFN(prim_job_finish) {
   RETURN(claim_unit(runtime.heap));
 }
 
+static PRIMTYPE(type_job_tag) {
+  return args.size() == 2 &&
+    args[0]->unify(Job::typeVar) &&
+    args[1]->unify(String::typeVar) &&
+    out->unify(Data::typeUnit);
+}
+
+static PRIMFN(prim_job_tag) {
+  EXPECT(2);
+  JOB(job, 0);
+  STRING(tag, 1);
+
+  runtime.heap.reserve(reserve_unit());
+  job->db->tag_job(job->job, tag->as_str());
+  RETURN(claim_unit(runtime.heap));
+}
+
 static PRIMTYPE(type_add_hash) {
   return args.size() == 2 &&
     args[0]->unify(String::typeVar) &&
@@ -1645,6 +1662,7 @@ void prim_register_job(JobTable *jobtable, PrimMap &pmap) {
   prim_register(pmap, "job_launch", prim_job_launch, type_job_launch,  PRIM_IMPURE, jobtable);
   prim_register(pmap, "job_virtual",prim_job_virtual,type_job_virtual, PRIM_IMPURE, jobtable);
   prim_register(pmap, "job_finish", prim_job_finish, type_job_finish,  PRIM_IMPURE);
+  prim_register(pmap, "job_tag",    prim_job_tag,    type_job_tag,     PRIM_IMPURE);
   prim_register(pmap, "job_fail_launch", prim_job_fail_launch, type_job_fail, PRIM_IMPURE);
   prim_register(pmap, "job_fail_finish", prim_job_fail_finish, type_job_fail, PRIM_IMPURE);
   prim_register(pmap, "job_kill",   prim_job_kill,   type_job_kill,    PRIM_IMPURE);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,29 +300,29 @@ int main(int argc, char **argv) {
   }
 
   if (job) {
-    auto hits = db.explain(std::atol(job), verbose);
+    auto hits = db.explain(std::atol(job), verbose || tag);
     describe(hits, script, debug, verbose, tag);
     if (hits.empty()) std::cerr << "Job '" << job << "' was not found in the database!" << std::endl;
   }
 
   if (input) {
     for (int i = 1; i < argc; ++i) {
-      describe(db.explain(make_canonical(wake_cwd + argv[i]), 1, verbose), script, debug, verbose, tag);
+      describe(db.explain(make_canonical(wake_cwd + argv[i]), 1, verbose || tag), script, debug, verbose, tag);
     }
   }
 
   if (output) {
     for (int i = 1; i < argc; ++i) {
-      describe(db.explain(make_canonical(wake_cwd + argv[i]), 2, verbose), script, debug, verbose, tag);
+      describe(db.explain(make_canonical(wake_cwd + argv[i]), 2, verbose || tag), script, debug, verbose, tag);
     }
   }
 
   if (last) {
-    describe(db.last(verbose), script, debug, verbose, tag);
+    describe(db.last(verbose || tag), script, debug, verbose, tag);
   }
 
   if (failed) {
-    describe(db.failed(verbose), script, debug, verbose, tag);
+    describe(db.failed(verbose || tag), script, debug, verbose, tag);
   }
 
   if (tagdag) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,6 +133,7 @@ int main(int argc, char **argv) {
     { 0,   "stop-after-ssa",        GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "no-optimize",           GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "tag-dag",               GOPT_ARGUMENT_REQUIRED  },
+    { 0,   "tag",                   GOPT_ARGUMENT_REQUIRED  },
     { 0,   "export-api",            GOPT_ARGUMENT_REQUIRED  },
     { 0,   "stdout",                GOPT_ARGUMENT_REQUIRED  },
     { 0,   "stderr",                GOPT_ARGUMENT_REQUIRED  },
@@ -181,6 +182,7 @@ int main(int argc, char **argv) {
   const char *job     = arg(options, "job")->argument;
   char       *shebang = arg(options, "shebang")->argument;
   const char *tagdag  = arg(options, "tag-dag")->argument;
+  const char *tag     = arg(options, "tag")->argument;
   const char *api     = arg(options, "export-api")->argument;
   const char *fd1     = arg(options, "stdout")->argument;
   const char *fd2     = arg(options, "stderr")->argument;
@@ -299,28 +301,28 @@ int main(int argc, char **argv) {
 
   if (job) {
     auto hits = db.explain(std::atol(job), verbose);
-    describe(hits, script, debug, verbose);
+    describe(hits, script, debug, verbose, tag);
     if (hits.empty()) std::cerr << "Job '" << job << "' was not found in the database!" << std::endl;
   }
 
   if (input) {
     for (int i = 1; i < argc; ++i) {
-      describe(db.explain(make_canonical(wake_cwd + argv[i]), 1, verbose), script, debug, verbose);
+      describe(db.explain(make_canonical(wake_cwd + argv[i]), 1, verbose), script, debug, verbose, tag);
     }
   }
 
   if (output) {
     for (int i = 1; i < argc; ++i) {
-      describe(db.explain(make_canonical(wake_cwd + argv[i]), 2, verbose), script, debug, verbose);
+      describe(db.explain(make_canonical(wake_cwd + argv[i]), 2, verbose), script, debug, verbose, tag);
     }
   }
 
   if (last) {
-    describe(db.last(verbose), script, debug, verbose);
+    describe(db.last(verbose), script, debug, verbose, tag);
   }
 
   if (failed) {
-    describe(db.failed(verbose), script, debug, verbose);
+    describe(db.failed(verbose), script, debug, verbose, tag);
   }
 
   if (tagdag) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,6 +130,7 @@ int main(int argc, char **argv) {
     { 0,   "stop-after-type-check", GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "stop-after-ssa",        GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "no-optimize",           GOPT_ARGUMENT_FORBIDDEN },
+    { 0,   "tag-dag",               GOPT_ARGUMENT_REQUIRED  },
     { 0,   "export-api",            GOPT_ARGUMENT_REQUIRED  },
     { 0,   "stdout",                GOPT_ARGUMENT_REQUIRED  },
     { 0,   "stderr",                GOPT_ARGUMENT_REQUIRED  },
@@ -176,6 +177,7 @@ int main(int argc, char **argv) {
   const char *in      = arg(options, "in")->argument;
   const char *exec    = arg(options, "exec")->argument;
   char       *shebang = arg(options, "shebang")->argument;
+  const char *tagdag  = arg(options, "tag-dag")->argument;
   const char *api     = arg(options, "export-api")->argument;
   const char *fd1     = arg(options, "stdout")->argument;
   const char *fd2     = arg(options, "stderr")->argument;
@@ -252,7 +254,7 @@ int main(int argc, char **argv) {
   bool targets = argc == 1 && !noargs;
 
   bool nodb = init;
-  bool noparse = nodb || output || input || last || failed;
+  bool noparse = nodb || output || input || last || failed || tagdag;
   bool notype = noparse || parse;
   bool noexecute = notype || html || tcheck || dumpssa || global || exports || api || targets;
 
@@ -310,6 +312,11 @@ int main(int argc, char **argv) {
 
   if (failed) {
     describe(db.failed(verbose), script, debug, verbose);
+  }
+
+  if (tagdag) {
+    JAST json = create_tagdag(db, tagdag);
+    std::cout << json << std::endl;
   }
 
   if (noparse) return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,7 @@ void print_help(const char *argv0) {
     << "    --init      DIR  Create or replace a wake.db in the specified directory"     << std::endl
     << "    --input  -i FILE Report recorded meta-data for jobs which read FILES"        << std::endl
     << "    --output -o FILE Report recorded meta-data for jobs which wrote FILES"       << std::endl
+    << "    --job       JOB  Report recorded meta-data for the specified job id"         << std::endl
     << "    --last     -l    Report recorded meta-data for all jobs run by last build"   << std::endl
     << "    --failed   -f    Report recorded meta-data for jobs which failed last build" << std::endl
     << "    --verbose  -v    Report recorded standard output and error of matching jobs" << std::endl
@@ -113,6 +114,7 @@ int main(int argc, char **argv) {
     { 'C', "chdir",                 GOPT_ARGUMENT_REQUIRED  },
     { 0,   "in",                    GOPT_ARGUMENT_REQUIRED  },
     { 'x', "exec",                  GOPT_ARGUMENT_REQUIRED  },
+    { 0,   "job",                   GOPT_ARGUMENT_REQUIRED  },
     { 'i', "input",                 GOPT_ARGUMENT_FORBIDDEN },
     { 'o', "output",                GOPT_ARGUMENT_FORBIDDEN },
     { 'l', "last",                  GOPT_ARGUMENT_FORBIDDEN },
@@ -176,6 +178,7 @@ int main(int argc, char **argv) {
   const char *chdir   = arg(options, "chdir")->argument;
   const char *in      = arg(options, "in")->argument;
   const char *exec    = arg(options, "exec")->argument;
+  const char *job     = arg(options, "job")->argument;
   char       *shebang = arg(options, "shebang")->argument;
   const char *tagdag  = arg(options, "tag-dag")->argument;
   const char *api     = arg(options, "export-api")->argument;
@@ -254,7 +257,7 @@ int main(int argc, char **argv) {
   bool targets = argc == 1 && !noargs;
 
   bool nodb = init;
-  bool noparse = nodb || output || input || last || failed || tagdag;
+  bool noparse = nodb || job || output || input || last || failed || tagdag;
   bool notype = noparse || parse;
   bool noexecute = notype || html || tcheck || dumpssa || global || exports || api || targets;
 
@@ -292,6 +295,12 @@ int main(int argc, char **argv) {
     sip_key[0] = dist(rd);
     sip_key[1] = dist(rd);
     db.entropy(&sip_key[0], 2);
+  }
+
+  if (job) {
+    auto hits = db.explain(std::atol(job), verbose);
+    describe(hits, script, debug, verbose);
+    if (hits.empty()) std::cerr << "Job '" << job << "' was not found in the database!" << std::endl;
   }
 
   if (input) {


### PR DESCRIPTION
Jobs can now have key-value annotations added to them in the database.
This is useful for tools which will introspect the database post-build.

For example, CI or a build server protocol implementation.

The new functionality works like this:
- setJobTag job "key" "value"
- wake -v --job &lt;job-id&gt; # Dump all tags for the specified job
- wake --tag-dag &lt;regexp&gt; # Dump a dependency DAG including only the tagged jobs
- wake --get-tag &lt;job-id&gt; &lt;tag-name&gt;