### PR TITLE
fuse: allow an environment variable to enable debug/trace

### DIFF
--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -60,8 +60,8 @@
 #define ENOATTR ENODATA
 #endif
 
-//#define TRACE(x) do { fprintf(stderr, "%s: %s\n", __FUNCTION__, x); fflush(stderr); } while (0)
-#define TRACE(x) (void)x
+bool enable_trace = false;
+#define TRACE(x) do { if (enable_trace) { fprintf(stderr, "%s: %s\n", __FUNCTION__, x); fflush(stderr); } } while (0)
 
 // We ensure STDIN is /dev/null, so this is a safe sentinel value for open files
 #define BAD_FD STDIN_FILENO
@@ -1417,6 +1417,10 @@ int main(int argc, char *argv[])
 			fprintf(stderr, "flock %s.log: %s\n", path.c_str(), strerror(errno));
 		}
 		goto term;
+	}
+
+	if (getenv("DEBUG_FUSE_WAKE")) {
+		enable_trace = true;
 	}
 
 	umask(0);

--- a/fuse/daemon_client.cpp
+++ b/fuse/daemon_client.cpp
@@ -46,7 +46,8 @@ bool daemon_client::connect(std::vector<std::string> &visible) {
 	for (int retry = 0; (ffd = open(is_running_path.c_str(), O_RDONLY)) == -1 && retry < 12; ++retry) {
 		pid_t pid = fork();
 		if (pid == 0) {
-			const char *env[2] = { "PATH=/usr/bin:/bin:/usr/sbin:/sbin", 0 };
+			const char *env[3] = { "PATH=/usr/bin:/bin:/usr/sbin:/sbin", 0, 0 };
+			if (getenv("DEBUG_FUSE_WAKE")) env[1] = "DEBUG_FUSE_WAKE=1";
 			execle(executable.c_str(), "fuse-waked", mount_path.c_str(), nullptr, env);
 			std::cerr << "execl " << executable << ": " << strerror(errno) << std::endl;
 			exit(1);

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -412,6 +412,7 @@ export def fuseRunner =
   def score plan =
     if plan.getPlanLocalOnly then Fail "would hide workspace" else Pass 1.0
   makeJSONRunnerPlan fuse score
+  | editJSONRunnerPlanExtraEnv (editEnvironment "DEBUG_FUSE_WAKE" (\_ getenv "DEBUG_FUSE_WAKE"))
   | makeJSONRunner
 
 export def preloadRunner =
@@ -438,11 +439,13 @@ export def defaultRunner = match sysname
 # A plan describing how to construct a JSONRunner
 # RawScript: the path to the script to run jobs with
 # ExtraArgs: extra arguments to pass to ``RawScript``
+# ExtraEnv: environment variables to pass to the script
 # Score: runJob chooses the runner with the largest score for a Plan
 # Estimate: predict local usage based on prior recorded usage
 tuple JSONRunnerPlan =
   export RawScript: String
   export ExtraArgs: List String
+  export ExtraEnv: List String
   export Score: Plan => Result Double String
   export Estimate: Usage => Usage
 
@@ -450,13 +453,14 @@ tuple JSONRunnerPlan =
 # rawScript: String; the path to the script to run jobs with
 # score: Plan => Double; runJob chooses the runner with the largest score for a Plan
 export def makeJSONRunnerPlan rawScript score =
-  JSONRunnerPlan rawScript Nil score (_)
+  JSONRunnerPlan rawScript Nil Nil score (_)
 
 # Make a Runner that runs a named script to run jobs
 # plan: JSONRunnerPlan; a tuple containing the arguments for this function
 export def makeJSONRunner plan =
   def rawScript = plan.getJSONRunnerPlanRawScript
   def extraArgs = plan.getJSONRunnerPlanExtraArgs
+  def extraEnv = plan.getJSONRunnerPlanExtraEnv
   def score = plan.getJSONRunnerPlanScore
   def estimate = plan.getJSONRunnerPlanEstimate
 
@@ -506,7 +510,7 @@ export def makeJSONRunner plan =
             Pass inFile =
               def outFile = "{build}/{prefix}.out.json"
               def cmd = script, inFile, outFile, extraArgs
-              def proxy = RunnerInput label cmd Nil environment "." "" Nil prefix (estimate record)
+              def proxy = RunnerInput label cmd Nil (extraEnv ++ environment) "." "" Nil prefix (estimate record)
               Pair (Pass proxy) inFile
   def post = match _
     Pair (Fail f) _ = Fail f


### PR DESCRIPTION
Often we need to diagnose a released version of wake.
This let's us easily inject some trace information.

DEBUG_FUSE_WAKE=1 wake ...

Fixes #594