### PR TITLE
LSP: defer reparsing of the project until 1s of no typing

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -82,5 +82,5 @@
         "vscode:prepublish": "npm run compile",
         "watch": "tsc -b -w"
     },
-    "version": "0.1.0"
+    "version": "0.1.1"
 }

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -82,5 +82,5 @@
         "vscode:prepublish": "npm run compile",
         "watch": "tsc -b -w"
     },
-    "version": "0.1.1"
+    "version": "0.1.3"
 }

--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -692,7 +692,7 @@ static void extract_def(std::vector<Definition> &out, long index, AST &&ast, con
   for (auto &m : ast.args) {
     AST pattern(ast.region, std::string(ast.name));
     pattern.type = std::move(ast.type);
-    std::string mname("_" + m.name);
+    std::string mname("_ " + m.name);
     for (auto &n : ast.args) {
       pattern.args.push_back(AST(m.token, "_"));
       if (&n == &m) {


### PR DESCRIPTION
Whenever a file is potentially changed, we record we're out-of-date.
Whenever a query arrives, if we are out-of-date, we update.
If no new requests arrive for 1 second, we update.

This should improve the perceived performance.