### PR TITLE
Emscripten

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,25 @@ jobs:
             - tests
             - scripts/sphinx/build/html
 
+  wasm:
+    machine:
+      image: ubuntu-1604:202007-01
+#      docker_layer_caching: true # paywalled feature: retain docker build results between runs
+#    resource_class: large
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: docker build -f /tmp/workspace/.circleci/dockerfiles/wasm -t wake-wasm .
+      - run: |
+          tar xJf /tmp/workspace/wake_*.tar.xz && \
+          docker run --rm --mount type=bind,source=$PWD,target=/build --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined wake-wasm make -C wake-* all && \
+          docker run --rm --mount type=bind,source=$PWD,target=/build --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -w /build/$(ls -d wake-*) wake-wasm ./bin/wake wasm && \
+          install -D -t release/wasm wake-*/lib/wake/*.wasm*
+      - persist_to_workspace:
+          root: .
+          paths:
+            - release/wasm
+
   alpine:
     machine:
       image: ubuntu-1604:202007-01
@@ -224,6 +243,9 @@ workflows:
   build:
     jobs:
       - tarball
+      - wasm:
+          requires:
+            - tarball
       - alpine:
           requires:
             - tarball
@@ -250,6 +272,7 @@ workflows:
             - tarball
       - release:
           requires:
+            - wasm
             - alpine
             - debian_testing # Newest everything
             - debian_wheezy  # Oldest supported compiler

--- a/.circleci/dockerfiles/wasm
+++ b/.circleci/dockerfiles/wasm
@@ -1,0 +1,5 @@
+FROM emscripten/emsdk:latest
+
+RUN apt-get update && apt-get install -y build-essential devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse
+
+WORKDIR /build

--- a/build.wake
+++ b/build.wake
@@ -19,8 +19,9 @@ from wake import _
 # Useful build variants (arguments to all)
 def toVariant = match _
     "default" = Pass (Pair "native-cpp11-release" "native-c99-release")
-    "static"  = Pass (Pair "native-cpp11-static" "native-c99-static")
-    "debug"   = Pass (Pair "native-cpp11-debug" "native-c99-debug")
+    "static"  = Pass (Pair "native-cpp11-static"  "native-c99-static")
+    "debug"   = Pass (Pair "native-cpp11-debug"   "native-c99-debug")
+    "wasm"    = Pass (Pair "wasm-cpp11-release"   "wasm-c99-release")
     s = Fail "Unknown build target ({s})".makeError
 
 export def build = match _

--- a/common/rusage.cpp
+++ b/common/rusage.cpp
@@ -51,6 +51,8 @@ RUsage RUsage::operator - (const RUsage &other) const {
 #define MEMBYTES(ru)    (ru.ru_maxrss*1024)
 #elif defined(__sun)
 #define MEMBYTES(ru)    (ru.ru_maxrss*getpagesize())
+#elif defined(__EMSCRIPTEN__)
+#define MEMBYTES(ru)	0
 #else
 #error Missing definition to access maxrss on this platform
 #endif

--- a/common/whereami.cpp
+++ b/common/whereami.cpp
@@ -660,6 +660,15 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
   return length;
 }
 
+#elif defined(__EMSCRIPTEN__)
+
+WAI_NOINLINE
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  return -1;
+}
+
 #else
 
 #error unsupported platform

--- a/fuse/fuse.cpp
+++ b/fuse/fuse.cpp
@@ -187,12 +187,12 @@ bool run_in_fuse(fuse_args &args, int &status, std::string &result_json) {
 		}
 
 		if (args.use_stdin_file) {
-			std::string stdin = args.stdin_file;
-			if (stdin.empty()) stdin = "/dev/null";
+			std::string stdin_file = args.stdin_file;
+			if (stdin_file.empty()) stdin_file = "/dev/null";
 
-			int fd = open(stdin.c_str(), O_RDONLY);
+			int fd = open(stdin_file.c_str(), O_RDONLY);
 			if (fd == -1) {
-				std::cerr << "open " << stdin << ":" << strerror(errno) << std::endl;
+				std::cerr << "open " << stdin_file << ":" << strerror(errno) << std::endl;
 				exit(1);
 			}
 			if (fd != STDIN_FILENO) {

--- a/lsp/emscripten.wake
+++ b/lsp/emscripten.wake
@@ -45,3 +45,9 @@ publish compileC = emccFn (makeCompileC "wasm-c99-release"   _ (c99Flags ++ rele
 publish compileC = emppFn (makeCompileC "wasm-cpp11-release" _ (c11Flags ++ releaseCFlags))
 publish linkO = emccFn (makeLinkO "wasm-c99-release"   _ (releaseLFlags))
 publish linkO = emppFn (makeLinkO "wasm-cpp11-release" _ (releaseLFlags))
+
+export def wasm _ =
+    require Pass variant = toVariant "wasm"
+    def working = buildFuse, buildShim, buildPreload, buildBSP, buildLSP, Nil
+    # not_working = buildWake (needs gmp+re2+sqlite3), buildFuseDaemon (needs fuse), buildPrelib (no shared libs)
+    map (_ variant) working | findFailFn getPathResult

--- a/lsp/emscripten.wake
+++ b/lsp/emscripten.wake
@@ -1,0 +1,47 @@
+# Copyright 2019 SiFive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You should have received a copy of LICENSE.Apache2 along with
+# this software. If not, you may obtain a copy at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package build_wake
+from wake import _
+from gcc_wake import _
+
+def emccFn fn = match emcc
+    None = Nil
+    Some x = fn x
+
+def emcc =
+    require Some path = getenv "PATH"
+    def emcc = whichIn path "emcc"
+    if matches `/.*` emcc then
+        Some emcc
+    else
+        None
+
+def emppFn fn = match empp
+    None = Nil
+    Some x = fn x
+
+def empp =
+    require Some path = getenv "PATH"
+    def empp = whichIn path "em++"
+    if matches `/.*` empp then
+        Some empp
+    else
+        None
+
+publish compileC = emccFn (makeCompileC "wasm-c99-release"   _ (c99Flags ++ releaseCFlags))
+publish compileC = emppFn (makeCompileC "wasm-cpp11-release" _ (c11Flags ++ releaseCFlags))
+publish linkO = emccFn (makeLinkO "wasm-c99-release"   _ (releaseLFlags))
+publish linkO = emppFn (makeLinkO "wasm-cpp11-release" _ (releaseLFlags))

--- a/preload/wrap.cpp
+++ b/preload/wrap.cpp
@@ -291,8 +291,8 @@ int main(int argc, const char **argv) {
   env.push_back(0);
 
   std::string dir = root + "/" + jast.get("directory").value;
-  std::string stdin = jast.get("stdin").value;
-  if (stdin.empty()) stdin = "/dev/null";
+  std::string stdin_file = jast.get("stdin").value;
+  if (stdin_file.empty()) stdin_file = "/dev/null";
 
   struct timeval start;
   gettimeofday(&start, 0);
@@ -303,9 +303,9 @@ int main(int argc, const char **argv) {
       std::cerr << "chdir " << dir << ": " << strerror(errno) << std::endl;
       exit(1);
     }
-    int fd = open(stdin.c_str(), O_RDONLY);
+    int fd = open(stdin_file.c_str(), O_RDONLY);
     if (fd == -1) {
-      std::cerr << "open " << stdin << ":" << strerror(errno) << std::endl;
+      std::cerr << "open " << stdin_file << ":" << strerror(errno) << std::endl;
       exit(1);
     }
     if (fd != 0) {

--- a/share/wake/lib/gcc_wake/gcc.wake
+++ b/share/wake/lib/gcc_wake/gcc.wake
@@ -15,14 +15,14 @@
 
 package gcc_wake
 
-def c11Flags      = ("-std=c++11", Nil)
-def c99Flags      = ("-std=c99", Nil)
-def debugCFlags   = ("-Wall", "-Wextra", "-O0", "-g", "-pg", Nil)
-def debugLFlags   = ("-g", "-pg", Nil)
-def releaseCFlags = ("-Wall", "-O2", "-flto", Nil)
-def releaseLFlags = ("-flto", Nil)
-def staticCFlags =  ("-Wall", "-O2", "-flto", Nil)
-def staticLFlags  = ("-flto", "-static", "-s", Nil)
+export def c11Flags      = ("-std=c++11", Nil)
+export def c99Flags      = ("-std=c99", Nil)
+export def debugCFlags   = ("-Wall", "-Wextra", "-O0", "-g", "-pg", Nil)
+export def debugLFlags   = ("-g", "-pg", Nil)
+export def releaseCFlags = ("-Wall", "-O2", "-flto", Nil)
+export def releaseLFlags = ("-flto", Nil)
+export def staticCFlags =  ("-Wall", "-O2", "-flto", Nil)
+export def staticLFlags  = ("-flto", "-static", "-s", Nil)
 
 def doCompileC variant gcc flags headers cfile =
     def obj = replace `\.c(pp)?$` ".{variant}.o" cfile.getPathName
@@ -43,10 +43,10 @@ def doLinkO variant linker flags objects targ =
     | runJob
     | getJobOutput
 
-def makeCompileC variant gcc flags =
+export def makeCompileC variant gcc flags =
     Pair variant (\extraFlags doCompileC variant gcc (flags ++ extraFlags)), Nil
 
-def makeLinkO variant linker flags =
+export def makeLinkO variant linker flags =
     Pair variant (\extraFlags doLinkO variant linker (flags ++ extraFlags)), Nil
 
 export topic compileC: Pair String ((extraFlags: List String) => (headers: List Path) => (cfile: Path) => Path)

--- a/share/wake/lib/gcc_wake/gcc.wake
+++ b/share/wake/lib/gcc_wake/gcc.wake
@@ -35,13 +35,20 @@ def doCompileC variant gcc flags headers cfile =
     | getJobOutput
 
 def doLinkO variant linker flags objects targ =
+    def output = "{targ}.{variant}"
     def cmdline =
-        (linker, "-o", "{targ}.{variant}", map getPathName objects) ++
+        (linker, "-o", output, map getPathName objects) ++
         distinctBy scmp flags
-    makeExecPlan cmdline (mkdir "{targ}/..", objects)
-    | setPlanLabel "link {replace `^.*/` '' linker} {targ}"
-    | runJob
-    | getJobOutput
+    def outputPaths =
+        makeExecPlan cmdline (mkdir "{targ}/..", objects)
+        | setPlanLabel "link {replace `^.*/` '' linker} {targ}"
+        | runJob
+        | getJobOutputs
+        | filter (matches output.quote _.getPathName)
+    match outputPaths
+        Nil = makeBadPath (makeError "Expected linker output not found")
+        x, Nil = x
+        _ = unreachable "two Paths cannot be identical"
 
 export def makeCompileC variant gcc flags =
     Pair variant (\extraFlags doCompileC variant gcc (flags ++ extraFlags)), Nil

--- a/src/gc.h
+++ b/src/gc.h
@@ -71,7 +71,12 @@ struct HeapObject {
 
   // this overload causes non-placement 'new' to become illegal (which we want)
   void *operator new(size_t size, void *free) { return free; }
-};
+}
+#ifdef __EMSCRIPTEN__
+// Emscripten needs some help getting our GC alignment right.
+__attribute__ ((aligned (8)))
+#endif
+;
 
 inline std::ostream & operator << (std::ostream &os, const HeapObject *value) {
   HeapObject::format(os, value);

--- a/src/regexp.cpp
+++ b/src/regexp.cpp
@@ -260,17 +260,6 @@ static PRIMFN(prim_rcat) {
 
   int offset = has_set_dot_nl<RE2::Options>::value ? 0 : 4;
 
-  size_t size = 0;
-  for (size_t i = 0; i < nargs; ++i) {
-    if (i % 2 == 0) {
-      STRING(s, i);
-      size += s->size();
-    } else {
-      REGEXP(r, i);
-      size += r->exp->pattern().size() - offset;
-    }
-  }
-
   std::string out;
   for (size_t i = 0; i < nargs; ++i) {
     if (i % 2 == 0) {


### PR DESCRIPTION
Adds support for compiling wake as a web assembly target.
This will be useful to produce a platform-agnostic image suitable for use in the vscode extension.