### PR TITLE
streams: add report stream and intensity control

### DIFF
--- a/share/wake/lib/core/print.wake
+++ b/share/wake/lib/core/print.wake
@@ -49,20 +49,33 @@ export data Colour =
     Cyan
     White
 
+export data Intensity =
+    Dim
+    Bright
+
 # makeLogLevel: define a new log level
 export def makeLogLevel (name: String) (colour: Option Colour): LogLevel =
+    makeLogLevel2 name colour None
+
+export def makeLogLevel2 (name: String) (colour: Option Colour) (intensity: Option Intensity): LogLevel =
     def set name code = prim "colour"
-    def code = match colour
-        None         = 9
-        Some Black   = 0
-        Some Red     = 1
-        Some Green   = 2
-        Some Yellow  = 3
-        Some Blue    = 4
-        Some Magenta = 5
-        Some Cyan    = 6
-        Some White   = 7
-    def _ = set name code
+    def colourCode = match colour
+        None   = 0
+        Some c = 8 + match c
+            Black   = 0
+            Red     = 1
+            Green   = 2
+            Yellow  = 3
+            Blue    = 4
+            Magenta = 5
+            Cyan    = 6
+            White   = 7
+    def intensityCode = match intensity
+        None   = 0
+        Some i = 16 * match i
+            Dim    = 1
+            Bright = 2
+    def _ = set name (colourCode+intensityCode)
     LogLevel name
 
 # The standard logging levels used in wake
@@ -75,13 +88,17 @@ export def logError: LogLevel =
 export def logWarning: LogLevel =
     makeLogLevel "warning" (Some Yellow)
 
+# logReport: logged to stdout unless run with -q
+export def logReport: LogLevel =
+    makeLogLevel "report" (Some Magenta)
+
 # logEcho: logged to stdout when run with -v
 export def logEcho: LogLevel =
     makeLogLevel "echo" None
 
 # logInfo: logged to stdout when run with -v
 export def logInfo: LogLevel =
-    makeLogLevel "info" None
+    makeLogLevel2 "info" None (Some Dim)
 
 # logDebug: logged to stdout on debug
 export def logDebug: LogLevel =
@@ -124,11 +141,11 @@ export def printlnLevel (level: LogLevel): String => Unit =
 #   # Print a diagnostic visible when run with -v
 #   def Unit = print "hello world\n"
 export def print: String => Unit =
-    printLevel logInfo
+    printLevel logReport
 
 # println: print a colourless String with a newline, visible when run with -v.
 #
 #   # Print a happy face visible when run with -v
 #   def Unit = println "{integerToUnicode 0x1f600}"
 export def println: String => Unit =
-    printlnLevel logInfo
+    printlnLevel logReport

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -197,7 +197,7 @@ void Heap::report() const {
         << std::endl;
     }
     s << "------------------------------------------" << std::endl;
-    status_write(STREAM_LOG, s.str());
+    status_write(STREAM_REPORT, s.str());
   }
 }
 
@@ -291,7 +291,7 @@ void Heap::GC(size_t requested_pads) {
           << std::endl;
       }
       s << "------------------------------------------" << std::endl;
-      status_write(STREAM_LOG, s.str());
+      status_write(STREAM_REPORT, s.str());
     }
 
     if (imp->last_pads > imp->most_pads) {

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -276,6 +276,7 @@ struct JobTable::detail {
   double active, limit; // CPUs
   uint64_t phys_active, phys_limit; // memory
   long max_children; // hard cap on jobs allowed
+  bool debug;
   bool verbose;
   bool quiet;
   bool check;
@@ -322,7 +323,8 @@ bool JobTable::exit_now() {
   return exit_asap;
 }
 
-JobTable::JobTable(Database *db, double percent, bool verbose, bool quiet, bool check, bool batch) : imp(new JobTable::detail) {
+JobTable::JobTable(Database *db, double percent, bool debug, bool verbose, bool quiet, bool check, bool batch) : imp(new JobTable::detail) {
+  imp->debug = debug;
   imp->verbose = verbose;
   imp->quiet = quiet;
   imp->check = check;
@@ -621,7 +623,7 @@ static void launch(JobTable *jobtable) {
     if (*i.job->dir != ".") s << "cd " << i.job->dir->c_str() << "; ";
     s << pretty;
     if (!i.job->stdin_file->empty()) s << " < " << shell_escape(i.job->stdin_file->c_str());
-    if (indirect && jobtable->imp->verbose) {
+    if (indirect && jobtable->imp->debug) {
       s << " # launched by: ";
       if (task.dir != ".") s << "cd " << task.dir << "; ";
       s << pretty_cmd(task.cmdline);

--- a/src/job.h
+++ b/src/job.h
@@ -27,7 +27,7 @@ struct JobTable {
   struct detail;
   std::unique_ptr<detail> imp;
 
-  JobTable(Database *db, double percent, bool verbose, bool quiet, bool check, bool batch);
+  JobTable(Database *db, double percent, bool debug, bool verbose, bool quiet, bool check, bool batch);
   ~JobTable();
 
   // Wait for a job to complete; false -> no more active jobs

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -481,11 +481,11 @@ int main(int argc, char **argv) {
   if (notype) return ok?0:1;
 
   /* Setup logging streams */
-  if (debug   && !fd1) fd1 = "debug,info,echo,warning,error";
-  if (verbose && !fd1) fd1 = "info,echo,warning,error";
+  if (debug   && !fd1) fd1 = "debug,info,echo,report,warning,error";
+  if (verbose && !fd1) fd1 = "info,echo,report,warning,error";
   if (quiet   && !fd1) fd1 = "error";
-  if (!tty    && !fd1) fd1 = "info,echo,warning,error";
-  if (!fd1) fd1 = "warning,error";
+  if (!tty    && !fd1) fd1 = "info,echo,report,warning,error";
+  if (!fd1) fd1 = "report,warning,error";
   if (!fd2) fd2 = "error";
 
   status_set_bulk_fd(1, fd1);
@@ -495,7 +495,7 @@ int main(int argc, char **argv) {
   status_set_bulk_fd(5, fd5);
 
   /* Primitives */
-  JobTable jobtable(&db, percent, verbose, quiet, check, !tty);
+  JobTable jobtable(&db, percent, debug, verbose, quiet, check, !tty);
   StringInfo info(verbose, debug, quiet, VERSION_STR, make_canonical(wake_cwd), cmdline);
   PrimMap pmap = prim_register_all(&info, &jobtable);
 

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -75,6 +75,16 @@ const char *term_colour(int code)
   return out;
 }
 
+const char *term_intensity(int code)
+{
+  static char dim_lit[] = "dim";
+  static char bold_lit[] = "bold";
+  if (!sgr0) return "";
+  if (code == 1) return tigetstr(dim_lit);
+  if (code == 2) return tigetstr(bold_lit);
+  return "";
+}
+
 const char *term_normal()
 {
   return sgr0?sgr0:"";
@@ -360,8 +370,12 @@ void status_write(const char *name, const char *data, int len)
   StreamSettings s = settings[name];
   if (s.fd != -1) {
     status_clear();
-    if (s.colour != TERM_DEFAULT)
-      write_all_str(s.fd, term_colour(s.colour));
+    if (s.colour != TERM_DEFAULT) {
+      int colour = s.colour % 8;
+      int intensity = s.colour / 16;
+      if (colour != TERM_DEFAULT) write_all_str(s.fd, term_colour(colour));
+      if (intensity != TERM_DEFAULT) write_all_str(s.fd, term_intensity(intensity));
+    }
     write_all(s.fd, data, len);
     if (s.colour != TERM_DEFAULT)
       write_all_str(s.fd, term_normal());

--- a/src/status.h
+++ b/src/status.h
@@ -47,6 +47,7 @@ extern StatusState status_state;
 
 #define STREAM_LOG	"debug"
 #define STREAM_INFO	"info"
+#define STREAM_REPORT	"report"
 #define STREAM_ECHO	"echo"
 #define STREAM_WARNING	"warning"
 #define STREAM_ERROR	"error"
@@ -63,15 +64,19 @@ void status_set_bulk_fd(int fd, const char *streams);
 
 void term_init(bool tty);
 
-#define TERM_BLACK	0
-#define TERM_RED	1
-#define TERM_GREEN	2
-#define TERM_YELLOW	3
-#define TERM_BLUE	4
-#define TERM_MAGENTA	5
-#define TERM_CYAN	6
-#define TERM_WHITE	7
-#define TERM_DEFAULT	9
+#define TERM_DEFAULT	0
+
+#define TERM_BLACK	(8+0)
+#define TERM_RED	(8+1)
+#define TERM_GREEN	(8+2)
+#define TERM_YELLOW	(8+3)
+#define TERM_BLUE	(8+4)
+#define TERM_MAGENTA	(8+5)
+#define TERM_CYAN	(8+6)
+#define TERM_WHITE	(8+7)
+
+#define TERM_DIM	(16*1)
+#define TERM_BRIGHT	(16*2)
 
 const char *term_colour(int code);
 const char *term_normal();


### PR DESCRIPTION
The report stream (magenta) is now used for println and profile-heap.
These should be output even without verbose mode.

The logInfo stream is now dim.  This makes echoed commands stick out when
compared to the intermingled standard output.

Fixes #592.