### PR TITLE
LSP: don't require immediate refresh for modified-file-closed

### DIFF
--- a/tools/lsp-wake/lsp.cpp
+++ b/tools/lsp-wake/lsp.cpp
@@ -537,7 +537,8 @@ private:
       std::string fileUri = receivedMessage.get("params").get("textDocument").get("uri").value;
       if (astree.changedFiles.erase(JSONConverter::stripRootUri(fileUri, rootUri)) > 0) {
         needsUpdate = true;
-        refresh("modified-file-closed");
+        // If a user hits 'undo' on a symbol rename, you can get hundreds of sequential didClose invocations
+        // Calling refresh here would cause the extension to 'hang' for a very long time.
       }
     }
 


### PR DESCRIPTION
If a user hits 'undo' on a symbol rename, you can get hundreds of sequential didClose invocations.
Calling refresh for each would cause the extension to 'hang' for a very long time.