### PR TITLE
gopt: allow repeated options that have a value

### DIFF
--- a/gopt/gopt-errors.c
+++ b/gopt/gopt-errors.c
@@ -53,6 +53,12 @@ void gopt_errors (const char *argv0, const struct option *options)
 
   for (i = 0; i < bad_option_index; i++)
   {
+    if (options[i].flags & GOPT_BUFFER_FULL)
+    {
+      fprintf (stderr, "%s: not enough memory allocated for parsing options: --%s\n", argv0, options[i].long_name);
+      exit (EX_USAGE);
+    }
+
     if ((options[i].flags & GOPT_SEEN_SHORT_WITHOUT) && (options[i].flags & GOPT_ARGUMENT_REQUIRED))
     {
       fprintf (stderr, "%s: option -%c requires an option-argument\n", argv0, options[i].short_name);

--- a/gopt/gopt.h
+++ b/gopt/gopt.h
@@ -34,6 +34,14 @@ struct option
   /* input/output: */
   unsigned int  flags;
 
+  /* input/output: array of char* allocated by caller, each char* filled by gopt.
+     Required for GOPT_REPEATABLE_VALUE, unused otherwise. */
+  char        **arguments;
+
+  /* input,
+     Required for GOPT_REPEATABLE_VALUE, unused otherwise */
+  unsigned int  max_args;
+
   /* output: */
   unsigned int  count;
   char         *argument;
@@ -50,6 +58,8 @@ struct option
 #define GOPT_SEEN_LONG_WITHOUT  0x040u /* long form of option was present without an option-argument in argv */
 #define GOPT_SEEN_LONG_WITH     0x080u /* long form of option was present with an option-argument in argv */
 #define GOPT_LAST               0x100u /* this is the last element of the array */
+#define GOPT_REPEATABLE_VALUE   (0x200u | GOPT_REPEATABLE) /* option may be specified with a value more than once */
+#define GOPT_BUFFER_FULL        0x400u /* not enough buffer space was given to GOPT_REPEATABLE_VALUE option */
 
 int gopt (char **argv, struct option *options);
 /*


### PR DESCRIPTION
Our gopt implementation allows you to repeat an option, but it will only store the value associated with the option _once_.
This PR changes that to store the repeated option's values in an array.
The array is allocated outside of gopt and passed in to the option struct.

Code example:
```
int main(int argc, char *argv[])
{
        unsigned int max_vals = argc / 2;
        char* vals[max_vals];
        struct option options[] {
                {'v', "value", GOPT_ARGUMENT_REQUIRED | GOPT_REPEATABLE_VALUE, vals, max_vals},
                {0,   0,       GOPT_LAST }
        };
        argc = gopt(argv, options);
        gopt_errors("test-cli", options);
        for (unsigned int i = 0; i < arg(options, "value")->count; i++)
                std::cout << "repeated value: " << vals[i] << std::endl;
```

It handles short, short without space, and long version of the argument
```
./cli-tester -v hello --value my -vname -v is positional-arg --value unknown                           
repeated value: hello
repeated value: my
repeated value: name
repeated value: is
```
`gopt_errors` will let you know if you failed to allocate enough space for the array of char*