### PR TITLE
fuse-wake: refactor daemon communication

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,8 @@ jobs:
 
             - name: "Install deps"
               run: |
-                brew install re2
                 brew install --cask osxfuse
+                brew install re2 || brew install re2 --head
 
             - name: "Build wake"
               run: make all -j3

--- a/fuse/fuse.h
+++ b/fuse/fuse.h
@@ -48,6 +48,6 @@ struct fuse_args : public json_args {
 
 bool json_as_struct(const std::string& json, json_args& result);
 
-int run_in_fuse(const fuse_args& args, std::string& result_json);
+int run_in_fuse(fuse_args& args, std::string& result_json);
 
 #endif


### PR DESCRIPTION
This starts the separating-out of the fuse daemon logic. 
This PR shouldn't result in a behavior change

-------------------------------------
Longer term:

In pseudocode, our current flow looks like
```
contact_fuse_daemon()
for mount_ops:
    if op == workspace
        bind_workspace_mount()
    else
        do_other_mount_op()
collect_results()
```
I'd like to make the 'contact the fuse daemon' logic become part of the 'workspace' mount op
```
for mount_ops:
    if op == workspace:
       contact_fuse_daemon()
       bind_workspace_mount()
    else
       do_other_mount_op()
if want_results:
   collect_results()
```



In json our current flow the input json looks like:
```
{
  "command": ["bash", "-c", "findmnt"],
  "visible": ["a-file", "b-file"],
  "mount-ops": [
    { "type": "workspace", "destination": "."}
  ]
}
```
but it could instead be:
```
{
  "command": ["bash", "-c", "findmnt"],
  "mount-ops": [
    { "type": "workspace", "destination": ".", "visible": ["a-file", "b-file"] }
  ]
}
```