### PR TITLE
fuse-wake: add label to json params file and in wake --failed

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -471,6 +471,7 @@ export def makeJSONRunner plan =
         def pmkdir m p = prim "mkdir"
         def pwrite m p d = prim "write"
         def json = JObject (
+          "label"       → JString label,
           "command"     → command     | map JString | JArray,
           "environment" → environment | map JString | JArray,
           "visible"     → visible | map (_.getPathName.JString) | JArray,

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -44,6 +44,7 @@ static void describe_human(const std::vector<JobReflection> &jobs, bool debug, b
     if (!job.label.empty())
       std::cout << " (" << job.label << ")";
     std::cout << ":" << std::endl
+      << "  Label: " << job.label << std::endl
       << "  Command-line:";
     for (auto &arg : job.commandline) std::cout << " " << shell_escape(arg);
     std::cout

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -44,7 +44,6 @@ static void describe_human(const std::vector<JobReflection> &jobs, bool debug, b
     if (!job.label.empty())
       std::cout << " (" << job.label << ")";
     std::cout << ":" << std::endl
-      << "  Label: " << job.label << std::endl
       << "  Command-line:";
     for (auto &arg : job.commandline) std::cout << " " << shell_escape(arg);
     std::cout


### PR DESCRIPTION
Helps with identifying Jobs when looking at params files, or in `wake --failed -v`