### PR TITLE
Switch emscripten LSP to using asyncify

### DIFF
--- a/src/parser/syntax.cpp
+++ b/src/parser/syntax.cpp
@@ -48,6 +48,9 @@ void parseWake(ParseInfo pi) {
     bool in_multiline_string = false;
     bool in_legacy_string = false;
 
+    // Prepare for parsing a new file
+    pi.fcontent->clearNewLines();
+
     // Silence a warning on older compilers
     nl.end = ws.end = nullptr;
 

--- a/src/parser/wakefiles.cpp
+++ b/src/parser/wakefiles.cpp
@@ -50,7 +50,7 @@ bool push_files(std::vector<std::string> &out, const std::string &path, int dirf
     if (f->d_name[0] == '.' && (f->d_name[1] == 0 || (f->d_name[1] == '.' && f->d_name[2] == 0))) continue;
     bool recurse;
     struct stat sbuf;
-#ifdef DT_DIR
+#if defined(DT_DIR) && !defined(__EMSCRIPTEN__)
     if (f->d_type != DT_UNKNOWN) {
       recurse = f->d_type == DT_DIR;
     } else {
@@ -62,7 +62,7 @@ bool push_files(std::vector<std::string> &out, const std::string &path, int dirf
       } else {
         recurse = S_ISDIR(sbuf.st_mode);
       }
-#ifdef DT_DIR
+#if defined(DT_DIR) && !defined(__EMSCRIPTEN__)
     }
 #endif
     std::string name(path == "." ? f->d_name : (path + "/" + f->d_name));
@@ -97,29 +97,10 @@ bool push_files(std::vector<std::string> &out, const std::string &path, int dirf
 }
 
 bool push_files(std::vector<std::string> &out, const std::string &path, const RE2& re, size_t skip) {
-#ifdef __EMSCRIPTEN__
-  // https://github.com/emscripten-core/emscripten/issues/7487
-  std::string command = "find " + path + " -name \\*.wake > .vscode.wakefiles";
-  system(command.c_str());
-  std::ifstream ifs(".vscode.wakefiles");
-  while (!ifs.eof()) {
-    std::string line;
-    std::getline(ifs, line);
-    if (line.empty()) continue;
-    if (line.substr(0,2) == "./") {
-      out.push_back(line.substr(2));
-    } else {
-      out.push_back(line);
-    }
-  }
-  unlink(".vscode.wakefiles");
-  return false;
-#else
   int flags, dirfd = open(path.c_str(), O_RDONLY);
   if ((flags = fcntl(dirfd, F_GETFD, 0)) != -1)
     fcntl(dirfd, F_SETFD, flags | FD_CLOEXEC);
   return dirfd == -1 || push_files(out, path, dirfd, re, skip);
-#endif
 }
 
 // . => ., hax/ => hax, foo/.././bar.z => bar.z, foo/../../bar.z => ../bar.z

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -23,7 +23,9 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+
 #include <algorithm>
+#include <fstream>
 
 #include "file.h"
 #include "diagnostic.h"
@@ -34,6 +36,19 @@ FileContent::FileContent(const char *filename_)
  : fname(filename_)
 {
     newlines.push_back(0);
+}
+
+FileContent::FileContent(FileContent &&o)
+ : ss(o.ss), fname(std::move(o.fname)), newlines(std::move(o.newlines)) {
+    o.ss.end = o.ss.start = &null[0];
+}
+
+FileContent &FileContent::operator = (FileContent &&o) {
+    ss = o.ss;
+    fname = std::move(o.fname);
+    newlines = std::move(o.newlines);
+    o.ss.end = o.ss.start = &null[0];
+    return *this;
 }
 
 void FileContent::addNewline(const uint8_t *first_column)
@@ -67,6 +82,26 @@ ExternalFile::ExternalFile(DiagnosticReporter &reporter, const char *filename_)
 {
     Location l(filename());
 
+#ifdef __EMSCRIPTEN__
+    // mmap with specified address is broken...
+    std::ifstream ifs(filename());
+    if (!ifs) {
+        reporter.reportError(l, std::string("open failed; ") + strerror(errno));
+        ss.end = ss.start = &null[0];
+        return;
+    }
+
+    ifs.seekg(0, std::ios::end);
+    size_t length = ifs.tellg();
+    ifs.seekg(0, std::ios::beg);
+
+    uint8_t *base = new uint8_t[length+1];
+    ifs.read(reinterpret_cast<char*>(base), length);
+
+    base[length] = 0;
+    ss.start = base;
+    ss.end = base + length;
+#else
     int fd = open(filename(), O_RDONLY);
     if (fd == -1) {
         reporter.reportError(l, std::string("open failed; ") + strerror(errno));
@@ -109,7 +144,8 @@ ExternalFile::ExternalFile(DiagnosticReporter &reporter, const char *filename_)
     size_t tail_start = (s.st_size+1) - tail_len;
 
     std::string buf(reinterpret_cast<const char*>(map) + tail_start, tail_len-1);
-    if (mmap(reinterpret_cast<uint8_t*>(map) + tail_start, pagesize, PROT_READ|PROT_WRITE, MAP_FIXED|MAP_PRIVATE|MAP_ANON, -1, 0) == MAP_FAILED) {
+    void *out = mmap(reinterpret_cast<uint8_t*>(map) + tail_start, pagesize, PROT_READ|PROT_WRITE, MAP_FIXED|MAP_PRIVATE|MAP_ANON, -1, 0);
+    if (out == MAP_FAILED || ((char*)out - (char*)map) != tail_start) {
         reporter.reportError(l, std::string("mmap anon failed; ") + strerror(errno));
         munmap(map, s.st_size+1);
         ss.end = ss.start = &null[0];
@@ -118,24 +154,17 @@ ExternalFile::ExternalFile(DiagnosticReporter &reporter, const char *filename_)
 
     // Fill in the last page
     memcpy(reinterpret_cast<uint8_t*>(map) + tail_start, buf.c_str(), tail_len);
-}
-
-ExternalFile::ExternalFile(ExternalFile &&o)
- : FileContent(o.filename()) {
-    ss = o.ss;
-    o.ss.end = o.ss.start = &null[0];
+#endif
 }
 
 ExternalFile::~ExternalFile() {
+#ifdef __EMSCRIPTEN__
+    if (ss.start != ss.end)
+        delete [] ss.start;
+#else
     if (ss.start != ss.end)
         munmap(const_cast<void*>(reinterpret_cast<const void*>(ss.start)), ss.size() + 1);
-}
-
-ExternalFile &ExternalFile::operator = (ExternalFile &&o) {
-    fname = std::move(o.fname);
-    ss = o.ss;
-    o.ss.end = o.ss.start = &null[0];
-    return *this;
+#endif
 }
 
 CPPFile::CPPFile(const char *filename)

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -35,20 +35,27 @@ static uint8_t null[1] = { 0 };
 FileContent::FileContent(const char *filename_)
  : fname(filename_)
 {
-    newlines.push_back(0);
 }
 
 FileContent::FileContent(FileContent &&o)
- : ss(o.ss), fname(std::move(o.fname)), newlines(std::move(o.newlines)) {
+ : ss(o.ss), fname(std::move(o.fname)), newlines(std::move(o.newlines))
+{
     o.ss.end = o.ss.start = &null[0];
 }
 
-FileContent &FileContent::operator = (FileContent &&o) {
+FileContent &FileContent::operator = (FileContent &&o)
+{
     ss = o.ss;
     fname = std::move(o.fname);
     newlines = std::move(o.newlines);
     o.ss.end = o.ss.start = &null[0];
     return *this;
+}
+
+void FileContent::clearNewLines()
+{
+    newlines.clear();
+    newlines.push_back(0);
 }
 
 void FileContent::addNewline(const uint8_t *first_column)
@@ -170,5 +177,4 @@ ExternalFile::~ExternalFile() {
 CPPFile::CPPFile(const char *filename)
  : FileContent(filename)
 {
-    newlines.clear();
 }

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -34,6 +34,7 @@ public:
     FileContent &operator = (FileContent &&o);
 
     Coordinates coordinates(const uint8_t *position) const;
+    void clearNewLines();
     void addNewline(const uint8_t *first_column);
 
     StringSegment segment() const { return ss; }

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -30,12 +30,18 @@ class DiagnosticReporter;
 class FileContent {
 public:
     FileContent(const char *filename_);
+    FileContent(FileContent &&o);
+    FileContent &operator = (FileContent &&o);
 
     Coordinates coordinates(const uint8_t *position) const;
     void addNewline(const uint8_t *first_column);
 
     StringSegment segment() const { return ss; }
     const char *filename() const { return fname.c_str(); }
+
+    // copy construction is forbidden
+    FileContent(const FileContent &) = delete;
+    FileContent &operator = (const FileContent &) = delete;
 
 protected:
     StringSegment ss;
@@ -46,6 +52,8 @@ protected:
 class StringFile : public FileContent {
 public:
     StringFile(const char *filename_, std::string &&content_);
+    StringFile(StringFile &&o) = default;
+    StringFile &operator = (StringFile &&o) = default;
 
 private:
     std::string content;
@@ -54,13 +62,10 @@ private:
 class ExternalFile : public FileContent {
 public:
     ExternalFile(DiagnosticReporter &reporter, const char *filename_);
-    ExternalFile(ExternalFile &&o);
     ~ExternalFile();
-    ExternalFile &operator = (ExternalFile &&o);
 
-    // copy construction is forbidden
-    ExternalFile(const ExternalFile &) = delete;
-    ExternalFile &operator = (const ExternalFile &) = delete;
+    ExternalFile(ExternalFile &&o) = default;
+    ExternalFile &operator = (ExternalFile &&o) = default;
 };
 
 class CPPFile : public FileContent {

--- a/vendor/emscripten.wake
+++ b/vendor/emscripten.wake
@@ -75,10 +75,10 @@ def emscriptenLFlags =
     Nil
 
 publish compileC =
-    emccFn (makeCompileC "wasm-c11-release"   _ (c11Flags ++ emscriptenCFlags))
+    emccFn (makeCompileC "wasm-c11-release"   _ ("-std=gnu11", emscriptenCFlags))
 
 publish compileC =
-    emppFn (makeCompileC "wasm-cpp11-release" _ (cpp11Flags ++ emscriptenCFlags))
+    emppFn (makeCompileC "wasm-cpp11-release" _ ("-std=c++11", emscriptenCFlags))
 
 publish linkO =
     emccFn (makeLinkO "wasm-c11-release"   _ emscriptenLFlags)

--- a/vendor/emscripten.wake
+++ b/vendor/emscripten.wake
@@ -62,10 +62,17 @@ def emmake =
         None
 
 def emscriptenCFlags =
-    "-Wall", "-O2", Nil
+    "-Wall", "-O3", Nil
 
 def emscriptenLFlags =
-    "-s", "NODERAWFS=1", "-s", "ALLOW_MEMORY_GROWTH=1", Nil
+    "-O3",
+    "-lnodefs.js",
+    "-s", "ALLOW_MEMORY_GROWTH",
+    "-s", "EXIT_RUNTIME",
+    "-s", "ASYNCIFY",
+    "-s", "ASYNCIFY_IGNORE_INDIRECT",
+    "-s", 'ASYNCIFY_IMPORTS=["nodejs_getstdin"]',
+    Nil
 
 publish compileC =
     emccFn (makeCompileC "wasm-c11-release"   _ (c11Flags ++ emscriptenCFlags))


### PR DESCRIPTION
Using asyncify makes it possible to read from stdin with a 1s timeout using native nodejs.
This PR also switches us from noderawfs to nodefs, which has less issues with readdir/etc.