### PR TITLE
exception: don't report C++ line numbers on panic

### DIFF
--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -64,8 +64,7 @@ static PRIMFN(prim_panic) {
   std::stringstream str;
   str << "PANIC: " << arg0->c_str() << std::endl;
   status_write(STREAM_ERROR, str.str());
-  bool panic_called = true;
-  REQUIRE(!panic_called);
+  require_fail("", 1, runtime, scope);
 }
 
 static PRIMTYPE(type_id) {


### PR DESCRIPTION
Printing out a failing REQUIRE line number for the c++ code on calls to `panic` was confusing.

This does not yet change panic to unreachable and then add back a "real" panic. That may be a follow-up PR down the road.