### PR TITLE
fuse.cpp: change dir before finding executable in PATH

### DIFF
--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -255,6 +255,11 @@ int run_in_fuse(fuse_args &args, std::string &result_json) {
 		}
 		dir = dir + "/" + args.directory;
 
+		if (chdir(dir.c_str()) != 0) {
+			std::cerr << "chdir " << dir << ": " << strerror(errno) << std::endl;
+			exit(1);
+		}
+
 		if (envs_from_mounts.size() > 0) {
 			// 'source' the environments provided by any mounts before running command.
 			// The shell will search the PATH for the executable location.
@@ -273,16 +278,14 @@ int run_in_fuse(fuse_args &args, std::string &result_json) {
 			command[0] = find_in_path(command[0], find_path(args.environment));
 		}
 #else
-		// Search the PATH for the executable location.
-		command[0] = find_in_path(command[0], find_path(args.environment));
-
 		std::string dir = daemon.mount_subdir + "/" + args.directory;
-#endif
 		if (chdir(dir.c_str()) != 0) {
 			std::cerr << "chdir " << dir << ": " << strerror(errno) << std::endl;
 			exit(1);
 		}
-
+		// Search the PATH for the executable location.
+		command[0] = find_in_path(command[0], find_path(args.environment));
+#endif
 		if (args.use_stdin_file) {
 			std::string stdin = args.stdin_file;
 			if (stdin.empty()) stdin = "/dev/null";


### PR DESCRIPTION
A recent change caused the full path to the executable to be not found when these are true:
* the job asks to be run within a subdir of the workspace
* the PATH contains relative locations
* the executable is contained in one of the relative PATH locations

This PR restores the previous behaviour where we would `chdir` into the subdirectory and only then search the PATH for the executable.