### PR TITLE
wakebox: cli interactive mode options

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -36,7 +36,13 @@ export def install = match _
   _ = Fail "no directory specified (try: install /opt/local)".makeError
 
 # Build all wake targets
-def targets = buildWake, buildWakeBox, buildFuse, buildFuseDaemon, buildShim, buildPreload, buildPrelib, buildBSP, Nil
+def targets =
+  def allPlatforms = buildWake, buildFuse, buildFuseDaemon, buildShim, buildPreload, buildPrelib, buildBSP, Nil
+  def linuxOnly = buildWakeBox, Nil
+  match sysname
+    "Linux" = allPlatforms ++ linuxOnly
+    _       = allPlatforms
+
 def all variant = map (_ variant) targets | findFailFn getPathResult
 
 # Install wake into a target location

--- a/fuse/client.cpp
+++ b/fuse/client.cpp
@@ -58,11 +58,24 @@ int main(int argc, char *argv[])
 	if (!json_as_struct(json, args))
 		return 1;
 
+#ifdef __linux__
+	args.command_running_dir = args.working_dir + "/" + args.directory;
+#else
+	// On non-linux platform like MacOS, run_in_fuse is unable to re-map the fuse
+	// mountpoint over the top of the original workspace.
+	// This can impact attempts to write wake build rules that are reproducable between
+	// repeated runs, for if the command requests the full path to a file in the workspace
+	// it may expose the temporary fuse mount as a component of the full path.
+	args.command_running_dir = args.daemon.mount_subdir + "/" + args.directory;
+#endif
+
+	int retcode; // unused
 	std::string result;
 	// Run the command contained in the json with the fuse daemon filtering
 	// the filesystem view of the workspace dir.
 	// Stdin/out/err will be closed.
-	int res = run_in_fuse(args, result);
+	if (!run_in_fuse(args, retcode, result))
+		return 1;
 
 	// Write output as json to argv[2]
 	ssize_t wrote = write(out_fd, result.c_str(), result.length());
@@ -72,5 +85,5 @@ int main(int argc, char *argv[])
 	if (0 != close(out_fd))
 		return errno;
 
-	return res;
+	return 0;
 }

--- a/fuse/fuse.h
+++ b/fuse/fuse.h
@@ -68,7 +68,8 @@ struct json_args {
 };
 
 struct fuse_args : public json_args {
-	std::string working_dir;
+	const std::string working_dir; // the original directory that this process was invoked from
+	std::string command_running_dir; // current working dir of the command when it executes
 	bool use_stdin_file;
 	daemon_client daemon;
 
@@ -78,6 +79,6 @@ struct fuse_args : public json_args {
 
 bool json_as_struct(const std::string& json, json_args& result);
 
-int run_in_fuse(fuse_args& args, std::string& result_json);
+bool run_in_fuse(fuse_args& args, int &retcode, std::string& result_json);
 
 #endif

--- a/fuse/namespace.cpp
+++ b/fuse/namespace.cpp
@@ -192,6 +192,12 @@ static bool equal_dev_ids(dev_t a, dev_t b) {
 }
 
 static bool do_squashfuse_mount(const std::string &source, const std::string &mountpoint) {
+	// The squashfuse executable doesn't give a clear error message when the file is missing.
+	if (access(source.c_str(), R_OK|F_OK) != 0) {
+		std::cerr << "squashfs mount ('" << source << "'): " << strerror(errno) << std::endl;
+		return false;
+	}
+
 	pid_t pid = fork();
 	if (pid == 0) {
 		// kernel to send SIGKILL to squashfuse when fuse-wake terminates
@@ -225,7 +231,7 @@ static bool do_squashfuse_mount(const std::string &source, const std::string &mo
 			usleep(10000 << i); // 10ms * 2^i
 	}
 
-	std::cerr << "squashfs mount missing: " << mountpoint << std::endl;
+	std::cerr << "squashfs mount failed: " << source << std::endl;
 	return false;
 }
 

--- a/fuse/namespace.h
+++ b/fuse/namespace.h
@@ -44,11 +44,6 @@ bool do_mounts(
 	const std::string &fuse_mount_path,
 	std::vector<std::string> &environments);
 
-bool get_workspace_dir(
-	const std::vector<mount_op> &mount_ops,
-	const std::string &host_workspace_dir,
-	std::string &out);
-
 #endif
 
 #endif

--- a/wakebox/main.cpp
+++ b/wakebox/main.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <fcntl.h>
 #include <unistd.h>
+#include <stdio.h>
 
 #include "execpath.h"
 #include "fuse.h"
@@ -32,50 +33,118 @@
 
 void print_help() {
 	std::cout <<
-		"Usage: wakebox [OPTIONS]\n"
-		"Options\n"
-		"    -p --params FILE         Json file specifying input parameters\n"
-		"    -o --output-stats FILE   Json file written to with output results\n"
-		"    -i --allow-interactive   Ignore params json file's stdin value\n"
-		"    -s --force-shell         Run shell instead of command from params.\n"
-		"                             Implies --allow-interactive.\n"
-		"                             Use 'eval $WAKEBOX_CMD' to run the command from params.\n"
-		"    -h --help                Print usage\n";
+	"Usage: wakebox [OPTIONS] [COMMAND...]                                                         \n"
+	"                                                                                              \n"
+	"Interactive options                                                                           \n"
+	"    -r --rootfs FILE         Use a squashfs file as the command's view of the root filesystem.\n"
+	"    -t --toolchain FILE      Make a toolchain visible on the command's view of the filesystem.\n"
+	"                             May be specified multiple times.                                 \n"
+	"    -b --bind DIR1:DIR2      Place the directory (or file) at DIR1 within the command's view  \n"
+	"                             of the filesystem at location DIR2.                              \n"
+	"                             May be specified multiple times.                                 \n"
+	"    -x                       Shorthand for '--bind $PWD:/tmp/workspace'                       \n"
+	"    COMMAND                  The command to run.                                              \n"
+	"                                                                                              \n"
+	"Batch options                                                                                 \n"
+	"    -p --params FILE         Json file specifying input parameters. Above interactive options \n"
+	// TODO allow --params to be used with the interactive options.
+	"                             will be ignored.                                                 \n"
+	"    -o --output-stats FILE   Json file written containing output results and return code.     \n"
+	"    -s --force-shell         Run shell instead of command from params file.                   \n"
+	"                             Implies --allow-interactive.                                     \n"
+	"                             Use 'eval $WAKEBOX_CMD' to run the command from params file.     \n"
+	"    -i --allow-interactive   Use default stdin, ignoring the params json file's stdin value.  \n"
+	"    -I --isolate-retcode     Don't allow COMMAND's return code to impact wakebox's return code.\n"
+	"                                                                                              \n"
+	"Other options                                                                                 \n"
+	"    -h --help                Print usage                                                      \n";
 }
 
-int main(int argc, char *argv[])
+// Decide the default working directory for the new process.
+// Wakebox does not provide direct control of the command running dir at this time.
+const std::string command_running_dir(
+	const std::vector<mount_op>& mount_ops,
+	const std::string& host_workspace_dir,
+	const std::string& subdir)
 {
-	struct option options[] {
-		{'p', "params",       GOPT_ARGUMENT_REQUIRED},
-		{'o', "output-stats", GOPT_ARGUMENT_REQUIRED},
-		{'i', "interactive",  GOPT_ARGUMENT_FORBIDDEN},
-		{'s', "force-shell",  GOPT_ARGUMENT_FORBIDDEN},
-		{'h', "help",         GOPT_ARGUMENT_FORBIDDEN},
-		{0,   0,              GOPT_LAST }
-	};
+	// If we have a workspace mount, we want to default to that location.
+	for (auto &x : mount_ops) {
+		if (x.type == "workspace") {
+			if (x.destination[0] == '/')
+				return x.destination + "/" + subdir;
+			else
+				// convert a workspace relative path into absolute path
+				return host_workspace_dir + "/" + x.destination + "/" + subdir;
+		}
+	}
+	// If we're binding in the parent namespace's current working directory, use that.
+	for (auto &x : mount_ops)
+		if (x.type == "bind" && host_workspace_dir == x.source)
+			return x.destination + "/" + subdir;
 
-	argc = gopt(argv, options);
-	gopt_errors("wakebox", options);
+	// If we have a replacement rootfs, we know we atleast have "/".
+	for (auto &x : mount_ops)
+		if (x.destination == "/")
+			return "/" + subdir;
 
-	bool has_output = arg(options, "output-stats")->count > 0;
-	bool use_stdin_file = arg(options, "interactive")->count == 0;
-	bool use_shell = arg(options, "force-shell")->count > 0;
+	// Try the current directory, which should exist if we have no replacement rootfs.
+	return host_workspace_dir + "/" + subdir;
+}
 
-	const char* params  = arg(options, "params" )->argument;
-	const char* result_path = arg(options, "output-stats")->argument;
+int run_interactive(
+	const std::string &rootfs,
+	const std::vector<std::string> &toolchains,
+	const std::vector<mount_op> &binds,
+	const std::vector<std::string> &command
+){
+	struct fuse_args fa(get_cwd(), false);
+	fa.command = command;
 
-	if (arg(options, "help")->count > 0 || !params) {
-		print_help();
-		return 1;
+	// Interactive mode does not provide userid control at this time.
+	fa.userid = 0;
+	fa.groupid = 0;
+
+	if (!rootfs.empty())
+		fa.mount_ops.push_back({"squashfs", rootfs, "/", false});
+
+	for (auto &tool : toolchains)
+		fa.mount_ops.push_back({"squashfs", tool, "", false});
+
+	fa.mount_ops.insert(fa.mount_ops.end(), binds.begin(), binds.end());
+
+	if (rootfs.empty()) {
+		fa.environment.push_back(std::string("HOME=") + std::getenv("HOME"));
+		fa.environment.push_back(std::string("USER=") + std::getenv("USER"));
 	}
 
+	const char *term = std::getenv("TERM");
+	fa.environment.push_back(std::string("TERM=") + term);
+
+	fa.command_running_dir = command_running_dir(fa.mount_ops, fa.working_dir, "");
+
+	int retcode;
+	std::string result;
+	if (!run_in_fuse(fa, retcode, result))
+		return 1;
+	return retcode;
+}
+
+
+int run_batch(
+	const char* params_path,
+	bool has_output,
+	bool use_stdin_file,
+	bool use_shell,
+	bool isolate_retcode,
+	const char* result_path
+){
 	// Read the params file
-	std::ifstream ifs(params);
+	std::ifstream ifs(params_path);
 	const std::string json(
 		(std::istreambuf_iterator<char>(ifs)),
 		(std::istreambuf_iterator<char>()));
 	if (ifs.fail()) {
-		std::cerr << "read " << argv[1] << ": " << strerror(errno) << std::endl;
+		std::cerr << "read " << params_path << ": " << strerror(errno) << std::endl;
 		return 1;
 	}
 	ifs.close();
@@ -83,6 +152,7 @@ int main(int argc, char *argv[])
 	fuse_args args(get_cwd(), use_stdin_file);
 	if (!json_as_struct(json, args))
 		return 1;
+	args.command_running_dir = command_running_dir(args.mount_ops, args.working_dir, args.directory);
 
 	if (args.command.empty() || args.command[0].empty()) {
 		std::cerr << "No command was provided." << std::endl;
@@ -102,9 +172,17 @@ int main(int argc, char *argv[])
 		std::cerr << "To execute the original command:\n\teval $WAKEBOX_CMD" << std::endl;
 	}
 
+	int retcode;
 	std::string result;
-	if (!has_output)
-		return run_in_fuse(args, result);
+	if (!has_output) {
+		if (!run_in_fuse(args, retcode, result))
+			return 1;
+
+		if (isolate_retcode)
+			return 0;
+		else
+			return retcode;
+	}
 
 	// Open the output file
 	int out_fd = open(result_path, O_WRONLY | O_CREAT | O_CLOEXEC, 0664);
@@ -113,14 +191,107 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	int res = run_in_fuse(args, result);
+	if (!run_in_fuse(args, retcode, result))
+		return 1;
+
 	// write output stats as json
 	ssize_t wrote = write(out_fd, result.c_str(), result.length());
-	if (wrote == -1)
+	if (wrote == -1 )
 		return errno;
-
 	if (0 != close(out_fd))
 		return errno;
 
-	return res;
+	if (isolate_retcode)
+		return 0;
+	else
+		return retcode;
+}
+
+int main(int argc, char *argv[])
+{
+	unsigned int max_pairs = argc / 2;
+	std::vector<char*> tools(max_pairs, nullptr);
+	std::vector<char*> binds(max_pairs, nullptr);
+
+	struct option options[] {
+		{'r', "rootfs",    GOPT_ARGUMENT_REQUIRED},
+		{'t', "toolchain", GOPT_ARGUMENT_REQUIRED | GOPT_REPEATABLE_VALUE, tools.data(), max_pairs},
+		{'b', "bind",      GOPT_ARGUMENT_REQUIRED | GOPT_REPEATABLE_VALUE, binds.data(), max_pairs},
+		{'x', "bind-cwd",  GOPT_ARGUMENT_FORBIDDEN},
+
+		{'p', "params",          GOPT_ARGUMENT_REQUIRED},
+		{'o', "output-stats",    GOPT_ARGUMENT_REQUIRED},
+		{'s', "force-shell",     GOPT_ARGUMENT_FORBIDDEN},
+		{'i', "interactive",     GOPT_ARGUMENT_FORBIDDEN},
+		{'I', "isolate-retcode", GOPT_ARGUMENT_FORBIDDEN},
+
+		{'h', "help", GOPT_ARGUMENT_FORBIDDEN},
+		{0,   0,      GOPT_LAST }
+	};
+
+	argc = gopt(argv, options);
+	gopt_errors("wakebox", options);
+
+	bool has_help = arg(options, "help")->count > 0;
+	bool has_params_file = arg(options, "params")->count > 0;
+	bool has_positional_cmd = argc > 1;
+	bool isolate_retcode = arg(options, "isolate-retcode")->count > 0;
+
+	if (has_help) {
+		print_help();
+		return 1;
+	}
+
+	if (has_positional_cmd && has_params_file) {
+		std::cerr
+			<< "The batch mode --params argument can't be used with the interactive"
+                           " mode command argument."
+			<< std::endl;
+		return 1;
+	}
+
+	if (has_positional_cmd) {
+		std::string rootfs;
+		if (arg(options, "rootfs")->count > 0)
+			rootfs = arg(options, "rootfs")->argument;
+
+		std::vector<std::string> toolchains;
+		for (unsigned int i = 0; i < arg(options, "toolchain")->count; i++)
+			toolchains.push_back(tools[i]);
+
+		std::vector<mount_op> bind_ops;
+		for (unsigned int i = 0; i < arg(options, "bind")->count; i++) {
+			const std::string s = binds[i];
+			std::string source = s.substr(0, s.find(":"));
+			std::string destination = s.substr(s.find(":")+1);
+			if (source.empty() || destination.empty() || s.find(":") == std::string::npos) {
+				std::cerr << "Invalid bind: " << s << std::endl;
+				return 1;
+			}
+			bind_ops.push_back({"bind", source, destination});
+		}
+		if (arg(options, "bind-cwd")->count > 0) {
+			bind_ops.push_back({"create-dir", "", "/tmp/workspace"});
+			bind_ops.push_back({"bind", get_cwd(), "/tmp/workspace"});
+		}
+
+		std::vector<std::string> positional_params;
+		for (int i = 1; i < argc; i++)
+			positional_params.push_back(argv[i]);
+		if (positional_params.empty()) {
+			std::cerr << "Must provide a command." << std::endl;
+			return 1;
+		}
+		return run_interactive(rootfs, toolchains, bind_ops, positional_params);
+
+	} else if (has_params_file) {
+		const char* params  = arg(options, "params" )->argument;
+		bool has_output = arg(options, "output-stats")->count > 0;
+		bool use_stdin_file = arg(options, "interactive")->count == 0;
+		bool use_shell = arg(options, "force-shell")->count > 0;
+		const char* result_path = arg(options, "output-stats")->argument;
+		return run_batch(params, has_output, use_stdin_file, use_shell, isolate_retcode, result_path);
+	}
+	print_help();
+	return 1;
 }


### PR DESCRIPTION
This replaces most of `wakebox.cpp` to provide a second mode of option from the CLI.
There is scope for more CLI work, but this is likely sufficient for use in the medium term

There is now
* batch mode, for use with json params files
* interactive mode, for adhoc cli usage

There are also some refactors
* wakebox only builds on linux
* the working directory of the eventual command to execute is now set in main.cpp/client.cpp, not in namespace.cpp
* the #ifdef linux section in fuse.cpp is much smaller