### PR TITLE
BSP expand message paths

### DIFF
--- a/bsp/bsp.cpp
+++ b/bsp/bsp.cpp
@@ -279,16 +279,12 @@ void ExecuteWakeProcess::executeLine(int i, std::string &&line) {
   }
 }
 
-static void makeAbsolute(JAST &node) {
-  for (auto &child : node.children) makeAbsolute(child.second);
+static void adjustJSON(JAST &node) {
+  struct timeval tv;
+  for (auto &child : node.children) adjustJSON(child.second);
   if (node.kind == JSON_STR && node.value.compare(0, sizeof(workspace)-1, &workspace[0]) == 0) {
     node.value = rooturi + node.value.substr(sizeof(workspace)-1);
   }
-}
-
-static void makeTime(JAST &node) {
-  struct timeval tv;
-  for (auto &child : node.children) makeTime(child.second);
   if (node.kind == JSON_STR && node.value == "time://now" && gettimeofday(&tv, 0) == 0) {
     node.value = std::to_string(tv.tv_sec*1000L + tv.tv_usec/1000);
   }
@@ -334,8 +330,7 @@ void EnumerateTargetsState::gotLine(JAST &row) {
     for (auto &dep : target.get("dependencies").children)
       dep.second.add("uri", std::string(idmap[dep.second.value]));
     // Resolve workspace:// identifiers
-    makeAbsolute(target);
-    makeTime(target);
+    adjustJSON(target);
     targets.children.emplace_back(std::string(), std::move(target));
   }
 }
@@ -360,8 +355,7 @@ struct CompileState : public ExecuteWakeProcess {
 };
 
 void CompileState::gotLine(JAST &row) {
-  makeAbsolute(row);
-  makeTime(row);
+  adjustJSON(row);
   sendMessage(row);
 }
 
@@ -413,8 +407,7 @@ ExtractBSPDocument::ExtractBSPDocument(const std::string &method, const JAST &pa
 }
 
 void ExtractBSPDocument::gotLine(JAST &row) {
-  makeAbsolute(row);
-  makeTime(row);
+  adjustJSON(row);
   items.children.emplace_back(std::string(), std::move(row));
 }
 


### PR DESCRIPTION
The BSP previously only transformed workspace:/// URIs in tags. Now it does it for messages too.