### PR TITLE
Move 'ifdef linux' to remove warning on MacOS, add MacOS CI test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,23 @@
+name: "Test"
+
+on:
+    pull_request:
+
+jobs:
+    build:
+        name: "MacOS build"
+        runs-on: macos-latest
+
+        steps:
+            - name: "Clone wake"
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+
+            - name: "Install deps"
+              run: |
+                brew install re2
+                brew install --cask osxfuse
+
+            - name: "Build wake"
+              run: make all -j3

--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -130,8 +130,6 @@ static bool do_mounts_from_json(const JAST& jast, const std::string& fuse_mount_
 	return true;
 }
 
-#endif
-
 static bool get_workspace_dir(const JAST& jast,
 		const std::string& host_workspace_dir, std::string& out)
 {
@@ -149,6 +147,7 @@ static bool get_workspace_dir(const JAST& jast,
 	}
 	return false;
 }
+#endif
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
This builds `wake` for MacOS.

I suspect that it's using the preload runner to do the build of wake, as `osxfuse` claims that it needs a reboot when it is being installed, but it should at least build-check the fuse codepath


```
osxfuse requires a kernel extension to work.
If the installation fails, retry after you enable it in:
  System Preferences → Security & Privacy → General

For more information, refer to vendor documentation or this Apple Technical Note:
  https://developer.apple.com/library/content/technotes/tn2459/_index.html

You must reboot for the installation of osxfuse to take effect.
```