### PR TITLE
Ignore enumeration failures

### DIFF
--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -569,8 +569,8 @@ std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbo
   std::string rel_libdir = make_relative(get_cwd(), make_canonical(abs_libdir));
 
   std::vector<std::string> acc;
-  ok = ok && !push_files(acc, rel_libdir, exp, 0);
-  if (workspace) ok = ok && !push_files(acc, ".", exp, 0);
+  if (push_files(acc, rel_libdir, exp, 0)) ok = false;
+  if (workspace && push_files(acc, ".", exp, 0)) ok = false;
 
   // make the output distinct
   std::sort(acc.begin(), acc.end());
@@ -669,7 +669,7 @@ static PRIMFN(prim_files) {
 
   std::vector<std::string> match;
   bool fail = push_files(match, root, *arg1->exp, skip);
-  if (fail) match.clear(); // !!! There's a hole in the API
+  (void)fail; // !!! There's a hole in the API
 
   size_t need = reserve_list(match.size());
   for (auto &x : match) need += String::reserve(x.size());


### PR DESCRIPTION
This is a critical work-around for a bug in our builds.

If something renders a portion of the workspace unreadable while wake starts, wake cannot abort.
The potential causes of this are: permission denied and/or directory/file deleted concurrently.

While it is certainly the case that both of these situations are bad and should be avoided, wake needs to bee as robust as possible. It's quite possible the affected files were not relevant to the build.