### PR TITLE
tuple: improve arrow operator

### DIFF
--- a/share/wake/lib/core/tuple.wake
+++ b/share/wake/lib/core/tuple.wake
@@ -24,7 +24,7 @@ export tuple Pair a b =
     export Second: b
 
 # Defines an arrow operator as an alternate way to initialize a ``Pair``.
-export def x → y = Pair x y
+from wake export def binary → = Pair
 
 # Creates a ``Triple``, a tuple containing three elements.
 export tuple Triple a b c =


### PR DESCRIPTION
By re-exporting Pair as → rather than defining it, we can use → also in patterns.