### PR TITLE
wakebox: Metadata from within squashfs

### DIFF
--- a/common/execpath.cpp
+++ b/common/execpath.cpp
@@ -71,6 +71,15 @@ std::string find_path(const char *const * env) {
   return ".:/bin:/usr/bin";
 }
 
+std::string find_path(const std::vector<std::string> &env) {
+  for (auto &s : env) {
+    if (!s.compare(0, 5, "PATH=")) {
+      return s.substr(5);
+    }
+  }
+  return ".:/bin:/usr/bin";
+}
+
 std::string get_cwd() {
   std::vector<char> buf;
   buf.resize(1024, '\0');

--- a/common/execpath.h
+++ b/common/execpath.h
@@ -19,10 +19,12 @@
 #define EXEC_PATH
 
 #include <string>
+#include <vector>
 
 std::string get_cwd();
 std::string find_execpath();
 std::string find_in_path(const std::string &file, const std::string &path);
 std::string find_path(const char *const * env);
+std::string find_path(const std::vector<std::string> &env);
 
 #endif

--- a/fuse/namespace.h
+++ b/fuse/namespace.h
@@ -36,17 +36,18 @@ bool setup_user_namespaces(
 	int id_user,
 	int id_group,
 	bool isolate_network,
-	const std::string& hostname,
-	const std::string& domainname);
+	const std::string &hostname,
+	const std::string &domainname);
 
 bool do_mounts(
-	const std::vector<mount_op>& mount_ops,
-	const std::string& fuse_mount_path);
+	const std::vector<mount_op> &mount_ops,
+	const std::string &fuse_mount_path,
+	std::vector<std::string> &environments);
 
 bool get_workspace_dir(
-	const std::vector<mount_op>& mount_ops,
-	const std::string& host_workspace_dir,
-	std::string& out);
+	const std::vector<mount_op> &mount_ops,
+	const std::string &host_workspace_dir,
+	std::string &out);
 
 #endif
 

--- a/wakebox/main.cpp
+++ b/wakebox/main.cpp
@@ -88,6 +88,11 @@ int main(int argc, char *argv[])
 	args.working_dir = get_cwd();
 	args.use_stdin_file = use_stdin_file;
 
+	if (args.command.empty() || args.command[0].empty()) {
+		std::cerr << "No command was provided." << std::endl;
+		return 1;
+	}
+
 	if (use_shell) {
 		std::stringstream ss;
 		ss << "WAKEBOX_CMD=";


### PR DESCRIPTION
This allows the squashfs to self-describe its expected mountpoint, environment modifications, and any required helper mounts.

A rootfs must specify it's destination in the params json, but a toolchain squashfs can place the expected mountpoint with itself at `.wakebox/mountpoint`

To modify environment variables, a sh-compatible file `.wakebox/environment` will be sourced.
If a rootfs requires additional helper mounts, `.wakebox/mounts` will contain json-formatted mount-ops (tmpfs & bind only for now).


Example wakebox input params json:
```
{
  "command": ["bash"],
  "user-id": 0,
  "group-id": 0,
  "mount-ops": [
    { "type": "squashfs", "source": "centos8.squashfs", "destination": "/"},
    { "type": "squashfs", "source": "gcc.squashfs"},
    { "type": "workspace", "destination": "/workspace"}
  ]
}
```
The files that provided by the mounts (viewed from within wakebox):
```
root@computer:/workspace$ cat /.wakebox/environment 
export PS1="\\u@\\H:\\w\$ "
export PATH=/bin:/usr/bin:/sbin:$PATH
[ -z "$USER" ] && export USER=root
[ -z "$HOME" ] && export HOME=/root
root@computer:/workspace$ cat /.wakebox/mounts      
{
  "mount-ops": [
    { "type": "bind", "source":"/proc", "destination": "/proc"},
    { "type": "bind", "source":"/sys", "destination": "/sys"},
    { "type": "bind", "source":"/dev", "destination": "/dev"},
    { "type": "tmpfs", "destination": "/tmp"},
    { "type": "tmpfs", "destination": "/run"},
    { "type": "tmpfs", "destination": "/var"},
    { "type": "tmpfs", "destination": "/home"},
    { "type": "tmpfs", "destination": "/tools"}
  ]
}
root@computer:/workspace$ cat /tools/gcc/.wakebox/mountpoint 
/tools/gcc
root@computer:/workspace$ cat /tools/gcc/.wakebox/environment
export PATH=/tools/gcc/bin:$PATH
root@computer:/workspace$ echo $PATH
/tools/gcc/bin:/bin:/usr/bin:/sbin:
```