### PR TITLE
fuse daemon: don't report .fuse_hidden prefixed files as outputs

### DIFF
--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -127,7 +127,18 @@ void Job::dump() {
 	s << "],\"outputs\":[";
 
 	first = true;
+	const std::string prefix = ".fuse_hidden";
 	for (auto &x : files_wrote) {
+		// files prefixed with .fuse_hidden are implementation details of libfuse
+		// and should not be treated as outputs.
+		// see: https://github.com/libfuse/libfuse/blob/fuse-3.10.3/include/fuse.h#L161-L177
+		size_t start = 0;
+		size_t lastslash = x.rfind("/");
+		if (lastslash != std::string::npos)
+			start = lastslash + 1;
+		if (x.compare(start, prefix.length(), prefix) == 0)
+			continue;
+
 		s << (first?"":",") << "\"" << json_escape(x) << "\"";
 		first = false;
 	}


### PR DESCRIPTION
libfuse will sometimes create files prefixed with `.fuse_hidden` (for example: `somedir/.fuse_hidden000002d500000001`)
```
	/**
	 * The default behavior is that if an open file is deleted,
	 * the file is renamed to a hidden file (.fuse_hiddenXXX), and
	 * only removed when the file is finally released.  This
	 * relieves the filesystem implementation of having to deal
	 * with this problem. This option disables the hiding
	 * behavior, and files are removed immediately in an unlink
	 * operation (or in a rename operation which overwrites an
	 * existing file).
	 *
	 * It is recommended that you not use the hard_remove
	 * option. When hard_remove is set, the following libc
	 * functions fail on unlinked files (returning errno of
	 * ENOENT): read(2), write(2), fsync(2), close(2), f*xattr(2),
	 * ftruncate(2), fstat(2), fchmod(2), fchown(2)
	 */
	int hard_remove;
```
(from https://github.com/libfuse/libfuse/blob/fuse-3.10.3/include/fuse.h#L161-L177)


These files are not true job outputs
This PR filters them out in the daemon when creating the output json