### PR TITLE
Add 'tmpfs' mount type to fuse-wake

### DIFF
--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -98,6 +98,7 @@ static bool validate_mount(
 		// must be sorted
 		"bind",
 		"pivot-root",
+		"tmpfs",
 		"workspace"
 	};
 
@@ -165,6 +166,15 @@ static bool do_pivot(const std::string& newroot) {
 	return true;
 }
 
+static bool mount_tmpfs(const std::string& destination) {
+	if (0 != mount("tmpfs", destination.c_str(), "tmpfs", 0UL, NULL)) {
+		std::cerr << "tmpfs mount (" << destination << "): "
+			<< strerror(errno) << std::endl;
+		return false;
+	}
+	return true;
+}
+
 // Do the mounts specified in the parsed input json.
 // The input/caller responsibility to ensure that the mountpoint exists,
 // that the platform supports the mount type/options, and to correctly order
@@ -188,6 +198,9 @@ static bool do_mounts_from_json(const JAST& jast, const std::string& fuse_mount_
 			return false;
 
 		if (op == "pivot-root" && !do_pivot(dest))
+			return false;
+
+		if (op == "tmpfs" && !mount_tmpfs(dest))
 			return false;
 
 	}


### PR DESCRIPTION
Add a `tmpfs` mount type to fuse-wake.

Tested with:
```
$ cat tmpfs.in.json
{
  "command": [
    "bash", "-c", "findmnt | grep mnt; ls -l /mnt; touch /mnt/foo; ls -l /mnt"
  ],
  "environment": [
    "PATH=/usr/bin:/bin"
  ],
  "visible": [],
  "directory": ".",
  "mounts": [
    {
      "type": "tmpfs",
      "destination":"/mnt"
    },
    {
      "type": "workspace",
      "destination": "."
    }
  ],
  "stdin": "",
  "resources": [],
  "version": "v0.21.0-alpha-4-gde85a32-dirty",
  "usage": {
    "status": 1,
    "runtime": 5.40870000000000031e-02,
    "cputime": 4.00000000000000008e-03,
    "membytes": 3289088,
    "inbytes": 0,
    "outbytes": 0
  }
}

$ ../fuse-wake tmpfs.in.json out.json
`-/mnt   tmpfs   tmpfs   rw,nodev,relatime,uid=1375,gid=1375
total 0
total 0
-rw-rw-r-- 1 matthew matthew 0 Feb 18 13:40 foo
```