### PR TITLE
getrusage: add platform-dependent maxrss accessor

### DIFF
--- a/common/membytes.h
+++ b/common/membytes.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MEMBYTES_H
+#define MEMBYTES_H
+
+#if   defined(__APPLE__)
+#define MEMBYTES(ru)	(ru.ru_maxrss)
+#elif defined(__FreeBSD__)
+#define MEMBYTES(ru)    (ru.ru_maxrss*1024)
+#elif defined(__linux__)
+#define MEMBYTES(ru)    (ru.ru_maxrss*1024)
+#elif defined(__NetBSD__)
+#define MEMBYTES(ru)    (ru.ru_maxrss*1024)
+#elif defined(__OpenBSD__)
+#define MEMBYTES(ru)    (ru.ru_maxrss*1024)
+#elif defined(__sun)
+#define MEMBYTES(ru)    (ru.ru_maxrss*getpagesize())
+#else
+#error Missing definition to access maxrss on this platform
+#endif
+
+#endif

--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -30,6 +30,7 @@
 
 #include "json5.h"
 #include "execpath.h"
+#include "membytes.h"
 
 #ifdef __linux__
 // For unshare and bind mount
@@ -291,7 +292,7 @@ int main(int argc, char *argv[])
 	ofs << "{\"usage\":{\"status\":" << status
 	  << ",\"runtime\":" << (stop.tv_sec - start.tv_sec + (stop.tv_usec - start.tv_usec)/1000000.0)
 	  << ",\"cputime\":" << (rusage.ru_utime.tv_sec + rusage.ru_stime.tv_sec + (rusage.ru_utime.tv_usec + rusage.ru_stime.tv_usec)/1000000.0)
-	  << ",\"membytes\":" << rusage.ru_maxrss
+	  << ",\"membytes\":" << MEMBYTES(rusage)
 	  << ",\"inbytes\":" << jast.get("ibytes").value
 	  << ",\"outbytes\":" << jast.get("obytes").value
 	  << "},\"inputs\":[";

--- a/preload/wrap.cpp
+++ b/preload/wrap.cpp
@@ -34,6 +34,7 @@
 #include "json5.h"
 #include "execpath.h"
 #include "unlink.h"
+#include "membytes.h"
 
 #define STR2(x) #x
 #define STR(x) STR2(x)
@@ -346,7 +347,7 @@ int main(int argc, const char **argv) {
   out << "{\"usage\":{\"status\":" << status
     << ",\"runtime\":" << (stop.tv_sec - start.tv_sec + (stop.tv_usec - start.tv_usec)/1000000.0)
     << ",\"cputime\":" << (rusage.ru_utime.tv_sec + rusage.ru_stime.tv_sec + (rusage.ru_utime.tv_usec + rusage.ru_stime.tv_usec)/1000000.0)
-    << ",\"membytes\":" << rusage.ru_maxrss
+    << ",\"membytes\":" << MEMBYTES(rusage)
     << ",\"inbytes\":" << rusage.ru_inblock * UINT64_C(512)
     << ",\"outbytes\":" << rusage.ru_oublock * UINT64_C(512)
     << "},\"inputs\":[";

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -24,6 +24,7 @@
 #include "execpath.h"
 #include "status.h"
 #include "shell.h"
+#include "membytes.h"
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/select.h>
@@ -829,7 +830,7 @@ bool JobTable::wait(Runtime &runtime) {
           i.job->reality.runtime  = i.runtime(now);
           i.job->reality.cputime  = (rusage.ru_utime.tv_sec  + rusage.ru_stime.tv_sec) +
                                     (rusage.ru_utime.tv_usec + rusage.ru_stime.tv_usec)/1000000.0;
-          i.job->reality.membytes = rusage.ru_maxrss;
+          i.job->reality.membytes = MEMBYTES(rusage);
           i.job->reality.ibytes   = rusage.ru_inblock * UINT64_C(512);
           i.job->reality.obytes   = rusage.ru_oublock * UINT64_C(512);
           runtime.heap.guarantee(WJob::reserve());


### PR DESCRIPTION
Fixes #530.

It turns out that the units of ru_maxrss is platform dependent.

Put all the platforms I could easily find documentation for into a new
shared header file.  Use this header macro instead of ru_maxrss.