### PR TITLE
Fix FUSE exit race

### DIFF
--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -1496,14 +1496,10 @@ int main(int argc, char *argv[])
 		close(null);
 	}
 
-	fprintf(stderr, "Starting main FUSE event loop\n");
-	fflush(stderr);
 	if (fuse_loop(fh) != 0) {
 		fprintf(stderr, "fuse_loop failed");
 		goto unmount;
 	}
-	fprintf(stderr, "Exited FUSE event loop cleanly\n");
-	fflush(stderr);
 
 	status = 0;
 

--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -1294,7 +1294,7 @@ static void *wakefuse_init(struct fuse_conn_info *conn)
 
 static void handle_exit(int sig)
 {
-	// It is possible that SIGLARM still gets delivered after a successful call to cancel_exit
+	// It is possible that SIGALRM still gets delivered after a successful call to cancel_exit
 	// In that case, we need to uphold the promise of cancel_exit
 	if (sig == SIGALRM && 0 == exit_attempts && !context.should_exit()) return;
 

--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -212,25 +212,10 @@ int main(int argc, char *argv[])
 		map_id("/proc/self/uid_map", euid, real_euid);
 		map_id("/proc/self/gid_map", egid, real_egid);
 
-		// Detect if there is a problem with access() before mount
-		if (access(rpath.c_str(), X_OK) != 0)
-			std::cerr << "access " << rpath << ": " << strerror(errno) << std::endl;
-		if (access(mpath.c_str(), X_OK) != 0)
-			std::cerr << "access " << mpath << ": " << strerror(errno) << std::endl;
-		if (access(cwd.c_str(), X_OK) != 0)
-			std::cerr << "access " << cwd << ": " << strerror(errno) << std::endl;
-
 		// Mount the fuse-visibility-protected view onto the workspace
-		int attempt = 0;
-		while (0 != mount(rpath.c_str(), workspace.c_str(), NULL, MS_BIND, NULL)) {
+		if (0 != mount(rpath.c_str(), workspace.c_str(), NULL, MS_BIND, NULL)) {
 			std::cerr << "mount " << rpath << ": " << strerror(errno) << std::endl;
-			if (attempt != 3) {
-				sleep(1);
-				++attempt;
-			} else {
-				std::cerr << "Giving up; failed to mount fuse-protected view of the workspace" << std::endl;
-				exit(2);
-			}
+			exit(1);
 		}
 
 		std::string dir = workspace + "/" + subdir;


### PR DESCRIPTION
If a client tried to connect to the FUSE daemon between the time when the FUSE daemon started to exit and when it succeeded in exiting, there was a race condition, whereby the open of '.f.fuse-waked' succeeds, but the daemon exits anyway, leaving the client unable to make forward progress.

The solution taken is to recognize that once an exit attempt had been made, it cannot be stopped.  Instead, any future attempts to open '.f.fuse-waked' must fail.  Careful synchonization is needed, because canceling the SIGALRM does not guarantee the absence of invocations of handle_exit.

Revert #521 since that debug code was/is not actually helpful... and should now be unreachable, anyway.