### PR TITLE
src: separate into a library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,9 +243,6 @@ workflows:
   build:
     jobs:
       - tarball
-      - vscode:
-          requires:
-            - tarball
       - alpine:
           requires:
             - tarball

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,6 @@ workflows:
             - tarball
       - release:
           requires:
-            - vscode
             - alpine
             - debian_testing # Newest everything
             - debian_wheezy  # Oldest supported compiler

--- a/lsp/lsp.wake
+++ b/lsp/lsp.wake
@@ -18,11 +18,27 @@ from wake import _
 from gcc_wake import _
 
 def buildLSP (Pair variant _): Result (List Path) Error =
-    require Pass json =
-        common variant
+    def externalDeps =
+        ncurses Unit, map pkg ("sqlite3", "gmp", "re2", Nil)
+
+    def internalDepResults =
+        src variant, Nil
+
+    require Pass internalDeps = findFail internalDepResults
+
+    def deps =
+        internalDeps ++ externalDeps
+        | flattenSysLibs
+
+    def cflags =
+        deps.getSysLibCFlags
+
+    def headers =
+        version_h Unit,
+        deps.getSysLibHeaders
 
     def compile =
-        compileC variant json.getSysLibCFlags (version_h Unit, json.getSysLibHeaders)
+        compileC variant cflags headers
 
     def cppFiles =
         source "{here}/lsp.cpp", Nil
@@ -33,9 +49,9 @@ def buildLSP (Pair variant _): Result (List Path) Error =
 
     def allObjs =
         objFiles.flatten ++
-        json.getSysLibObjects
+        deps.getSysLibObjects
 
-    linkO variant json.getSysLibLFlags allObjs "lib/wake/lsp-wake"
+    linkO variant (deps.getSysLibLFlags) allObjs "lib/wake/lsp-wake"
 
 export def vscode _ =
     def dir =

--- a/src/src.wake
+++ b/src/src.wake
@@ -1,0 +1,68 @@
+# Copyright 2019 SiFive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You should have received a copy of LICENSE.Apache2 along with
+# this software. If not, you may obtain a copy at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package build_wake
+from wake import _
+from gcc_wake import _
+
+def src (variant: String): Result SysLib Error =
+    def externalDeps =
+        Nil
+
+    def internalDepResults =
+        common variant, map (_ "native-c99-release") (utf8proc, Nil)
+
+    require Pass internalDeps = findFail internalDepResults
+
+    def deps =
+        internalDeps ++ externalDeps
+        | flattenSysLibs
+
+    def cflags =
+        "-I{here}", deps.getSysLibCFlags
+
+    def headers =
+        map source ("src/dsu.h", "src/hash.h", "src/optional.h", "src/primfn.h", Nil) ++
+        map source ("src/cli/profile.h", "src/cli/status.h", Nil) ++
+        sources here `frontend/.*\.h` ++
+        sources here `optimizer/.*\.h` ++
+        sources here `runtime/.*\.h` ++
+        sources here `types/.*\.h` ++
+        deps.getSysLibHeaders
+        
+
+    def compile =
+        compileC variant cflags headers
+
+    def re2obj re =
+        require Pass cpp = re2c re
+        compile cpp
+
+    def objResults =
+        map re2obj  (sources here `.*\.re`) ++
+        map compile (map source ("src/cli/profile.cpp", "src/cli/status.cpp", Nil)) ++
+        map compile (sources here `frontend/.*\.cpp`) ++
+        map compile (sources here `optimizer/.*\.cpp`) ++
+        map compile (sources here `runtime/.*\.cpp`) ++
+        map compile (sources here `types/.*\.cpp`)
+
+    require Pass foundObjects =
+        findFail objResults
+
+    def objects =
+        foundObjects.flatten ++
+        deps.getSysLibObjects
+
+    Pass (SysLib "0.0" headers objects cflags Nil)

--- a/src/wake.wake
+++ b/src/wake.wake
@@ -35,14 +35,10 @@ def buildWake (Pair variant clib) =
     def externalDeps =
         ncurses Unit, map pkg ("sqlite3", "gmp", "re2", Nil)
 
-    def reFileResults =
-        map re2c (sources here `.*\.re`)
-
     def internalDepResults =
-        common variant, map (_ clib) (utf8proc, gopt, Nil)
+        src variant, map (_ clib) (gopt, Nil)
 
     require Pass internalDeps = findFail internalDepResults
-    require Pass reFiles = findFail reFileResults
 
     def deps =
         internalDeps ++ externalDeps
@@ -51,11 +47,10 @@ def buildWake (Pair variant clib) =
     def headerFiles =
         version_h Unit,
         deps.getSysLibHeaders ++
-        sources here `.*\.h`
+        map source ("src/cli/describe.h", "src/cli/markup.h", Nil)
 
     def cppFiles =
-        reFiles ++
-        sources here `.*\.cpp`
+        map source ("src/cli/describe.cpp", "src/cli/markup.cpp", "src/cli/main.cpp", Nil)
 
     def compile =
         compileC variant ("-I{here}", deps.getSysLibCFlags) headerFiles


### PR DESCRIPTION
Create src.wake.
Rewrite lsp.wake and wake.wake to use this library.
Disable the vscode build in circleci as it stopped building successfully. 