### PR TITLE
bind: check the body of an expression with a bad type signature

### DIFF
--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -934,12 +934,12 @@ static std::unique_ptr<Expr> fracture(Top &top, bool anon, const std::string &na
     return expr;
   } else if (expr->type == &Ascribe::type) {
     Ascribe *asc = static_cast<Ascribe*>(expr.get());
+    asc->body = fracture(top, true, name, std::move(asc->body), binding);
     if (qualify_type(binding, asc->signature)) {
-      asc->body = fracture(top, true, name, std::move(asc->body), binding);
+      return expr;
     } else {
-      expr.reset();
+      return std::move(asc->body);
     }
-    return expr;
   } else if (expr->type == &Prim::type) {
     // Use all the arguments
     for (ResolveBinding *iter = binding;


### PR DESCRIPTION
Now `def _foo: Foo = 21 + "asd"` will still tell you about bad addition
after it tells you that 'Foo' is undefined.