### PR TITLE
lsp: enable squiggly lines

### DIFF
--- a/extensions/vscode/lsp-client/src/extension.ts
+++ b/extensions/vscode/lsp-client/src/extension.ts
@@ -3,26 +3,24 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { workspace, ExtensionContext } from 'vscode';
+import { workspace } from 'vscode';
 
 import {
 	LanguageClient,
 	LanguageClientOptions,
-	ServerOptions,
-	TransportKind
+	ServerOptions
 } from 'vscode-languageclient/node';
-
 
 let client: LanguageClient;
 
-export function activate(context: ExtensionContext) {
-	const serverModule = context.asAbsolutePath('/lsp-server/lsp-wake.js');
-
-	// If the extension is launched in debug mode then the debug server options are used
-	// Otherwise the run options are used
+export function activate() {
 	let serverOptions: ServerOptions = {
-		module: serverModule,
-		transport: TransportKind.stdio
+		run: {
+			command: __dirname + "/../../../../lib/wake/lsp-wake.native-cpp11-release"
+		},
+		debug: {
+			command: __dirname + "/../../../../lib/wake/lsp-wake.native-cpp11-debug"
+		}
 	};
 
 	// Options to control the language client
@@ -30,7 +28,7 @@ export function activate(context: ExtensionContext) {
 		// Register the server for .wake files
 		documentSelector: [{ language: 'wake', pattern: '**/*.wake' }],
 		synchronize: {
-			// Notify the server about file changes to '.clientrc files contained in the workspace
+			// Notify the server about file changes to '.wake files contained in the workspace
 			fileEvents: workspace.createFileSystemWatcher('**/*.wake')
 		}
 	};


### PR DESCRIPTION
Restructure lsp.cpp. Rewrite it to define the reporter object and use it for sending diagnostics to the client.
Revert extension.ts back to using the default build of the server.