### PR TITLE
LSP: support windows and following references from standard libraries

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -38,7 +38,7 @@ A Visual Studio Code extension with support for the Wake build tool and language
 
 ## Requirements
 
- A Linux or macOS machine
+ A Linux, Windows, or MacOS machine.
 
 ## Wake versions
 

--- a/src/compat/aligned_alloc.c
+++ b/src/compat/aligned_alloc.c
@@ -23,9 +23,5 @@
 #include "aligned_alloc.h"
 
 void *my_aligned_alloc(size_t alignment, size_t size) {
-#ifdef __EMSCRIPTEN__
-    return malloc(size);
-#else
     return aligned_alloc(alignment, size); // This is a C11 feature
-#endif
 }

--- a/src/compat/readable.c
+++ b/src/compat/readable.c
@@ -28,6 +28,7 @@
 int is_readable(const char *filename) {
   int out = EM_ASM_INT({
     try {
+      const fs = require('fs');
       fs.accessSync(UTF8ToString($0), fs.constants.R_OK);
       return 1;
     } catch (err) {

--- a/src/compat/readable.c
+++ b/src/compat/readable.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Open Group Base Specifications Issue 7
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
+
+#include "readable.h"
+
+#ifdef __EMSCRIPTEN__
+
+#include <emscripten/emscripten.h>
+
+int is_readable(const char *filename) {
+  int out = EM_ASM_INT({
+    try {
+      fs.accessSync(UTF8ToString($0), fs.constants.R_OK);
+      return 1;
+    } catch (err) {
+      return 0;
+    }
+  }, filename);
+
+  return out;
+}
+
+#else
+
+#include <unistd.h>
+
+int is_readable(const char *filename) {
+  return access(filename, R_OK) == 0;
+}
+
+#endif

--- a/src/compat/readable.h
+++ b/src/compat/readable.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef READABLE_H
+#define READABLE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Return if the file is not readable (1) or not (0).
+int is_readable(const char *filename);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/compat/windows.c
+++ b/src/compat/windows.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(_WIN32)
+
+int is_windows() { return 1; }
+
+#elif defined(__EMSCRIPTEN__)
+#include <emscripten/emscripten.h>
+
+int is_windows() {
+  return EM_ASM_INT({
+    if (process.platform == 'win32') {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+}
+
+#else
+
+int is_windows() { return 0; }
+
+#endif

--- a/src/compat/windows.h
+++ b/src/compat/windows.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WINDOWS_H
+#define WINDOWS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int is_windows();
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/parser/wakefiles.cpp
+++ b/src/parser/wakefiles.cpp
@@ -33,6 +33,7 @@
 #include <fstream>
 #include <algorithm>
 
+#include "compat/readable.h"
 #include "util/execpath.h"
 #include "wakefiles.h"
 
@@ -395,7 +396,7 @@ std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbo
   std::string rel_libdir = make_relative(get_cwd(), make_canonical(abs_libdir));
 
   std::vector<std::string> acc;
-  if (!workspace || access("share/wake/lib/core/boolean.wake", R_OK) != 0)
+  if (!workspace || !is_readable("share/wake/lib/core/boolean.wake"))
     if (push_files(acc, rel_libdir, exp, 0)) ok = false;
   if (workspace && push_files(acc, ".", exp, 0)) ok = false;
 

--- a/src/parser/wakefiles.cpp
+++ b/src/parser/wakefiles.cpp
@@ -218,45 +218,6 @@ std::string make_canonical(const std::string &x) {
   }
 }
 
-// dir + path must be canonical
-std::string make_relative(std::string &&dir, std::string &&path) {
-  if ((!path.empty() && path[0] == '/') !=
-  (!dir .empty() && dir [0] == '/')) {
-    return std::move(path);
-  }
-
-  if (dir == ".") dir = "";
-  else if (dir != "/") dir += '/';
-  path += '/';
-
-  size_t skip = 0, end = std::min(path.size(), dir.size());
-  for (size_t i = 0; i < end; ++i) {
-    if (dir[i] != path[i])
-      break;
-    if (dir[i] == '/') skip = i+1;
-  }
-
-  std::stringstream str;
-  for (size_t i = skip; i < dir.size(); ++i)
-    if (dir[i] == '/')
-      str << "../";
-
-  std::string x;
-  std::string last(path, skip, path.size()-skip-1);
-  if (last.empty() || last == ".") {
-    // remove trailing '/'
-    x = str.str();
-    if (x.empty()) x = ".";
-    else x.resize(x.size()-1);
-  } else {
-    str << last;
-    x = str.str();
-  }
-
-  if (x.empty()) return ".";
-  return x;
-}
-
 struct WakeFilter {
     size_t prefix;
     bool allow;

--- a/src/parser/wakefiles.cpp
+++ b/src/parser/wakefiles.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 
 #include "compat/readable.h"
+#include "compat/windows.h"
 #include "util/execpath.h"
 #include "util/diagnostic.h"
 #include "util/file.h"
@@ -43,7 +44,7 @@
 #include <emscripten/emscripten.h>
 
 EM_JS(char *, nodejs_getfiles, (const char *dir, int *ok), {
-  const Path = require("path");
+  const Path = require("path").posix;
   const FS   = require("fs");
   let files  = [];
 
@@ -182,7 +183,11 @@ std::string make_canonical(const std::string &x) {
   bool repeat;
   bool pop = false;
   do {
-    scan = x.find_first_of('/', tok);
+    if (is_windows()) {
+      scan = x.find_first_of("\\/", tok);
+    } else {
+      scan = x.find_first_of('/', tok);
+    }
     repeat = scan != std::string::npos;
     std::string token(x, tok, repeat?(scan-tok):scan);
     tok = scan+1;

--- a/src/parser/wakefiles.h
+++ b/src/parser/wakefiles.h
@@ -24,6 +24,6 @@ bool push_files(std::vector<std::string> &out, const std::string &path, const re
 std::string make_canonical(const std::string &x);
 std::string make_relative(std::string &&dir, std::string &&path);
 std::string glob2regexp(const std::string &glob);
-std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbose, const std::string &abs_libdir);
+std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbose, const std::string &libdir, const std::string &workdir);
 
 #endif

--- a/src/parser/wakefiles.h
+++ b/src/parser/wakefiles.h
@@ -22,7 +22,6 @@ namespace re2 { class RE2; };
 
 bool push_files(std::vector<std::string> &out, const std::string &path, const re2::RE2& re, size_t skip);
 std::string make_canonical(const std::string &x);
-std::string make_relative(std::string &&dir, std::string &&path);
 std::string glob2regexp(const std::string &glob);
 std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbose, const std::string &libdir, const std::string &workdir);
 

--- a/src/runtime/gc.h
+++ b/src/runtime/gc.h
@@ -71,12 +71,7 @@ struct HeapObject {
 
   // this overload causes non-placement 'new' to become illegal (which we want)
   void *operator new(size_t size, void *free) { return free; }
-}
-#ifdef __EMSCRIPTEN__
-// Emscripten needs some help getting our GC alignment right.
-__attribute__ ((aligned (8)))
-#endif
-;
+};
 
 inline std::ostream & operator << (std::ostream &os, const HeapObject *value) {
   HeapObject::format(os, value);

--- a/src/runtime/sources.cpp
+++ b/src/runtime/sources.cpp
@@ -57,6 +57,45 @@ bool make_workspace(const std::string &dir) {
   return true;
 }
 
+// dir + path must be canonical
+static std::string make_relative(std::string &&dir, std::string &&path) {
+  if ((!path.empty() && path[0] == '/') !=
+  (!dir .empty() && dir [0] == '/')) {
+    return std::move(path);
+  }
+
+  if (dir == ".") dir = "";
+  else if (dir != "/") dir += '/';
+  path += '/';
+
+  size_t skip = 0, end = std::min(path.size(), dir.size());
+  for (size_t i = 0; i < end; ++i) {
+    if (dir[i] != path[i])
+      break;
+    if (dir[i] == '/') skip = i+1;
+  }
+
+  std::stringstream str;
+  for (size_t i = skip; i < dir.size(); ++i)
+    if (dir[i] == '/')
+      str << "../";
+
+  std::string x;
+  std::string last(path, skip, path.size()-skip-1);
+  if (last.empty() || last == ".") {
+    // remove trailing '/'
+    x = str.str();
+    if (x.empty()) x = ".";
+    else x.resize(x.size()-1);
+  } else {
+    str << last;
+    x = str.str();
+  }
+
+  if (x.empty()) return ".";
+  return x;
+}
+
 bool chdir_workspace(const char *chdirto, std::string &wake_cwd, std::string &src_dir) {
   wake_cwd = get_cwd();
 

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -96,6 +96,7 @@ ExternalFile::ExternalFile(DiagnosticReporter &reporter, const char *filename_)
     int32_t length;
     uint8_t *base = (uint8_t*)EM_ASM_INT({
       try {
+        const fs = require('fs');
         const fileBuffer = fs.readFileSync(UTF8ToString($1));
         const wasmPointer = Module._malloc(fileBuffer.length+1);
         fileBuffer.copy(Module.HEAPU8, wasmPointer);

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -22,6 +22,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
+#include <stdlib.h>
 #include <errno.h>
 
 #include <algorithm>
@@ -84,31 +85,55 @@ StringFile::StringFile(const char *filename_, std::string &&content_)
     ss.end = ss.start + content.size();
 }
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+
 ExternalFile::ExternalFile(DiagnosticReporter &reporter, const char *filename_)
  : FileContent(filename_)
 {
     Location l(filename());
 
-#ifdef __EMSCRIPTEN__
-    // mmap with specified address is broken...
-    std::ifstream ifs(filename());
-    if (!ifs) {
-        reporter.reportError(l, std::string("open failed; ") + strerror(errno));
-        ss.end = ss.start = &null[0];
-        return;
+    int32_t length;
+    uint8_t *base = (uint8_t*)EM_ASM_INT({
+      try {
+        const fileBuffer = fs.readFileSync(UTF8ToString($1));
+        const wasmPointer = Module._malloc(fileBuffer.length+1);
+        fileBuffer.copy(Module.HEAPU8, wasmPointer);
+        setValue($0, fileBuffer.length, "i32");
+        return wasmPointer;
+      } catch (err) {
+        const lengthBytes = lengthBytesUTF8(err.message)+1;
+        const stringOnWasmHeap = _malloc(lengthBytes);
+        stringToUTF8(err.message, stringOnWasmHeap, lengthBytes);
+        setValue($0, -1, "i32");
+        return stringOnWasmHeap;
+      }
+    }, &length, filename());
+
+    if (length == -1) {
+      reporter.reportError(l, std::string("readFileSync failed; ") + reinterpret_cast<char*>(base));
+      free(base);
+      ss.end = ss.start = &null[0];
+      return;
     }
-
-    ifs.seekg(0, std::ios::end);
-    size_t length = ifs.tellg();
-    ifs.seekg(0, std::ios::beg);
-
-    uint8_t *base = new uint8_t[length+1];
-    ifs.read(reinterpret_cast<char*>(base), length);
 
     base[length] = 0;
     ss.start = base;
     ss.end = base + length;
+}
+
+ExternalFile::~ExternalFile() {
+    if (ss.start != ss.end)
+        free((void*)ss.start);
+}
+
 #else
+
+ExternalFile::ExternalFile(DiagnosticReporter &reporter, const char *filename_)
+ : FileContent(filename_)
+{
+    Location l(filename());
+
     int fd = open(filename(), O_RDONLY);
     if (fd == -1) {
         reporter.reportError(l, std::string("open failed; ") + strerror(errno));
@@ -161,18 +186,14 @@ ExternalFile::ExternalFile(DiagnosticReporter &reporter, const char *filename_)
 
     // Fill in the last page
     memcpy(reinterpret_cast<uint8_t*>(map) + tail_start, buf.c_str(), tail_len);
-#endif
 }
 
 ExternalFile::~ExternalFile() {
-#ifdef __EMSCRIPTEN__
-    if (ss.start != ss.end)
-        delete [] ss.start;
-#else
     if (ss.start != ss.end)
         munmap(const_cast<void*>(reinterpret_cast<const void*>(ss.start)), ss.size() + 1);
-#endif
 }
+
+#endif
 
 CPPFile::CPPFile(const char *filename)
  : FileContent(filename)

--- a/tools/lsp-wake/astree.cpp
+++ b/tools/lsp-wake/astree.cpp
@@ -50,7 +50,7 @@ void ASTree::diagnoseProject(const std::function<void(FileDiagnostics &)> &proce
   comments.clear();
 
   bool enumok = true;
-  auto allFiles = find_all_wakefiles(enumok, true, false, stdLib);
+  auto allFiles = find_all_wakefiles(enumok, true, false, stdLib, ".");
 
   std::map<std::string, std::vector<Diagnostic>> diagnostics;
   LSPReporter lspReporter(diagnostics, allFiles);

--- a/tools/lsp-wake/astree.cpp
+++ b/tools/lsp-wake/astree.cpp
@@ -39,9 +39,9 @@
 
 static CPPFile cppFile(__FILE__);
 
-ASTree::ASTree(): stdLib() {}
+ASTree::ASTree() {}
 
-ASTree::ASTree(std::string _stdLib) : stdLib(std::move(_stdLib)) {}
+ASTree::ASTree(std::string _absLibDir) : absLibDir(std::move(_absLibDir)) {}
 
 void ASTree::diagnoseProject(const std::function<void(FileDiagnostics &)> &processFileDiagnostics) {
   usages.clear();
@@ -50,7 +50,7 @@ void ASTree::diagnoseProject(const std::function<void(FileDiagnostics &)> &proce
   comments.clear();
 
   bool enumok = true;
-  auto allFiles = find_all_wakefiles(enumok, true, false, stdLib, ".");
+  auto allFiles = find_all_wakefiles(enumok, true, false, absLibDir, absWorkDir);
 
   std::map<std::string, std::vector<Diagnostic>> diagnostics;
   LSPReporter lspReporter(diagnostics, allFiles);

--- a/tools/lsp-wake/astree.h
+++ b/tools/lsp-wake/astree.h
@@ -35,7 +35,7 @@ public:
 
     ASTree();
 
-    explicit ASTree(std::string _stdLib);
+    explicit ASTree(std::string _absLibDir);
 
     typedef std::pair<const std::string, std::vector<Diagnostic>> FileDiagnostics;
 
@@ -53,7 +53,9 @@ public:
 
     std::vector<SymbolDefinition> workspaceSymbol(const std::string &query);
 
-    std::string stdLib;
+    std::string absLibDir;
+    std::string absWorkDir;
+
 private:
     struct SymbolUsage {
         Location usage;

--- a/tools/lsp-wake/json_converter.cpp
+++ b/tools/lsp-wake/json_converter.cpp
@@ -146,19 +146,6 @@ namespace JSONConverter {
       return message;
     }
 
-    JAST createInitializeResultCrashed(const JAST &receivedMessage) {
-      JAST message = createResponseMessage(receivedMessage);
-      JAST &result = message.add("result", JSON_OBJECT);
-
-      JAST &capabilities = result.add("capabilities", JSON_OBJECT);
-      capabilities.add("textDocumentSync", 1);
-
-      JAST &serverInfo = result.add("serverInfo", JSON_OBJECT);
-      serverInfo.add("name", "lsp wake server");
-
-      return message;
-    }
-
     JAST createInitializeResultInvalidSTDLib(const JAST &receivedMessage) {
       JAST message = createResponseMessage(receivedMessage);
       JAST &result = message.add("result", JSON_OBJECT);

--- a/tools/lsp-wake/json_converter.h
+++ b/tools/lsp-wake/json_converter.h
@@ -24,7 +24,8 @@
 #include "symbol_definition.h"
 
 namespace JSONConverter {
-    std::string stripRootUri(const std::string &fileUri, const std::string& rootUri);
+    std::string decodePath(const std::string &fileUri);
+    std::string encodePath(const std::string &filePath);
 
     JAST createMessage();
 
@@ -36,7 +37,7 @@ namespace JSONConverter {
 
     JAST createRequestMessage();
 
-    Location getLocationFromJSON(JAST receivedMessage, const std::string& rootUri);
+    Location getLocationFromJSON(JAST receivedMessage);
 
     JAST createInitializeResultDefault(const JAST &receivedMessage);
 
@@ -44,19 +45,19 @@ namespace JSONConverter {
 
     JAST createInitializeResultInvalidSTDLib(const JAST &receivedMessage);
 
-    JAST fileDiagnosticsToJSON(const std::string &filePath, const std::vector<Diagnostic> &fileDiagnostics, const std::string& rootUri);
+    JAST fileDiagnosticsToJSON(const std::string &filePath, const std::vector<Diagnostic> &fileDiagnostics);
 
-    JAST definitionLocationToJSON(JAST receivedMessage, const Location &definitionLocation, const std::string& rootUri);
+    JAST definitionLocationToJSON(JAST receivedMessage, const Location &definitionLocation);
 
-    JAST referencesToJSON(JAST receivedMessage, const std::vector<Location> &references, const std::string& rootUri);
+    JAST referencesToJSON(JAST receivedMessage, const std::vector<Location> &references);
 
     JAST highlightsToJSON(JAST receivedMessage, const std::vector<Location> &occurrences);
 
     JAST hoverInfoToJSON(JAST receivedMessage, const std::vector<SymbolDefinition> &hoverInfoPieces);
 
-    void appendSymbolToJSON(const SymbolDefinition& def, JAST &json, const std::string& rootUri);
+    void appendSymbolToJSON(const SymbolDefinition& def, JAST &json);
 
-    JAST workspaceEditsToJSON(JAST receivedMessage, const std::vector<Location> &references, const std::string &newName, const std::string& rootUri);
+    JAST workspaceEditsToJSON(JAST receivedMessage, const std::vector<Location> &references, const std::string &newName);
 }
 
 #endif

--- a/tools/lsp-wake/json_converter.h
+++ b/tools/lsp-wake/json_converter.h
@@ -41,8 +41,6 @@ namespace JSONConverter {
 
     JAST createInitializeResultDefault(const JAST &receivedMessage);
 
-    JAST createInitializeResultCrashed(const JAST &receivedMessage);
-
     JAST createInitializeResultInvalidSTDLib(const JAST &receivedMessage);
 
     JAST fileDiagnosticsToJSON(const std::string &filePath, const std::vector<Diagnostic> &fileDiagnostics);

--- a/tools/lsp-wake/lsp.cpp
+++ b/tools/lsp-wake/lsp.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 #include <algorithm>
 
+#include "compat/readable.h"
 #include "util/location.h"
 #include "util/execpath.h"
 #include "util/diagnostic.h"
@@ -348,7 +349,7 @@ private:
       if (!isSTDLibValid) {
         notifyAboutInvalidSTDLib();
         message = JSONConverter::createInitializeResultInvalidSTDLib(receivedMessage);
-      } else if (access(crashedFlagFilename.c_str(), F_OK) != -1) {
+      } else if (is_readable(crashedFlagFilename.c_str())) {
         message = JSONConverter::createInitializeResultCrashed(receivedMessage);
         isCrashed = true;
       } else {
@@ -593,7 +594,7 @@ int main(int argc, const char **argv) {
 #endif
 
   LSPServer lsp;
-  if (access((stdLib + "/core/boolean.wake").c_str(), F_OK) != -1) {
+  if (is_readable((stdLib + "/core/boolean.wake").c_str())) {
     lsp = LSPServer(stdLib);
   } else {
     lsp = LSPServer(false, stdLib);

--- a/tools/lsp-wake/lsp.cpp
+++ b/tools/lsp-wake/lsp.cpp
@@ -556,7 +556,7 @@ private:
 int main(int argc, const char **argv) {
   std::string stdLib;
   if (argc >= 2) {
-    stdLib = argv[1];
+    stdLib = make_canonical(argv[1]);
   } else {
     stdLib = make_canonical(find_execpath() + "/../../share/wake/lib");
   }

--- a/tools/lsp-wake/lsp.cpp
+++ b/tools/lsp-wake/lsp.cpp
@@ -240,7 +240,9 @@ private:
 #ifdef __EMSCRIPTEN__
         char *buf = nodejs_getstdin();
         if (!buf) {
+#ifdef CERR_DEBUG
           std::cerr << "Client did not shutdown cleanly" << std::endl;
+#endif
           exit(1);
         }
 
@@ -283,7 +285,9 @@ private:
 
         // End-of-file reached?
         if (got == 0) {
+#ifdef CERR_DEBUG
           std::cerr << "Client did not shutdown cleanly" << std::endl;
+#endif
           exit(1);
         }
 

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -369,8 +369,8 @@ int main(int argc, char **argv) {
   if (noparse) return 0;
 
   bool enumok = true;
-  std::string abs_libdir = find_execpath() + "/../share/wake/lib";
-  auto wakefilenames = find_all_wakefiles(enumok, workspace, verbose, abs_libdir);
+  std::string libdir = make_canonical(find_execpath() + "/../share/wake/lib");
+  auto wakefilenames = find_all_wakefiles(enumok, workspace, verbose, libdir, ".");
   if (!enumok) {
     if (verbose) std::cerr << "Workspace wake file enumeration failed" << std::endl;
     // Try to run the build anyway; if wake files are missing, it will fail later

--- a/vendor/emscripten.wake
+++ b/vendor/emscripten.wake
@@ -66,7 +66,6 @@ def emscriptenCFlags =
 
 def emscriptenLFlags =
     "-O3",
-    "-lnodefs.js",
     "-s", "ALLOW_MEMORY_GROWTH",
     "-s", "EXIT_RUNTIME",
     "-s", "ASYNCIFY",

--- a/vendor/whereami/whereami.c
+++ b/vendor/whereami/whereami.c
@@ -677,9 +677,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
 {
   char *path = (char*)EM_ASM_INT({
     const path = require('path');
-    buffer = path.dirname(__filename);
-    let lengthBytes = lengthBytesUTF8(buffer)+1;
-    let stringOnWasmHeap = _malloc(lengthBytes);
+    const buffer = path.dirname(__filename);
+    const lengthBytes = lengthBytesUTF8(buffer)+1;
+    const stringOnWasmHeap = _malloc(lengthBytes);
     stringToUTF8(buffer, stringOnWasmHeap, lengthBytes);
     return stringOnWasmHeap;
   });


### PR DESCRIPTION
This PR revamps how the LSP tracks files. It now tracks them using absolute paths. The URI is also now %-decoded/encoded properly. This makes it possible to reference to/from files in the standard library, which do not lie under the workspace. As the LSP also no longer uses relative paths, it's working directory is irrelevant to its operation, which should alleviate the neovim headaches. Finally, using absolute paths makes it relatively easy to support windows, where the standard library and the workspace might be on different volumes.

In other words, this PR:
- Fixes 'neovim must be invoked from workspace root'
- Fixes 'find references' from the standard library
- Fixes handling of filenames with non-alphanumeric characters
- Adds support for Windows