### PR TITLE
Always use 'recursive' for bind mounts

### DIFF
--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -68,7 +68,7 @@ static bool bind_mount(const std::string& source, const std::string& destination
 	const char* src = source.c_str();
 	const char* dest = destination.c_str();
 
-	if (0 != mount(src, dest, NULL, MS_BIND, NULL)) {
+	if (0 != mount(src, dest, NULL, MS_BIND | MS_REC, NULL)) {
 		std::cerr << "bind mount (" << source << " -> " << destination << "): "
 			<< strerror(errno) << std::endl;
 		return false;
@@ -76,7 +76,7 @@ static bool bind_mount(const std::string& source, const std::string& destination
 	// Re-mount to set destination as read-only.
 	// Source filesystem must not have 'MS_NODEV' (a.k.a. 'nodev') set.
 	if (readonly) {
-		if (0 != mount(src, dest, NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL)) {
+		if (0 != mount(src, dest, NULL, MS_BIND | MS_REC | MS_RDONLY | MS_REMOUNT, NULL)) {
 			std::cerr << "bind mount (" << source << " -> " << destination << "): "
 				<< strerror(errno) << std::endl;
 			return false;

--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -63,6 +63,9 @@ static void map_id(const char *file, uint32_t from, uint32_t to)
 	write_file(file, buf, strlen(buf));
 }
 
+// Inside a user namespace, you are not allowed to separate mounts that you inherit from another
+// mount namespace from their child mounts.
+// Therefore, when a mount has subdirectories containing other mounts we must be recursive when we bind mount.
 static bool bind_mount(const std::string& source, const std::string& destination, bool readonly)
 {
 	const char* src = source.c_str();


### PR DESCRIPTION
Inside a user namespace, you are not allowed to separate mounts that you inherited from another mount namespace from their child mounts.
(though you're allowed to remount over the children in your own namespace)

So whenever a mount has subdirectories with mounts in them, we _must_ be recursive when we bind mount.
Since there is no downside to requesting recursive when the mount has no children, we apply `MS_REC` to all bind mounts. We could make this configurable in the future if we found a need to.

I ran into this when being denied trying to bind mount `/proc` which has the child `/proc/sys/fs/binfmt_misc`