### PR TITLE
fuse-wake: accept string inputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ bin/wake:	src/symbol.o $(COMMON)				\
 		$(patsubst %.c,%.o,utf8proc/utf8proc.c gopt/gopt.c gopt/gopt-errors.c)
 	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(CORE_LDFLAGS)
 
-lib/wake/fuse-wake:	fuse/fuse.cpp fuse/namespace.cpp $(COMMON)
+lib/wake/fuse-wake:	fuse/client.cpp fuse/fuse.cpp fuse/namespace.cpp $(COMMON)
 	$(CXX) $(CFLAGS) $(LOCAL_CFLAGS) $^ -o $@ $(LDFLAGS)
 
 lib/wake/fuse-waked:	fuse/daemon.cpp $(COMMON)

--- a/common/jparser.cpp
+++ b/common/jparser.cpp
@@ -209,7 +209,7 @@ bool JAST::parse(const char *file, std::ostream& errs, JAST &out) {
   }
 }
 
-bool JAST::parse(std::string &body, std::ostream& errs, JAST &out) {
+bool JAST::parse(const std::string &body, std::ostream& errs, JAST &out) {
   JLexer jlex(body);
   out = parse_jvalue(jlex, errs);
   expect(JSON_END, jlex, errs);

--- a/common/json5.h
+++ b/common/json5.h
@@ -53,7 +53,7 @@ struct JAST {
   JAST(SymbolJSON kind_, JChildren &&children_) : kind(kind_), children(std::move(children_)) { }
 
   static bool parse(const char *file,  std::ostream& errs, JAST &out);
-  static bool parse(std::string &body, std::ostream& errs, JAST &out);
+  static bool parse(const std::string &body, std::ostream& errs, JAST &out);
   static bool parse(const char *body, size_t len, std::ostream& errs, JAST &out);
 
   const JAST &get(const std::string &key) const;

--- a/fuse/client.cpp
+++ b/fuse/client.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
 		(std::istreambuf_iterator<char>()));
 	if (ifs.fail()) {
 		std::cerr << "read " << argv[1] << ": " << strerror(errno) << std::endl;
-		return 1;
+		return 2;
 	}
 	ifs.close();
 
@@ -56,8 +56,8 @@ int main(int argc, char *argv[])
 	// Write output as json to argv[2]
 	std::ofstream ofs(result_path, std::ios_base::trunc);
 	if (ofs.fail()) {
-		std::cerr << "write " << result_path << ": " << strerror(errno) << std::endl;
-		return 1;
+		// stderr was closed by run_fuse().
+		return 3;
 	}
 	ofs << result;
 	ofs.close();

--- a/fuse/client.cpp
+++ b/fuse/client.cpp
@@ -47,8 +47,9 @@ int main(int argc, char *argv[])
 
 	// Run the command contained in the json with the fuse daemon filtering
 	// the filesystem view of the workspace dir.
+	std::string working_dir = get_cwd();
 	std::string result;
-	int res = run_fuse(json, result);
+	int res = run_fuse(working_dir, json, result);
 
 	// Write output as json to argv[2]
 	std::ofstream ofs(result_path, std::ios_base::trunc);

--- a/fuse/client.cpp
+++ b/fuse/client.cpp
@@ -45,11 +45,13 @@ int main(int argc, char *argv[])
 	}
 	ifs.close();
 
+	const std::string daemon = find_execpath() + "/fuse-waked";
+	const std::string working_dir = get_cwd();
+	std::string result;
 	// Run the command contained in the json with the fuse daemon filtering
 	// the filesystem view of the workspace dir.
-	std::string working_dir = get_cwd();
-	std::string result;
-	int res = run_fuse(working_dir, json, result);
+	// Stdin/out/err will be closed.
+	int res = run_fuse(daemon, working_dir, json, result);
 
 	// Write output as json to argv[2]
 	std::ofstream ofs(result_path, std::ios_base::trunc);

--- a/fuse/client.cpp
+++ b/fuse/client.cpp
@@ -1,0 +1,63 @@
+/* Wake FUSE launcher to capture inputs/outputs
+ *
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "execpath.h"
+#include "fuse.h"
+#include "json5.h"
+
+int main(int argc, char *argv[])
+{
+	if (argc != 3) {
+		std::cerr << "Syntax: fuse-wake <input-json> <output-json>" << std::endl;
+		return 1;
+	}
+	std::string input_path = argv[1];
+	std::string result_path = argv[2];
+
+	// Read the input file
+	std::ifstream ifs(input_path);
+	const std::string json(
+		(std::istreambuf_iterator<char>(ifs)),
+		(std::istreambuf_iterator<char>()));
+	if (ifs.fail()) {
+		std::cerr << "read " << argv[1] << ": " << strerror(errno) << std::endl;
+		return 1;
+	}
+	ifs.close();
+
+	// Run the command contained in the json with the fuse daemon filtering
+	// the filesystem view of the workspace dir.
+	std::string result;
+	int res = run_fuse(json, result);
+
+	// Write output as json to argv[2]
+	std::ofstream ofs(result_path, std::ios_base::trunc);
+	if (ofs.fail()) {
+		std::cerr << "write " << result_path << ": " << strerror(errno) << std::endl;
+		return 1;
+	}
+	ofs << result;
+	ofs.close();
+
+	return res;
+}

--- a/fuse/client.cpp
+++ b/fuse/client.cpp
@@ -31,8 +31,8 @@ int main(int argc, char *argv[])
 		std::cerr << "Syntax: fuse-wake <input-json> <output-json>" << std::endl;
 		return 1;
 	}
-	std::string input_path = argv[1];
-	std::string result_path = argv[2];
+	const std::string input_path = argv[1];
+	const std::string result_path = argv[2];
 
 	// Read the input file
 	std::ifstream ifs(input_path);

--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -37,7 +37,7 @@
 #include "namespace.h"
 #endif
 
-int run_fuse(
+int run_in_fuse(
 	const std::string& daemon_path,
 	const std::string& working_dir,
 	const std::string& json,

--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -37,7 +37,12 @@
 #include "namespace.h"
 #endif
 
-int run_fuse(const std::string& working_dir, const std::string& json, std::string& result_json) {
+int run_fuse(
+	const std::string& daemon_path,
+	const std::string& working_dir,
+	const std::string& json,
+	std::string& result_json)
+{
 	if (0 != chdir(working_dir.c_str())) {
 		std::cerr << "chdir " << working_dir << ": " << strerror(errno) << std::endl;
 		return 1;
@@ -47,8 +52,6 @@ int run_fuse(const std::string& working_dir, const std::string& json, std::strin
 	if (!JAST::parse(json, std::cerr, jast))
 		return 1;
 
-	std::string exedir = find_execpath();
-	std::string daemon = exedir + "/fuse-waked";
 	std::string name  = std::to_string(getpid());
 	// mpath is where the fuse filesystem is mounted
 	std::string mpath = working_dir + "/.fuse";
@@ -65,8 +68,8 @@ int run_fuse(const std::string& working_dir, const std::string& json, std::strin
 		pid_t pid = fork();
 		if (pid == 0) {
 			const char *env[2] = { "PATH=/usr/bin:/bin:/usr/sbin:/sbin", 0 };
-			execle(daemon.c_str(), "fuse-waked", mpath.c_str(), nullptr, env);
-			std::cerr << "execl " << daemon << ": " << strerror(errno) << std::endl;
+			execle(daemon_path.c_str(), "fuse-waked", mpath.c_str(), nullptr, env);
+			std::cerr << "execl " << daemon_path << ": " << strerror(errno) << std::endl;
 			exit(1);
 		}
 		usleep(wait);

--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -58,8 +58,12 @@ int run_fuse(
 	std::string fpath = mpath + "/.f.fuse-waked";
 	// rpath is a subdir in the fuse filesystem that will be used by this fuse-wake
 	std::string rpath = mpath + "/" + name;
+	// Lock file held by each child of fuse-wake. When all children close it,
+	// the daemon releases the resources for that job
 	std::string lpath = mpath + "/.l." + name;
+	// Input (as json) to the fuse daemon to setup visible files.
 	std::string ipath = mpath + "/.i." + name;
+	// Result metadata from the daemon
 	std::string opath = mpath + "/.o." + name;
 
 	int ffd = -1;

--- a/fuse/fuse.h
+++ b/fuse/fuse.h
@@ -1,0 +1,26 @@
+/* Wake FUSE launcher to capture inputs/outputs
+ *
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FUSE_H
+#define FUSE_H
+
+#include <string>
+
+int run_fuse(const std::string& json, std::string& result_json);
+
+#endif

--- a/fuse/fuse.h
+++ b/fuse/fuse.h
@@ -21,6 +21,6 @@
 
 #include <string>
 
-int run_fuse(const std::string& json, std::string& result_json);
+int run_fuse(const std::string& working_dir, const std::string& json, std::string& result_json);
 
 #endif

--- a/fuse/fuse.h
+++ b/fuse/fuse.h
@@ -21,7 +21,7 @@
 
 #include <string>
 
-int run_fuse(
+int run_in_fuse(
 	const std::string& daemon_path,
 	const std::string& working_dir,
 	const std::string& json,

--- a/fuse/fuse.h
+++ b/fuse/fuse.h
@@ -21,6 +21,10 @@
 
 #include <string>
 
-int run_fuse(const std::string& working_dir, const std::string& json, std::string& result_json);
+int run_fuse(
+	const std::string& daemon_path,
+	const std::string& working_dir,
+	const std::string& json,
+	std::string& result_json);
 
 #endif

--- a/fuse/fuse.wake
+++ b/fuse/fuse.wake
@@ -18,8 +18,8 @@ from wake import _
 
 def buildFuse (Pair variant _) =
   def json = common variant
-  def compile = compileC variant json.getSysLibCFlags (source "fuse/namespace.h", json.getSysLibHeaders)
-  def cppFiles = sources "fuse" `(fuse|namespace).cpp`
+  def compile = compileC variant json.getSysLibCFlags (sources "fuse" `.*\.h` ++ json.getSysLibHeaders)
+  def cppFiles = sources "fuse" `(fuse|client|namespace).cpp`
   def objFiles = map compile cppFiles ++ json.getSysLibObjects
   linkO variant json.getSysLibLFlags objFiles "lib/wake/fuse-wake"
 


### PR DESCRIPTION
This further breaks up the fuse-wake fuse.cpp `main()` function

* main() function created in new file: client.cpp
* main() handles `argv` and reads/writes the input/output json files
* run_fuse() handles the bulk of the work that main() used to do
* some queries of global state are moved out of run_fuse() into main()

The commits in the series are mostly meaningful