### PR TITLE
wakebox: a CLI separate from fuse-wake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,11 @@ jobs:
           at: /tmp/workspace
       - run: docker build -f /tmp/workspace/.circleci/dockerfiles/debian-wheezy -t wake-debian-wheezy .
       - run: |
-          x=(/tmp/workspace/wake_*.tar.xz); y=${x%.tar.xz}; cp "$x" "${y##*/}.orig.tar.xz"
-          tar xJf wake_*.orig.tar.xz
-          cp -a /tmp/workspace/debian wake-*
-          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build -w /build/$(ls -d wake-*) wake-debian-wheezy debuild -us -uc
-          docker run --rm --mount type=bind,source=$PWD,target=/build wake-debian-wheezy /bin/sh -c "dpkg -i *.deb; wake --no-workspace -x 'shellJob \"ls /\" Nil | getJobStdout'"
+          x=(/tmp/workspace/wake_*.tar.xz); y=${x%.tar.xz}; cp "$x" "${y##*/}.orig.tar.xz" && \
+          tar xJf wake_*.orig.tar.xz && \
+          cp -a /tmp/workspace/debian wake-* && \
+          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build -w /build/$(ls -d wake-*) wake-debian-wheezy debuild -us -uc && \
+          docker run --rm --mount type=bind,source=$PWD,target=/build wake-debian-wheezy /bin/sh -c "dpkg -i *.deb; wake --no-workspace -x 'shellJob \"ls /\" Nil | getJobStdout'" && \
           install -D -t release/debian_wheezy *.deb *.gz *.xz *.changes *.dsc
       - persist_to_workspace:
           root: .

--- a/.circleci/dockerfiles/centos-6.6
+++ b/.circleci/dockerfiles/centos-6.6
@@ -1,9 +1,0 @@
-FROM centos:6.6
-
-RUN yum -y update && yum clean all
-RUN yum --setopt=skip_missing_names_on_install=False install -y rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools
-RUN yum --setopt=skip_missing_names_on_install=False install -y epel-release centos-release-scl
-RUN yum --setopt=skip_missing_names_on_install=False install -y tar xz dash git which make devtoolset-7-gcc devtoolset-7-gcc-c++ fuse fuse-devel gmp-devel ncurses-devel sqlite-devel re2-devel gcc gcc-c++
-RUN rpmdev-setuptree
-
-WORKDIR /build

--- a/.circleci/dockerfiles/centos-7.6
+++ b/.circleci/dockerfiles/centos-7.6
@@ -3,7 +3,7 @@ FROM centos:7.6.1810
 RUN yum -y update && yum clean all
 RUN yum --setopt=skip_missing_names_on_install=False install -y rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools
 RUN yum --setopt=skip_missing_names_on_install=False install -y epel-release
-RUN yum --setopt=skip_missing_names_on_install=False install -y tar xz dash git which make gcc gcc-c++ fuse fuse-devel gmp-devel ncurses-devel sqlite-devel re2-devel
+RUN yum --setopt=skip_missing_names_on_install=False install -y tar xz dash git which make gcc gcc-c++ fuse fuse-devel gmp-devel ncurses-devel sqlite-devel re2-devel squashfuse
 RUN rpmdev-setuptree
 
 WORKDIR /build

--- a/.circleci/dockerfiles/debian-testing
+++ b/.circleci/dockerfiles/debian-testing
@@ -1,5 +1,5 @@
 FROM debian:testing
 
-RUN apt-get update && apt-get install -y build-essential devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config
+RUN apt-get update && apt-get install -y build-essential devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse
 
 WORKDIR /build

--- a/.circleci/dockerfiles/ubuntu-16.04
+++ b/.circleci/dockerfiles/ubuntu-16.04
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y build-essential debhelper devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config
+RUN apt-get update && apt-get install -y build-essential debhelper devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse
 
 WORKDIR /build

--- a/.circleci/dockerfiles/ubuntu-18.04
+++ b/.circleci/dockerfiles/ubuntu-18.04
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y build-essential debhelper devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config
+RUN apt-get update && apt-get install -y build-essential debhelper devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse
 
 WORKDIR /build

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@
 /wake.spec
 /src/symbol.cpp
 /common/jlexer.cpp
-/bin/wake
-/bin/wake.*
+/bin/wake*
 /src/version.h
 /lib/wake/bsp-wake
 /lib/wake/bsp-wake.*

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ static:	wake.db
 
 bin/wake:	src/symbol.o $(COMMON)				\
 		$(patsubst %.cpp,%.o,$(wildcard src/*.cpp))	\
-		$(patsubst %.c,%.o,utf8proc/utf8proc.c gopt/gopt.c gopt/gopt-errors.c)
+		$(patsubst %.c,%.o,utf8proc/utf8proc.c gopt/gopt.c gopt/gopt-errors.c gopt/gopt-arg.c)
 	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(CORE_LDFLAGS)
 
 lib/wake/fuse-wake:	fuse/client.cpp fuse/fuse.cpp fuse/namespace.cpp $(COMMON)

--- a/build.wake
+++ b/build.wake
@@ -36,7 +36,7 @@ export def install = match _
   _ = Fail "no directory specified (try: install /opt/local)".makeError
 
 # Build all wake targets
-def targets = buildWake, buildFuse, buildFuseDaemon, buildShim, buildPreload, buildPrelib, buildBSP, Nil
+def targets = buildWake, buildWakeBox, buildFuse, buildFuseDaemon, buildShim, buildPreload, buildPrelib, buildBSP, Nil
 def all variant = map (_ variant) targets | findFailFn getPathResult
 
 # Install wake into a target location

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Vcs-Git: https://github.com/sifive/wake.git
 Package: wake
 Architecture: any
 Depends: fuse, dash, ${shlibs:Depends}, ${misc:Depends}
+Recommends: squashfuse
 Description: flexible build orchestration tool and language
  Wake is a build orchestration tool and language.
  If you have a build whose steps cannot be adequately expressed in

--- a/fuse/client.cpp
+++ b/fuse/client.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
 	// Run the command contained in the json with the fuse daemon filtering
 	// the filesystem view of the workspace dir.
 	// Stdin/out/err will be closed.
-	int res = run_in_fuse(daemon, working_dir, json, result);
+	int res = run_in_fuse(daemon, working_dir, json, true, result);
 
 	// Write output as json to argv[2]
 	ssize_t wrote = write(out_fd, result.c_str(), result.length());

--- a/fuse/fuse.wake
+++ b/fuse/fuse.wake
@@ -18,10 +18,17 @@ from wake import _
 
 def buildFuse (Pair variant _) =
   def json = common variant
-  def compile = compileC variant json.getSysLibCFlags (sources "fuse" `.*\.h` ++ json.getSysLibHeaders)
-  def cppFiles = sources "fuse" `(fuse|client|namespace).cpp`
-  def objFiles = map compile cppFiles ++ json.getSysLibObjects
+  def headers = json.getSysLibHeaders ++ sources "fuse" `.*\.h`
+  def client = compileC variant json.getSysLibCFlags headers (source "fuse/client.cpp")
+  def objFiles = client, buildFuseLibObjs variant
   linkO variant json.getSysLibLFlags objFiles "lib/wake/fuse-wake"
+
+def buildFuseLibObjs variant =
+  def json = common variant
+  def headers = json.getSysLibHeaders ++ sources "fuse" `.*\.h`
+  def cppFiles = sources "fuse" `(fuse|namespace).cpp`
+  def compile = compileC variant json.getSysLibCFlags headers
+  map compile cppFiles ++ json.getSysLibObjects
 
 def buildFuseDaemon (Pair variant _) =
   def json = common variant

--- a/gopt/gopt-arg.c
+++ b/gopt/gopt-arg.c
@@ -1,5 +1,4 @@
-/* Wake FUSE launcher to capture inputs/outputs
- *
+/*
  * Copyright 2019 SiFive, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,16 +15,17 @@
  * limitations under the License.
  */
 
-#ifndef FUSE_H
-#define FUSE_H
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include <string>
+#include "gopt-arg.h"
 
-int run_in_fuse(
-	const std::string& daemon_path,
-	const std::string& working_dir,
-	const std::string& json,
-	bool use_stdin_file,
-	std::string& result_json);
+struct option *arg(struct option opts[], const char *name) {
+  for (int i = 0; !(opts[i].flags & GOPT_LAST); ++i)
+    if (!strcmp(opts[i].long_name, name))
+      return opts + i;
 
-#endif
+  fprintf(stderr, "Wake option parser bug: %s\n", name);
+  exit(1);
+}

--- a/gopt/gopt-arg.h
+++ b/gopt/gopt-arg.h
@@ -1,6 +1,5 @@
-/* Wake FUSE launcher to capture inputs/outputs
- *
- * Copyright 2019 SiFive, Inc.
+/*
+ * Copyright 2021 SiFive, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +15,22 @@
  * limitations under the License.
  */
 
-#ifndef FUSE_H
-#define FUSE_H
+#ifndef GOPT_ARG_H_INCLUDED
+#define GOPT_ARG_H_INCLUDED
 
-#include <string>
+#include "gopt.h"
 
-int run_in_fuse(
-	const std::string& daemon_path,
-	const std::string& working_dir,
-	const std::string& json,
-	bool use_stdin_file,
-	std::string& result_json);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+  Search for an option by long name.
+*/
+struct option *arg(struct option opts[], const char *name);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "database.h"
 #include "status.h"
 #include "gopt.h"
+#include "gopt-arg.h"
 #include "runtime.h"
 #include "shell.h"
 #include "markup.h"
@@ -86,15 +87,6 @@ void print_help(const char *argv0) {
     << "    --help    -h     Print this help message and exit"                           << std::endl
     << std::endl;
     // debug-db, no-optimize, stop-after-* are secret undocumented options
-}
-
-static struct option *arg(struct option opts[], const char *name) {
-  for (int i = 0; !(opts[i].flags & GOPT_LAST); ++i)
-    if (!strcmp(opts[i].long_name, name))
-      return opts + i;
-
-  std::cerr << "Wake option parser bug: " << name << std::endl;
-  exit(1);
 }
 
 int main(int argc, char **argv) {

--- a/wake.spec.in
+++ b/wake.spec.in
@@ -6,7 +6,7 @@ License:       Apache-2; MIT; TFL; WTFPL; CC0
 URL:           https://github.com/sifive/wake
 Vendor:        SiFive, Inc.
 Source0:       https://github.com/sifive/wake/releases/%{name}_%{version}.tar.xz
-Requires:      fuse dash
+Requires:      fuse dash squashfuse
 Prefix:        /usr
 BuildRequires: fuse-devel dash sqlite-devel gmp-devel ncurses-devel pkgconfig git gcc gcc-c++ re2-devel
 
@@ -29,6 +29,7 @@ mkdir -p %{buildroot}/var/cache/wake
 
 %files
 /usr/bin/wake
+/usr/bin/wakebox
 /usr/lib/wake
 /usr/share/wake
 /usr/build/wake

--- a/wakebox/build.wake
+++ b/wakebox/build.wake
@@ -1,4 +1,4 @@
-# Copyright 2019 SiFive, Inc.
+# Copyright 2021 SiFive, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,13 @@
 package build_wake
 from wake import _
 
-def gopt variant =
-  def cflags = "-I{here}", Nil
-  def headers = sources here `.*\.h`
-  def compile x = compileC variant cflags headers (source "{here}/{x}")
-  def objects = ("gopt.c", "gopt-errors.c", "gopt-arg.c", Nil) | map compile
-  SysLib "10.0" headers objects cflags Nil
+def buildWakeBox (Pair cpplib clib) =
+  def jsonLib = common cpplib
+  def goptLib = gopt clib
+  def libs = (jsonLib, goptLib, Nil) | flattenSysLibs
+  def headers = source "fuse/fuse.h", goptLib.getSysLibHeaders ++ jsonLib.getSysLibHeaders
+  def compile = compileC cpplib ("-Ifuse", goptLib.getSysLibCFlags ++ jsonLib.getSysLibCFlags) headers
+  def cppFiles = sources "wakebox" `.*\.cpp`
+  def objFiles = goptLib.getSysLibObjects ++ map compile cppFiles ++ (buildFuseLibObjs cpplib)
+  linkO cpplib libs.getSysLibLFlags objFiles "bin/wakebox"
+  | installAs "bin/wakebox"

--- a/wakebox/main.cpp
+++ b/wakebox/main.cpp
@@ -1,0 +1,100 @@
+/* Wake FUSE launcher to capture inputs/outputs
+ *
+ * Copyright 2021 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "execpath.h"
+#include "fuse.h"
+#include "gopt.h"
+#include "gopt-arg.h"
+
+void print_help() {
+	std::cout <<
+		"Usage: wakebox [OPTIONS]\n"
+		"Options\n"
+		"    -p --params FILE         Json file specifying input parameters\n"
+		"    -o --output-stats FILE   Json file written to with output results\n"
+		"    -i --allow-interactive   Ignore params json file's stdin value\n"
+		"    -h --help                Print usage\n";
+}
+
+int main(int argc, char *argv[])
+{
+	struct option options[] {
+		{'p', "params",       GOPT_ARGUMENT_REQUIRED},
+		{'o', "output-stats", GOPT_ARGUMENT_REQUIRED},
+		{'i', "interactive",  GOPT_ARGUMENT_FORBIDDEN},
+		{'h', "help",         GOPT_ARGUMENT_FORBIDDEN},
+		{0,   0,              GOPT_LAST }
+	};
+
+	argc = gopt(argv, options);
+	gopt_errors("wakebox", options);
+
+	bool has_output = arg(options, "output-stats")->count > 0;
+	bool use_stdin_file = arg(options, "interactive")->count == 0;
+
+	const char* params  = arg(options, "params" )->argument;
+	const char* result_path = arg(options, "output-stats")->argument;
+
+	if (arg(options, "help")->count > 0 || !params) {
+		print_help();
+		return 1;
+	}
+
+	// Read the params file
+	std::ifstream ifs(params);
+	const std::string json(
+		(std::istreambuf_iterator<char>(ifs)),
+		(std::istreambuf_iterator<char>()));
+	if (ifs.fail()) {
+		std::cerr << "read " << argv[1] << ": " << strerror(errno) << std::endl;
+		return 1;
+	}
+	ifs.close();
+
+	const std::string daemon = find_execpath() + "/../lib/wake/fuse-waked";
+	const std::string working_dir = get_cwd();
+	std::string result;
+
+	if (!has_output)
+		return run_in_fuse(daemon, working_dir, json, use_stdin_file, result);
+
+	// Open the output file
+	int out_fd = open(result_path, O_WRONLY | O_CREAT | O_CLOEXEC, 0664);
+	if (out_fd < 0) {
+		std::cerr << "open " << result_path << ": " << strerror(errno) << std::endl;
+		return 1;
+	}
+
+	int res = run_in_fuse(daemon, working_dir, json, use_stdin_file, result);
+	// write output stats as json
+	ssize_t wrote = write(out_fd, result.c_str(), result.length());
+	if (wrote == -1)
+		return errno;
+
+	if (0 != close(out_fd))
+		return errno;
+
+	return res;
+}


### PR DESCRIPTION
This creates a separate executable for wakebox, so that it can evolve its CLI independently of fuse wake.
Longer term, we may move all the linux-only code to be wakebox only, and leave fuse-wake for non-linux platforms.

The actual arguments for the CLI are not final and will likely change in the near future.

Some refactoring happened too
* `arg` for gopt has moved into a shared location
* an argument to ignore the `stdin` json value is passed through to fuse.cpp
* Added squashfuse dependency to deb/rpm packages

I suspect that debian wheezy, ubuntu 14.04 and centos 6.6 are simply too old to use _any_ of the user namespace functionality, and they also don't have squashfuse packages. So they're likely broken as we haven't been feature testing the kernel to check if we should mount .fuse/$PID over the workspace