### PR TITLE
getJobResult

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -323,9 +323,7 @@ export def runJob (p: Plan): Job = match p
 
 # Get result for job with the list of output files/dirs.
 export def getJobResultOutputs (job: Job): Result (List Path) Error =
-    map getPathResult job.getJobOutputs
-    | findFail
-
+    findFailFn getPathResult job.getJobOutputs
 
 # Get result for job with exactly one output Path.
 export def getJobResultOutput (job: Job): Result Path Error =

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -320,6 +320,21 @@ export def runJob (p: Plan): Job = match p
         def _ = wait (\_ badfinish job error) (badlaunch job error)
         job
 
+
+# Get result for job with the list of output files/dirs.
+export def getJobResultOutputs (job: Job) : Result (List Path) Error =
+  map getPathResult job.getJobOutputs
+  | findFail
+
+
+# Get result for job with exacally one output Path.
+export def getJobResultOutput (job: Job) : Result Path Error =
+  match job.getJobOutputs
+    path, Nil = path.getPathResult
+    _ = failWithError "Job must have exacally one output path: {job.getJobDescription}'"
+
+
+# SString => String => Job => Job
 # Set the value of a tag on a Job
 # This is useful for post-build reflection into the database
 export def setJobTag (key: String) (value: String) (job: Job): Job =

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -322,19 +322,17 @@ export def runJob (p: Plan): Job = match p
 
 
 # Get result for job with the list of output files/dirs.
-export def getJobResultOutputs (job: Job) : Result (List Path) Error =
-  map getPathResult job.getJobOutputs
-  | findFail
+export def getJobResultOutputs (job: Job): Result (List Path) Error =
+    map getPathResult job.getJobOutputs
+    | findFail
 
 
 # Get result for job with exactly one output Path.
-export def getJobResultOutput (job: Job) : Result Path Error =
-  match job.getJobOutputs
-    path, Nil = path.getPathResult
-    _ = failWithError "Job must have exacally one output path: {job.getJobDescription}'"
+export def getJobResultOutput (job: Job): Result Path Error =
+    job.getJobOutput
+    | getPathResult
 
 
-# SString => String => Job => Job
 # Set the value of a tag on a Job
 # This is useful for post-build reflection into the database
 export def setJobTag (key: String) (value: String) (job: Job): Job =

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -327,7 +327,7 @@ export def getJobResultOutputs (job: Job) : Result (List Path) Error =
   | findFail
 
 
-# Get result for job with exacally one output Path.
+# Get result for job with exactly one output Path.
 export def getJobResultOutput (job: Job) : Result Path Error =
   match job.getJobOutputs
     path, Nil = path.getPathResult


### PR DESCRIPTION
Adding this as I don't think we have a one liner to do `Job => Result (List Path) Error`

Regardless of future api changes to Plan/Job, we should have something like this for now so we're not asking people to do something like this on each job:
```
job
| getJobOutputs
| map getPathResult
| findFail
```