### PR TITLE
todst: fix the location for typed cyclic values

### DIFF
--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -819,7 +819,7 @@ static void dst_def(CSTElement def, DefMap &map, Package *package, Symbols *glob
     }
 
     if (type)
-      body = new Ascribe(FRAGMENT_CPP_LINE, std::move(*type), body, body->fragment);
+      body = new Ascribe(body->fragment, std::move(*type), body, body->fragment);
 
     if (target) {
       if (tohash == 0) ERROR(fn.location(), "target definition of '" << name << "' must have at least one hashed argument");


### PR DESCRIPTION
Consider this buggy code:
```
def x: Integer = y
def y: Integer = x
```

Now wake reports:
```
build.wake:159:[18-19]: definition of 'y@build_wake' references 'x@build_wake' forming an illegal cyclic value
build.wake:158:18: definition of 'x@build_wake' references 'y@build_wake' forming an illegal cyclic value
```

Instead of:
```
src/dst/todst.cpp:822:1: definition of 'y@build_wake' references 'x@build_wake' forming an illegal cyclic value
src/dst/todst.cpp:822:1: definition of 'x@build_wake' references 'y@build_wake' forming an illegal cyclic value
```

Fixes #721.