### PR TITLE
lsp: add hover, search definitions by name, rename

### DIFF
--- a/lsp/lsp.cpp
+++ b/lsp/lsp.cpp
@@ -348,7 +348,8 @@ private:
         runSyntaxChecker(file, *top);
 
       PrimMap pmap = prim_register_all(nullptr, nullptr);
-      std::unique_ptr<Expr> root = bind_refs(std::move(top), pmap);
+      bool isTreeBuilt = true;
+      std::unique_ptr<Expr> root = bind_refs(std::move(top), pmap, isTreeBuilt);
 
       for (auto &file: allFiles)
         reportFileDiagnostics(file, diagnostics[file]);

--- a/lsp/lsp.cpp
+++ b/lsp/lsp.cpp
@@ -465,12 +465,6 @@ private:
 
     void reportReferences(JAST receivedMessage, const std::vector<Location> &references) {
       JAST message = createResponseMessage(std::move(receivedMessage));
-      if (references.empty()) {
-        JAST result = message.add("result", JSON_NULLVAL);
-        sendMessage(message);
-        return;
-      }
-
       JAST &result = message.add("result", JSON_ARRAY);
       for (const Location &location: references) {
         result.children.emplace_back("", createLocationJSON(location));
@@ -522,12 +516,6 @@ private:
 
     static void reportHighlights(JAST receivedMessage, const std::vector<Location> &occurrences) {
       JAST message = createResponseMessage(std::move(receivedMessage));
-      if (occurrences.empty()) {
-        JAST result = message.add("result", JSON_NULLVAL);
-        sendMessage(message);
-        return;
-      }
-
       JAST &result = message.add("result", JSON_ARRAY);
       for (const Location &location: occurrences) {
         result.children.emplace_back("", createDocumentHighlightJSON(location));
@@ -572,16 +560,14 @@ private:
 
     static void reportHoverInfo(JAST receivedMessage, const std::vector<Definition> &hoverInfoPieces) {
       JAST message = createResponseMessage(std::move(receivedMessage));
-      if (hoverInfoPieces.empty()) {
-        JAST result = message.add("result", JSON_NULLVAL);
-        sendMessage(message);
-        return;
-      }
-
       JAST &result = message.add("result", JSON_OBJECT);
-      JAST &contents = result.add("contents", JSON_ARRAY);
+
+      JAST contents(JSON_ARRAY);
       for (const Definition& def: hoverInfoPieces) {
         contents.add((def.name + ": " + def.type).c_str());
+      }
+      if (!contents.children.empty()) {
+        result.children.emplace_back("contents", contents);
       }
       sendMessage(message);
     }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -519,8 +519,9 @@ int main(int argc, char **argv) {
   StringInfo info(verbose, debug, quiet, VERSION_STR, make_canonical(wake_cwd), cmdline);
   PrimMap pmap = prim_register_all(&info, &jobtable);
 
-  std::unique_ptr<Expr> root = bind_refs(std::move(top), pmap);
-  if (!root) ok = false;
+  bool isTreeBuilt = true;
+  std::unique_ptr<Expr> root = bind_refs(std::move(top), pmap, isTreeBuilt);
+  if (!isTreeBuilt) ok = false;
   ok = ok && sums_ok();
 
   if (!ok || (fwarning && warnings)) {

--- a/src/frontend/parser.cpp
+++ b/src/frontend/parser.cpp
@@ -509,7 +509,7 @@ static void extract_def(std::vector<Definition> &out, long index, AST &&ast, con
   for (auto &m : ast.args) {
     AST pattern(ast.region, std::string(ast.name));
     pattern.type = std::move(ast.type);
-    std::string mname("_" + m.name);
+    std::string mname("_ " + m.name);
     for (auto &n : ast.args) {
       pattern.args.push_back(AST(m.token, "_"));
       if (&n == &m) {

--- a/src/types/bind.cpp
+++ b/src/types/bind.cpp
@@ -1522,12 +1522,12 @@ static bool explore(Expr *expr, ExploreState &state, NameBinding *binding) {
   }
 }
 
-std::unique_ptr<Expr> bind_refs(std::unique_ptr<Top> top, const PrimMap &pmap) {
+std::unique_ptr<Expr> bind_refs(std::unique_ptr<Top> top, const PrimMap &pmap, bool &isTreeBuilt) {
   NameBinding bottom;
   ExploreState state(pmap);
   Top &topr = *top;
   std::unique_ptr<Expr> out = fracture(topr, false, "", std::move(top), 0);
-  if (out && !explore(out.get(), state, &bottom)) out.reset();
+  if (out && !explore(out.get(), state, &bottom)) isTreeBuilt = false;
   return out;
 }
 

--- a/src/types/bind.h
+++ b/src/types/bind.h
@@ -26,7 +26,7 @@ struct Expr;
 
 // Eliminate DefMap + Top + Subscribe expressions
 extern int warnings;
-std::unique_ptr<Expr> bind_refs(std::unique_ptr<Top> top, const PrimMap &pmap);
+std::unique_ptr<Expr> bind_refs(std::unique_ptr<Top> top, const PrimMap &pmap, bool &isTreeBuilt);
 bool flatten_exports(Top &top);
 
 #endif


### PR DESCRIPTION
On mouse hover the name and type of a symbol is provided.
By pressing Ctrl+Shift+P you can go to the command palette and from there:
- By starting with @ search for symbol definitions in the open document.
- By starting with # search for symbol definitions in the project folder.
By pressing F2 you can rename a symbol.

Additionally, features are being provided even if there are type errors.