### PR TITLE
wakebox: add --force-shell arg

### DIFF
--- a/wakebox/build.wake
+++ b/wakebox/build.wake
@@ -17,11 +17,11 @@ package build_wake
 from wake import _
 
 def buildWakeBox (Pair cpplib clib) =
-  def jsonLib = common cpplib
+  def commonLib = common cpplib
   def goptLib = gopt clib
-  def libs = (jsonLib, goptLib, Nil) | flattenSysLibs
-  def headers = sources "fuse" `.*\.h` ++ goptLib.getSysLibHeaders ++ jsonLib.getSysLibHeaders
-  def compile = compileC cpplib ("-Ifuse", goptLib.getSysLibCFlags ++ jsonLib.getSysLibCFlags) headers
+  def libs = (commonLib, goptLib, Nil) | flattenSysLibs
+  def headers = sources "fuse" `.*\.h` ++ goptLib.getSysLibHeaders ++ commonLib.getSysLibHeaders
+  def compile = compileC cpplib ("-Ifuse", goptLib.getSysLibCFlags ++ commonLib.getSysLibCFlags) headers
   def cppFiles = sources "wakebox" `.*\.cpp`
   def objFiles = goptLib.getSysLibObjects ++ map compile cppFiles ++ (buildFuseLibObjs cpplib)
   linkO cpplib libs.getSysLibLFlags objFiles "bin/wakebox"


### PR DESCRIPTION
In wakebox it's useful to directly enter a shell environment, disregarding the `command` value from the params file.

This adds an option `-s/--force-shell` which changes the run command to `/bin/sh` and adds the originally intended command to an environment variable called `WAKEBOX_CMD` which can be eval'd

```
matthew@computer:/home/matthew/work$ wakebox -s -p example.wb
user@wakebox:/workspace$ env | grep WAKE
WAKEBOX_CMD="bash" "-c" "echo \"hello world\""
user@wakebox:/workspace$ eval $WAKEBOX_CMD
hello world
```

~There's also some refactoring, moving the JAST parse() into main()~