### PR TITLE
fuse-wake: add create-file and create-dir mount operations

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -465,7 +465,7 @@ export def makeJSONRunner plan =
           "stdin"       → JString stdin,
           "resources"   → res | map JString | JArray,
           "version"     → JString version,
-          "mounts"      → JArray (
+          "mount-ops"      → JArray (
             JObject (
               "type"        → JString "workspace",
               "destination" → JString ".",


### PR DESCRIPTION
It can be useful to be able to create directories inside tmpfs mounts to act as further mount points.
Additionally, if you want to bind a file in you may want to create a file as a destination mount point.

Example use-case: run an X11 application using the .Xauthority file to authenticate with the X server
```
{
  "command": [
    "xeyes"
  ],
  "environment": [
    "PATH=/usr/bin:/bin",
    "HOME=/home/user",
    "DISPLAY=":0"
  ],
  "mount-ops": [
    { "type": "bind", "source":"/tmp/rootfs", "destination": "/mnt"},       
    { "type": "tmpfs", "destination": "/mnt/home"},
    { "type": "create-dir", "destination": "/mnt/home/user" },
    { "type": "create-file", "destination": "/mnt/home/user/.Xauthority" },
    { "type": "bind", source: "/home/myusername/.Xauthority", "destination": "/mnt/home/user/.Xauthority" },
...
```