### PR TITLE
parser: don't lose tags on typed function arguments

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -585,12 +585,10 @@ static std::vector<Definition> parse_def(Lexer &lex, long index, bool target, bo
     }
     for (size_t i = 0; i < ast.args.size(); ++i) {
       AST &arg = ast.args[i];
+      args.emplace_back(arg.name, arg.token);
       if (arg.type) {
-        args.emplace_back("_ " + std::to_string(i), LOCATION);
-        dm->defs.insert(std::make_pair(arg.name, DefValue(arg.region, std::unique_ptr<Expr>(
-          new Ascribe(LOCATION, std::move(*arg.type), new VarRef(LOCATION, "_ " + std::to_string(i)), arg.token)))));
-      } else {
-        args.emplace_back(arg.name, arg.token);
+        dm->defs.insert(std::make_pair("_type " + arg.name, DefValue(arg.region, std::unique_ptr<Expr>(
+          new Ascribe(LOCATION, std::move(*arg.type), new VarRef(LOCATION, arg.name), arg.token)))));
       }
     }
     body = dm;


### PR DESCRIPTION
Previously, `def f x = x+42` would have type `(x: Integer) => Integer`.
With the new type patterns `def f (x: Integer): Integer = x+42`, it was becoming `Integer => Integer`.

This happens because the type ascription caused the code to be rewritten as:
```
def f '_ x' =
  def x = '_ x': Integer
  (x+42): Integer
```
... and the name `_x` is rejected as a nametag since it starts with `_`.

Instead, just discard the result of the type ascription construct:
```
def f x =
  def '_type x' = x: Integer
  (x+42): Integer
```