### PR TITLE
build: have variant ALWAYS mean both C and C++

### DIFF
--- a/bsp/bsp.wake
+++ b/bsp/bsp.wake
@@ -17,10 +17,28 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-def buildBSP (Pair (variant: String) _): Result (List Path) Error =
-    require Pass json = common variant
-    def compile = compileC variant json.getSysLibCFlags (version_h Unit, json.getSysLibHeaders)
-    def cppFiles = source "{here}/bsp.cpp", Nil
-    require Pass objects = map compile cppFiles | findFail
-    def objFiles = objects.flatten ++ json.getSysLibObjects
-    linkO variant json.getSysLibLFlags objFiles "lib/wake/bsp-wake"
+def buildBSP variant: Result (List Path) Error =
+    require Pass json =
+        common variant
+
+    def Pair cppVariant _ =
+        variant
+
+    def headers =
+        version_h Unit,
+        json.getSysLibHeaders
+
+    def compileCPP =
+        compileC cppVariant json.getSysLibCFlags headers
+
+    def cppFiles =
+        source "{here}/bsp.cpp", Nil
+
+    require Pass objects =
+        map compileCPP cppFiles
+        | findFail
+
+    def objFiles =
+        objects.flatten ++ json.getSysLibObjects
+
+    linkO cppVariant json.getSysLibLFlags objFiles "lib/wake/bsp-wake"

--- a/common/common.wake
+++ b/common/common.wake
@@ -17,23 +17,30 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-def common (variant: String): Result SysLib Error =
+def common variant: Result SysLib Error =
+    def Pair cppVariant cVariant =
+        variant
+
     def cflags =
         "-I{here}", Nil
 
     def headers =
         sources here `.*\.h`
 
-    def compile =
-        compileC variant cflags headers
+    def compileCPP =
+        compileC cppVariant cflags headers
+
+    def compileCC =
+        compileC cVariant cflags headers
 
     def re2obj re =
         require Pass cpp = re2c re
-        compile cpp
+        compileCPP cpp
 
     def objResults =
-        map re2obj  (sources here `.*\.re`) ++
-        map compile (sources here `.*\.cpp`)
+        map re2obj     (sources here `.*\.re`)  ++
+        map compileCPP (sources here `.*\.cpp`) ++
+        map compileCC  (sources here `.*\.c`)
 
     require Pass objects =
         findFail objResults

--- a/fuse/fuse.wake
+++ b/fuse/fuse.wake
@@ -17,7 +17,10 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-def buildFuse (Pair (variant: String) _): Result (List Path) Error =
+def buildFuse variant: Result (List Path) Error =
+    def Pair cppVariant _ =
+        variant
+
     def libobjsResult =
         buildFuseLibObjs variant
 
@@ -29,14 +32,17 @@ def buildFuse (Pair (variant: String) _): Result (List Path) Error =
         sources "fuse" `.*\.h`
 
     require Pass client =
-        compileC variant json.getSysLibCFlags headers (source "fuse/client.cpp")
+        compileC cppVariant json.getSysLibCFlags headers (source "fuse/client.cpp")
 
     require Pass libobjs =
         libobjsResult
 
-    linkO variant json.getSysLibLFlags (client ++ libobjs) "bin/fuse-wake"
+    linkO cppVariant json.getSysLibLFlags (client ++ libobjs) "bin/fuse-wake"
 
-def buildFuseLibObjs (variant: String): Result (List Path) Error =
+def buildFuseLibObjs variant: Result (List Path) Error =
+    def Pair cppVariant _ =
+        variant
+
     require Pass json =
         common variant
 
@@ -48,7 +54,7 @@ def buildFuseLibObjs (variant: String): Result (List Path) Error =
         sources "fuse" `(fuse|namespace|daemon_client).cpp`
 
     def compile =
-        compileC variant json.getSysLibCFlags headers
+        compileC cppVariant json.getSysLibCFlags headers
 
     require Pass objs =
         map compile cppFiles
@@ -56,7 +62,10 @@ def buildFuseLibObjs (variant: String): Result (List Path) Error =
 
     Pass (objs.flatten ++ json.getSysLibObjects)
 
-def buildFuseDaemon (Pair (variant: String) _): Result (List Path) Error =
+def buildFuseDaemon variant: Result (List Path) Error =
+    def Pair cppVariant _ =
+        variant
+
     def fuseOption =
         pkgConfig "fuse"
 
@@ -72,8 +81,8 @@ def buildFuseDaemon (Pair (variant: String) _): Result (List Path) Error =
         flattenSysLibs (json, fuse, Nil)
 
     require Pass daemon =
-        compileC variant deps.getSysLibCFlags deps.getSysLibHeaders (source "{here}/daemon.cpp")
+        compileC cppVariant deps.getSysLibCFlags deps.getSysLibHeaders (source "{here}/daemon.cpp")
 
     def objFiles = daemon ++ deps.getSysLibObjects
 
-    linkO variant deps.getSysLibLFlags objFiles "lib/wake/fuse-waked"
+    linkO cppVariant deps.getSysLibLFlags objFiles "lib/wake/fuse-waked"

--- a/gopt/gopt.wake
+++ b/gopt/gopt.wake
@@ -17,7 +17,10 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-def gopt (variant: String): Result SysLib Error =
+def gopt variant: Result SysLib Error =
+    def Pair _ cVariant =
+        variant
+
     def cflags =
         "-I{here}", Nil
 
@@ -25,7 +28,7 @@ def gopt (variant: String): Result SysLib Error =
         sources here `.*\.h`
 
     def compile x =
-        compileC variant cflags headers (source "{here}/{x}")
+        compileC cVariant cflags headers (source "{here}/{x}")
 
     def sourceFiles =
         "gopt.c", "gopt-errors.c", "gopt-arg.c", Nil

--- a/lsp/lsp.wake
+++ b/lsp/lsp.wake
@@ -17,7 +17,10 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-def buildLSP (Pair variant _): Result (List Path) Error =
+def buildLSP variant: Result (List Path) Error =
+    def Pair cppVariant _ =
+        variant
+
     def externalDeps =
         ncurses Unit, map pkg ("sqlite3", "gmp", "re2", Nil)
 
@@ -37,21 +40,21 @@ def buildLSP (Pair variant _): Result (List Path) Error =
         version_h Unit,
         deps.getSysLibHeaders
 
-    def compile =
-        compileC variant cflags headers
+    def compileCPP =
+        compileC cppVariant cflags headers
 
     def cppFiles =
         source "{here}/lsp.cpp", Nil
 
     require Pass objFiles =
-        map compile cppFiles
+        map compileCPP cppFiles
         | findFail
 
     def allObjs =
         objFiles.flatten ++
         deps.getSysLibObjects
 
-    linkO variant (deps.getSysLibLFlags) allObjs "lib/wake/lsp-wake"
+    linkO cppVariant (deps.getSysLibLFlags) allObjs "lib/wake/lsp-wake"
 
 export def vscode _ =
     def dir =

--- a/preload/preload.wake
+++ b/preload/preload.wake
@@ -32,7 +32,10 @@ def liblflags = match sysname
     "Darwin" = "-dynamiclib", Nil
     _ = "-shared", "-ldl", Nil
 
-def buildPreload (Pair variant _): Result (List Path) Error =
+def buildPreload variant: Result (List Path) Error =
+    def Pair cppVariant _ =
+        variant
+
     require Pass json =
         common variant
 
@@ -47,19 +50,22 @@ def buildPreload (Pair variant _): Result (List Path) Error =
         "-DEXT={libext}", "-DENV={loadenv}", json.getSysLibCFlags
 
     require Pass ofiles =
-        map (compileC variant cppFlags headers) cppFiles
+        map (compileC cppVariant cppFlags headers) cppFiles
         | findFail
 
-    linkO variant Nil (ofiles.flatten ++ json.getSysLibObjects) "bin/preload-wake"
+    linkO cppVariant Nil (ofiles.flatten ++ json.getSysLibObjects) "bin/preload-wake"
 
-def buildPrelib (Pair _ variant): Result (List Path) Error =
+def buildPrelib variant: Result (List Path) Error =
+    def Pair _ cVariant =
+        variant
+
     def cfiles =
         sources here `.*\.c`
 
     require Pass ofiles =
-         map (compileC variant libcflags Nil) cfiles
+         map (compileC cVariant libcflags Nil) cfiles
          | findFail
 
-    linkO variant liblflags ofiles.flatten "lib/wake/libpreload-wake.{libext}"
+    linkO cVariant liblflags ofiles.flatten "lib/wake/libpreload-wake.{libext}"
 
 # publish runner = makeJSONRunner "preload/wrap" (\_ Pass 2.0) (\_ None), Nil

--- a/shim/shim.wake
+++ b/shim/shim.wake
@@ -17,16 +17,19 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-def buildShim (Pair cxx variant): Result (List Path) Error =
+def buildShim variant: Result (List Path) Error =
+    def Pair _ cVariant =
+        variant
+
     require Pass nofollow =
-        common cxx
+        common variant
 
     def headers =
         nofollow.getSysLibHeaders ++
         sources here `.*\.h`
 
     def compile =
-        compileC variant nofollow.getSysLibCFlags headers
+        compileC cVariant nofollow.getSysLibCFlags headers
 
     def cppFiles =
         sources here `.*\.c`
@@ -35,4 +38,4 @@ def buildShim (Pair cxx variant): Result (List Path) Error =
         map compile cppFiles
         | findFail
 
-    linkO variant Nil objFiles.flatten "lib/wake/shim-wake"
+    linkO cVariant Nil objFiles.flatten "lib/wake/shim-wake"

--- a/src/runtime.wake
+++ b/src/runtime.wake
@@ -17,12 +17,15 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-def runtime (variant: String): Result SysLib Error =
+def runtime variant: Result SysLib Error =
+    def Pair cppVariant _ =
+        variant
+
     def externalDeps =
         ncurses Unit, map pkg ("sqlite3", "gmp", "re2", Nil)
 
     def internalDepResults =
-        common variant, map (_ "native-c99-release") (utf8proc, Nil)
+        map (_ variant) (common, utf8proc, Nil)
 
     require Pass internalDeps =
         findFail internalDepResults
@@ -43,7 +46,7 @@ def runtime (variant: String): Result SysLib Error =
         deps.getSysLibHeaders
         
     def compile =
-        compileC variant cflags headers
+        compileC cppVariant cflags headers
 
     def re2obj re =
         require Pass cpp = re2c re

--- a/src/wake.wake
+++ b/src/wake.wake
@@ -31,9 +31,12 @@ def ncurses Unit =
     | getOrElseFn (\Unit pkg "ncurses")
     | editSysLibCFlags (filter (matches `-I.*` _)) # remove feature test manipulation
 
-def buildWake (Pair variant clib) =
+def buildWake variant =
+    def Pair cppVariant _ =
+        variant
+
     def internalDepResults =
-        runtime variant, map (_ clib) (gopt, Nil)
+        map (_ variant) (runtime, gopt, Nil)
 
     require Pass internalDeps =
         findFail internalDepResults
@@ -50,7 +53,7 @@ def buildWake (Pair variant clib) =
         map source ("src/cli/describe.cpp", "src/cli/markup.cpp", "src/cli/main.cpp", Nil)
 
     def compile =
-        compileC variant ("-I{here}", deps.getSysLibCFlags) headerFiles
+        compileC cppVariant ("-I{here}", deps.getSysLibCFlags) headerFiles
 
     require Pass objFiles =
         map compile cppFiles
@@ -60,4 +63,4 @@ def buildWake (Pair variant clib) =
         objFiles.flatten ++
         deps.getSysLibObjects
 
-    linkO variant deps.getSysLibLFlags allObjs "bin/wake"
+    linkO cppVariant deps.getSysLibLFlags allObjs "bin/wake"

--- a/utf8proc/utf8proc.wake
+++ b/utf8proc/utf8proc.wake
@@ -21,6 +21,9 @@ from gcc_wake import _
 def utf8proc variant = match (pkgConfig "utf8proc")
     Some x = Pass x
     None   =
+        def Pair _ cVariant =
+            variant
+
         def cflags =
             "-I{here}", Nil
 
@@ -29,6 +32,6 @@ def utf8proc variant = match (pkgConfig "utf8proc")
             sources here `.*\.h`
 
         require Pass objs =
-            compileC variant cflags headers (source "{here}/utf8proc.c")
+            compileC cVariant cflags headers (source "{here}/utf8proc.c")
 
         Pass (SysLib "2.2.0" headers objs cflags Nil)

--- a/wakebox/build.wake
+++ b/wakebox/build.wake
@@ -17,15 +17,18 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-def buildWakeBox (Pair cpplib clib) =
+def buildWakeBox variant =
+    def Pair cppVariant _ =
+        variant
+
     def commonLibResult =
-        common cpplib
+        common variant
 
     def fuseLibResult =
-        buildFuseLibObjs cpplib
+        buildFuseLibObjs variant
 
     def goptLibResult =
-        gopt clib
+        gopt variant
 
     require Pass commonLib = commonLibResult
     require Pass goptLib = goptLibResult
@@ -41,7 +44,7 @@ def buildWakeBox (Pair cpplib clib) =
         commonLib.getSysLibHeaders
 
     def compile =
-        compileC cpplib ("-Ifuse", goptLib.getSysLibCFlags ++ commonLib.getSysLibCFlags) headers
+        compileC cppVariant ("-Ifuse", goptLib.getSysLibCFlags ++ commonLib.getSysLibCFlags) headers
 
     def cppFiles =
         sources "wakebox" `.*\.cpp`
@@ -55,4 +58,4 @@ def buildWakeBox (Pair cpplib clib) =
         goptLib.getSysLibObjects ++
         objs.flatten
 
-    linkO cpplib libs.getSysLibLFlags objFiles "bin/wakebox"
+    linkO cppVariant libs.getSysLibLFlags objFiles "bin/wakebox"


### PR DESCRIPTION
It's just too messy to have these differ by target.