### PR TITLE
Add 'workspace' mount type

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -465,6 +465,14 @@ export def makeJSONRunner plan =
           "stdin"       → JString stdin,
           "resources"   → res | map JString | JArray,
           "version"     → JString version,
+          "mounts"      → JArray (
+            JObject (
+              "type"        → JString "workspace",
+              "destination" → JString ".",
+              Nil
+            ),
+            Nil
+          ),
           "usage"       → JObject (
             "status"    → JInteger status,
             "runtime"   → JDouble  runtime,


### PR DESCRIPTION
The workspace location is no longer hardcoded in fuse-wake, but instead hardcoded via wakelang (where it could become flexible later)

* Add `type` field to fuse-wake mount fields, define `bind` and `workspace` as fields.
* Remove the automatic 'hide fuse' mount of `workspace/.fuse/$PID -> workspace`.
* In wakelang's `makeJSONRunner`, add `workspace` mount type to replace the above 'hide fuse'.
* Consolidate logic for choosing the directory to run the job in (on the fuse-wake side).

The `workspace` mount type is just a `bind` mount type, except that the `source` is not provided by the json, instead it is the `.fuse/$PID` directory.