### PR TITLE
Fix handling of symbolic links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ manifest.wake
 /lib/wake/shim-wake
 /lib/wake/shim-wake.*
 /lib/wake/libpreload-wake.*
-/install
+/tmp
 *.swp
 *.swo
 *.swn

--- a/build.wake
+++ b/build.wake
@@ -146,20 +146,7 @@ from test_wake import topic wakeTestBinary
 publish wakeTestBinary = defaultWake, Nil
 
 def defaultWake Unit =
-    require Pass variant =
-        toVariant "default"
-
     require Pass wakeVisible =
-        all variant # build wake to test
+        doInstall "tmp" "default"
 
-    def wakeShare =
-        sources "share" `.*`
-
-    require Some wakeBin =
-        wakeVisible
-        | filter (matches `bin/wake.*` _.getPathName)
-        | head
-    else
-        Fail (makeError "Wake compilation did not produce an executable to test!")
-
-    Pass (Pair wakeBin.getPathName (wakeVisible ++ wakeShare))
+    Pass (Pair "tmp/bin/wake" wakeVisible)

--- a/common/unlink.cpp
+++ b/common/unlink.cpp
@@ -31,9 +31,9 @@ int deep_unlink(int parentfd, const char *path) {
 	(void)ignore;
 
 	// Capture a persistent handle to the directory
-	int dirfd = openat(parentfd, path, O_RDONLY|O_DIRECTORY);
+	int dirfd = openat(parentfd, path, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
 	if (dirfd == -1) {
-		if (errno == ENOTDIR) {
+		if (errno == ENOTDIR || errno == ELOOP) {
 			// The directory became a file between readdir and openat.
 			// This should not count as failure unless we can't remove it.
 			if (unlinkat(parentfd, path, 0)) {

--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -1388,6 +1388,7 @@ int main(int argc, char *argv[])
 	sigset_t block;
 	struct sigaction sa;
 	struct fuse_args args;
+	struct flock fl;
 	pid_t pid;
 	int log, null;
 	bool madedir;
@@ -1410,15 +1411,6 @@ int main(int argc, char *argv[])
 		goto term;
 	}
 
-	if (flock(log, LOCK_EX|LOCK_NB) != 0) {
-		if (errno == EWOULDBLOCK) {
-			status = 0; // another daemon is already running
-		} else {
-			fprintf(stderr, "flock %s.log: %s\n", path.c_str(), strerror(errno));
-		}
-		goto term;
-	}
-
 	if (getenv("DEBUG_FUSE_WAKE")) {
 		enable_trace = true;
 	}
@@ -1437,6 +1429,7 @@ int main(int argc, char *argv[])
 		goto rmroot;
 	}
 
+	// Become a daemon
 	pid = fork();
 	if (pid == -1) {
 		perror("fork");
@@ -1457,6 +1450,22 @@ int main(int argc, char *argv[])
 		goto rmroot;
 	} else if (pid != 0) {
 		status = 0;
+		goto term;
+	}
+
+	// Open the logfile and use as lock on it to ensure we retain ownership
+	// This has to happen after fork (which would drop the lock)
+	memset(&fl, 0, sizeof(fl));
+	fl.l_type = F_WRLCK;
+	fl.l_whence = SEEK_SET;
+	fl.l_start = 0;
+	fl.l_len = 0; // 0=largest possible
+	if (fcntl(log, F_SETLK, &fl) != 0) {
+		if (errno == EAGAIN || errno == EACCES) {
+			status = 0; // another daemon is already running
+		} else {
+			fprintf(stderr, "flock %s.log: %s\n", path.c_str(), strerror(errno));
+		}
 		goto term;
 	}
 
@@ -1518,7 +1527,7 @@ int main(int argc, char *argv[])
 
 	if (log != STDOUT_FILENO) dup2(log, STDOUT_FILENO);
 	if (log != STDERR_FILENO) dup2(log, STDERR_FILENO);
-	if (log != STDOUT_FILENO && log != STDERR_FILENO) close(log);
+	// NOTE: We CANNOT close log, as that would release our lock
 
 	if (null != STDIN_FILENO) {
 		dup2(null, STDIN_FILENO);

--- a/fuse/daemon.cpp
+++ b/fuse/daemon.cpp
@@ -18,10 +18,15 @@
  * limitations under the License.
  */
 
+#define _XOPEN_SOURCE 700
 #define FUSE_USE_VERSION 26
 
-#ifdef linux
-#define _XOPEN_SOURCE 700
+/* Unfortunately, OS/X so far only implements issue 6.
+ * O_NOFOLLOW was added by issue 7.
+ * O_DIRECTORY was added by issue 7.
+ */
+#if !defined(O_NOFOLLOW) || !defined(O_DIRECTORY)
+#define _DARWIN_C_SOURCE 1
 #endif
 
 #define MAX_JSON (128*1024*1024)

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -603,6 +603,10 @@ target hashcode f =
       True (x, Nil) = x
       _ _ = "BadHash"
 
+export def getPathHash = match _
+  Path    x = hashcode x
+  BadPath _ = "BadHash"
+
 # Whenever possible, use 'job' if:
 #   cmd can run under FUSE
 #   cmd guarantees to produce the same outputs given the same inputs

--- a/shim/shim.c
+++ b/shim/shim.c
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#define _XOPEN_SOURCE 700
+
 /* Wake vfork exec shim */
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -36,26 +38,40 @@ static int do_hash_dir() {
   return 0;
 }
 
-static int do_hash(const char *file) {
-  struct stat stat;
-  int fd, got;
-  uint8_t hash[HASH_BYTES], buffer[8192];
+static int do_hash_link(const char *link) {
   blake2b_state S;
+  uint8_t hash[HASH_BYTES];
+  size_t len = 8192;
+  char *buffer = malloc(len);
 
-  fd = open(file, O_RDONLY);
-  if (fd == -1) {
-    if (errno == EISDIR) return do_hash_dir();
-    fprintf(stderr, "hash_open: %s: %s\n", file, strerror(errno));
-    return 1;
+  ssize_t out;
+  while (len == (out = readlink(link, buffer, len))) {
+    len += len;
+    buffer = realloc(buffer, len);
   }
 
-  if (fstat(fd, &stat) != 0) {
-    if (errno == EISDIR) return do_hash_dir();
-    fprintf(stderr, "hash_fstat: %s: %s\n", file, strerror(errno));
-    return 1;
+  if (out == -1) {
+     fprintf(stderr, "shim hash readlink(%s): %s\n", link, strerror(errno));
+     free(buffer);
+     return 1;
   }
 
-  if (S_ISDIR(stat.st_mode)) return do_hash_dir();
+  blake2b_init(&S, sizeof(hash));
+  blake2b_update(&S, (uint8_t*)buffer, out);
+  blake2b_final(&S, &hash[0], sizeof(hash));
+  free(buffer);
+
+  for (int i = 0; i < (int)sizeof(hash); ++i)
+    printf("%02x", hash[i]);
+  printf("\n");
+
+  return 0;
+}
+
+static int do_hash_file(const char *file, int fd) {
+  blake2b_state S;
+  uint8_t hash[HASH_BYTES], buffer[8192];
+  ssize_t got;
 
   blake2b_init(&S, sizeof(hash));
   while ((got = read(fd, &buffer[0], sizeof(buffer))) > 0)
@@ -63,7 +79,7 @@ static int do_hash(const char *file) {
   blake2b_final(&S, &hash[0], sizeof(hash));
 
   if (got < 0) {
-    fprintf(stderr, "hash_read: %s: %s\n", file, strerror(errno));
+    fprintf(stderr, "shim hash read(%s): %s\n", file, strerror(errno));
     return 1;
   }
 
@@ -72,6 +88,30 @@ static int do_hash(const char *file) {
   printf("\n");
 
   return 0;
+}
+
+static int do_hash(const char *file) {
+  struct stat stat;
+  int fd;
+
+  fd = open(file, O_RDONLY|O_NOFOLLOW);
+  if (fd == -1) {
+    if (errno == EISDIR) return do_hash_dir();
+    if (errno == ELOOP) return do_hash_link(file);
+    fprintf(stderr, "shim hash open(%s): %s\n", file, strerror(errno));
+    return 1;
+  }
+
+  if (fstat(fd, &stat) != 0) {
+    if (errno == EISDIR) return do_hash_dir();
+    fprintf(stderr, "shim hash fstat(%s): %s\n", file, strerror(errno));
+    return 1;
+  }
+
+  if (S_ISDIR(stat.st_mode)) return do_hash_dir();
+  if (S_ISLNK(stat.st_mode)) return do_hash_link(file);
+
+  return do_hash_file(file, fd);
 }
 
 int main(int argc, char **argv) {

--- a/shim/shim.c
+++ b/shim/shim.c
@@ -17,6 +17,13 @@
 
 #define _XOPEN_SOURCE 700
 
+/* Unfortunately, OS/X so far only implements issue 6.
+ * O_NOFOLLOW was added by issue 7.
+ */
+#if !defined(O_NOFOLLOW)
+#define _DARWIN_C_SOURCE 1
+#endif
+
 /* Wake vfork exec shim */
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -22,6 +22,7 @@
 #include "utf8.h"
 #include "gc.h"
 #include "shell.h"
+#include "unlink.h"
 #include <sstream>
 #include <fstream>
 #include <iostream>
@@ -31,6 +32,7 @@
 #include <string.h>
 #include <utf8proc.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 static PRIMTYPE(type_vcat) {
   bool ok = out->unify(String::typeVar);
@@ -238,6 +240,7 @@ static PRIMFN(prim_write) {
   REQUIRE(mpz_cmp_si(mode, 0x1ff) <= 0);
   long mask = mpz_get_si(mode);
 
+  deep_unlink(AT_FDCWD, path->c_str());
   std::ofstream t(path->c_str(), std::ios_base::trunc);
   if (!t.fail()) {
     t.write(body->c_str(), body->size());

--- a/tests/runtime/symlinks/pass.sh
+++ b/tests/runtime/symlinks/pass.sh
@@ -1,0 +1,26 @@
+#! /bin/sh
+
+set -ex
+
+rm -f datFile badLink goodLink wake.db
+"${1:-wake}" -v test
+"${1:-wake}" -v test
+
+rm wake.db
+"${1:-wake}" -v test
+
+rm -f datFile badLink goodLink
+ln -s whatever datFile
+ln -s whatever badLink
+ln -s whatever goodLink
+"${1:-wake}" -v test
+"${1:-wake}" -v test
+
+rm -f datFile badLink goodLink wake.db
+ln -s whatever datFile
+ln -s whatever badLink
+ln -s whatever goodLink
+"${1:-wake}" -v test
+"${1:-wake}" -v test
+
+echo "Symlinks work!"

--- a/tests/runtime/symlinks/test.wake
+++ b/tests/runtime/symlinks/test.wake
@@ -1,0 +1,47 @@
+export def datFile Unit =
+    write "datFile" "hello world"
+
+export def goodLink Unit =
+    makeExecPlan ("ln", "-s", "datFile", "goodLink", Nil) (datFile Unit, Nil)
+    | runJob
+    | getJobOutput
+
+export def badLink Unit =
+    makeExecPlan ("ln", "-s", "badFile", "badLink", Nil) Nil
+    | runJob
+    | getJobOutput
+    | getPathResult
+
+export def shouldWork Unit =
+    makeExecPlan ("cat", "goodLink", Nil) (goodLink Unit, datFile Unit, Nil)
+    | editPlanEnvironment (setEnvironment "TEST" "1")
+    | runJob
+    | getJobInputs
+    | findFailFn getPathResult
+
+export def shouldFail1 Unit =
+    makeExecPlan ("cat", "goodLink", Nil) (goodLink Unit, Nil)
+    | editPlanEnvironment (setEnvironment "TEST" "2")
+    | runJob
+    | getJobInputs
+    | findFailFn getPathResult
+
+export def shouldFail2 Unit =
+    makeExecPlan ("cat", "goodLink", Nil) (datFile Unit, Nil)
+    | editPlanEnvironment (setEnvironment "TEST" "3")
+    | runJob
+    | getJobInputs
+    | findFailFn getPathResult
+
+export def test _ =
+    require Pass link = badLink Unit
+    require True = getPathHash link !=* "BadHash"
+    else failWithError "cannot hash a dangling symlink"
+    require Pass what = shouldWork Unit
+    require Fail _ = shouldFail1 Unit else failWithError "fail1 passed!"
+    require Fail _ = shouldFail2 Unit else failWithError "fail2 passed!"
+    require a, b, Nil = what
+    else failWithError "did not detect both inputs ({format what})"
+    require True = getPathHash a !=* getPathHash b
+    else failWithError "identical hashes should not be identical"
+    Pass 0

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -117,9 +117,10 @@ def runTest testScript =
         wakeToTest Unit
 
     def testJob =
-        makeExecPlan (testScript.getPathName.inTestDir, wakeBin.inTestDir, Nil) (visibleFiles ++ wakeVisible)
+        makeExecPlan ("./{testScript.getPathName.inTestDir}", wakeBin.inTestDir, Nil) (visibleFiles ++ wakeVisible)
         | setPlanDirectory testDirectory
         | setPlanLabel "testing: {testName}"
+        | setPlanLocalOnly True # On OS/X you cannot mount fuse within fuse
         | setPlanStdout logNever
         | setPlanStderr logNever
         | runJob


### PR DESCRIPTION
It turns out there were three distinct bugs with symlinks:
- wake's unlink wrapper could not remove them (this led to problems where jobs meant to overwrite a symlink, but instead created the link destination instead)
- the wake shim would hash the contents of the destination instead of the link (Fixes #560)
- the wake 'write' command would not follow a symlink to create the target instead

This PR fixes all of the above issues. It also:
- adds a unit test which fails if any of these three bugs are present
- adds a `getPathHash` method for introspecting hash codes
- fixes a recursive-fuse-bug in the unit testing framework on os/x