### PR TITLE
claimFileInPath: improve for use as an 'input file' processing API

### DIFF
--- a/share/wake/lib/system/incremental.wake
+++ b/share/wake/lib/system/incremental.wake
@@ -31,7 +31,7 @@ export def claimFileAsPathIn outputDirectory existingFile desiredName =
   else
     def desiredWorkspacePath = simplify "{outputDirectory.getPathName}/{desiredName}"
     def visible = outputDirectory, Nil
-    def cmdline = which "ln", "-f", existingFile, desiredWorkspacePath, Nil
+    def cmdline = which "cp", existingFile, desiredWorkspacePath, Nil
     makeExecPlan cmdline visible
     | setPlanLocalOnly   True
     | setPlanPersistence Once

--- a/share/wake/lib/system/incremental.wake
+++ b/share/wake/lib/system/incremental.wake
@@ -34,7 +34,7 @@ export def claimFileAsPathIn outputDirectory existingFile desiredName =
     def cmdline = which "ln", "-f", existingFile, desiredWorkspacePath, Nil
     makeExecPlan cmdline visible
     | setPlanLocalOnly   True
-    | setPlanPersistence ReRun
+    | setPlanPersistence Once
     | setPlanFnOutputs   (\_ desiredWorkspacePath, Nil)
     | runJobWith localRunner
     | getJobOutput


### PR DESCRIPTION
This makes claimFileAsPathIn work when:
- invoked multiple times
- used to claim a file from another file system