### PR TITLE
silence '<hash>' messages

### DIFF
--- a/src/cli/status.cpp
+++ b/src/cli/status.cpp
@@ -144,6 +144,12 @@ static void status_redraw(bool idle)
   int rows3 = rows/3;
   int overall = status_state.remain > 0 ? 1 : 0;
   if (tty && rows3 >= 2+overall && cols > 16) for (auto &x : status_state.jobs) {
+
+    // Silence wake-internal messages like '<hash>'
+    std::string msg_prefix = "'<";
+    if (x.cmdline.compare(0, msg_prefix.size(), msg_prefix) == 0)
+        continue;
+
     double runtime =
       (now.tv_sec  - x.launch.tv_sec) +
       (now.tv_usec - x.launch.tv_usec) / 1000000.0;


### PR DESCRIPTION
This PR removes the huge number of `[#         ] '<hash>' foo/baa/abc` messages when building interactively, 
simply filtering them all out <ins>unconditionally</ins>, but only at the display layer.
This applies to all messages that start with `'<`, such as `'<hash>'` and `'<mkdir>'`

Files that fail to hash still produce an error message as before:
```
$ cat do.wake
global def do _ =
    "echo hello"
    | makePlan "" Nil
    | setPlanFnOutputs (\_ "/foo", Nil)
    | runJob
```
```
$ wake do
shim hash open(/foo): No such file or directory
Job 150067
```
```
$ wake --failed -v
Job 150068:
  Command-line: '<hash>' /foo
  Environment:
  Directory: .
  Built:     2021-07-22 00:44:25
  Runtime:   0.001472
  CPUtime:   9.9e-05
  Mem bytes: 0
  In  bytes: 0
  Out bytes: 0
  Status:    1
  Stdin:     /dev/null
Visible:
Inputs:
Outputs:
Stderr:
  shim hash open(/foo): No such file or directory
```

Fixes #666