### PR TITLE
map: include an example of how to format comments

### DIFF
--- a/share/wake/lib/core/list.wake
+++ b/share/wake/lib/core/list.wake
@@ -67,16 +67,16 @@ export def tail: List a => List a = match _
     Nil  = Nil
     _, t = t
 
-# Create a new List by applying the function *mapFn* to each element of *list*.
-# The *map* function (along with *foldl*) is generally how one implements loops in wake.
-# This function (like most in wake) runs *mapFn* in parallel.
+# Create a new List by applying the function `mapFn` to each element of `list`.
+# The `map` function (along with `foldl`) is generally how one implements loops in wake.
+# This function (like most in wake) runs `mapFn` in parallel.
 #
 # Parameters:
-#  - *mapFn*: The function to apply to each element
-#  - *list*: The List of elements to feed to *mapFn*
+#  - `mapFn`: The function to apply to each element
+#  - `list`: The List of elements to feed to `mapFn`
 #
 # Guarantees:
-#  - The resultant List has the same length as *list*
+#  - The resultant List has the same length as `list`
 #
 # ```
 # map str     (3, 9, Nil) = "3", "9", Nil

--- a/share/wake/lib/core/list.wake
+++ b/share/wake/lib/core/list.wake
@@ -360,17 +360,29 @@ export def forall (f: a => Boolean): List a => Boolean =
     def not = ! f _
     ! exists not _
 
-# splitBy: partition a List into those elements with `f` True and False
+# Partition one `list` into two Lists based on the output of `acceptFn`.
+# Every element of `list` appears in exactly one of the output Lists.
+# Two elements in an output List retain the order they had in `list`.
 #
-#   def isEven x = x%2 == 0
-#   splitBy isEven (seq 6) = Pair (0, 2, 4, Nil) (1, 3, 5, Nil)
-export def splitBy (f: a => Boolean): List a => Pair (List a) (List a) =
-    def loop = match _
+# Parameters:
+#  - `acceptFn`: The Boolean function which categorizes each element
+#  - `list`: The List of elements to be categorized by `True` / `False`
+#
+# Returns `Pair true false`, where:
+#  - `true`:  List of elements from `list` for which `acceptFn` returned `True`
+#  - `false`: List of elements from `list` for which `acceptFn` returned `False`
+#
+# ```
+# def isEven x = x%2 == 0
+# splitBy isEven (0, 1, 3, 5, 6, Nil) = Pair (0, 6, Nil) (1, 3, 5, Nil)
+# ```
+export def splitBy (acceptFn: a => Boolean): List a => Pair (true: List a) (false: List a) =
+    def loop list = match list
         Nil  = Pair Nil Nil
         h, t =
             # don't wait on f to process tail:
             def Pair u v = loop t
-            if f h then
+            if acceptFn h then
                 Pair (h, u) v
             else
                 Pair u (h, v)

--- a/share/wake/lib/core/list.wake
+++ b/share/wake/lib/core/list.wake
@@ -74,14 +74,13 @@ export def tail: List a => List a = match _
 # Parameters:
 #  - *mapFn*: The function to apply to each element
 #  - *list*: The List of elements to feed to *mapFn*
-#  - returns: A new List with the outputs of *mapFn*
 #
 # Guarantees:
 #  - The resultant List has the same length as *list*
 #
 # ```
-# map str    (seq 5) = "0", "1", "2", "3", "4", Nil
-# map (_+10) (seq 5) = 10, 11, 12, 13, 14, Nil
+# map str     (3, 9, Nil) = "3", "9", Nil
+# map (_+100) (3, 9, Nil) = 103, 109, Nil
 # ```
 export def map (mapFn: a => b): List a => List b =
     def loop list = match list

--- a/share/wake/lib/core/list.wake
+++ b/share/wake/lib/core/list.wake
@@ -67,14 +67,26 @@ export def tail: List a => List a = match _
     Nil  = Nil
     _, t = t
 
-# map: create a new List by applying a function f to each element of a List.
+# Create a new List by applying the function *mapFn* to each element of *list*.
+# The *map* function (along with *foldl*) is generally how one implements loops in wake.
+# This function (like most in wake) runs *mapFn* in parallel.
 #
-#   map str    (seq 5) = "0", "1", "2", "3", "4", Nil
-#   map (_+10) (seq 5) = 10, 11, 12, 13, 14, Nil
-export def map (f: a => b): List a => List b =
-    def loop = match _
+# Parameters:
+#  - *mapFn*: The function to apply to each element
+#  - *list*: The List of elements to feed to *mapFn*
+#  - returns: A new List with the outputs of *mapFn*
+#
+# Guarantees:
+#  - The resultant List has the same length as *list*
+#
+# ```
+# map str    (seq 5) = "0", "1", "2", "3", "4", Nil
+# map (_+10) (seq 5) = 10, 11, 12, 13, 14, Nil
+# ```
+export def map (mapFn: a => b): List a => List b =
+    def loop list = match list
         Nil  = Nil
-        h, t = f h, loop t
+        h, t = mapFn h, loop t
     loop
 
 # mapFlat: create a new List by applying a function f to each element and concatenating the output.

--- a/share/wake/lib/core/syntax.wake
+++ b/share/wake/lib/core/syntax.wake
@@ -56,11 +56,17 @@ export def wait (f: a => b) (x: a): b =
         True  = f x
         False = unreachable "true returned false"
 
-# unreachable: tell the wake interpreter that something is impossible.
-# >>>>>> THIS FUNCTION IS NOT INTENDED TO STOP A BUILD! <<<<<<<<
-# >>>>>>>>>>>>> To report Errors use a Result <<<<<<<<<<<<<<<<<<
+# Tell the wake interpreter that it is impossible to reach this expression.
+# The behaviour of an execution which DOES reach `unreachable` is undefined.
 #
-# # An example of a legitimate use of unreachable:
+# ### FUNCTION IS NOT INTENDED TO STOP A BUILD! ###
+# ### To report Errors use a Result             ###
+#
+# Parameters:
+#  - `reason`: A String describing why this code is impossible to reach
+#
+# An example of a legitimate use of unreachable:
+# ```
 # def hasUniqueMinimum list =
 #   match (sortBy (_<_) list)
 #     Nil     = False
@@ -68,22 +74,27 @@ export def wait (f: a => b) (x: a): b =
 #     x, y, _ = match (x <=> y)
 #       LT = True
 #       EQ = False
-#       GT = unreachable "Sorted list is not sorted"
+#       GT = unreachable "Sorted list {format list} is not sorted"
+# ```
 #
-# # Here is an example of why you should never use unreachable for error reporting:
-# # The optimizer can legally remove unreachables (they are by definition unreachable).
-# # Furthermore, the optimizer can even eliminate code that coexists with a unreachable.
+# The optimizer can legally remove unreachables (they are by definition unreachable).
+# Furthermore, the optimizer can even eliminate code that coexists with a unreachable.
+# Thus, here is an example of why you should never use unreachable for error reporting:
+# ```
 # def myFun x =
 #   def _ = unreachable "stop the program"
 #   42 + x
+# ```
 #
+# When this funciton is called from the command-line, the behaviour is undefined:
+# ```
 # $ wake --no-optimize -x 'myFun 33'
 # PANIC: stop the program
 # $ wake -x 'myFun 33'
 # 75
-#
-# ... but a future version of wake might return 0 or 20 or "hello world"!
-# If you tell the interpreter the body of myFun is unreachable, myFun is undefined.
-export def unreachable (str: String): a =
+# $ future-version-of-wake -x 'myFun 33'
+# 200
+# ```
+export def unreachable (reason: String): a =
     def f x = prim "unreachable"
-    f str
+    f reason


### PR DESCRIPTION
Notice in the PR how I also added a name for the inner function argument and it then made it into the type signature shown in the tool-tip, matching the documentation.

![Screen Shot 2021-09-14 at 5 07 41 PM](https://user-images.githubusercontent.com/1101706/133349795-505d4b46-edd4-4b7a-bc8e-2d0a258fcfc0.png)
