### PR TITLE
core: add basic type annotations to exported symbols

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -24,14 +24,14 @@ def toVariant = match _
     "wasm"    = Pass (Pair "wasm-cpp11-release"   "wasm-c11-release")
     s = Fail "Unknown build target ({s})".makeError
 
-export def build = match _
+export def build: List String => Result String Error = match _
     "tarball", Nil = tarball Unit | rmap (\_ "TARBALL")
     kind, Nil =
         require Pass variant = toVariant kind
         all variant | rmap (\_ "BUILD")
     _ = Fail "no target specified (try: build default/debug/tarball)".makeError
 
-export def install = match _
+export def install: List String => Result String Error = match _
     dest, kind, Nil = doInstall (in cwd dest) kind | rmap (\_ "INSTALL")
     dest, Nil = doInstall (in cwd dest) "default" | rmap (\_ "INSTALL")
     _ = Fail "no directory specified (try: install /opt/local)".makeError
@@ -131,7 +131,7 @@ def tarball Unit =
         | getJobOutput
     findFailFn getPathResult (tarball, changelog, Nil)
 
-export def static _ =
+export def static _: Result Path Error =
     def filesResult = doInstall "tmp" "static"
     def releaseResult = buildAs Unit
     def timeResult = buildOn Unit

--- a/extensions/vscode/vscode.wake
+++ b/extensions/vscode/vscode.wake
@@ -16,7 +16,7 @@
 package build_wake
 from wake import _
 
-export def vscode _ =
+export def vscode _: Result Path Error =
     require Pass variant =
         toVariant "wasm"
 

--- a/share/wake/lib/core/boolean.wake
+++ b/share/wake/lib/core/boolean.wake
@@ -24,7 +24,11 @@ export data Boolean =
 # Unary operator for Boolean NOT.
 # !True  = False
 # !False = True
-export def !x = if x then False else True
+export def !(x: Boolean): Boolean =
+    if x then
+        False
+    else
+        True
 
 # Binary operator for Boolean AND.
 # BEWARE: unlike other languages, in wake, expression 'y' is evaluated even if 'x' is False
@@ -32,7 +36,11 @@ export def !x = if x then False else True
 # False && True  = False
 # True  && False = False
 # False && False = False
-export def x && y = if x then y else False
+export def (x: Boolean) && (y: Boolean): Boolean =
+    if x then
+        y
+    else
+        False
 
 # Binary operator for Boolean OR.
 # BEWARE: unlike other languages, in wake, expression 'y' is evaluated even if 'x' is True
@@ -40,4 +48,8 @@ export def x && y = if x then y else False
 # False || True  = True
 # True  || False = True
 # False || False = False
-export def x || y = if x then True else y
+export def (x: Boolean) || (y: Boolean): Boolean =
+    if x then
+        True
+    else
+        y

--- a/share/wake/lib/core/double.wake
+++ b/share/wake/lib/core/double.wake
@@ -27,12 +27,12 @@ export def dabs (x: Double): Double =
 # Unary negative sign for a Double.
 # -. (-. 2.5) =  2.5
 # -. (+. 2.5) = -2.5
-export def   -. (x: Double): Double =
+export def -. (x: Double): Double =
     (\_ prim "dneg") x
 
 # Unary positive sign for a Double.
 # +. 2.5 = 2.5
-export def +. (x: Double) =
+export def +. (x: Double): Double =
     x
 
 # Binary addition operator for Double values.

--- a/share/wake/lib/core/integer.wake
+++ b/share/wake/lib/core/integer.wake
@@ -146,7 +146,7 @@ export def lcm (x: Integer) (y: Integer): Integer =
 # Computes (x^y) % m.
 # powm 2 7 5 = 4
 # powm 3 2 2 = 1
-export def powm (x: Integer) (y: Integer) (m: Integer) =
+export def powm (x: Integer) (y: Integer) (m: Integer): Integer =
     (\_\_\_ prim "powm") x y m
 
 # Compare two Integers for Order

--- a/share/wake/lib/core/json.wake
+++ b/share/wake/lib/core/json.wake
@@ -25,39 +25,39 @@ export data JValue =
   JObject  (List (Pair String JValue))
   JArray   (List JValue)
 
-export def getJString = match _
+export def getJString: JValue => Option String = match _
   JString x               = Some x
   JArray (JString x, Nil) = Some x
   _                       = None
-export def getJInteger = match _
+export def getJInteger: JValue => Option Integer = match _
   JInteger x               = Some x
   JArray (JInteger x, Nil) = Some x
   _                        = None
-export def getJDouble = match _
+export def getJDouble: JValue => Option Double = match _
   JDouble x               = Some x
   JInteger x              = dint x
   JArray (JDouble x, Nil) = Some x
   JArray (JInteger x, Nil)= dint x
   _                       = None
-export def getJBoolean = match _
+export def getJBoolean: JValue => Option Boolean = match _
   JBoolean x               = Some x
   JArray (JBoolean x, Nil) = Some x
   _                        = None
-export def getJObject = match _
+export def getJObject: JValue => Option (List (Pair String JValue)) = match _
   JObject x               = Some x
   JArray (JObject x, Nil) = Some x
   _                       = None
-export def getJArray = match _
+export def getJArray: JValue => Option (List JValue) = match _
   JArray x = Some x
   _        = None
 
-export def parseJSONBody body =
+export def parseJSONBody (body: String): Result JValue Error =
   def imp b = prim "json_body"
   match (imp body)
     Pass jvalue = Pass jvalue
     Fail cause = Fail (makeError cause)
 
-export def parseJSONFile path =
+export def parseJSONFile (path: Path): Result JValue Error =
   def imp f = prim "json_file"
   match (getPathResult path)
     Pass f = match (imp f.getPathName)
@@ -73,7 +73,7 @@ tuple JSONFormat =
   export Double:  Double  => String
   export Indent:  Integer
 
-def doFormat fmt lhs =
+def doFormat (fmt: JSONFormat) (lhs: JValue): List String =
   def indent = fmt.getJSONFormatIndent
   def space = if indent > 0 then " " else ""
   def indention = tab (\_ ' ') indent | cat
@@ -99,7 +99,7 @@ def doFormat fmt lhs =
         else "\{{tabbeder}", foldr helper ("{tabbed}\}", rhs) list | tail
   rec Nil (if indent > 0 then Some "" else None) lhs
 
-export def defaultJSONFormat =
+export def defaultJSONFormat: JSONFormat =
   def formatDouble d =
     match (dclass d)
       DoubleInfinite if d <. 0e0 = "-1e9999"

--- a/share/wake/lib/core/list.wake
+++ b/share/wake/lib/core/list.wake
@@ -42,7 +42,7 @@ export data List a =
 #   empty (seq 0)  = True
 #   empty (1, Nil) = False
 #   empty (seq 9)  = False
-export def empty = match _
+export def empty: List a => Boolean = match _
     Nil = True
     _   = False
 
@@ -71,7 +71,7 @@ export def tail: List a => List a = match _
 #
 #   map str    (seq 5) = "0", "1", "2", "3", "4", Nil
 #   map (_+10) (seq 5) = 10, 11, 12, 13, 14, Nil
-export def map (f: a => b): (List a => List b) =
+export def map (f: a => b): List a => List b =
     def loop = match _
         Nil  = Nil
         h, t = f h, loop t
@@ -82,7 +82,7 @@ export def map (f: a => b): (List a => List b) =
 #   def twice x = x, x, Nil
 #   mapFlat twice (seq 3) = 0, 0, 1, 1, 2, 2, Nil
 #   mapFlat seq (seq 5) = 0, 0, 1, 0, 1, 2, 0, 1, 2, 3, Nil
-export def mapFlat (f: a => List b): (List a => List b) =
+export def mapFlat (f: a => List b): List a => List b =
     def loop = match _
         Nil  = Nil
         h, t = f h ++ loop t
@@ -92,7 +92,7 @@ export def mapFlat (f: a => List b): (List a => List b) =
 # Partial functions can return None, in which case the result is not included in the output.
 #
 #   mapPartial int ("3", "x", "44", Nil) = 3, 44, Nil
-export def mapPartial (f: a => Option b): (List a => List b) =
+export def mapPartial (f: a => Option b): List a => List b =
     def loop = match _
         Nil  = Nil
         h, t =
@@ -277,7 +277,7 @@ export def at (i: Integer) (l: List a): Option a =
 #   splitUntil (_>=4) (seq 8) = Pair (0, 1, 2, 3, Nil) (4, 5, 6, 7, Nil)
 #   splitUntil (_>=0) (seq 8) = Pair Nil (0, 1, 2, 3, 4, 5, 6, 7, Nil)
 #   splitUntil (_>=8) (seq 8) = Pair (0, 1, 2, 3, 4, 5, 6, 7, Nil) Nil
-export def splitUntil (stopFn: a => Boolean): (List a => Pair (List a) (List a)) =
+export def splitUntil (stopFn: a => Boolean): List a => Pair (List a) (List a) =
     def loop l = match l
         Nil  = Pair Nil Nil
         h, t =
@@ -296,7 +296,7 @@ export def splitUntil (stopFn: a => Boolean): (List a => Pair (List a) (List a))
 #   takeUntil (_>=4) (seq 8) = 0, 1, 2, 3, Nil
 #   takeUntil (_>=0) (seq 8) = Nil
 #   takeUntil (_>=8) (seq 8) = 0, 1, 2, 3, 4, 5, 6, 7, Nil
-export def takeUntil (f: a => Boolean): (List a => List a) =
+export def takeUntil (f: a => Boolean): List a => List a =
     def loop = match _
         Nil         = Nil
         h, _ if f h = Nil
@@ -311,7 +311,7 @@ export def takeUntil (f: a => Boolean): (List a => List a) =
 #   dropUntil (_>=4) (seq 8) = 4, 5, 6, 7, Nil
 #   dropUntil (_>=0) (seq 8) = 0, 1, 2, 3, 4, 5, 6, 7, Nil
 #   dropUntil (_>=8) (seq 8) = Nil
-export def dropUntil (f: a => Boolean): (List a => List a) =
+export def dropUntil (f: a => Boolean): List a => List a =
     def loop l = match l
         Nil         = Nil
         h, _ if f h = l
@@ -327,7 +327,7 @@ export def dropUntil (f: a => Boolean): (List a => List a) =
 #   def l = seq 10 | map (_+10)
 #   find (_%4==0) l = Some (Pair 12 2)
 #   find (_%4==4) l = None
-export def find (f: a => Boolean): (List a => Option (Pair a Integer)) =
+export def find (f: a => Boolean): List a => Option (Pair a Integer) =
     def loop i = match _
         Nil         = None
         h, _ if f h = Some (Pair h i)
@@ -338,7 +338,7 @@ export def find (f: a => Boolean): (List a => Option (Pair a Integer)) =
 # Once `f` returns True, `f` is not evaulated on further elements.
 # This means that `f` is applied to the List mostly sequentially.
 # If more parallelism is desired, use 'map f | exists (_)'.
-export def exists (f: a => Boolean): (List a => Boolean) =
+export def exists (f: a => Boolean): List a => Boolean =
     find f _ | isSome
 
 # forall: does `f` return True for all elements in the list?
@@ -353,7 +353,7 @@ export def forall (f: a => Boolean): List a => Boolean =
 #
 #   def isEven x = x%2 == 0
 #   splitBy isEven (seq 6) = Pair (0, 2, 4, Nil) (1, 3, 5, Nil)
-export def splitBy (f: a => Boolean): (List a => Pair (List a) (List a)) =
+export def splitBy (f: a => Boolean): List a => Pair (List a) (List a) =
     def loop = match _
         Nil  = Pair Nil Nil
         h, t =
@@ -369,7 +369,7 @@ export def splitBy (f: a => Boolean): (List a => Pair (List a) (List a)) =
 #
 #   def isEven x = x%2 == 0
 #   filter isEven (seq 10) = 0, 2, 4, 6, 8, Nil
-export def filter (f: a => Boolean): (List a => List a) =
+export def filter (f: a => Boolean): List a => List a =
     def loop = match _
         Nil  = Nil
         h, t =
@@ -426,7 +426,7 @@ export def sortBy (lessThanFn: a => a => Boolean): List a => List a =
 # The order of non-duplicated elements is retained.
 #
 #   distinctBy (_<=>_) (1, 2, 1, 3, 4, 3, Nil) = 1, 2, 3, 4, Nil
-export def distinctBy (cmp: a => a => Order): (List a => List a) =
+export def distinctBy (cmp: a => a => Order): List a => List a =
     def loop tree = match _
         Nil = Nil
         x, tail =
@@ -441,7 +441,7 @@ export def distinctBy (cmp: a => a => Order): (List a => List a) =
 # distinctRunBy: keep only the first occurrence in a run of equal values
 #
 #  distinctRunBy (_==_) (1, 1, 2, 1, 3, 3, Nil) = 1, 2, 1, 3, Nil
-export def distinctRunBy (eqFn: a => a => Boolean): (List a => List a) =
+export def distinctRunBy (eqFn: a => a => Boolean): List a => List a =
     def loop l =
         require x, y, t = l
         if eqFn x y then
@@ -455,7 +455,7 @@ export def distinctRunBy (eqFn: a => a => Boolean): (List a => List a) =
 #   cmp (_<=>_) (seq 5)  (seq 5)  = EQ
 #   cmp (_<=>_) (seq 5)  (seq 4)  = GT
 #   cmp (_<=>_) (0, Nil) (1, Nil) = LT
-export def cmp (f: a => b => Order): (List a => List b => Order) =
+export def cmp (f: a => b => Order): List a => List b => Order =
     def loop = match _ _
         Nil Nil = EQ
         Nil _   = LT
@@ -468,7 +468,7 @@ export def cmp (f: a => b => Order): (List a => List b => Order) =
 # tab: create a list of specified size by calling `f` on the index to generate.
 #
 #   tab (_+100) 5 = 100, 101, 102, 103, 104, Nil
-export def tab (f: Integer => a): (Integer => List a) =
+export def tab (f: Integer => a): Integer => List a =
     def loop a n =
         if n <= 0 then
             a

--- a/share/wake/lib/core/tree.wake
+++ b/share/wake/lib/core/tree.wake
@@ -54,18 +54,19 @@ def build v = match (vlen v)
     Bin len (build l) (vat_ mid v) (build r)
 
 # Returns the total length of the Tree.
-export def tlen (Tree _ root) = size root
+export def tlen (Tree _ root: Tree a): Integer =
+  size root
 def size = match _
   Tip         = 0
   Bin s _ _ _ = s
 
 # Returns True if the Tree is empty, False otherwise.
-export def tempty (Tree _ root) = match root
+export def tempty (Tree _ root: Tree a): Boolean = match root
   Tip = True
   _   = False
 
-# Insert y into the tree only if no other keys = y
-export def tinsert y (Tree cmp root) =
+# Insert y into the tree only if no other keys == y
+export def tinsert (y: a) (Tree cmp root: Tree a): Tree a =
   def helper t = match t
     Tip         = Bin 1 Tip y Tip
     Bin _ l x r = match (cmp x y)
@@ -74,8 +75,8 @@ export def tinsert y (Tree cmp root) =
       LT = balanceR l x (helper r)
   Tree cmp (helper root)
 
-# Insert y into the tree, removing any existing keys = y
-export def tinsertReplace y (Tree cmp root) =
+# Insert y into the tree, removing any existing keys == y
+export def tinsertReplace (y: a) (Tree cmp root: Tree a): Tree a =
   def helper t = match t
     Tip         = Bin 1 Tip y Tip
     Bin _ l x r = match (cmp x y)
@@ -85,7 +86,7 @@ export def tinsertReplace y (Tree cmp root) =
   Tree cmp (helper root)
 
 # Insert y into the tree at the lowest rank of keys = y
-export def tinsertMulti y (Tree cmp root) =
+export def tinsertMulti (y: a) (Tree cmp root: Tree a): Tree a =
   def helper = match _
     Tip         = Bin 1 Tip y Tip
     Bin _ l x r = match (cmp x y)
@@ -121,7 +122,7 @@ export def tsubset (Tree _ aroot) (Tree cmp broot) =
   helper aroot broot
 
 # Deletes all keys that are equal to y.
-export def tdelete y (Tree cmp root) =
+export def tdelete (y: a) (Tree cmp root: Tree a): Tree a =
   Tree cmp (delete cmp y root)
 def delete cmp y t =
   def helper = match _
@@ -170,7 +171,7 @@ export def tappi f (Tree _ root) =
   helper 0 root
 
 # Extract the i-th ranked element
-export def tat i (Tree _ root) =
+export def tat (i: Integer) (Tree _ root: Tree a): Option a =
   def helper i = match _
     Tip = None
     Bin _ l x r =
@@ -182,7 +183,7 @@ export def tat i (Tree _ root) =
   helper i root
 
 # Split elements ranked [0,i) and [i,inf) into two trees
-export def tsplitAt i (Tree cmp root) =
+export def tsplitAt (i: Integer) (Tree cmp root: Tree a): Pair (Tree a) (Tree a) =
   def helper i = match _
     Tip = Pair Tip Tip
     Bin _ l x r =
@@ -257,7 +258,7 @@ def split y cmp root =
   helper root
 
 # Split tree into those elements where f x = True and those where f x = False
-export def tsplitBy f (Tree cmp root) =
+export def tsplitBy (f: a => Boolean) (Tree cmp root: Tree a): Pair (Tree a) (Tree a) =
   def helper t = match t
     Tip = Pair Tip Tip
     Bin _ l x r = match (helper l) (helper r)
@@ -269,7 +270,7 @@ export def tsplitBy f (Tree cmp root) =
     Pair t f = Pair (Tree cmp t) (Tree cmp f)
 
 # Remove all elements x such that f x = False.
-export def tfilter f (Tree cmp root) =
+export def tfilter (f: a => Boolean) (Tree cmp root: Tree a): Tree a =
   def helper t = match t
     Tip = Tip
     Bin _ l x r =
@@ -279,7 +280,7 @@ export def tfilter f (Tree cmp root) =
   Tree cmp (helper root)
 
 # Return the smallest element in the tree.
-export def tmin (Tree _ root) = min_ root
+export def tmin (Tree _ root: Tree a): Option a = min_ root
 def min_ root =
   def none = match _
     Tip         = None
@@ -290,7 +291,7 @@ def min_ root =
   none root
 
 # Return the largest element in the tree.
-export def tmax (Tree _ root) = max_ root
+export def tmax (Tree _ root: Tree a): Option a = max_ root
 def max_ root =
   def none = match _
     Tip         = None
@@ -300,15 +301,15 @@ def max_ root =
     Bin _ _ y r = some y r
   none root
 
-# Lowest rank element with x >= y.
-export def tlowerGE y (Tree cmp root) =
+# Lowest rank element with x >= y, along with that rank.
+export def tlowerGE (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
   def f x = match (cmp x y)
     LT = False
     _  = True
   lower f root
 
-# Lowest rank element with x > y.
-export def tlowerGT y (Tree cmp root) =
+# Lowest rank element with x > y, along with that rank.
+export def tlowerGT (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
   def f x = match (cmp x y)
     GT = True
     _  = False
@@ -327,15 +328,15 @@ def lower f root =
     Bin s l x r = if f x then someL x i l else someR z (i+s) r
   none root
 
-# Highest rank element with x < y
-export def tupperLT y (Tree cmp root) =
+# Highest rank element with x < y, along with that rank.
+export def tupperLT (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
   def f x = match (cmp x y)
     LT = False
     _  = True
   upper f root
 
-# Highest rank element with x <= y
-export def tupperLE y (Tree cmp root) =
+# Highest rank element with x <= y, along with that rank.
+export def tupperLE (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
   def f x = match (cmp x y)
     GT = True
     _  = False
@@ -383,7 +384,7 @@ export def x ∋ y = y ∈ x
 # Returns True if x does NOT contain y, False otherwise.
 export def x ∌ y = y ∉ x
 
-export def tcontains y t =
+export def tcontains (y: a) (t: Tree a): Boolean =
   match t (tupperLE y t)
     (Tree _   _) None              = False
     (Tree cmp _) (Some (Pair x _)) = match (cmp x y)
@@ -391,18 +392,18 @@ export def tcontains y t =
       _  = False
 
 # Eliminate duplicates, as identified by cmp
-export def tdistinctBy cmp t = match t
+export def tdistinctBy (cmp: a => a => Order) (t: Tree a): Tree a = match t
   Tree tcmp _ = listToTree tcmp (distinctBy cmp (treeToList t))
 
 # Eliminate duplicates, as identified by f
-export def tdistinctRunBy f t = match t
+export def tdistinctRunBy (f: a => a => Boolean) (t: Tree a): Tree a = match t
   Tree cmp _ = Tree cmp (build (vdistinctRunBy f (treeToVector t)))
 
 # Returns the union of trees a and b, keeps only values from a if they are equal to values in b.
 export def a ∪ b = tunion a b
 
 # Returns the union of two trees, given their roots.
-export def tunion (Tree _ aroot) (Tree cmp broot) =
+export def tunion (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
   Tree cmp (union cmp aroot broot)
 def union cmp aroot broot =
   def helper a b = match a b
@@ -432,7 +433,7 @@ def unionMulti cmp aroot broot =
   helper aroot broot
 
 # Returns the set difference of A and B, that is, a tree containing all elements of A which are not in B.
-export def tsubtract (Tree _ aroot) (Tree cmp broot) =
+export def tsubtract (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
   def helper a b = match a b
     Tip _ = Tip
     _ Tip = a
@@ -457,7 +458,7 @@ export def tintersect (Tree _ aroot) (Tree cmp broot) =
   Tree cmp (helper aroot broot)
 
 # Pretty print the tree shape for debug
-#export def tshape (Tree _ root) =
+#export def tshape (Tree _ root: Tree a): String =
 #  def row x =
 #    def helper i = match _
 #      Tip = Nil

--- a/share/wake/lib/core/vector.wake
+++ b/share/wake/lib/core/vector.wake
@@ -61,7 +61,8 @@ export def vectorToList: Vector a => List a =
 #
 #   vempty (vseq 4) = False
 #   vempty (vseq 0) = True
-export def vempty (Vector _ s e: Vector a): Boolean =
+export def vempty (v: Vector a): Boolean =
+    def Vector _ s e = v
     s == e
 
 # vlen: returns the length of the ``Vector``.
@@ -69,7 +70,8 @@ export def vempty (Vector _ s e: Vector a): Boolean =
 #   vlen (vseq x) = x
 #   vlen [] = 0
 #   vlen [0, 5] = 2
-export def vlen (Vector _ s e: Vector a): Integer =
+export def vlen (v: Vector a): Integer =
+    def Vector _ s e = v
     e - s
 
 # vsplitAt: given an index, cut a Vector into elements before and after the index

--- a/share/wake/lib/core/vector.wake
+++ b/share/wake/lib/core/vector.wake
@@ -61,7 +61,7 @@ export def vectorToList: Vector a => List a =
 #
 #   vempty (vseq 4) = False
 #   vempty (vseq 0) = True
-export def vempty (Vector _ s e): Boolean =
+export def vempty (Vector _ s e: Vector a): Boolean =
     s == e
 
 # vlen: returns the length of the ``Vector``.
@@ -69,7 +69,7 @@ export def vempty (Vector _ s e): Boolean =
 #   vlen (vseq x) = x
 #   vlen [] = 0
 #   vlen [0, 5] = 2
-export def vlen (Vector _ s e): Integer =
+export def vlen (Vector _ s e: Vector a): Integer =
     e - s
 
 # vsplitAt: given an index, cut a Vector into elements before and after the index

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -23,7 +23,7 @@ export tuple Usage = # Unknown quantities are 0
   export InBytes:  Integer
   export OutBytes: Integer
 
-export def getUsageThreads (Usage _ run cpu _ _ _) =
+export def getUsageThreads (Usage _ run cpu _ _ _: Usage): Double =
   if run ==. 0.0 then cpu else cpu /. run
 
 # RunnerInput is a subset of the fields supplied in the execution Plan
@@ -94,14 +94,14 @@ tuple Plan =
   export FnInputs:     (List String => List String) # Modify the Runner's reported inputs  (files read)
   export FnOutputs:    (List String => List String) # Modify the Runner's reported outputs (files created)
 
-def isOnce = match _
+def isOnce: Persistence => Boolean = match _
   ReRun = False
   _     = True
-def isKeep = match _
+def isKeep: Persistence => Boolean = match _
   ReRun = False
   Once  = False
   _     = True
-def isShare = match _
+def isShare: Persistence => Boolean = match _
   Share = True
   _     = False
 
@@ -115,15 +115,15 @@ export def setPlanKeep  v p = editPlanKeep  (\_ v) p
 export def setPlanShare v p = editPlanShare (\_ v) p
 
 # Prepend 'value' to the Plan's 'PATH' environment value
-export def prependPlanPath value plan =
+export def prependPlanPath (value: String) (plan: Plan): Plan =
   editPlanEnvironment (addEnvironmentPath value) plan
 
 # Set an environment variable in a Plan
-export def setPlanEnvVar name value plan =
+export def setPlanEnvVar (name: String) (value: String) (plan: Plan): Plan =
   editPlanEnvironment ("{name}={value}", _) plan
 
 # Helper methods that maintain the invariant that: Share => Keep => Once
-export def editPlanOnce f =
+export def editPlanOnce (f: Boolean => Boolean): Plan => Plan =
   def helper = match _
     ReRun if   f False = Once
     Once  if ! f True  = ReRun
@@ -132,7 +132,7 @@ export def editPlanOnce f =
     x                  = x
   editPlanPersistence helper
 
-export def editPlanKeep f =
+export def editPlanKeep (f: Boolean => Boolean): Plan => Plan =
   def helper = match _
     ReRun if   f False = Keep
     Once  if   f False = Keep
@@ -141,7 +141,7 @@ export def editPlanKeep f =
     x                  = x
   editPlanPersistence helper
 
-export def editPlanShare f =
+export def editPlanShare (f: Boolean => Boolean): Plan => Plan =
   def helper = match _
     ReRun if   f False = Share
     Once  if   f False = Share
@@ -169,16 +169,16 @@ export def getPlanHash (plan: Plan): Integer =
 #   The prior Input dirs observe the same set of Visible files
 
 # Create a labeled shell plan.
-export def makePlan label visible command =
+export def makePlan (label: String) (visible: List Path) (command: String): Plan =
   makeShellPlan command visible
   | setPlanLabel label
 
 # Set reasonable defaults for all Plan arguments
 def id x = x
-export def makeExecPlan cmd visible =
+export def makeExecPlan (cmd: List String) (visible: List Path): Plan =
   Plan "" cmd visible environment "." "" logInfo logWarning logEcho Share False Nil (\_ True) defaultUsage id id
 
-export def makeShellPlan script visible =
+export def makeShellPlan (script: String) (visible: List Path): Plan =
   makeExecPlan (which "dash", "-c", script, Nil) visible
 
 def defaultUsage = Usage 0 0.0 1.0 0 0 0
@@ -290,7 +290,7 @@ data RunnerOption =
   Reject (why: String)
 
 # Run the job!
-export def runJob p = match p
+export def runJob (p: Plan): Job = match p
   Plan label cmd vis env dir stdin stdout stderr echo pers _lo res rf usage finputs foutputs =
     # Transform the 'List Runner' into 'List RunnerOption'
     def qualify runner = match runner
@@ -348,7 +348,8 @@ export def getJobRecord (job: Job): Option Usage =
   def raw job = prim "job_record"
   raw job | at 0 | omap toUsage
 
-export def makeBadPath error = BadPath error
+export def makeBadPath (error: Error): Path =
+  BadPath error
 
 # Control a running/finished Job
 def stdio job fd  = prim "job_output" # 1=stdout, 2=stderr; blocks till closed
@@ -425,9 +426,9 @@ export def preloadRunner: Runner =
   makeJSONRunnerPlan preload score
   | makeJSONRunner
 
-export def rOK = 0
-export def wOK = 1
-export def xOK = 2
+export def rOK: Integer = 0
+export def wOK: Integer = 1
+export def xOK: Integer = 2
 export def access (file: String) (mode: Integer): Boolean =
   (\f\m prim "access") file mode
 

--- a/share/wake/lib/versions/v0_19.wake
+++ b/share/wake/lib/versions/v0_19.wake
@@ -15,7 +15,7 @@ from gcc_wake export type SysLib
 from gcc_wake export def SysLib compileC editSysLibCFlags editSysLibHeaders editSysLibLFlags editSysLibObjects editSysLibVerison flattenSysLibs getSysLibCFlags getSysLibHeaders getSysLibLFlags getSysLibObjects getSysLibVerison linkO makeSysLib pkgConfig setSysLibCFlags setSysLibHeaders setSysLibLFlags setSysLibObjects setSysLibVerison
 from gcc_wake export topic compileC linkO
 
-export def tapLevel level formatFn value =
+export def tapLevel (level: LogLevel) (formatFn: a => String) (value: a): a =
     def _ = printlnLevel level (formatFn value)
     value
 
@@ -25,29 +25,31 @@ export def tapNormal  = tapLevel logNormal
 export def tapVerbose = tapLevel logVerbose
 export def tapDebug   = tapLevel logDebug
 
-export def installIn x y =
+export def installIn (x: String) (y: Path): Path =
     from wake import installIn
     installIn x "." y
 
-export def makePlan = makeExecPlan
+export def makePlan: List String => List Path => Plan =
+    makeExecPlan
 
 export def vfoldmap f a g v = vmapReduce g f a v
 export def vfold f a v = vmapReduce (_) f a v
 export def vscanmap f a g v = vmapScan g f a v
 
-export def idouble x = match (dmodf x)
+export def idouble (x: Double): Option Integer = match (dmodf x)
     Pair x 0.0 = Some x
     _ = None
 
-export def panic = unreachable
+export def panic: String => a =
+    unreachable
 
-export def stringToRegExp s =
+export def stringToRegExp (s: String): Result RegExp String =
     from wake import def real=stringToRegExp
     match (real s)
         Pass ok = Pass ok
         Fail error = Fail error.getErrorCause
 
-export def strbase n x =
+export def strbase (n: Integer) (x: Integer): String =
     from wake import def real=strbase
     match (real n)
         Some f = f x

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -29,7 +29,7 @@ def wakeToTest Unit = match (subscribe wakeTestBinary)
     Nil = Pass (Pair "{wakePath}/wake" Nil)
     _ = Fail (makeError "Two wake binaries declared for testing!")
 
-export def runTests cmdline =
+export def runTests (cmdline: List String): Result String Error =
     require Pass filter = match cmdline
         Nil      = Pass `.*`
         arg, Nil = stringToRegExp arg
@@ -77,7 +77,7 @@ export def runTests cmdline =
 
     Pass "All {len tests | str} tests completed successfully."
 
-def runTest testScript =
+def runTest (testScript: Path): Result Unit Error =
     def shouldPass =
         testScript
         | getPathName


### PR DESCRIPTION
I've been reading through the Wake code and making sure I stay attentive by adding type annotations.  This is unfortunately a rather large PR, but it should hopefully be relatively straight-forward to review (I extracted the harder-to-glance-at patches to be sent later).  Let me know if you'd prefer smaller chunks, in which case I'll probably just break this up by file.