### PR TITLE
lsp: don't discard empty diagnostics

### DIFF
--- a/tools/lsp-wake/astree.cpp
+++ b/tools/lsp-wake/astree.cpp
@@ -53,7 +53,7 @@ void ASTree::diagnoseProject(const std::function<void(FileDiagnostics &)> &proce
   auto allFiles = find_all_wakefiles(enumok, true, false, stdLib);
 
   std::map<std::string, std::vector<Diagnostic>> diagnostics;
-  LSPReporter lspReporter(diagnostics);
+  LSPReporter lspReporter(diagnostics, allFiles);
   reporter = &lspReporter;
 
   std::unique_ptr<Top> top(new Top);
@@ -387,5 +387,10 @@ void ASTree::LSPReporter::report(Diagnostic diagnostic) {
   diagnostics[diagnostic.getFilename()].push_back(diagnostic);
 }
 
-ASTree::LSPReporter::LSPReporter(std::map<std::string, std::vector<Diagnostic>> &_diagnostics)  : diagnostics(
-  _diagnostics) {}
+ASTree::LSPReporter::LSPReporter(std::map<std::string, std::vector<Diagnostic>> &_diagnostics, const std::vector<std::string> &allFiles)  : diagnostics(
+  _diagnostics) {
+  // create an empty diagnostics vector for each file
+  for (const std::string &fileName: allFiles) {
+    diagnostics[fileName];
+  }
+}

--- a/tools/lsp-wake/astree.h
+++ b/tools/lsp-wake/astree.h
@@ -79,7 +79,7 @@ private:
 
         void report(Diagnostic diagnostic) override;
     public:
-        explicit LSPReporter(std::map<std::string, std::vector<Diagnostic>> &_diagnostics);
+        explicit LSPReporter(std::map<std::string, std::vector<Diagnostic>> &_diagnostics, const std::vector<std::string> &allFiles);
     };
 
     void explore(Expr *expr, bool isGlobal);


### PR DESCRIPTION
When a file has no diagnostics, report an empty diagnostics array to indicate that there are no errors.