### PR TITLE
core: update the docs to use the proper often-short-circuit values

### DIFF
--- a/share/wake/lib/core/boolean.wake
+++ b/share/wake/lib/core/boolean.wake
@@ -27,7 +27,7 @@ export data Boolean =
 export def !x = if x then False else True
 
 # Binary operator for Boolean AND.
-# BEWARE: unlike other languages, in wake, expression 'y' is evaluated even if 'x' is True
+# BEWARE: unlike other languages, in wake, expression 'y' is evaluated even if 'x' is False
 # True  && True  = True
 # False && True  = False
 # True  && False = False
@@ -35,7 +35,7 @@ export def !x = if x then False else True
 export def x && y = if x then y else False
 
 # Binary operator for Boolean OR.
-# BEWARD: unlike other languages, in wake, expression 'y' is evaluated even if 'x' is False
+# BEWARE: unlike other languages, in wake, expression 'y' is evaluated even if 'x' is True
 # True  || True  = True
 # False || True  = True
 # True  || False = True


### PR DESCRIPTION
Most programming languages realize that a True value left of an OR can satisfy the equation and False for AND, but the docs had them switched.  I also fixed a typo on the same line.