### PR TITLE
Type annotation and style formatting

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -18,31 +18,50 @@ from wake import _
 
 # Useful build variants (arguments to all)
 def toVariant = match _
-    "default" = Pass (Pair "native-cpp11-release" "native-c11-release")
-    "static"  = Pass (Pair "native-cpp11-static"  "native-c11-static")
-    "debug"   = Pass (Pair "native-cpp11-debug"   "native-c11-debug")
-    "wasm"    = Pass (Pair "wasm-cpp11-release"   "wasm-c11-release")
-    s = Fail "Unknown build target ({s})".makeError
+    "default" =
+        Pass (Pair "native-cpp11-release" "native-c11-release")
+    "static"  =
+        Pass (Pair "native-cpp11-static"  "native-c11-static")
+    "debug"   =
+        Pass (Pair "native-cpp11-debug"   "native-c11-debug")
+    "wasm"    =
+        Pass (Pair "wasm-cpp11-release"   "wasm-c11-release")
+    s =
+        Fail "Unknown build target ({s})".makeError
 
 export def build: List String => Result String Error = match _
-    "tarball", Nil = tarball Unit | rmap (\_ "TARBALL")
+    "tarball", _ =
+        tarball Unit
+        | rmap (\_ "TARBALL")
     kind, Nil =
-        require Pass variant = toVariant kind
-        all variant | rmap (\_ "BUILD")
-    _ = Fail "no target specified (try: build default/debug/tarball)".makeError
+        require Pass variant =
+            toVariant kind
+        all variant
+        | rmap (\_ "BUILD")
+    _ =
+        Fail "no target specified (try: build default/debug/tarball)".makeError
 
 export def install: List String => Result String Error = match _
-    dest, kind, Nil = doInstall (in cwd dest) kind | rmap (\_ "INSTALL")
-    dest, Nil = doInstall (in cwd dest) "default" | rmap (\_ "INSTALL")
-    _ = Fail "no directory specified (try: install /opt/local)".makeError
+    dest, kind, _ =
+        doInstall (in cwd dest) kind
+        | rmap (\_ "INSTALL")
+    dest, Nil =
+        doInstall (in cwd dest) "default"
+        | rmap (\_ "INSTALL")
+    _ =
+        Fail "no directory specified (try: install /opt/local)".makeError
 
 # Build all wake targets
 def targets =
-    def allPlatforms = buildWake, buildFuse, buildFuseDaemon, buildShim, buildPreload, buildPrelib, buildBSP, buildLSP, Nil
-    def linuxOnly = buildWakeBox, Nil
+    def allPlatforms =
+        buildWake, buildFuse, buildFuseDaemon, buildShim, buildPreload, buildPrelib, buildBSP, buildLSP, Nil
+    def linuxOnly =
+        buildWakeBox, Nil
     match sysname
-        "Linux" = allPlatforms ++ linuxOnly
-        _       = allPlatforms
+        "Linux" =
+            allPlatforms ++ linuxOnly
+        _ =
+            allPlatforms
 
 def all variant =
     require Pass x =
@@ -52,41 +71,54 @@ def all variant =
 
 # Install wake into a target location
 def doInstall dest kind =
-    require Pass variant = toVariant kind
-    def datfiles = sources "{here}/share" `.*`
-    def binfilesResult = all variant
-    def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
-    def datinstall = map (installIn dest ".") datfiles
-    def readme = installIn "{dest}/share/doc/wake" "." (source "README.md")
-    require Pass binfiles = binfilesResult
-    def bininstall = map releaseBin binfiles
-    def outputs = readme, bininstall ++ datinstall
+    require Pass variant =
+        toVariant kind
+    def datfiles =
+        sources "{here}/share" `.*`
+    def binfilesResult =
+        all variant
+    def releaseBin exe =
+        installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
+    def datinstall =
+        map (installIn dest ".") datfiles
+    def readme =
+        installIn "{dest}/share/doc/wake" "." (source "README.md")
+    require Pass binfiles =
+        binfilesResult
+    def bininstall =
+        map releaseBin binfiles
+    def outputs =
+        readme, bininstall ++ datinstall
     findFailFn getPathResult outputs
 
 # Create a release tarball
 def tarball Unit =
-    def releaseResult = buildAs Unit
-    def timeResult = buildOn Unit
-    require Pass release = releaseResult
-    require Pass time = timeResult
+    require Pass release =
+        buildAs Unit
+    require Pass time =
+        buildOn Unit
     # Create debian + RedHat package files
     def setVersion file =
-        def in = source "{file}.in"
+        def in =
+            source "{file}.in"
         def script = "%
             set -e
             sed "s/@VERSION@/%{release}/g" "%{in.getPathName}" > "%{file}.tmp"
             mv "%{file}.tmp" "%{file}"
             %"
         shellJob script (in, Nil) | getJobOutput
-    def changelog = setVersion "debian/changelog"
-    def spec = setVersion "wake.spec"
+    def changelog =
+        setVersion "debian/changelog"
+    def spec =
+        setVersion "wake.spec"
     # Identify those sources files to include in the tarball
     def srcs =
         sources "." `.*`
         | filter (! matches `(debian/|wake.spec).*` _.getPathName) # omit packaging files
         | filter (! matches `(\.circleci/|\.github/).*|\.dockerignore` _.getPathName) # omit CI files
         | filter (! matches `(.*/)*\.gitignore` _.getPathName) # omit git files
-    def Pair testPaths wakePaths = splitBy (matches `tests/.*` _.getPathName) srcs
+    def Pair testPaths wakePaths =
+        splitBy (matches `tests/.*` _.getPathName) srcs
     def wakeSourcesString =
         wakePaths
         | map (_.getPathName.format)
@@ -116,14 +148,23 @@ def tarball Unit =
           %{testSourcesString}Nil
         %"
     # Create a manifest which describes the release and source files
-    def manifest = write "manifest.wake" manifestStr
-    def testManifest = write "tests/manifest.wake" testsManifestStr
+    def manifest =
+        write "manifest.wake" manifestStr
+    def testManifest =
+        write "tests/manifest.wake" testsManifestStr
     # Execute tar to create a tarball of manifest + sources
     def tarball =
         def cmd =
-            def gnutar = which "gnutar"
-            def tar = if gnutar ==* "gnutar" then which "tar" else gnutar
-            def files = map getPathName (manifest, testManifest, spec, srcs) | sortBy (_<*_)
+            def gnutar =
+                which "gnutar"
+            def tar =
+                if gnutar ==* "gnutar" then
+                    which "tar"
+                else
+                    gnutar
+            def files =
+                map getPathName (manifest, testManifest, spec, srcs)
+                | sortBy (_<*_)
             tar, "--mtime={time}", "--transform=s@^@wake-{release}/@",
             "--owner=0", "--group=0", "--numeric-owner", "-cJf",
             "wake_{release}.tar.xz", files
@@ -132,22 +173,29 @@ def tarball Unit =
     findFailFn getPathResult (tarball, changelog, Nil)
 
 export def static _: Result Path Error =
-    def filesResult = doInstall "tmp" "static"
-    def releaseResult = buildAs Unit
-    def timeResult = buildOn Unit
-    require Pass release = releaseResult
-    require Pass time = timeResult
-    require Pass files = filesResult
+    require Pass files =
+        doInstall "tmp" "static"
+    require Pass release =
+        buildAs Unit
+    require Pass time =
+        buildOn Unit
     def cmd =
-        which "tar", "--mtime={time}", "--transform=s@^tmp/@wake-{release}/@",
-        "--owner=0", "--group=0", "--numeric-owner", "-cJf",
-        "wake-static_{release}.tar.xz", map getPathName files | sortBy (_<*_)
+        which "tar",
+        "--mtime={time}",
+        "--transform=s@^tmp/@wake-{release}/@",
+        "--owner=0",
+        "--group=0",
+        "--numeric-owner",
+        "-cJf",
+        "wake-static_{release}.tar.xz",
+        map getPathName files | sortBy (_<*_)
     job cmd files
     | getJobOutput
     | getPathResult
 
 from test_wake import topic wakeTestBinary
-publish wakeTestBinary = defaultWake, Nil
+publish wakeTestBinary =
+    defaultWake, Nil
 
 def defaultWake Unit =
     require Pass wakeVisible =

--- a/share/wake/lib/core/json.wake
+++ b/share/wake/lib/core/json.wake
@@ -17,165 +17,284 @@ package wake
 
 # The JSON data type
 export data JValue =
-  JString  String
-  JInteger Integer
-  JDouble  Double
-  JBoolean Boolean
-  JNull
-  JObject  (List (Pair String JValue))
-  JArray   (List JValue)
+    JString  String
+    JInteger Integer
+    JDouble  Double
+    JBoolean Boolean
+    JNull
+    JObject  (List (Pair String JValue))
+    JArray   (List JValue)
 
 export def getJString: JValue => Option String = match _
-  JString x               = Some x
-  JArray (JString x, Nil) = Some x
-  _                       = None
+    JString x =
+        Some x
+    JArray (JString x, Nil) =
+        Some x
+    _ =
+        None
 export def getJInteger: JValue => Option Integer = match _
-  JInteger x               = Some x
-  JArray (JInteger x, Nil) = Some x
-  _                        = None
+    JInteger x =
+        Some x
+    JArray (JInteger x, Nil) =
+        Some x
+    _ =
+        None
 export def getJDouble: JValue => Option Double = match _
-  JDouble x               = Some x
-  JInteger x              = dint x
-  JArray (JDouble x, Nil) = Some x
-  JArray (JInteger x, Nil)= dint x
-  _                       = None
+    JDouble x =
+        Some x
+    JInteger x =
+        dint x
+    JArray (JDouble x, Nil) =
+        Some x
+    JArray (JInteger x, Nil)=
+        dint x
+    _ =
+        None
 export def getJBoolean: JValue => Option Boolean = match _
-  JBoolean x               = Some x
-  JArray (JBoolean x, Nil) = Some x
-  _                        = None
+    JBoolean x =
+        Some x
+    JArray (JBoolean x, Nil) =
+        Some x
+    _ =
+        None
 export def getJObject: JValue => Option (List (Pair String JValue)) = match _
-  JObject x               = Some x
-  JArray (JObject x, Nil) = Some x
-  _                       = None
+    JObject x =
+        Some x
+    JArray (JObject x, Nil) =
+        Some x
+    _ =
+        None
 export def getJArray: JValue => Option (List JValue) = match _
-  JArray x = Some x
-  _        = None
+    JArray x =
+        Some x
+    _ =
+        None
 
 export def parseJSONBody (body: String): Result JValue Error =
-  def imp b = prim "json_body"
-  match (imp body)
-    Pass jvalue = Pass jvalue
-    Fail cause = Fail (makeError cause)
+    def imp b =
+        prim "json_body"
+    match (imp body)
+        Pass jvalue =
+            Pass jvalue
+        Fail cause =
+            failWithError cause
 
 export def parseJSONFile (path: Path): Result JValue Error =
-  def imp f = prim "json_file"
-  match (getPathResult path)
-    Pass f = match (imp f.getPathName)
-      Pass body = Pass body
-      Fail f = Fail (makeError f)
-    Fail f = Fail f
+    def imp f =
+        prim "json_file"
+    match (getPathResult path)
+        Pass f = match (imp f.getPathName)
+            Pass body =
+                Pass body
+            Fail f =
+                failWithError f
+        Fail f =
+            Fail f
 
 export def jsonEscape (str: String): String =
-  prim "json_str"
+    def imp s =
+        prim "json_str"
+    imp str
 
 tuple JSONFormat =
-  export String:  String  => String
-  export Integer: Integer => String
-  export Double:  Double  => String
-  export Indent:  Integer
+    export String: String => String
+    export Integer: Integer => String
+    export Double: Double => String
+    export Indent: Integer
 
 def doFormat (fmt: JSONFormat) (lhs: JValue): List String =
-  def indent = fmt.getJSONFormatIndent
-  def space = if indent > 0 then " " else ""
-  def indention = tab (\_ ' ') indent | cat
-  def rec rhs depth lhs =
-    def deeper = omap ("{indention}{_}") depth
-    def tabbed = omap ("\n{_}") depth | getOrElse ""
-    def tabbeder = omap ("\n{_}") deeper | getOrElse ""
-    match lhs
-      JString  s    = '"', fmt.getJSONFormatString s, '"', rhs
-      JInteger i    = fmt.getJSONFormatInteger i,          rhs
-      JDouble  d    = fmt.getJSONFormatDouble d,           rhs
-      JBoolean True = "true",   rhs
-      JBoolean False= "false",  rhs
-      JNull         = "null",   rhs
-      JArray   list =
-        def helper value acc = ",{tabbeder}", rec acc deeper value
-        if list.empty then '[]', rhs
-        else "[{tabbeder}", foldr helper ("{tabbed}]", rhs) list | tail
-      JObject  list =
-        def helper (Pair key value) acc =
-          ",{tabbeder}", '"', jsonEscape key, ("\":{space}", rec acc deeper value)
-        if list.empty then '{}', rhs
-        else "\{{tabbeder}", foldr helper ("{tabbed}\}", rhs) list | tail
-  rec Nil (if indent > 0 then Some "" else None) lhs
+    def indent =
+        fmt.getJSONFormatIndent
+    def space =
+        if indent > 0 then
+            " "
+        else
+            ""
+    def indention =
+        tab (\_ ' ') indent
+        | cat
+    def rec rhs depth lhs =
+        def deeper =
+            omap ("{indention}{_}") depth
+        def tabbed =
+            omap ("\n{_}") depth
+            | getOrElse ""
+        def tabbeder =
+            omap ("\n{_}") deeper
+            | getOrElse ""
+        match lhs
+            JString s =
+                '"'
+                , fmt.getJSONFormatString s
+                , '"'
+                , rhs
+            JInteger i =
+                fmt.getJSONFormatInteger i
+                , rhs
+            JDouble d =
+                fmt.getJSONFormatDouble d
+                , rhs
+            JBoolean True =
+                "true"
+                , rhs
+            JBoolean False =
+                "false"
+                , rhs
+            JNull =
+                "null"
+                , rhs
+            JArray list =
+                def helper value acc =
+                    ",{tabbeder}"
+                    , rec acc deeper value
+                if list.empty then
+                    '[]'
+                    , rhs
+                else
+                    "[{tabbeder}"
+                    , foldr helper ("{tabbed}]", rhs) list | tail
+            JObject list =
+                def helper (Pair key value) acc =
+                    ",{tabbeder}"
+                    , '"'
+                    , jsonEscape key
+                    , "\":{space}"
+                    , rec acc deeper value
+                if list.empty then
+                    '{}'
+                    , rhs
+                else
+                    "\{{tabbeder}"
+                    , foldr helper ("{tabbed}\}", rhs) list | tail
+    rec Nil (if indent > 0 then Some "" else None) lhs
 
 export def defaultJSONFormat: JSONFormat =
-  def formatDouble d =
-    match (dclass d)
-      DoubleInfinite if d <. 0e0 = "-1e9999"
-      DoubleInfinite = "1e9999"
-      DoubleNaN      = "NaN"
-      _              = dstr d
-  JSONFormat jsonEscape str formatDouble 0
+    def formatDouble d =
+        match (dclass d)
+            DoubleInfinite if d <. 0e0 =
+                "-1e9999"
+            DoubleInfinite =
+                "1e9999"
+            DoubleNaN =
+                "NaN"
+            _ =
+                dstr d
+    JSONFormat jsonEscape str formatDouble 0
 
 export def prettyJSONFormat: JSONFormat =
-  defaultJSONFormat
-  | setJSONFormatIndent 2
+    defaultJSONFormat
+    | setJSONFormatIndent 2
 
 export def customFormatJSON (fmt: JSONFormat) (body: JValue): String =
-  doFormat fmt body
-  | cat
+    doFormat fmt body
+    | cat
 export def formatJSON: JValue => String =
-  customFormatJSON defaultJSONFormat
+    customFormatJSON defaultJSONFormat
 export def prettyJSON: JValue => String =
-  customFormatJSON prettyJSONFormat
+    customFormatJSON prettyJSONFormat
 
 export def (root: JValue) /| (filterFn: JValue => Boolean): JValue =
-  jfilter filterFn root
+    jfilter filterFn root
 export def jfilter (filterFn: JValue => Boolean) (root: JValue): JValue = match root
-  JArray l = JArray (filter filterFn l)
-  _ = if filterFn root then JArray (root, Nil) else JArray Nil
+    JArray l =
+        JArray (filter filterFn l)
+    _ if filterFn root =
+        JArray (root, Nil)
+    _ =
+        JArray Nil
 
 export def (root: JValue) /../ (filterFn: JValue => Boolean): JValue =
-  jfind filterFn root
+    jfind filterFn root
 export def jfind (filterFn: JValue => Boolean) (root: JValue): JValue =
-  def helper node acc = match node
-    JArray l =
-      def tail = foldr helper acc l
-      if filterFn node then node, tail else tail
-    JObject l =
-      def tail = foldr (helper _.getPairSecond _) acc l
-      if filterFn node then node, tail else tail
-    _ =
-      if filterFn node then node, acc else acc
-  helper root Nil | JArray
+    def helper node acc = match node
+        JArray l =
+            def tail =
+                foldr helper acc l
+            if filterFn node then
+                node, tail
+            else
+                tail
+        JObject l =
+            def tail =
+                foldr (helper _.getPairSecond _) acc l
+            if filterFn node then
+                node, tail
+            else
+                tail
+        _ =
+            if filterFn node then
+                node, acc
+            else
+                acc
+    helper root Nil
+    | JArray
 
 export def jempty (root: JValue): Boolean =
-  empty (jlist root)
+    empty (jlist root)
 export def jlist (root: JValue): List JValue = match root
-  JArray x = x
-  _ = root, Nil
+    JArray x =
+        x
+    _ =
+        root, Nil
 
 export def (x: JValue) // (y: RegExp): JValue =
-  def helper tail = match _
-    JString  _ = tail
-    JInteger _ = tail
-    JDouble  _ = tail
-    JBoolean _ = tail
-    JNull      = tail
-    JObject  l =
-      def flatten v tail = match v.getPairSecond
-        JArray l = l ++ tail
-        w = w, tail
-      foldr flatten tail (filter (matches y _.getPairFirst) l)
-    JArray   l =
-      def flatten v tail = helper tail v
-      foldr flatten tail l
-  JArray (helper Nil x)
+    def helper tail = match _
+        JString _ =
+            tail
+        JInteger _ =
+            tail
+        JDouble _ =
+            tail
+        JBoolean _ =
+            tail
+        JNull =
+            tail
+        JObject l =
+            def flatten v tail = match v.getPairSecond
+                JArray l =
+                    l ++ tail
+                w =
+                    w, tail
+            filter (matches y _.getPairFirst) l
+            | foldr flatten tail
+        JArray l =
+            def flatten v tail =
+                helper tail v
+            foldr flatten tail l
+    JArray (helper Nil x)
 
 export def (x: JValue) ==/ (y: JValue): Boolean = match x y
-  (JString  a) (JString  b) = a ==~ b
-  (JInteger a) (JInteger b) = a ==  b
-  (JDouble  a) (JDouble  b) = a ==. b
-  (JBoolean a) (JBoolean b) = if a then b else !b
-  JNull        JNull        = True
-  (JObject  a) (JObject  b) =
-    def helper (Pair (Pair k c) (Pair l d)) = k ==~ l && c ==/ d
-    if a.len != b.len then False else zip a b | forall helper
-  (JArray   a) (JArray   b) =
-    def helper (Pair c d) = c ==/ d
-    if a.len != b.len then False else zip a b | forall helper
-  (JArray a) _ = exists (_ ==/ y) a
-  _ (JArray b) = exists (_ ==/ x) b
-  _ _ = False
+    (JString a) (JString b) =
+        a ==~ b
+    (JInteger a) (JInteger b) =
+        a == b
+    (JDouble a) (JDouble b) =
+        a ==. b
+    (JBoolean a) (JBoolean b) =
+        if a then
+            b
+        else
+            !b
+    JNull JNull = True
+    (JObject a) (JObject b) =
+        def helper (Pair (Pair k c) (Pair l d)) =
+            k ==~ l && c ==/ d
+        if a.len != b.len then
+            False
+        else
+            zip a b
+            | forall helper
+    (JArray a) (JArray b) =
+        def helper (Pair c d) =
+            c ==/ d
+        if a.len != b.len then
+            False
+        else
+            zip a b
+            | forall helper
+    (JArray a) _ =
+        exists (_ ==/ y) a
+    _ (JArray b) =
+        exists (_ ==/ x) b
+    _ _ =
+        False

--- a/share/wake/lib/core/json.wake
+++ b/share/wake/lib/core/json.wake
@@ -65,7 +65,8 @@ export def parseJSONFile (path: Path): Result JValue Error =
       Fail f = Fail (makeError f)
     Fail f = Fail f
 
-export def jsonEscape str = prim "json_str"
+export def jsonEscape (str: String): String =
+  prim "json_str"
 
 tuple JSONFormat =
   export String:  String  => String
@@ -108,19 +109,27 @@ export def defaultJSONFormat: JSONFormat =
       _              = dstr d
   JSONFormat jsonEscape str formatDouble 0
 
-export def prettyJSONFormat = defaultJSONFormat | setJSONFormatIndent 2
+export def prettyJSONFormat: JSONFormat =
+  defaultJSONFormat
+  | setJSONFormatIndent 2
 
-export def customFormatJSON fmt body = doFormat fmt body | cat
-export def formatJSON = customFormatJSON defaultJSONFormat
-export def prettyJSON = customFormatJSON prettyJSONFormat
+export def customFormatJSON (fmt: JSONFormat) (body: JValue): String =
+  doFormat fmt body
+  | cat
+export def formatJSON: JValue => String =
+  customFormatJSON defaultJSONFormat
+export def prettyJSON: JValue => String =
+  customFormatJSON prettyJSONFormat
 
-export def root /| filterFn = jfilter filterFn root
-export def jfilter filterFn root = match root
+export def (root: JValue) /| (filterFn: JValue => Boolean): JValue =
+  jfilter filterFn root
+export def jfilter (filterFn: JValue => Boolean) (root: JValue): JValue = match root
   JArray l = JArray (filter filterFn l)
   _ = if filterFn root then JArray (root, Nil) else JArray Nil
 
-export def root /../ filterFn = jfind filterFn root
-export def jfind filterFn root =
+export def (root: JValue) /../ (filterFn: JValue => Boolean): JValue =
+  jfind filterFn root
+export def jfind (filterFn: JValue => Boolean) (root: JValue): JValue =
   def helper node acc = match node
     JArray l =
       def tail = foldr helper acc l
@@ -132,12 +141,13 @@ export def jfind filterFn root =
       if filterFn node then node, acc else acc
   helper root Nil | JArray
 
-export def jempty root = empty (jlist root)
-export def jlist root = match root
+export def jempty (root: JValue): Boolean =
+  empty (jlist root)
+export def jlist (root: JValue): List JValue = match root
   JArray x = x
   _ = root, Nil
 
-export def x // y =
+export def (x: JValue) // (y: RegExp): JValue =
   def helper tail = match _
     JString  _ = tail
     JInteger _ = tail
@@ -154,7 +164,7 @@ export def x // y =
       foldr flatten tail l
   JArray (helper Nil x)
 
-export def x ==/ y = match x y
+export def (x: JValue) ==/ (y: JValue): Boolean = match x y
   (JString  a) (JString  b) = a ==~ b
   (JInteger a) (JInteger b) = a ==  b
   (JDouble  a) (JDouble  b) = a ==. b

--- a/share/wake/lib/core/tree.wake
+++ b/share/wake/lib/core/tree.wake
@@ -31,17 +31,22 @@ def ratioQ = 3
 def ratioD = 2
 
 # Create a new Tree, sorted by cmp.
-export def tnew cmp = Tree cmp Tip
+export def tnew (cmp: a => a => Order): Tree a =
+  Tree cmp Tip
 
+# Convert a List to a Tree, removing any duplicate values.
+export def listToTree (cmp: a => a => Order) (list: List a): Tree a =
+  vectorToTree cmp (listToVector list)
 # Convert a List to a Tree.
-export def listToTree cmp list = vectorToTree cmp (listToVector list)
-export def listToTreeMulti cmp list = vectorToTreeMulti cmp (listToVector list)
-
-export def vectorToTreeMulti cmp v =
-  Tree cmp (build (vsortBy (cmp _ _ | isLT) v))
+export def listToTreeMulti (cmp: a => a => Order) (list: List a): Tree a =
+  vectorToTreeMulti cmp (listToVector list)
 
 # Convert a Vector to a Tree.
-export def vectorToTree cmp v =
+export def vectorToTreeMulti (cmp: a => a => Order) (v: Vector a): Tree a =
+  Tree cmp (build (vsortBy (cmp _ _ | isLT) v))
+
+# Convert a Vector to a Tree, removing any duplicate values.
+export def vectorToTree (cmp: a => a => Order) (v: Vector a): Tree a =
   Tree cmp (build (vdistinctRunBy (cmp _ _ | isEQ) (vsortBy (cmp _ _ | isLT) v)))
 
 def build v = match (vlen v)
@@ -95,25 +100,31 @@ export def tinsertMulti (y: a) (Tree cmp root: Tree a): Tree a =
   Tree cmp (helper root)
 
 # Returns True if a is a subset of b, otherwise False.
-export def a ⊆ b = tsubset a b
+export def (a: Tree a) ⊆ (b: Tree a): Boolean =
+  tsubset a b
 
 # Returns True if a is a superset of b, otherwise False.
-export def a ⊇ b = tsubset b a
+export def (a: Tree a) ⊇ (b: Tree a): Boolean =
+  tsubset b a
 
 # Returns True if a is NOT a superset of b, otherwise False.
-export def a ⊉ b = ! a ⊇ b
+export def (a: Tree a) ⊉ (b: Tree a): Boolean =
+  ! a ⊇ b
 
 # Returns True if a is NOT a subset of b, otherwise False.
-export def a ⊈ b = ! a ⊆ b
+export def (a: Tree a) ⊈ (b: Tree a): Boolean =
+  ! a ⊆ b
 
 # Returns True if a is a proper subset of b, otherwise False.
-export def a ⊊ b = a ⊆ b && b ⊈ a # strict
+export def (a: Tree a) ⊊ (b: Tree a): Boolean =
+  a ⊆ b && b ⊈ a # strict
 
 # Returns True if a is a proper superset of b, otherwise False.
-export def a ⊋ b = a ⊇ b && b ⊉ a # strict
+export def (a: Tree a) ⊋ (b: Tree a): Boolean =
+  a ⊇ b && b ⊉ a # strict
 
 # Returns True if every element of a is also in b, otherwise false.
-export def tsubset (Tree _ aroot) (Tree cmp broot) =
+export def tsubset (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Boolean =
   def helper a b = match a b
     Tip _ = True
     _ Tip = False
@@ -134,32 +145,34 @@ def delete cmp y t =
   helper t
 
 # Folds from left to right.
-export def tfoldl f a (Tree _ root) =
+export def tfoldl (f: b => a => b) (acc: b) (Tree _ root: Tree a): b =
   def helper a = match _
     Tip         = a
     Bin _ l x r = helper (f (helper a l) x) r
-  helper a root
+  helper acc root
 
 # Folds from right to left.
-export def tfoldr f a (Tree _ root) =
+export def tfoldr (f: a => b => b) (acc: b) (Tree _ root: Tree a): b =
   def helper a = match _
     Tip         = a
     Bin _ l x r = helper (f x (helper a r)) l
-  helper a root
+  helper acc root
 
 # Fold in parallel; assumes f is an associative operator and has type: a => a => a
-export def tfoldmap f a g (Tree _ root) =
-  def helper a = match _
-    Tip = g a
-    Bin _ l x r = f (helper a l) (helper x r)
-  helper a root
+export def tfoldmap (f: b => b => b) (acc: a) (g: a => b) (Tree _ root: Tree a): b =
+  def helper acc = match _
+    Tip = g acc
+    Bin _ l x r = f (helper acc l) (helper x r)
+  helper acc root
 
-export def tfold f a t = tfoldmap f a (_) t
+export def tfold (f: a => a => a) (a: a) (t: Tree a): a =
+  tfoldmap f a (_) t
 
 # Converts a Tree to a List.
-export def treeToList = tfoldr (_,_) Nil
+export def treeToList: Tree a => List a =
+  tfoldr (_,_) Nil
 
-export def tappi f (Tree _ root) =
+export def tappi (f: Integer => a => b) (Tree _ root: Tree a): Unit =
   def helper i = match _
     Tip = Unit
     Bin _ l x r =
@@ -196,11 +209,13 @@ export def tsplitAt (i: Integer) (Tree cmp root: Tree a): Pair (Tree a) (Tree a)
   match (helper i root)
     Pair l r = Pair (Tree cmp l) (Tree cmp r)
 
-export def ttake i t = tsplitAt i t | getPairFirst
-export def tdrop i t = tsplitAt i t | getPairSecond
+export def ttake (i: Integer) (t: Tree a): Tree a =
+  tsplitAt i t | getPairFirst
+export def tdrop (i: Integer) (t: Tree a): Tree a =
+  tsplitAt i t | getPairSecond
 
-# Lowest rank element where f x = True  => Option (Pair x rank)
-export def tfind f (Tree _ root) =
+# Lowest rank element where f x == True, along with that rank.
+export def tfind (f: a => Boolean) (Tree _ root: Tree a): Option (Pair a Integer) =
   def helper = match _
     Tip         = None
     Bin s l x r = match (helper l) (f x) (helper r)
@@ -210,24 +225,27 @@ export def tfind f (Tree _ root) =
       _        _    _       = None
   helper root
 
-export def tsplitUntil f t =
+export def tsplitUntil (f: a => Boolean) (t: Tree a): Pair (Tree a) (Tree a) =
   match (tfind f t)
     None = match t
       (Tree cmp _) = Pair t (Tree cmp Tip)
     Some (Pair _ i) = tsplitAt i t
 
-export def ttakeUntil f t = tsplitUntil f t | getPairFirst
-export def tdropUntil f t = tsplitUntil f t | getPairSecond
+export def ttakeUntil (f: a => Boolean) (t: Tree a): Tree a =
+  tsplitUntil f t | getPairFirst
+export def tdropUntil (f: a => Boolean) (t: Tree a): Tree a =
+  tsplitUntil f t | getPairSecond
 
 # Returns True if there exists an x in t where f x = True
-export def texists f t = match (tfind f t)
+export def texists (f: a => Boolean) (t: Tree a): Boolean = match (tfind f t)
   Some _ = True
   None   = False
 
-export def tforall f t = ! texists (! f _) t
+export def tforall (f: a => Boolean) (t: Tree a): Boolean =
+  ! texists (! f _) t
 
 # Split tree into those elements <, =, and > y
-export def tsplit y (Tree cmp root) =
+export def tsplit (y: a) (Tree cmp root: Tree a): Triple (Tree a) (Tree a) (Tree a) =
   match (split y cmp root)
     Triple l e g = Triple (Tree cmp l) (Tree cmp e) (Tree cmp g)
 
@@ -355,9 +373,8 @@ def upper f root =
     Bin s l x r = if f x then someL z i l else someR x (i+s) r
   none root
 
-# Extract all elements from the tree which are equal to y
-# => Pair (matches: List x) (rank: Integer)
-export def tequal y (Tree cmp root) =
+# Extract all elements from the tree which are equal to y, along with their highest rank.
+export def tequal (y: a) (Tree cmp root: Tree a): Pair (List a) Integer=
   def helperR i out = match _ # i = size including self
     Tip         = Pair out i
     Bin s l x r = match (cmp x y)
@@ -373,16 +390,20 @@ export def tequal y (Tree cmp root) =
   helperL 0 Nil root
 
 # Returns True if x is an element of y, False otherwise.
-export def x ∈ y = tcontains x y
+export def (x: a) ∈ (y: Tree a): Boolean =
+  tcontains x y
 
 # Returns True if x is NOT an element of y, False otherwise.
-export def x ∉ y = ! x ∈ y
+export def (x: a) ∉ (y: Tree a): Boolean =
+  ! x ∈ y
 
 # Returns True if x contains y, False otherwise.
-export def x ∋ y = y ∈ x
+export def (x: Tree a) ∋ (y: a): Boolean =
+  y ∈ x
 
 # Returns True if x does NOT contain y, False otherwise.
-export def x ∌ y = y ∉ x
+export def (x: Tree a) ∌ (y: a): Boolean =
+  y ∉ x
 
 export def tcontains (y: a) (t: Tree a): Boolean =
   match t (tupperLE y t)
@@ -399,8 +420,9 @@ export def tdistinctBy (cmp: a => a => Order) (t: Tree a): Tree a = match t
 export def tdistinctRunBy (f: a => a => Boolean) (t: Tree a): Tree a = match t
   Tree cmp _ = Tree cmp (build (vdistinctRunBy f (treeToVector t)))
 
-# Returns the union of trees a and b, keeps only values from a if they are equal to values in b.
-export def a ∪ b = tunion a b
+# Returns the union of trees a and b, preferencing values from a if any are in both trees
+export def (a: Tree a) ∪ (b: Tree a): Tree a =
+  tunion a b
 
 # Returns the union of two trees, given their roots.
 export def tunion (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
@@ -414,8 +436,9 @@ def union cmp aroot broot =
   helper aroot broot
 
 # Union of two trees, keeping equal values of a before equal values of b
-export def a ⊎ b = tunionMulti a b
-export def tunionMulti (Tree _ aroot) (Tree cmp broot) =
+export def (a: Tree a) ⊎ (b: Tree a): Tree a =
+  tunionMulti a b
+export def tunionMulti (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
   Tree cmp (unionMulti cmp aroot broot)
 
 def unionMulti cmp aroot broot =
@@ -442,8 +465,9 @@ export def tsubtract (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
   Tree cmp (helper aroot broot)
 
 # Returns a tree containing all elements of A which are also in B.
-export def a ∩ b = tintersect a b
-export def tintersect (Tree _ aroot) (Tree cmp broot) =
+export def (a: Tree a) ∩ (b: Tree a): Tree a =
+  tintersect a b
+export def tintersect (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
   def helper a b = match a b
     Tip _ = Tip
     _ Tip = Tip

--- a/share/wake/lib/core/tree.wake
+++ b/share/wake/lib/core/tree.wake
@@ -16,13 +16,14 @@
 package wake
 
 # balanced order-statistic trees
-data Tree a = Tree (a => a => Order) (TreeNode a) # cmp root
+data Tree a =
+    Tree (cmp: a => a => Order) (root: TreeNode a)
 
 from wake export type Tree
 
 data TreeNode a =
-  Tip
-  Bin Integer (TreeNode a) a (TreeNode a) # size left key right
+    Tip
+    Bin (size: Integer) (left: TreeNode a) (key: a) (right: TreeNode a)
 
 # delta = 2.5, gamma = 1.5 for a reasonably tight balance
 def deltaQ = 5
@@ -32,454 +33,621 @@ def ratioD = 2
 
 # Create a new Tree, sorted by cmp.
 export def tnew (cmp: a => a => Order): Tree a =
-  Tree cmp Tip
+    Tree cmp Tip
 
 # Convert a List to a Tree, removing any duplicate values.
 export def listToTree (cmp: a => a => Order) (list: List a): Tree a =
-  vectorToTree cmp (listToVector list)
+    listToVector list
+    | vectorToTree cmp
 # Convert a List to a Tree.
 export def listToTreeMulti (cmp: a => a => Order) (list: List a): Tree a =
-  vectorToTreeMulti cmp (listToVector list)
+    listToVector list
+    | vectorToTreeMulti cmp
 
 # Convert a Vector to a Tree.
 export def vectorToTreeMulti (cmp: a => a => Order) (v: Vector a): Tree a =
-  Tree cmp (build (vsortBy (cmp _ _ | isLT) v))
+    vsortBy (cmp _ _ | isLT) v
+    | build
+    | Tree cmp
 
 # Convert a Vector to a Tree, removing any duplicate values.
 export def vectorToTree (cmp: a => a => Order) (v: Vector a): Tree a =
-  Tree cmp (build (vdistinctRunBy (cmp _ _ | isEQ) (vsortBy (cmp _ _ | isLT) v)))
+    vsortBy (cmp _ _ | isLT) v
+    | vdistinctRunBy (cmp _ _ | isEQ)
+    | build
+    | Tree cmp
 
-def build v = match (vlen v)
-  0 = Tip
-  1 = Bin 1 Tip (vat_ 0 v) Tip
-  len =
-    def mid = len >> 1
-    def l = vtake mid v
-    def r = vdrop (mid+1) v
-    Bin len (build l) (vat_ mid v) (build r)
+def build (v: Vector a): TreeNode a = match (vlen v)
+    0 =
+        Tip
+    1 =
+        Bin 1 Tip (vat_ 0 v) Tip
+    len =
+        def mid =
+            len >> 1
+        def l =
+            vtake mid v
+        def r =
+            vdrop (mid+1) v
+        Bin len (build l) (vat_ mid v) (build r)
 
 # Returns the total length of the Tree.
 export def tlen (Tree _ root: Tree a): Integer =
-  size root
-def size = match _
-  Tip         = 0
-  Bin s _ _ _ = s
+    size root
+def size: (root: TreeNode a) => Integer = match _
+    Tip =
+        0
+    Bin s _ _ _ =
+        s
 
 # Returns True if the Tree is empty, False otherwise.
 export def tempty (Tree _ root: Tree a): Boolean = match root
-  Tip = True
-  _   = False
+    Tip =
+        True
+    _ =
+        False
 
 # Insert y into the tree only if no other keys == y
 export def tinsert (y: a) (Tree cmp root: Tree a): Tree a =
-  def helper t = match t
-    Tip         = Bin 1 Tip y Tip
-    Bin _ l x r = match (cmp x y)
-      GT = balanceL (helper l) x r
-      EQ = t
-      LT = balanceR l x (helper r)
-  Tree cmp (helper root)
+    def helper t = match t
+        Tip =
+            Bin 1 Tip y Tip
+        Bin _ l x r = match (cmp x y)
+            GT =
+                balanceL (helper l) x r
+            EQ =
+                t
+            LT =
+                balanceR l x (helper r)
+    helper root
+    | Tree cmp
 
 # Insert y into the tree, removing any existing keys == y
 export def tinsertReplace (y: a) (Tree cmp root: Tree a): Tree a =
-  def helper t = match t
-    Tip         = Bin 1 Tip y Tip
-    Bin _ l x r = match (cmp x y)
-      GT = join3 (helper l) x r
-      EQ = join3 (delete cmp y l) y (delete cmp y r)
-      LT = join3 l x (helper r)
-  Tree cmp (helper root)
+    def helper t = match t
+        Tip =
+            Bin 1 Tip y Tip
+        Bin _ l x r = match (cmp x y)
+            GT =
+                join3 (helper l) x r
+            EQ =
+                join3 (delete cmp y l) y (delete cmp y r)
+            LT =
+                join3 l x (helper r)
+    helper root
+    | Tree cmp
 
-# Insert y into the tree at the lowest rank of keys = y
+# Insert y into the tree at the lowest rank of keys == y
 export def tinsertMulti (y: a) (Tree cmp root: Tree a): Tree a =
-  def helper = match _
-    Tip         = Bin 1 Tip y Tip
-    Bin _ l x r = match (cmp x y)
-      GT = balanceL (helper l) x r
-      _  = balanceR l x (helper r)
-  Tree cmp (helper root)
+    def helper = match _
+        Tip =
+            Bin 1 Tip y Tip
+        Bin _ l x r = match (cmp x y)
+            GT =
+                balanceL (helper l) x r
+            _ =
+                balanceR l x (helper r)
+    helper root
+    | Tree cmp
 
 # Returns True if a is a subset of b, otherwise False.
 export def (a: Tree a) ⊆ (b: Tree a): Boolean =
-  tsubset a b
+    tsubset a b
 
 # Returns True if a is a superset of b, otherwise False.
 export def (a: Tree a) ⊇ (b: Tree a): Boolean =
-  tsubset b a
+    tsubset b a
 
 # Returns True if a is NOT a superset of b, otherwise False.
 export def (a: Tree a) ⊉ (b: Tree a): Boolean =
-  ! a ⊇ b
+    ! a ⊇ b
 
 # Returns True if a is NOT a subset of b, otherwise False.
 export def (a: Tree a) ⊈ (b: Tree a): Boolean =
-  ! a ⊆ b
+    ! a ⊆ b
 
 # Returns True if a is a proper subset of b, otherwise False.
 export def (a: Tree a) ⊊ (b: Tree a): Boolean =
-  a ⊆ b && b ⊈ a # strict
+    a ⊆ b && b ⊈ a # strict
 
 # Returns True if a is a proper superset of b, otherwise False.
 export def (a: Tree a) ⊋ (b: Tree a): Boolean =
-  a ⊇ b && b ⊉ a # strict
+    a ⊇ b && b ⊉ a # strict
 
 # Returns True if every element of a is also in b, otherwise false.
 export def tsubset (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Boolean =
-  def helper a b = match a b
-    Tip _ = True
-    _ Tip = False
-    _ (Bin _ bl bx br) = match (split bx cmp a)
-      Triple al _ ag = helper al bl && helper ag br
-  helper aroot broot
+    def helper a b = match a b
+        Tip _ =
+            True
+        _ Tip =
+            False
+        _ (Bin _ bl bx br) =
+            def Triple al _ ag =
+                split bx cmp a
+            helper al bl && helper ag br
+    helper aroot broot
 
 # Deletes all keys that are equal to y.
 export def tdelete (y: a) (Tree cmp root: Tree a): Tree a =
-  Tree cmp (delete cmp y root)
-def delete cmp y t =
-  def helper = match _
-    Tip = Tip
-    Bin _ l x r = match (cmp x y)
-      GT = join3 (helper l) x r
-      EQ = join2 (helper l) (helper r)
-      LT = join3 l x (helper r)
-  helper t
+    delete cmp y root
+    | Tree cmp
+def delete (cmp: a => a => Order) (y: a) (t: TreeNode a) =
+    def helper = match _
+        Tip =
+            Tip
+        Bin _ l x r = match (cmp x y)
+            GT =
+                join3 (helper l) x r
+            EQ =
+                join2 (helper l) (helper r)
+            LT =
+                join3 l x (helper r)
+    helper t
 
 # Folds from left to right.
 export def tfoldl (f: b => a => b) (acc: b) (Tree _ root: Tree a): b =
-  def helper a = match _
-    Tip         = a
-    Bin _ l x r = helper (f (helper a l) x) r
-  helper acc root
+    def helper a = match _
+        Tip =
+            a
+        Bin _ l x r =
+            helper (f (helper a l) x) r
+    helper acc root
 
 # Folds from right to left.
 export def tfoldr (f: a => b => b) (acc: b) (Tree _ root: Tree a): b =
-  def helper a = match _
-    Tip         = a
-    Bin _ l x r = helper (f x (helper a r)) l
-  helper acc root
+    def helper a = match _
+        Tip =
+            a
+        Bin _ l x r =
+            helper (f x (helper a r)) l
+    helper acc root
 
-# Fold in parallel; assumes f is an associative operator and has type: a => a => a
+# Fold in parallel; assumes f is an associative operator
 export def tfoldmap (f: b => b => b) (acc: a) (g: a => b) (Tree _ root: Tree a): b =
-  def helper acc = match _
-    Tip = g acc
-    Bin _ l x r = f (helper acc l) (helper x r)
-  helper acc root
+    def helper acc = match _
+        Tip =
+            g acc
+        Bin _ l x r =
+            f (helper acc l) (helper x r)
+    helper acc root
 
 export def tfold (f: a => a => a) (a: a) (t: Tree a): a =
-  tfoldmap f a (_) t
+    tfoldmap f a (_) t
 
 # Converts a Tree to a List.
 export def treeToList: Tree a => List a =
-  tfoldr (_,_) Nil
+    tfoldr (_,_) Nil
 
+# Apply some function to every element in the tree, additionally passing the
+# rank of that element.  As the tree is not modified, the function will most
+# commonly be a logging function to print the contents of the tree.
 export def tappi (f: Integer => a => b) (Tree _ root: Tree a): Unit =
-  def helper i = match _
-    Tip = Unit
-    Bin _ l x r =
-      def ix = i + size l
-      def _ = helper i l
-      def _ = helper (ix+1) r
-      def _ = f ix x
-      Unit
-  helper 0 root
+    def helper i = match _
+        Tip =
+            Unit
+        Bin _ l x r =
+            def ix =
+                i + size l
+            # Apply the tap function to each side of the tree, and then the node itself.
+            def _ =
+                helper i l
+            def _ =
+                helper (ix + 1) r
+            def _ =
+                f ix x
+            Unit
+    helper 0 root
 
 # Extract the i-th ranked element
 export def tat (i: Integer) (Tree _ root: Tree a): Option a =
-  def helper i = match _
-    Tip = None
-    Bin _ l x r =
-      def sizeL = size l
-      match (icmp i sizeL)
-        LT = helper i l
-        EQ = Some x
-        GT = helper (i-sizeL-1) r
-  helper i root
+    def helper i = match _
+        Tip =
+            None
+        Bin _ l x r =
+            def sizeL =
+                size l
+            match (icmp i sizeL)
+                LT =
+                    helper i l
+                EQ =
+                    Some x
+                GT =
+                    helper (i - sizeL - 1) r
+    helper i root
 
 # Split elements ranked [0,i) and [i,inf) into two trees
 export def tsplitAt (i: Integer) (Tree cmp root: Tree a): Pair (Tree a) (Tree a) =
-  def helper i = match _
-    Tip = Pair Tip Tip
-    Bin _ l x r =
-      def sizeL = size l
-      if i > sizeL
-      then match (helper (i-sizeL-1) r)
-        Pair rl rr = Pair (join3 l x rl) rr
-      else match (helper i l)
-        Pair ll lr = Pair ll (join3 lr x r)
-  match (helper i root)
-    Pair l r = Pair (Tree cmp l) (Tree cmp r)
+    def helper i = match _
+        Tip =
+            Pair Tip Tip
+        Bin _ l x r =
+            def sizeL =
+                size l
+            if i > sizeL then
+                def Pair rl rr =
+                    helper (i - sizeL - 1) r
+                Pair (join3 l x rl) rr
+            else
+                def Pair ll lr =
+                    helper i l
+                Pair ll (join3 lr x r)
+    def Pair l r =
+        helper i root
+    Pair (Tree cmp l) (Tree cmp r)
 
 export def ttake (i: Integer) (t: Tree a): Tree a =
-  tsplitAt i t | getPairFirst
+    tsplitAt i t
+    | getPairFirst
 export def tdrop (i: Integer) (t: Tree a): Tree a =
-  tsplitAt i t | getPairSecond
+    tsplitAt i t
+    | getPairSecond
 
 # Lowest rank element where f x == True, along with that rank.
 export def tfind (f: a => Boolean) (Tree _ root: Tree a): Option (Pair a Integer) =
-  def helper = match _
-    Tip         = None
-    Bin s l x r = match (helper l) (f x) (helper r)
-      (Some p) _    _       = Some p
-      _        True _       = Some (Pair x (s-size r-1))
-      _ _ (Some (Pair x i)) = Some (Pair x (i+size l+1))
-      _        _    _       = None
-  helper root
+    def helper = match _
+        Tip =
+            None
+        Bin s l x r = match (helper l) (f x) (helper r)
+            (Some p) _ _ =
+                Some p
+            _ True _ =
+                s - size r - 1
+                | Pair x
+                | Some
+            _ _ (Some (Pair x i)) =
+                i + size l + 1
+                | Pair x
+                | Some
+            _ _ _ =
+                None
+    helper root
 
 export def tsplitUntil (f: a => Boolean) (t: Tree a): Pair (Tree a) (Tree a) =
-  match (tfind f t)
-    None = match t
-      (Tree cmp _) = Pair t (Tree cmp Tip)
-    Some (Pair _ i) = tsplitAt i t
+    match (tfind f t)
+        None =
+            def Tree cmp _ =
+                t
+            Pair t (Tree cmp Tip)
+        Some (Pair _ i) =
+            tsplitAt i t
 
 export def ttakeUntil (f: a => Boolean) (t: Tree a): Tree a =
-  tsplitUntil f t | getPairFirst
+    tsplitUntil f t
+    | getPairFirst
 export def tdropUntil (f: a => Boolean) (t: Tree a): Tree a =
-  tsplitUntil f t | getPairSecond
+    tsplitUntil f t
+    | getPairSecond
 
-# Returns True if there exists an x in t where f x = True
-export def texists (f: a => Boolean) (t: Tree a): Boolean = match (tfind f t)
-  Some _ = True
-  None   = False
+# Returns True if there exists an x in t where f x == True
+export def texists (f: a => Boolean) (t: Tree a): Boolean =
+    tfind f t
+    | isSome
 
 export def tforall (f: a => Boolean) (t: Tree a): Boolean =
-  ! texists (! f _) t
+    ! texists (! f _) t
 
-# Split tree into those elements <, =, and > y
+# Split tree into those elements <, ==, and > y
 export def tsplit (y: a) (Tree cmp root: Tree a): Triple (Tree a) (Tree a) (Tree a) =
-  match (split y cmp root)
-    Triple l e g = Triple (Tree cmp l) (Tree cmp e) (Tree cmp g)
+    def Triple l e g =
+        split y cmp root
+    Triple (Tree cmp l) (Tree cmp e) (Tree cmp g)
 
 def split y cmp root =
-  def helper = match _
-    Tip = Triple Tip Tip Tip
-    Bin _ l x r = match (cmp x y)
-      LT = match (helper r)
-        Triple rl re rg = Triple (join3 l x rl) re rg
-      GT = match (helper l)
-        Triple ll le lg = Triple ll le (join3 lg x r)
-      EQ = match (splitlt l) (splitgt r)
-        (Pair ll le) (Pair re rg) = Triple ll (join3 le x re) rg
-  def splitlt = match _
-    Tip = Pair Tip Tip
-    Bin _ l x r = match (cmp x y)
-      LT = match (splitlt r)
-        Pair rl re = Pair (join3 l x rl) re
-      _  = match (splitlt l)
-        Pair ll le = Pair ll (join3 le x r)
-  def splitgt = match _
-    Tip = Pair Tip Tip
-    Bin _ l x r = match (cmp x y)
-      GT = match (splitgt l)
-        Pair le lg = Pair le (join3 lg x r)
-      _  = match (splitgt r)
-        Pair re rg = Pair (join3 l x re) rg
-  helper root
+    def helper = match _
+        Tip =
+            Triple Tip Tip Tip
+        Bin _ l x r = match (cmp x y)
+            LT =
+                def Triple rl re rg =
+                    helper r
+                Triple (join3 l x rl) re rg
+            GT =
+                def Triple ll le lg =
+                    helper l
+                Triple ll le (join3 lg x r)
+            EQ =
+                def Pair ll le =
+                    splitlt l
+                def Pair re rg =
+                    splitgt r
+                Triple ll (join3 le x re) rg
+    def splitlt = match _
+        Tip =
+            Pair Tip Tip
+        Bin _ l x r = match (cmp x y)
+            LT =
+                def Pair rl re =
+                    splitlt r
+                Pair (join3 l x rl) re
+            _ =
+                def Pair ll le =
+                    splitlt l
+                Pair ll (join3 le x r)
+    def splitgt = match _
+        Tip =
+            Pair Tip Tip
+        Bin _ l x r = match (cmp x y)
+            GT =
+                def Pair le lg =
+                    splitgt l
+                Pair le (join3 lg x r)
+            _ =
+                def Pair re rg =
+                    splitgt r
+                Pair (join3 l x re) rg
+    helper root
 
-# Split tree into those elements where f x = True and those where f x = False
+# Split tree into those elements where f x == True and those where f x == False
 export def tsplitBy (f: a => Boolean) (Tree cmp root: Tree a): Pair (Tree a) (Tree a) =
-  def helper t = match t
-    Tip = Pair Tip Tip
-    Bin _ l x r = match (helper l) (helper r)
-      (Pair tl fl) (Pair tr fr) =
-        if f x
-        then Pair (join3 tl x tr) (join2 fl fr)
-        else Pair (join2 tl tr) (join3 fl x fr)
-  match (helper root)
-    Pair t f = Pair (Tree cmp t) (Tree cmp f)
+    def helper t = match t
+        Tip =
+            Pair Tip Tip
+        Bin _ l x r =
+            def Pair tl fl =
+                helper l
+            def Pair tr fr =
+                helper r
+            if f x then
+                Pair (join3 tl x tr) (join2 fl fr)
+            else
+                Pair (join2 tl tr) (join3 fl x fr)
+    def Pair trues falses =
+        helper root
+    Pair (Tree cmp trues) (Tree cmp falses)
 
-# Remove all elements x such that f x = False.
+# Remove all elements x such that f x == False.
 export def tfilter (f: a => Boolean) (Tree cmp root: Tree a): Tree a =
-  def helper t = match t
-    Tip = Tip
-    Bin _ l x r =
-      def l_ = helper l
-      def r_ = helper r
-      if f x then join3 l_ x r_ else join2 l_ r_
-  Tree cmp (helper root)
+    def helper t = match t
+        Tip =
+            Tip
+        Bin _ l x r =
+            def l_ =
+                helper l
+            def r_ =
+                helper r
+            if f x then
+                join3 l_ x r_
+            else
+                join2 l_ r_
+    Tree cmp (helper root)
 
 # Return the smallest element in the tree.
-export def tmin (Tree _ root: Tree a): Option a = min_ root
-def min_ root =
-  def none = match _
-    Tip         = None
-    Bin _ l x _ = some x l
-  def some x = match _
-    Tip         = Some x
-    Bin _ l y _ = some y l
-  none root
+export def tmin (Tree _ root: Tree a): Option a =
+    def min_ = match _
+        Tip =
+            None
+        Bin _ l x _ =
+            min_ l
+            | getOrElse x
+            | Some
+    min_ root
 
 # Return the largest element in the tree.
-export def tmax (Tree _ root: Tree a): Option a = max_ root
-def max_ root =
-  def none = match _
-    Tip         = None
-    Bin _ _ x r = some x r
-  def some x = match _
-    Tip         = Some x
-    Bin _ _ y r = some y r
-  none root
+export def tmax (Tree _ root: Tree a): Option a =
+    def max_ = match _
+        Tip =
+            None
+        Bin _ _ x r =
+            max_ r
+            | getOrElse x
+            | Some
+    max_ root
 
 # Lowest rank element with x >= y, along with that rank.
 export def tlowerGE (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
-  def f x = match (cmp x y)
-    LT = False
-    _  = True
-  lower f root
+    def f x = match (cmp x y)
+        LT =
+            False
+        _ =
+            True
+    lower f root
 
 # Lowest rank element with x > y, along with that rank.
 export def tlowerGT (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
-  def f x = match (cmp x y)
-    GT = True
-    _  = False
-  lower f root
+    def f x = match (cmp x y)
+        GT =
+            True
+        _ =
+            False
+    lower f root
 
-# Lowest rank element f x = True   => Option (Pair x rank)
+# Lowest rank element f x == True => Option (Pair x rank)
 def lower f root =
-  def none = match _
-    Tip         = None
-    Bin s l x r = if f x then someL x (size root - s) l else none r
-  def someR z i = match _ # i = size including self
-    Tip         = Some (Pair z i)
-    Bin s l x r = if f x then someL x (i-s) l else someR z i r
-  def someL z i = match _ # i = size left of self
-    Tip         = Some (Pair z i)
-    Bin s l x r = if f x then someL x i l else someR z (i+s) r
-  none root
+    def lower_ = match _
+        Tip =
+            None
+        Bin _ l x r =
+            def upperResult =
+                if f x then
+                    Some (Pair x (size l))
+                else
+                    lower_ r
+                    | omap (editPairSecond (size l + 1 + _))
+            lower_ l
+            | orElse upperResult
+    lower_ root
 
 # Highest rank element with x < y, along with that rank.
 export def tupperLT (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
-  def f x = match (cmp x y)
-    LT = False
-    _  = True
-  upper f root
+    def f x = match (cmp x y)
+        LT =
+            False
+        _ =
+            True
+    upper f root
 
 # Highest rank element with x <= y, along with that rank.
 export def tupperLE (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
-  def f x = match (cmp x y)
-    GT = True
-    _  = False
-  upper f root
+    def f x = match (cmp x y)
+        GT =
+            True
+        _ =
+            False
+    upper f root
 
-# Highest rank element with f x = False  => Option (Pair x rank)
+# Highest rank element with f x == False => Option (Pair x rank)
 def upper f root =
-  def none = match _
-    Tip         = None
-    Bin s l x r = if f x then none l else someR x s r
-  def someR z i = match _ # i = size including self
-    Tip         = Some (Pair z (i-1))
-    Bin s l x r = if f x then someL z (i-s) l else someR x i r
-  def someL z i = match _ # i = size left of self
-    Tip         = Some (Pair z (i-1))
-    Bin s l x r = if f x then someL z i l else someR x (i+s) r
-  none root
+    def upper_ = match _
+        Tip =
+            None
+        Bin _ l x r =
+            def lesserResult =
+                if f x then
+                    Some (Pair x (size l))
+                else
+                    upper_ l
+            upper_ r
+            | omap (editPairSecond (size l + 1 + _))
+            | orElse lesserResult
+    upper_ root
 
 # Extract all elements from the tree which are equal to y, along with their highest rank.
 export def tequal (y: a) (Tree cmp root: Tree a): Pair (List a) Integer=
-  def helperR i out = match _ # i = size including self
-    Tip         = Pair out i
-    Bin s l x r = match (cmp x y)
-      LT = helperR i out r
-      GT = helperL (i-s) out l
-      EQ = helperL (i-s) (x, helperR i out r | getPairFirst) l
-  def helperL i out = match _ # i = size left of self
-    Tip         = Pair out i
-    Bin s l x r = match (cmp x y)
-      LT = helperR (i+s) out r
-      GT = helperL i out l
-      EQ = helperL i (x, helperR (i+s) out r | getPairFirst) l
-  helperL 0 Nil root
+    def helperR i out = match _ # i = size including self
+        Tip =
+            Pair out i
+        Bin s l x r = match (cmp x y)
+            LT =
+                helperR i out r
+            GT =
+                helperL (i-s) out l
+            EQ =
+                helperL (i-s) (x, helperR i out r | getPairFirst) l
+    def helperL i out = match _ # i = size left of self
+        Tip =
+            Pair out i
+        Bin s l x r = match (cmp x y)
+            LT =
+                helperR (i+s) out r
+            GT =
+                helperL i out l
+            EQ =
+                helperL i (x, helperR (i+s) out r | getPairFirst) l
+    helperL 0 Nil root
 
 # Returns True if x is an element of y, False otherwise.
 export def (x: a) ∈ (y: Tree a): Boolean =
-  tcontains x y
+    tcontains x y
 
 # Returns True if x is NOT an element of y, False otherwise.
 export def (x: a) ∉ (y: Tree a): Boolean =
-  ! x ∈ y
+    ! x ∈ y
 
 # Returns True if x contains y, False otherwise.
 export def (x: Tree a) ∋ (y: a): Boolean =
-  y ∈ x
+    y ∈ x
 
 # Returns True if x does NOT contain y, False otherwise.
 export def (x: Tree a) ∌ (y: a): Boolean =
-  y ∉ x
+    y ∉ x
 
 export def tcontains (y: a) (t: Tree a): Boolean =
-  match t (tupperLE y t)
-    (Tree _   _) None              = False
-    (Tree cmp _) (Some (Pair x _)) = match (cmp x y)
-      EQ = True
-      _  = False
+    match t (tupperLE y t)
+        _ None =
+            False
+        (Tree cmp _) (Some (Pair x _)) = match (cmp x y)
+            EQ =
+                True
+            _ =
+                False
 
 # Eliminate duplicates, as identified by cmp
-export def tdistinctBy (cmp: a => a => Order) (t: Tree a): Tree a = match t
-  Tree tcmp _ = listToTree tcmp (distinctBy cmp (treeToList t))
+export def tdistinctBy (cmp: a => a => Order) (t: Tree a): Tree a =
+    def Tree tcmp _ = t
+    treeToList t
+    | distinctBy cmp
+    | listToTree tcmp
 
 # Eliminate duplicates, as identified by f
-export def tdistinctRunBy (f: a => a => Boolean) (t: Tree a): Tree a = match t
-  Tree cmp _ = Tree cmp (build (vdistinctRunBy f (treeToVector t)))
+export def tdistinctRunBy (f: a => a => Boolean) (t: Tree a): Tree a =
+    def Tree cmp _ = t
+    treeToVector t
+    | vdistinctRunBy f
+    | build
+    | Tree cmp
 
 # Returns the union of trees a and b, preferencing values from a if any are in both trees
 export def (a: Tree a) ∪ (b: Tree a): Tree a =
-  tunion a b
+    tunion a b
 
 # Returns the union of two trees, given their roots.
 export def tunion (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
-  Tree cmp (union cmp aroot broot)
+    Tree cmp (union cmp aroot broot)
 def union cmp aroot broot =
-  def helper a b = match a b
-    Tip _ = b
-    _ Tip = a
-    (Bin _ al ax ar) _ = match (split ax cmp b)
-      Triple bl _ bg = join3 (helper al bl) ax (helper ar bg)
-  helper aroot broot
+    def helper a b = match a b
+        Tip _ =
+            b
+        _ Tip =
+            a
+        (Bin _ al ax ar) _ =
+            def Triple bl _ bg =
+                split ax cmp b 
+            join3 (helper al bl) ax (helper ar bg)
+    helper aroot broot
 
 # Union of two trees, keeping equal values of a before equal values of b
 export def (a: Tree a) ⊎ (b: Tree a): Tree a =
-  tunionMulti a b
+    tunionMulti a b
 export def tunionMulti (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
-  Tree cmp (unionMulti cmp aroot broot)
+    Tree cmp (unionMulti cmp aroot broot)
 
 def unionMulti cmp aroot broot =
-  def helper a b = match a b
-    Tip _ = b
-    _ Tip = a
-    (Bin _ _ ax _) _ = match (split ax cmp a) (split ax cmp b)
-      (Triple al ae ag) (Triple bl be bg) =
-        def l = helper al bl
-        def r = helper ag bg
-        def r_ = join2 be r # fast if be=Tip
-        if size ae == 1
-        then join3 l ax r_
-        else join2 (join2 l ae) r_
-  helper aroot broot
+    def helper a b = match a b
+        Tip _ =
+            b
+        _ Tip =
+            a
+        (Bin _ _ ax _) _ = match (split ax cmp a) (split ax cmp b)
+            (Triple al ae ag) (Triple bl be bg) =
+                def l =
+                    helper al bl
+                def r =
+                    helper ag bg
+                def r_ =
+                    join2 be r # fast if be=Tip
+                if size ae == 1 then
+                    join3 l ax r_
+                else
+                    join2 (join2 l ae) r_
+    helper aroot broot
 
 # Returns the set difference of A and B, that is, a tree containing all elements of A which are not in B.
 export def tsubtract (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
-  def helper a b = match a b
-    Tip _ = Tip
-    _ Tip = a
-    _ (Bin _ bl bx br) = match (split bx cmp a)
-      Triple al _ ag = join2 (helper al bl) (helper ag br)
-  Tree cmp (helper aroot broot)
+    def helper a b = match a b
+        Tip _ =
+            Tip
+        _ Tip =
+            a
+        _ (Bin _ bl bx br) =
+            def Triple al _ ag =
+                split bx cmp a
+            join2 (helper al bl) (helper ag br)
+    Tree cmp (helper aroot broot)
 
 # Returns a tree containing all elements of A which are also in B.
 export def (a: Tree a) ∩ (b: Tree a): Tree a =
-  tintersect a b
+    tintersect a b
 export def tintersect (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
-  def helper a b = match a b
-    Tip _ = Tip
-    _ Tip = Tip
-    _ (Bin _ bl bx br) = match (split bx cmp a)
-      Triple al ae ag =
-        def l = helper al bl
-        def r = helper ag br
-        match ae
-          Tip = join2 l r
-          Bin aes _ aex _ =
-            if aes == 1 then join3 l aex r else join2 (join2 l ae) r
-  Tree cmp (helper aroot broot)
+    def helper a b = match a b
+        Tip _ =
+            Tip
+        _ Tip =
+            Tip
+        _ (Bin _ bl bx br) =
+            def Triple al ae ag =
+                split bx cmp a
+            def l =
+                helper al bl
+            def r =
+                helper ag br
+            match ae
+                Tip =
+                    join2 l r
+                Bin 1 _ aex _ =
+                    join3 l aex r
+                Bin _ _ _ _ =
+                    join2 (join2 l ae) r
+    Tree cmp (helper aroot broot)
 
 # Pretty print the tree shape for debug
 #export def tshape (Tree _ root: Tree a): String =
@@ -494,65 +662,122 @@ export def tintersect (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
 
 # Create a balanced tree with with order: l:Tree x:Element r:Tree
 def join3 l x r = match l r
-  Tip _ = insertMin x r
-  _ Tip = insertMax x l
-  (Bin ls ll lx lr) (Bin rs rl rx rr) =
-    if deltaQ*ls < deltaD*rs then balanceL (join3 l x rl) rx rr else
-    if deltaQ*rs < deltaD*ls then balanceR ll lx (join3 lr x r) else
-    Bin (ls+rs+1) l x r
+    Tip _ =
+        insertMin x r
+    _ Tip =
+        insertMax x l
+    (Bin ls ll lx lr) (Bin rs rl rx rr) =
+        if deltaQ*ls < deltaD*rs then
+            balanceL (join3 l x rl) rx rr
+        else if deltaQ*rs < deltaD*ls then
+            balanceR ll lx (join3 lr x r)
+        else
+            Bin (ls + rs + 1) l x r
 
 # Create a balanced tree with with order: l:Tree r:Tree
 def join2 l r = match l
-  Tip = r
-  Bin _ ll lx lr = match (splitLast ll lx lr)
-    Pair l_ x_ = join3 l_ x_ r
+    Tip =
+        r
+    Bin _ ll lx lr =
+        def Pair l_ x_ =
+            splitLast ll lx lr
+        join3 l_ x_ r
 
 def splitLast l x r = match r
-  Tip = Pair l x
-  Bin _ rl rx rr = match (splitLast rl rx rr)
-    Pair l_ x_ = Pair (join3 l x l_) x_
+    Tip =
+        Pair l x
+    Bin _ rl rx rr =
+        def Pair l_ x_ =
+            splitLast rl rx rr
+        Pair (join3 l x l_) x_
 
 def insertMax x = match _
-  Tip = Bin 1 Tip x Tip
-  Bin _ l y r = balanceR l y (insertMax x r)
+    Tip =
+        Bin 1 Tip x Tip
+    Bin _ l y r =
+        insertMax x r
+        | balanceR l y
 
 def insertMin x = match _
-  Tip = Bin 1 Tip x Tip
-  Bin _ l y r = balanceL (insertMin x l) y r
+    Tip =
+        Bin 1 Tip x Tip
+    Bin _ l y r =
+        insertMin x l
+        | (balanceL _ y r)
 
-# Written while reading the Haskell Set implementation 
+# Written while reading the Haskell Set implementation
 def balanceL l x r = match l r
-  Tip Tip = Bin 1 Tip x Tip
-  (Bin ls ll lx lr) Tip = match ll lr
-    Tip Tip = Bin 2 l x Tip
-    ll  Tip = Bin 3 ll lx (Bin 1 Tip x Tip)
-    Tip (Bin _ _ lrx _) = Bin 3 (Bin 1 Tip lx Tip) lrx (Bin 1 Tip x Tip)
-    (Bin lls _ _ _) (Bin lrs lrl lrx lrr) = match (ratioD*lrs < ratioQ*lls)
-      True  = Bin (1+ls) ll lx (Bin (1+lrs) lr x Tip)
-      False = Bin (1+ls) (Bin (1+lls+size lrl) ll lx lrl) lrx (Bin (1+size lrr) lrr x Tip)
-  Tip (Bin rs _ _ _) = Bin (1+rs) Tip x r
-  (Bin ls ll lx lr) (Bin rs _ _ _) = match (ls*deltaD > deltaQ*rs)
-    True = match ll lr
-      (Bin lls _ _ _) (Bin lrs lrl lrx lrr) = match (ratioD*lrs < ratioQ*lls)
-        True  = Bin (1+ls+rs) ll lx (Bin (1+rs+lrs) lr x r)
-        False = Bin (1+ls+rs) (Bin (1+lls+size lrl) ll lx lrl) lrx (Bin (1+rs+size lrr) lrr x r)
-      _ _ = unreachable "tree balance invariant violated in Tree.balanceL"
-    False = Bin (1+ls+rs) l x r
+    Tip Tip =
+        Bin 1 Tip x Tip
+    (Bin ls ll lx lr) Tip = match ll lr
+        Tip Tip =
+            Bin 2 l x Tip
+        ll Tip =
+            Bin 3 ll lx (Bin 1 Tip x Tip)
+        Tip (Bin _ _ lrx _) =
+            Bin 3 (Bin 1 Tip lx Tip) lrx (Bin 1 Tip x Tip)
+        (Bin lls _ _ _) (Bin lrs lrl lrx lrr) =
+            if ratioD*lrs < ratioQ*lls then
+                Bin (1+ls) ll lx (Bin (1+lrs) lr x Tip)
+            else
+                def l_ =
+                    Bin (1+lls+size lrl) ll lx lrl
+                def r_ =
+                    Bin (1+size lrr) lrr x Tip
+                Bin (1+ls) l_ lrx r_
+    Tip (Bin rs _ _ _) =
+        Bin (1+rs) Tip x r
+    (Bin ls ll lx lr) (Bin rs _ _ _) =
+        if ls*deltaD > deltaQ*rs then
+            match ll lr
+                (Bin lls _ _ _) (Bin lrs lrl lrx lrr) =
+                    if ratioD*lrs < ratioQ*lls then
+                        Bin (1+ls+rs) ll lx (Bin (1+rs+lrs) lr x r)
+                    else
+                        def l_ =
+                            Bin (1+lls+size lrl) ll lx lrl
+                        def r_ =
+                            Bin (1+rs+size lrr) lrr x r
+                        Bin (1+ls+rs) l_ lrx r_
+                _ _ =
+                    unreachable "tree balance invariant violated in Tree.balanceL"
+        else
+            Bin (1+ls+rs) l x r
 
 def balanceR l x r = match l r
-  Tip Tip = Bin 1 Tip x Tip
-  Tip (Bin rs rl rx rr) = match rl rr
-    Tip Tip = Bin 2 Tip x r
-    Tip _   = Bin 3 (Bin 1 Tip x Tip) rx rr
-    (Bin _ _ rlx _) Tip = Bin 3 (Bin 1 Tip x Tip) rlx (Bin 1 Tip rx Tip)
-    (Bin rls rll rlx rlr) (Bin rrs _ _ _) = match (ratioD*rls < ratioQ*rrs)
-      True  = Bin (1+rs) (Bin (1+rls) Tip x rl) rx rr
-      False = Bin (1+rs) (Bin (1+size rll) Tip x rll) rlx (Bin (1+rrs+size rlr) rlr rx rr)
-  (Bin ls _ _ _) Tip = Bin (1+ls) l x Tip
-  (Bin ls _ _ _) (Bin rs rl rx rr) = match (deltaD*rs > deltaQ*ls)
-    True = match rl rr
-      (Bin rls rll rlx rlr) (Bin rrs _ _ _) = match (ratioD*rls < ratioQ*rrs)
-        True  = Bin (1+ls+rs) (Bin (1+ls+rls) l x rl) rx rr
-        False = Bin (1+ls+rs) (Bin (1+ls+size rll) l x rll) rlx (Bin (1+rrs+size rlr) rlr rx rr)
-      _ _ = unreachable "tree balance invariant violated in Tree.balanceR"
-    False = Bin (1+ls+rs) l x r
+    Tip Tip =
+        Bin 1 Tip x Tip
+    Tip (Bin rs rl rx rr) = match rl rr
+        Tip Tip =
+            Bin 2 Tip x r
+        Tip _ =
+            Bin 3 (Bin 1 Tip x Tip) rx rr
+        (Bin _ _ rlx _) Tip =
+            Bin 3 (Bin 1 Tip x Tip) rlx (Bin 1 Tip rx Tip)
+        (Bin rls rll rlx rlr) (Bin rrs _ _ _) =
+            if ratioD*rls < ratioQ*rrs then
+                Bin (1+rs) (Bin (1+rls) Tip x rl) rx rr
+            else
+                def l_ =
+                    Bin (1+size rll) Tip x rll
+                def r_ =
+                    Bin (1+rrs+size rlr) rlr rx rr
+                Bin (1+rs) l_ rlx r_
+    (Bin ls _ _ _) Tip =
+        Bin (1+ls) l x Tip
+    (Bin ls _ _ _) (Bin rs rl rx rr) =
+        if deltaD*rs > deltaQ*ls then
+            match rl rr
+                (Bin rls rll rlx rlr) (Bin rrs _ _ _) =
+                    if ratioD*rls < ratioQ*rrs then
+                        Bin (1+ls+rs) (Bin (1+ls+rls) l x rl) rx rr
+                    else
+                        def l_ =
+                            Bin (1+ls+size rll) l x rll
+                        def r_ =
+                            Bin (1+rrs+size rlr) rlr rx rr
+                        Bin (1+ls+rs) l_ rlx r_
+                _ _ =
+                    unreachable "tree balance invariant violated in Tree.balanceR"
+        else
+            Bin (1+ls+rs) l x r

--- a/share/wake/lib/core/tuple.wake
+++ b/share/wake/lib/core/tuple.wake
@@ -43,13 +43,13 @@ export tuple Triple a b c =
 export data a; b = a; b
 
 # Handy accessor methods
-export def _0 (x; _) = x
-export def _1 (_; x; _) = x
-export def _2 (_; _; x; _) = x
-export def _3 (_; _; _; x; _) = x
-export def _4 (_; _; _; _; x; _) = x
-export def _5 (_; _; _; _; _; x; _) = x
-export def _6 (_; _; _; _; _; _; x; _) = x
-export def _7 (_; _; _; _; _; _; _; x; _) = x
-export def _8 (_; _; _; _; _; _; _; _; x; _) = x
-export def _9 (_; _; _; _; _; _; _; _; _; x; _) = x
+export def _0 ((x: a); _): a = x
+export def _1 (_; (x: b); _): b = x
+export def _2 (_; _; (x: c); _): c = x
+export def _3 (_; _; _; (x: d); _): d = x
+export def _4 (_; _; _; _; (x: e); _): e = x
+export def _5 (_; _; _; _; _; (x: f); _): f = x
+export def _6 (_; _; _; _; _; _; (x: g); _): g = x
+export def _7 (_; _; _; _; _; _; _; (x: h); _): h = x
+export def _8 (_; _; _; _; _; _; _; _; (x: i); _): i = x
+export def _9 (_; _; _; _; _; _; _; _; _; (x: j); _): j = x

--- a/share/wake/lib/gcc_wake/gcc.wake
+++ b/share/wake/lib/gcc_wake/gcc.wake
@@ -15,16 +15,24 @@
 
 package gcc_wake
 
-export def cpp11Flags    = ("-std=c++11", Nil)
-export def c11Flags      = ("-std=c11", Nil)
-export def debugCFlags   = ("-Wall", "-Wextra", "-O0", "-g", "-pg", Nil)
-export def debugLFlags   = ("-g", "-pg", Nil)
-export def releaseCFlags = ("-Wall", "-O2", Nil)
-export def releaseLFlags = (Nil)
-export def staticCFlags =  ("-Wall", "-O2", "-flto", Nil)
-export def staticLFlags  = ("-flto", "-static", "-s", Nil)
+export def cpp11Flags: List String =
+    "-std=c++11", Nil
+export def c11Flags: List String =
+    "-std=c11", Nil
+export def debugCFlags: List String =
+    "-Wall", "-Wextra", "-O0", "-g", "-pg", Nil
+export def debugLFlags: List String =
+    "-g", "-pg", Nil
+export def releaseCFlags: List String =
+    "-Wall", "-O2", Nil
+export def releaseLFlags: List String =
+    Nil
+export def staticCFlags: List String =
+    "-Wall", "-O2", "-flto", Nil
+export def staticLFlags: List String =
+    "-flto", "-static", "-s", Nil
 
-def doCompileC variant gcc flags headers cfile =
+def doCompileC (variant: String) (gcc: String) (flags: List String) (headers: List Path) (cfile: Path): Result (List Path) Error =
     def obj = replace `\.c(pp)?$` ".{variant}.o" cfile.getPathName
     def cmdline =
         gcc, flags ++
@@ -35,7 +43,7 @@ def doCompileC variant gcc flags headers cfile =
     | getJobOutputs
     | findFailFn getPathResult
 
-def doLinkO variant linker flags objects targ =
+def doLinkO (variant: String) (linker: String) (flags: List String) (objects: List Path) (targ: String): Result (List Path) Error =
     def cmdline =
         (linker, "-o", "{targ}.{variant}", map getPathName objects) ++
         flags
@@ -45,10 +53,10 @@ def doLinkO variant linker flags objects targ =
     | getJobOutputs
     | findFailFn getPathResult
 
-export def makeCompileC variant gcc flags =
+export def makeCompileC (variant: String) (gcc: String) (flags: List String): List (Pair String (List String => List Path => Path => Result (List Path) Error)) =
     Pair variant (\extraFlags doCompileC variant gcc (flags ++ extraFlags)), Nil
 
-export def makeLinkO variant linker flags =
+export def makeLinkO (variant: String) (linker: String) (flags: List String): List (Pair String (List String => List Path => String => Result (List Path) Error)) =
     Pair variant (\extraFlags doLinkO variant linker (flags ++ extraFlags)), Nil
 
 export topic compileC: Pair String ((extraFlags: List String) => (headers: List Path) => (cfile: Path) => Result (List Path) Error)
@@ -77,5 +85,5 @@ def pickVariant variant variants =
 export def compileC (variant: String): (extraFlags: List String) => (headers: List Path) => (cfile: Path) => Result (List Path) Error =
     pickVariant variant (subscribe compileC)
 
-export def linkO    (variant: String): (extraFlags: List String) => (objects: List Path) => (targ: String) => Result (List Path) Error =
+export def linkO (variant: String): (extraFlags: List String) => (objects: List Path) => (targ: String) => Result (List Path) Error =
     pickVariant variant (subscribe linkO)

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -16,38 +16,41 @@
 package wake
 
 export tuple Usage = # Unknown quantities are 0
-  export Status:   Integer
-  export Runtime:  Double
-  export CPUtime:  Double
-  export MemBytes: Integer
-  export InBytes:  Integer
-  export OutBytes: Integer
+    export Status:   Integer
+    export Runtime:  Double
+    export CPUtime:  Double
+    export MemBytes: Integer
+    export InBytes:  Integer
+    export OutBytes: Integer
 
 export def getUsageThreads (Usage _ run cpu _ _ _: Usage): Double =
-  if run ==. 0.0 then cpu else cpu /. run
+    if run ==. 0.0 then
+        cpu
+    else
+        cpu /. run
 
 # RunnerInput is a subset of the fields supplied in the execution Plan
 export tuple RunnerInput =
-  export Label:       String
-  export Command:     List String
-  export Visible:     List Path
-  export Environment: List String
-  export Directory:   String
-  export Stdin:       String
-  export Resources:   List String
-  export Prefix:      String        # a unique prefix for this job
-  export Record:      Usage         # previous resource usage
+    export Label:       String
+    export Command:     List String
+    export Visible:     List Path
+    export Environment: List String
+    export Directory:   String
+    export Stdin:       String
+    export Resources:   List String
+    export Prefix:      String        # a unique prefix for this job
+    export Record:      Usage         # previous resource usage
 
 export tuple RunnerOutput =
-  export Inputs:  List String
-  export Outputs: List String
-  export Usage:   Usage
+    export Inputs:  List String
+    export Outputs: List String
+    export Usage:   Usage
 
 # A Runner describes a way to invoke a Plan to get a Job
 tuple Runner =
-  export Name:  String
-  export Score: Plan => Result Double String
-  Fn:           Job => Result RunnerInput Error => Result RunnerOutput Error
+    export Name: String
+    export Score: Plan => Result Double String
+    Fn: Job => Result RunnerInput Error => Result RunnerOutput Error
 
 # Create new Runner given pre- and post-hooks around an existing Runner
 # param name: String
@@ -61,106 +64,130 @@ tuple Runner =
 #   i.e. localRISCVRunner is built on localRunner.
 
 export def makeRunner (name: String) (score: Plan => Result Double String) (pre: Result RunnerInput Error => Pair (Result RunnerInput Error) a) (post: Pair (Result RunnerOutput Error) a => Result RunnerOutput Error) (Runner _ _ run: Runner): Runner =
-  def doit job preInput = match (pre preInput)
-    Pair runInput state =
-      def runOutput = run job runInput
-      def final _ = post (Pair runOutput state)
-      # Don't run any 'post' steps until the Job has stopped running
-      waitJobMerged final job
-  Runner name score doit
+    def doit job preInput =
+        def Pair runInput state =
+            pre preInput
+        def runOutput =
+            run job runInput
+        def final _ =
+            post (Pair runOutput state)
+        # Don't run any 'post' steps until the Job has stopped running
+        waitJobMerged final job
+    Runner name score doit
 
 export data Persistence =
-  ReRun	# Job should be re-executed on every runJob call
-  Once	# Job should only be run once in a given wake execution
-  Keep	# Job should output be reusable between wake invocations
-  Share	# Job should output be shared between workspaces
+    ReRun   # Job should be re-executed on every runJob call
+    Once    # Job should only be run once in a given wake execution
+    Keep    # Job should output be reusable between wake invocations
+    Share   # Job should output be shared between workspaces
 
 # A Plan describes a not-yet-executed Job
 tuple Plan =
-  export Label:        String       # The label used when showing the command during execution
-  export Command:      List String  # The command-line arguments (the first is the command to run)
-  export Visible:      List Path    # Only these files should be available to the command
-  export Environment:  List String  # KEY=VALUE environment variables fed to the command
-  export Directory:    String       # The directory in which the command should be run
-  export Stdin:        String       # The file to which standard input should be connected
-  export Stdout:       LogLevel     # How should standard output be displayed during a build
-  export Stderr:       LogLevel     # How should standard error be displayed during a build
-  export Echo:         LogLevel     # Echo the command to this stream
-  export Persistence:  Persistence  # See Persistence table above
-  export LocalOnly:    Boolean      # Must run directly in the local workspace; no output detection performed
-  export Resources:    List String  # The resources a runner must provide to the job (licenses/etc)
-  export RunnerFilter: Runner => Boolean # Reject from consideration Runners which the Plan deems inappropriate
-  export Usage:        Usage        # User-supplied usage prediction; overruled by database statistics (if any)
-  export FnInputs:     (List String => List String) # Modify the Runner's reported inputs  (files read)
-  export FnOutputs:    (List String => List String) # Modify the Runner's reported outputs (files created)
+    export Label:        String       # The label used when showing the command during execution
+    export Command:      List String  # The command-line arguments (the first is the command to run)
+    export Visible:      List Path    # Only these files should be available to the command
+    export Environment:  List String  # KEY=VALUE environment variables fed to the command
+    export Directory:    String       # The directory in which the command should be run
+    export Stdin:        String       # The file to which standard input should be connected
+    export Stdout:       LogLevel     # How should standard output be displayed during a build
+    export Stderr:       LogLevel     # How should standard error be displayed during a build
+    export Echo:         LogLevel     # Echo the command to this stream
+    export Persistence:  Persistence  # See Persistence table above
+    export LocalOnly:    Boolean      # Must run directly in the local workspace; no output detection performed
+    export Resources:    List String  # The resources a runner must provide to the job (licenses/etc)
+    export RunnerFilter: Runner => Boolean # Reject from consideration Runners which the Plan deems inappropriate
+    export Usage:        Usage        # User-supplied usage prediction; overruled by database statistics (if any)
+    export FnInputs:     List String => List String # Modify the Runner's reported inputs  (files read)
+    export FnOutputs:    List String => List String # Modify the Runner's reported outputs (files created)
 
 def isOnce: Persistence => Boolean = match _
-  ReRun = False
-  _     = True
+    ReRun =
+        False
+    _ =
+        True
 def isKeep: Persistence => Boolean = match _
-  ReRun = False
-  Once  = False
-  _     = True
+    ReRun =
+        False
+    Once =
+        False
+    _ =
+        True
 def isShare: Persistence => Boolean = match _
-  Share = True
-  _     = False
+    Share =
+        True
+    _ =
+        False
 
 # Convenience accessor methods
 export def getPlanOnce (p: Plan): Boolean =
-  isOnce (getPlanPersistence p)
+    isOnce (getPlanPersistence p)
 export def getPlanKeep (p: Plan): Boolean =
-  isKeep (getPlanPersistence p)
+    isKeep (getPlanPersistence p)
 export def getPlanShare (p: Plan): Boolean =
-  isShare (getPlanPersistence p)
+    isShare (getPlanPersistence p)
 
 export def setPlanOnce (v: Boolean) (p: Plan): Plan =
-  editPlanOnce (\_ v) p
+    editPlanOnce (\_ v) p
 export def setPlanKeep (v: Boolean) (p: Plan): Plan =
-  editPlanKeep (\_ v) p
+    editPlanKeep (\_ v) p
 export def setPlanShare (v: Boolean) (p: Plan): Plan =
-  editPlanShare (\_ v) p
+    editPlanShare (\_ v) p
 
 # Prepend 'value' to the Plan's 'PATH' environment value
 export def prependPlanPath (value: String) (plan: Plan): Plan =
-  editPlanEnvironment (addEnvironmentPath value) plan
+    editPlanEnvironment (addEnvironmentPath value) plan
 
 # Set an environment variable in a Plan
 export def setPlanEnvVar (name: String) (value: String) (plan: Plan): Plan =
-  editPlanEnvironment ("{name}={value}", _) plan
+    editPlanEnvironment ("{name}={value}", _) plan
 
 # Helper methods that maintain the invariant that: Share => Keep => Once
 export def editPlanOnce (f: Boolean => Boolean): Plan => Plan =
-  def helper = match _
-    ReRun if   f False = Once
-    Once  if ! f True  = ReRun
-    Keep  if ! f True  = ReRun
-    Share if ! f True  = ReRun
-    x                  = x
-  editPlanPersistence helper
+    def helper = match _
+        ReRun if   f False =
+            Once
+        Once  if ! f True =
+            ReRun
+        Keep  if ! f True =
+            ReRun
+        Share if ! f True =
+            ReRun
+        x = x
+    editPlanPersistence helper
 
 export def editPlanKeep (f: Boolean => Boolean): Plan => Plan =
-  def helper = match _
-    ReRun if   f False = Keep
-    Once  if   f False = Keep
-    Keep  if ! f True  = Once
-    Share if ! f True  = Once
-    x                  = x
-  editPlanPersistence helper
+    def helper = match _
+        ReRun if   f False =
+            Keep
+        Once  if   f False =
+            Keep
+        Keep  if ! f True =
+            Once
+        Share if ! f True =
+            Once
+        x = x
+    editPlanPersistence helper
 
 export def editPlanShare (f: Boolean => Boolean): Plan => Plan =
-  def helper = match _
-    ReRun if   f False = Share
-    Once  if   f False = Share
-    Keep  if   f False = Share
-    Share if ! f True  = Keep
-    x                  = x
-  editPlanPersistence helper
+    def helper = match _
+        ReRun if   f False =
+            Share
+        Once  if   f False =
+            Share
+        Keep  if   f False =
+            Share
+        Share if ! f True =
+            Keep
+        x = x
+    editPlanPersistence helper
 
 # Get a unique hash-code for the job
 export def getPlanHash (plan: Plan): Integer =
-  def signature cmd env dir stdin = prim "hash"
-  def Plan _ cmd _ env dir stdin _ _ _ _ _ _ _ _ _ _ = plan
-  signature cmd env dir stdin
+    def signature cmd env dir stdin =
+        prim "hash"
+    def Plan _ cmd _ env dir stdin _ _ _ _ _ _ _ _ _ _ =
+        plan
+    signature cmd env dir stdin
 
 # The criteria which determine if Job execution can be skipped:
 #   Once  is True and a matching job was run by this wake invocation
@@ -176,243 +203,344 @@ export def getPlanHash (plan: Plan): Integer =
 
 # Create a labeled shell plan.
 export def makePlan (label: String) (visible: List Path) (command: String): Plan =
-  makeShellPlan command visible
-  | setPlanLabel label
+    makeShellPlan command visible
+    | setPlanLabel label
 
 # Set reasonable defaults for all Plan arguments
 def id x = x
 export def makeExecPlan (cmd: List String) (visible: List Path): Plan =
-  Plan "" cmd visible environment "." "" logInfo logWarning logEcho Share False Nil (\_ True) defaultUsage id id
+    Plan "" cmd visible environment "." "" logInfo logWarning logEcho Share False Nil (\_ True) defaultUsage id id
 
 export def makeShellPlan (script: String) (visible: List Path): Plan =
-  makeExecPlan (which "dash", "-c", script, Nil) visible
+    makeExecPlan (which "dash", "-c", script, Nil) visible
 
 def defaultUsage = Usage 0 0.0 1.0 0 0 0
 
 # This runner does not detect inputs/outputs on it's own
 # You must use Fn{Inputs,Outputs} to fill in this information
 export def localRunner: Runner =
-  def launch job dir stdin env cmd status runtime cputime membytes ibytes obytes = prim "job_launch"
-  def badlaunch job error = prim "job_fail_launch"
-  def doit job = match _
-    Fail e =
-      def _ = badlaunch job e
-      Fail e
-    Pass (RunnerInput _ cmd vis env dir stdin _ _ predict) = match (findSomeFn getPathError vis)
-      Some e =
-        def _ = badlaunch job e
-        Fail e
-      None =
-        def Usage status runtime cputime mem in out = predict
-        def _ = launch job dir stdin env.implode cmd.implode status runtime cputime mem in out
-        match (getJobReality job)
-          Pass reality = Pass (RunnerOutput (map getPathName vis) Nil reality)
-          Fail f = Fail f
-  def score plan =
-    if plan.getPlanLocalOnly then Pass 1.0 else Fail "cannot detect outputs"
-  Runner "local" score doit
+    def launch job dir stdin env cmd status runtime cputime membytes ibytes obytes =
+        prim "job_launch"
+    def badlaunch job error =
+        prim "job_fail_launch"
+    def doit job = match _
+        Fail e =
+            def _ = badlaunch job e
+            Fail e
+        Pass (RunnerInput _ cmd vis env dir stdin _ _ predict) = match (findSomeFn getPathError vis)
+            Some e =
+                def _ = badlaunch job e
+                Fail e
+            None =
+                def Usage status runtime cputime mem in out =
+                    predict
+                def _ = launch job dir stdin env.implode cmd.implode status runtime cputime mem in out
+                match (getJobReality job)
+                    Pass reality =
+                        Pass (RunnerOutput (map getPathName vis) Nil reality)
+                    Fail f =
+                        Fail f
+    def score plan =
+        if plan.getPlanLocalOnly then
+            Pass 1.0
+        else
+            Fail "cannot detect outputs"
+    Runner "local" score doit
 
 export def virtualRunner: Runner =
-  def virtual job stdout stderr status runtime cputime membytes ibytes obytes = prim "job_virtual"
-  def badlaunch job error = prim "job_fail_launch"
-  def doit job = match _
-    Fail e =
-      def _ = badlaunch job e
-      Fail e
-    Pass (RunnerInput _ _ vis _ _ _ _ _ predict) = match (findSomeFn getPathError vis)
-      Some e =
-        def _ = badlaunch job e
-        Fail e
-      None =
-        def Usage status runtime cputime mem in out = predict
-        def _ = virtual job "" "" status runtime cputime mem in out # sets predict+reality
-        match (getJobReality job)
-          Pass reality = Pass (RunnerOutput (map getPathName vis) Nil reality)
-          Fail f = Fail f
-  Runner "virtual" (\_ Pass 0.0) doit
+    def virtual job stdout stderr status runtime cputime membytes ibytes obytes =
+        prim "job_virtual"
+    def badlaunch job error =
+        prim "job_fail_launch"
+    def doit job = match _
+        Fail e =
+            def _ = badlaunch job e
+            Fail e
+        Pass (RunnerInput _ _ vis _ _ _ _ _ predict) = match (findSomeFn getPathError vis)
+            Some e =
+                def _ = badlaunch job e
+                Fail e
+            None =
+                def Usage status runtime cputime mem in out =
+                    predict
+                def _ = virtual job "" "" status runtime cputime mem in out # sets predict+reality
+                match (getJobReality job)
+                    Pass reality =
+                        Pass (RunnerOutput (map getPathName vis) Nil reality)
+                    Fail f =
+                        Fail f
+    Runner "virtual" (\_ Pass 0.0) doit
 
-def pid = prim "pid"
+def pid =
+    prim "pid"
 
-def implode l = cat (foldr (_, "\0", _) Nil l)
+def implode l =
+    cat (foldr (_, "\0", _) Nil l)
 def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo stdout stderr label: Job =
-  def create label dir stdin env cmd signature visible keep echo stdout stderr = prim "job_create"
-  def finish job inputs outputs status runtime cputime membytes ibytes obytes = prim "job_finish"
-  def badfinish job error = prim "job_fail_finish"
-  def cache dir stdin env cmd signature visible = prim "job_cache"
-  def signature cmd res fni fno keep = prim "hash"
-  def hash = signature cmd res finputs foutputs keep
-  def build Unit =
-    def getPathOpt = match _
-      Path name = Some name
-      BadPath _ = None
-    def job = create label dir stdin env.implode cmd.implode hash (mapPartial getPathOpt vis).implode (if keep then 1 else 0) echo stdout stderr
-    def prefix = "{str pid}.{str (getJobId job)}"
-    def usage = getJobRecord job | getOrElse uusage
-    def output = run job (Pass (RunnerInput label cmd vis env dir stdin res prefix usage))
-    def final _ = match output
-      Fail e =
-        badfinish job e
-      Pass (RunnerOutput inputs outputs (Usage status runtime cputime mem in out)) =
-        def input  = finputs  inputs  | map simplify | implode
-        def output = foutputs outputs | map addhash  | implode
-        finish job input output status runtime cputime mem in out
-    # Make sure we don't hash files before the job has stopped running
-    def _ = waitJobMerged final job
-    job
-  def confirm abort last job =
-    # notOk cannot be deadcode eliminated thanks to printlnLevel having effects
-    def notOk (Pair name hash) =
-      if hashcode name ==* hash then Unit else
-      if abort # The panic will not be deadcode dropped, because it's an alternative return of the effect-ful notOk
-      # This use of unreachable is not ok!
-      then unreachable "The hashcode of output file '{name}' has changed from {hash} (when wake last ran) to {hashcode name} (when inspected this time). Presumably it was hand edited. Please move this file out of the way. Aborting the build to prevent loss of your data."
-      else printlnLevel logError "Wake was run with '-c' and the hashcode of output file '{name}' has changed, despite being produced from identical inputs. In the prior run, it was {hash} and now it is {hashcode name}. Hashes of dependent jobs using this file will not be checked."
-    def _ = waitJobMerged (\_ map notOk last) job
-    job
-  match keep
-    False = build Unit
-    True  = match (cache dir stdin env.implode cmd.implode hash (map getPathName vis).implode)
-      Pair (job, _) last = confirm True  last job
-      Pair Nil      last = confirm False last (build Unit)
+    def create label dir stdin env cmd signature visible keep echo stdout stderr =
+        prim "job_create"
+    def finish job inputs outputs status runtime cputime membytes ibytes obytes =
+        prim "job_finish"
+    def badfinish job error =
+        prim "job_fail_finish"
+    def cache dir stdin env cmd signature visible =
+        prim "job_cache"
+    def signature cmd res fni fno keep =
+        prim "hash"
+    def hash =
+        signature cmd res finputs foutputs keep
+    def build Unit =
+        def getPathOpt = match _
+            Path name =
+                Some name
+            BadPath _ =
+                None
+        def job =
+            create label dir stdin env.implode cmd.implode hash (mapPartial getPathOpt vis).implode (if keep then 1 else 0) echo stdout stderr
+        def prefix =
+            "{str pid}.{str (getJobId job)}"
+        def usage =
+            getJobRecord job
+            | getOrElse uusage
+        def output =
+            RunnerInput label cmd vis env dir stdin res prefix usage
+            | Pass
+            | run job
+        def final _ = match output
+            Fail e =
+                badfinish job e
+            Pass (RunnerOutput inputs outputs (Usage status runtime cputime mem in out)) =
+                def input =
+                    finputs inputs
+                    | map simplify
+                    | implode
+                def output =
+                    foutputs outputs
+                    | map addhash
+                    | implode
+                finish job input output status runtime cputime mem in out
+        # Make sure we don't hash files before the job has stopped running
+        def _ = waitJobMerged final job
+        job
+    def confirm abort last job =
+        # notOk cannot be deadcode eliminated thanks to printlnLevel having effects
+        def notOk (Pair name hash) =
+            if hashcode name ==* hash then
+                Unit
+            else if abort then
+                # The panic will not be deadcode dropped, because it's an alternative return of the effect-ful notOk
+                # This use of unreachable is not ok!
+                unreachable "The hashcode of output file '{name}' has changed from {hash} (when wake last ran) to {hashcode name} (when inspected this time). Presumably it was hand edited. Please move this file out of the way. Aborting the build to prevent loss of your data."
+            else
+                printlnLevel logError "Wake was run with '-c' and the hashcode of output file '{name}' has changed, despite being produced from identical inputs. In the prior run, it was {hash} and now it is {hashcode name}. Hashes of dependent jobs using this file will not be checked."
+        def _ = waitJobMerged (\_ map notOk last) job
+        job
+    match keep
+        False =
+            build Unit
+        True = match (cache dir stdin env.implode cmd.implode hash (map getPathName vis).implode)
+            Pair (job, _) last =
+                confirm True last job
+            Pair Nil last =
+                build Unit
+                | confirm False last
 
 # Only run if the first four arguments differ
 target runOnce cmd env dir stdin \ res usage finputs foutputs vis keep run echo stdout stderr label =
-  runAlways cmd env dir stdin res usage finputs foutputs vis keep run echo stdout stderr label
+    runAlways cmd env dir stdin res usage finputs foutputs vis keep run echo stdout stderr label
 
 # Default runners provided by wake
 export topic runner: Runner
-publish runner = localRunner, defaultRunner, Nil
+publish runner =
+    localRunner, defaultRunner, Nil
 
 def runJobImp label cmd env dir stdin res usage finputs foutputs vis pers run (LogLevel echo) (LogLevel stdout) (LogLevel stderr) =
-  if isOnce pers
-  then runOnce   cmd env dir stdin res usage finputs foutputs vis (isKeep pers) run echo stdout stderr label
-  else runAlways cmd env dir stdin res usage finputs foutputs vis (isKeep pers) run echo stdout stderr label
+    def runFn =
+        if isOnce pers then
+            runOnce
+        else
+            runAlways
+    runFn cmd env dir stdin res usage finputs foutputs vis (isKeep pers) run echo stdout stderr label
 
 export def runJobWith (Runner _ _ run: Runner) (Plan label cmd vis env dir stdin stdout stderr echo pers _ res _ usage finputs foutputs: Plan): Job =
-  runJobImp label cmd env dir stdin res usage finputs foutputs vis pers run echo stdout stderr
+    runJobImp label cmd env dir stdin res usage finputs foutputs vis pers run echo stdout stderr
 
 data RunnerOption =
-  Accept (score: Double) (runnerFn: Job => Result RunnerInput Error => Result RunnerOutput Error)
-  Reject (why: String)
+    Accept (score: Double) (runnerFn: Job => Result RunnerInput Error => Result RunnerOutput Error)
+    Reject (why: String)
 
 # Run the job!
 export def runJob (p: Plan): Job = match p
-  Plan label cmd vis env dir stdin stdout stderr echo pers _lo res rf usage finputs foutputs =
-    # Transform the 'List Runner' into 'List RunnerOption'
-    def qualify runner = match runner
-      Runner name _ _ if ! rf runner = Reject "{name}: rejected by Plan"
-      Runner name scorefn fn = match (scorefn p)
-        Pass x if x <=. 0.0 = Reject "{name}: non-positive score"
-        Pass x = Accept x fn
-        Fail x = Reject "{name} {x}"
-    def opts = subscribe runner | map qualify
-    def best acc = match _ acc
-      (Reject _) _ = acc
-      (Accept score fn) (Pair bests _bestr) =
-        if score >. bests then Pair score (Some fn) else acc
-    match (opts | foldl best (Pair 0.0 None) | getPairSecond)
-      Some r = runJobImp label cmd env dir stdin res usage finputs foutputs vis pers r echo stdout stderr
-      None =
-        def create label dir stdin env cmd signature visible keep echo stdout stderr = prim "job_create"
-        def badfinish job e = prim "job_fail_finish"
-        def badlaunch job e = prim "job_fail_launch"
-        def job = create label dir stdin env.implode cmd.implode 0 "" 0 "echo" "info" "error"
-        def error =
-          def pretty = match _
-            Accept _ _ = ""
-            Reject why = why
-          makeError "No runner for '{job.getJobDescription}' available, because: {map pretty opts | catWith ", "}"
-        # Make sure badlaunch completes before badfinish
-        def _ = wait (\_ badfinish job error) (badlaunch job error)
-        job
+    Plan label cmd vis env dir stdin stdout stderr echo pers _lo res rf usage finputs foutputs =
+        # Transform the 'List Runner' into 'List RunnerOption'
+        def qualify runner = match runner
+            Runner name _ _ if ! rf runner =
+                Reject "{name}: rejected by Plan"
+            Runner name scorefn fn = match (scorefn p)
+                Pass x if x <=. 0.0 =
+                    Reject "{name}: non-positive score"
+                Pass x =
+                    Accept x fn
+                Fail x =
+                    Reject "{name} {x}"
+        def opts =
+            subscribe runner
+            | map qualify
+        def best acc = match _ acc
+            (Reject _) _ =
+                acc
+            (Accept score fn) (Pair bests _bestr) =
+                if score >. bests then
+                    Pair score (Some fn)
+                else
+                    acc
+        match (opts | foldl best (Pair 0.0 None) | getPairSecond)
+            Some r =
+                runJobImp label cmd env dir stdin res usage finputs foutputs vis pers r echo stdout stderr
+            None =
+                def create label dir stdin env cmd signature visible keep echo stdout stderr =
+                    prim "job_create"
+                def badfinish job e =
+                    prim "job_fail_finish"
+                def badlaunch job e =
+                    prim "job_fail_launch"
+                def job =
+                    create label dir stdin env.implode cmd.implode 0 "" 0 "echo" "info" "error"
+                def error =
+                    def pretty = match _
+                        Accept _ _ =
+                            ""
+                        Reject why =
+                            why
+                    makeError "No runner for '{job.getJobDescription}' available, because: {map pretty opts | catWith ", "}"
+                # Make sure badlaunch completes before badfinish
+                def _ = wait (\_ badfinish job error) (badlaunch job error)
+                job
 
 # Set the value of a tag on a Job
 # This is useful for post-build reflection into the database
 export def setJobTag (key: String) (value: String) (job: Job): Job =
-  def p job key value = prim "job_tag"
-  def _ = p job key value
-  job
+    def p job key value =
+        prim "job_tag"
+    def _ = p job key value
+    job
 
 def toUsage (Pair (Pair status runtime) (Pair (Pair cputime membytes) (Pair ibytes obytes))) =
-  Usage status runtime cputime membytes ibytes obytes
+    Usage status runtime cputime membytes ibytes obytes
 
 def getJobReality (job: Job): Result Usage Error =
-  def raw job = prim "job_reality"
-  raw job | rmap toUsage
+    def raw job =
+        prim "job_reality"
+    raw job
+    | rmap toUsage
 
 def waitJobMerged (f: Unit => a) (job: Job): a =
-  def raw job = prim "job_reality"
-  wait (\_ f Unit) (raw job)
+    def raw job =
+        prim "job_reality"
+    raw job
+    | wait (\_ f Unit)
 
 # Actual usage of a finished job
 export def getJobReport (job: Job): Result Usage Error =
-  def raw job = prim "job_report"
-  raw job | rmap toUsage
+    def raw job =
+        prim "job_report"
+    raw job
+    | rmap toUsage
 
 # From database, available the moment a Job exists
 export def getJobRecord (job: Job): Option Usage =
-  def raw job = prim "job_record"
-  raw job | at 0 | omap toUsage
+    def raw job =
+        prim "job_record"
+    raw job
+    | at 0
+    | omap toUsage
 
 export def makeBadPath (error: Error): Path =
-  BadPath error
+    BadPath error
 
 # Control a running/finished Job
-def stdio job fd  = prim "job_output" # 1=stdout, 2=stderr; blocks till closed
-def tree  job typ = prim "job_tree"   # 0=visible, 1=input, 2=output; blocks till finished
+def stdio job fd =
+    prim "job_output" # 1=stdout, 2=stderr; blocks till closed
+def tree job typ =
+    prim "job_tree"   # 0=visible, 1=input, 2=output; blocks till finished
 def treeOk (Pair f h) = match h
-  "BadHash" = BadPath (makeError "Could not hash {f}")
-  _ = Path f
+    "BadHash" =
+        BadPath (makeError "Could not hash {f}")
+    _ =
+        Path f
 def guardPath job = match _
-  Fail e = BadPath e, Nil
-  Pass l if job.isJobOk = map treeOk l
-  _ = makeBadPath (makeError "Non-zero exit status ({format job.getJobStatus}) for '{job.getJobDescription}'"), Nil
+    Fail e =
+        BadPath e, Nil
+    Pass l if job.isJobOk =
+        map treeOk l
+    _ =
+        makeError "Non-zero exit status ({format job.getJobStatus}) for '{job.getJobDescription}'"
+        | (makeBadPath _, Nil)
 def mapPath = match _
-  Fail e = BadPath e, Nil
-  Pass l = map treeOk l
+    Fail e =
+        BadPath e, Nil
+    Pass l =
+        map treeOk l
 
 export def killJob (job: Job) (signal: Integer): Unit =
-  (\j\s prim "job_kill") job signal # send signal to job
+    (\j\s prim "job_kill") job signal # send signal to job
 export def getJobStdout (job: Job): Result String Error =
-  stdio job 1
+    stdio job 1
 export def getJobStderr (job: Job): Result String Error =
-  stdio job 2
+    stdio job 2
 export def getJobInputs (job: Job): List Path =
-  tree job 1 | guardPath job
+    tree job 1
+    | guardPath job
 export def getJobOutputs (job: Job): List Path =
-  tree job 2 | guardPath job
+    tree job 2
+    | guardPath job
 export def getJobFailedInputs (job: Job): List Path =
-  tree job 1 | mapPath
+    tree job 1
+    | mapPath
 export def getJobFailedOutputs (job: Job): List Path =
-  tree job 2 | mapPath
+    tree job 2
+    | mapPath
 export def getJobId (job: Job): Integer =
-  (\j prim "job_id") job
+    (\j prim "job_id") job
 export def getJobDescription (job: Job): String =
-  (\j prim "job_desc") job
+    (\j prim "job_desc") job
 export def getJobOutput (job: Job): Path = match (tree job 2)
-  Fail e = BadPath e
-  Pass l if job.isJobOk = match l
-    (Pair f _), Nil = Path f
-    Nil    = makeBadPath (makeError "No outputs available from '{job.getJobDescription}'")
-    _      = makeBadPath (makeError "More than one output found from '{job.getJobDescription}'")
-  _ = makeBadPath (makeError "Non-zero exit status ({format job.getJobStatus}) for '{job.getJobDescription}'")
+    Fail e =
+        BadPath e
+    Pass l if job.isJobOk = match l
+        (Pair f _), Nil =
+            Path f
+        Nil =
+            makeError "No outputs available from '{job.getJobDescription}'"
+            | makeBadPath
+        _ =
+            makeError "More than one output found from '{job.getJobDescription}'"
+            | makeBadPath
+    _ =
+        makeError "Non-zero exit status ({format job.getJobStatus}) for '{job.getJobDescription}'"
+        | makeBadPath
 
 export def isJobOk (job: Job): Boolean = match (getJobReport job)
-  Fail _ = False
-  Pass u = u.getUsageStatus == 0
+    Fail _ =
+        False
+    Pass u =
+        u.getUsageStatus == 0
 
 export data Status =
-  Exited   Integer
-  Signaled Integer
-  Aborted  Error
+    Exited   Integer
+    Signaled Integer
+    Aborted  Error
 
 export def getJobStatus (job: Job): Status = match (getJobReport job)
-  Fail f = Aborted f
-  Pass u =
-    def status = u.getUsageStatus
-    if status >= 0
-    then Exited status
-    else Signaled (-status)
+    Fail f =
+        Aborted f
+    Pass u =
+        def status =
+            u.getUsageStatus
+        if status >= 0 then
+            Exited status
+        else
+            Signaled (-status)
 
 # Implement FUSE-based Runner
 # The FUSE runner on linux supports a few isolation options via resources:
@@ -422,36 +550,50 @@ export def getJobStatus (job: Job): Status = match (getJobReport job)
 # - "isolate/workspace": makes the build appear run in /var/cache/wake
 #    ... if /var/cache/wake does not exist, a directory 'build/wake' is
 #        used relative to where wake has been installed
-export def wakePath: String = prim "execpath" # location of the wake executable
+export def wakePath: String =
+    prim "execpath" # location of the wake executable
 export def fuseRunner: Runner =
-  def fuse = "{wakePath}/fuse-wake"
-  def score plan =
-    if plan.getPlanLocalOnly then Fail "would hide workspace" else Pass 1.0
-  makeJSONRunnerPlan fuse score
-  | editJSONRunnerPlanExtraEnv (editEnvironment "DEBUG_FUSE_WAKE" (\_ getenv "DEBUG_FUSE_WAKE"))
-  | makeJSONRunner
+    def fuse =
+        "{wakePath}/fuse-wake"
+    def score plan =
+        if plan.getPlanLocalOnly then
+            Fail "would hide workspace"
+        else
+            Pass 1.0
+    makeJSONRunnerPlan fuse score
+    | editJSONRunnerPlanExtraEnv (editEnvironment "DEBUG_FUSE_WAKE" (\_ getenv "DEBUG_FUSE_WAKE"))
+    | makeJSONRunner
 
 export def preloadRunner: Runner =
-  def preload = "{wakePath}/preload-wake"
-  def score plan =
-    if plan.getPlanLocalOnly then Fail "would hide workspace" else Pass 1.0
-  makeJSONRunnerPlan preload score
-  | makeJSONRunner
+    def preload =
+        "{wakePath}/preload-wake"
+    def score plan =
+        if plan.getPlanLocalOnly then
+            Fail "would hide workspace"
+        else
+            Pass 1.0
+    makeJSONRunnerPlan preload score
+    | makeJSONRunner
 
 export def rOK: Integer = 0
 export def wOK: Integer = 1
 export def xOK: Integer = 2
 export def access (file: String) (mode: Integer): Boolean =
-  (\f\m prim "access") file mode
+    (\f\m prim "access") file mode
 
 export def defaultRunner: Runner = match sysname
-  "Darwin" = fuseRunner
-  _ = match (getenv "USE_FUSE_WAKE")
-    Some "0" = preloadRunner
-    Some _ = fuseRunner
-    None =
-      def fuse = access "/dev/fuse" wOK
-      if fuse then fuseRunner else preloadRunner
+    "Darwin" = fuseRunner
+    _ = match (getenv "USE_FUSE_WAKE")
+        Some "0" =
+            preloadRunner
+        Some _ =
+            fuseRunner
+        None =
+            def fuse = access "/dev/fuse" wOK
+            if fuse then
+                fuseRunner
+            else
+                preloadRunner
 
 # A plan describing how to construct a JSONRunner
 # RawScript: the path to the script to run jobs with
@@ -460,169 +602,231 @@ export def defaultRunner: Runner = match sysname
 # Score: runJob chooses the runner with the largest score for a Plan
 # Estimate: predict local usage based on prior recorded usage
 tuple JSONRunnerPlan =
-  export RawScript: String
-  export ExtraArgs: List String
-  export ExtraEnv: List String
-  export Score: Plan => Result Double String
-  export Estimate: Usage => Usage
+    export RawScript: String
+    export ExtraArgs: List String
+    export ExtraEnv: List String
+    export Score: Plan => Result Double String
+    export Estimate: Usage => Usage
 
 # make a ``JSONRunnerPlan`` with ``Nil`` and ``(_)`` as defaults for ``ExtraArgs`` and ``Estimate`` respectively
 # rawScript: String; the path to the script to run jobs with
 # score: runJob chooses the runner with the largest score for a Plan
 export def makeJSONRunnerPlan (rawScript: String) (score: Plan => Result Double String): JSONRunnerPlan =
-  JSONRunnerPlan rawScript Nil Nil score (_)
+    JSONRunnerPlan rawScript Nil Nil score (_)
 
 # Make a Runner that runs a named script to run jobs
 # plan: JSONRunnerPlan; a tuple containing the arguments for this function
 export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
-  def rawScript = plan.getJSONRunnerPlanRawScript
-  def extraArgs = plan.getJSONRunnerPlanExtraArgs
-  def extraEnv = plan.getJSONRunnerPlanExtraEnv
-  def score = plan.getJSONRunnerPlanScore
-  def estimate = plan.getJSONRunnerPlanEstimate
+    def rawScript =
+        plan.getJSONRunnerPlanRawScript
+    def extraArgs =
+        plan.getJSONRunnerPlanExtraArgs
+    def extraEnv =
+        plan.getJSONRunnerPlanExtraEnv
+    def score =
+        plan.getJSONRunnerPlanScore
+    def estimate =
+        plan.getJSONRunnerPlanEstimate
 
-  def script = which (simplify rawScript)
-  def ok = access script xOK
-  def pre = match _
-    Fail f = Pair (Fail f) ""
-    _ if ! ok = Pair (Fail (makeError "Runner {script} is not executable")) ""
-    Pass (RunnerInput label command visible environment directory stdin res prefix record) = match (findSomeFn getPathError visible)
-      Some e = Pair (Fail e) ""
-      None =
-        def Usage status runtime cputime membytes inbytes outbytes = record
-        def pmkdir m p = prim "mkdir"
-        def pwrite m p d = prim "write"
-        def json = JObject (
-          "label"       → JString label,
-          "command"     → command     | map JString | JArray,
-          "environment" → environment | map JString | JArray,
-          "visible"     → visible | map (_.getPathName.JString) | JArray,
-          "directory"   → JString directory,
-          "stdin"       → JString stdin,
-          "resources"   → res | map JString | JArray,
-          "version"     → JString version,
-          "mount-ops"      → JArray (
-            JObject (
-              "type"        → JString "workspace",
-              "destination" → JString ".",
-              Nil
-            ),
-            Nil
-          ),
-          "usage"       → JObject (
-            "status"    → JInteger status,
-            "runtime"   → JDouble  runtime,
-            "cputime"   → JDouble  cputime,
-            "membytes"  → JInteger membytes,
-            "inbytes"   → JInteger inbytes,
-            "outbytes"  → JInteger outbytes,
-            Nil
-          ),
-          Nil
-        )
-        match (pmkdir 0775 ".build")
-          Fail f = Pair (Fail (makeError f)) ""
-          Pass build = match (pwrite 0664 "{build}/{prefix}.in.json" (prettyJSON json))
-            Fail f = Pair (Fail (makeError f)) ""
-            Pass inFile =
-              def outFile = "{build}/{prefix}.out.json"
-              def cmd = script, inFile, outFile, extraArgs
-              def proxy = RunnerInput label cmd Nil (extraEnv ++ environment) "." "" Nil prefix (estimate record)
-              Pair (Pass proxy) inFile
-  def post = match _
-    Pair (Fail f) _ = Fail f
-    Pair (Pass (RunnerOutput _ _ (Usage x _ _ _ _ _))) inFile if x != 0 =
-      Fail (makeError "Non-zero exit status ({str x}) for JSON runner {script} on {inFile}")
-    Pair (Pass _) inFile =
-      def unlink f =
-        def fn _ = prim "unlink"
-        match (getenv "FUSE_WAKE_KEEP_IO_FILES")
-          Some "1" = Unit
-          _        = fn f
-      def outFile = replace `\.in\.json$` ".out.json" inFile
-      def json = parseJSONFile (Path outFile)
-      def _ = unlink inFile
-      match json
-        Fail f = Fail f
-        Pass content =
-          def _ = unlink outFile
-          def field name = match _ _
-             _ (Fail f) = Fail f
-             None (Pass fn) = Fail "{script} produced {outFile}, which is missing usage/{name}"
-             (Some x) (Pass fn) = Pass (fn x)
-          def usage = content // `usage`
-          def usageResult =
-            Pass (Usage _ _ _ _ _ _)
-            | field "status"   (usage // `status`   | getJInteger)
-            | field "runtime"  (usage // `runtime`  | getJDouble)
-            | field "cputime"  (usage // `cputime`  | getJDouble)
-            | field "membytes" (usage // `membytes` | getJInteger)
-            | field "inbytes"  (usage // `inbytes`  | getJInteger)
-            | field "outbytes" (usage // `outbytes` | getJInteger)
-          def getK exp = content // exp | getJArray | getOrElse Nil | mapPartial getJString
-          match usageResult
-            Fail f = Fail (makeError f)
-            Pass usage = Pass (RunnerOutput (getK `inputs`) (getK `outputs`) usage)
-  makeRunner "json-{script}" score pre post localRunner
+    def script =
+        simplify rawScript
+        | which
+    def ok =
+        access script xOK
+    def pre = match _
+        Fail f =
+            Pair (Fail f) ""
+        _ if ! ok =
+            failWithError "Runner {script} is not executable"
+            | (Pair _ "")
+        Pass (RunnerInput label command visible environment directory stdin res prefix record) = match (findSomeFn getPathError visible)
+            Some e =
+                Pair (Fail e) ""
+            None =
+                def Usage status runtime cputime membytes inbytes outbytes = record
+                def pmkdir m p =
+                    prim "mkdir"
+                def pwrite m p d =
+                    prim "write"
+                def json = JObject (
+                    "label"       → JString label,
+                    "command"     → command | map JString | JArray,
+                    "environment" → environment | map JString | JArray,
+                    "visible"     → visible | map (_.getPathName.JString) | JArray,
+                    "directory"   → JString directory,
+                    "stdin"       → JString stdin,
+                    "resources"   → res | map JString | JArray,
+                    "version"     → JString version,
+                    "mount-ops"   → JArray (
+                        JObject (
+                            "type"        → JString "workspace",
+                            "destination" → JString ".",
+                            Nil
+                        ),
+                        Nil
+                    ),
+                    "usage" → JObject (
+                        "status"    → JInteger status,
+                        "runtime"   → JDouble runtime,
+                        "cputime"   → JDouble cputime,
+                        "membytes"  → JInteger membytes,
+                        "inbytes"   → JInteger inbytes,
+                        "outbytes"  → JInteger outbytes,
+                        Nil
+                    ),
+                    Nil
+                )
+                match (pmkdir 0775 ".build")
+                    Fail f =
+                        Pair (failWithError f) ""
+                    Pass build = match (prettyJSON json | pwrite 0664 "{build}/{prefix}.in.json")
+                        Fail f = Pair (failWithError f) ""
+                        Pass inFile =
+                            def outFile =
+                                "{build}/{prefix}.out.json"
+                            def cmd =
+                                script, inFile, outFile, extraArgs
+                            def proxy =
+                                RunnerInput label cmd Nil (extraEnv ++ environment) "." "" Nil prefix (estimate record)
+                            Pair (Pass proxy) inFile
+    def post = match _
+        Pair (Fail f) _ = Fail f
+        Pair (Pass (RunnerOutput _ _ (Usage x _ _ _ _ _))) inFile if x != 0 =
+            failWithError "Non-zero exit status ({str x}) for JSON runner {script} on {inFile}"
+        Pair (Pass _) inFile =
+            def unlink f =
+                def fn _ =
+                    prim "unlink"
+                match (getenv "FUSE_WAKE_KEEP_IO_FILES")
+                    Some "1" =
+                        Unit
+                    _ =
+                        fn f
+            def outFile =
+                replace `\.in\.json$` ".out.json" inFile
+            def json =
+                Path outFile
+                | parseJSONFile
+            def _ = unlink inFile
+            match json
+                Fail f =
+                    Fail f
+                Pass content =
+                    def _ = unlink outFile
+                    def field name = match _ _
+                        _ (Fail f) =
+                            Fail f
+                        None (Pass fn) =
+                            Fail "{script} produced {outFile}, which is missing usage/{name}"
+                        (Some x) (Pass fn) =
+                            Pass (fn x)
+                    def usage =
+                        content // `usage`
+                    def usageResult =
+                        Pass (Usage _ _ _ _ _ _)
+                        | field "status"   (usage // `status`   | getJInteger)
+                        | field "runtime"  (usage // `runtime`  | getJDouble)
+                        | field "cputime"  (usage // `cputime`  | getJDouble)
+                        | field "membytes" (usage // `membytes` | getJInteger)
+                        | field "inbytes"  (usage // `inbytes`  | getJInteger)
+                        | field "outbytes" (usage // `outbytes` | getJInteger)
+                    def getK exp =
+                        content // exp
+                        | getJArray
+                        | getOrElse Nil
+                        | mapPartial getJString
+                    match usageResult
+                        Fail f =
+                            failWithError f
+                        Pass usage =
+                            Pass (RunnerOutput (getK `inputs`) (getK `outputs`) usage)
+    makeRunner "json-{script}" score pre post localRunner
 
 # Paths differ from Strings in that they have been hashed; their content is frozen
 from wake export type Path # Path constructor stays private!
 data Path =
-  Path    (name: String)
-  BadPath (error: Error)
+    Path    (name: String)
+    BadPath (error: Error)
 
 export def getPathResult (path: Path): Result Path Error = match path
-  BadPath e = Fail e
-  _         = Pass path
+    BadPath e =
+        Fail e
+    _ =
+        Pass path
 
 export def getPathError (path: Path): Option Error = match path
-  Path _    = None
-  BadPath e = Some e
+    Path _ =
+        None
+    BadPath e =
+        Some e
 
 export def getPathName (path: Path): String = match path
-  Path name = name
-  BadPath _ = "BADPATH"
+    Path name =
+        name
+    BadPath _ =
+        "BADPATH"
 
 export def getPathChild (path: Path): String = match path
-  Path name = replace `^.*/` '' name
-  BadPath _ = "BADPATH"
+    Path name =
+        replace `^.*/` '' name
+    BadPath _ =
+        "BADPATH"
 
 export def getPathParent (path: Path): Path = match path
-  Path name = Path (simplify "{name}/..")
-  BadPath e = BadPath e
+    Path name =
+        Path (simplify "{name}/..")
+    BadPath e =
+        BadPath e
 
 export def isPathDir: Path => Boolean = match _
-  BadPath _ = False
-  Path str = matches `0+` (hashcode str)
+    BadPath _ =
+        False
+    Path str =
+        matches `0+` (hashcode str)
 
 export def sortPaths (paths: List Path): List Path =
-  def fn a b = a.getPathName <~ b.getPathName
-  sortBy fn paths
+    def fn a b =
+        a.getPathName <~ b.getPathName
+    sortBy fn paths
 
 def addhash (f: String): String =
-  def p = simplify f
-  def add f h = prim "add_hash"
-  add p (hashcode p)
+    def p =
+        simplify f
+    def add f h =
+        prim "add_hash"
+    add p (hashcode p)
 
-def hashUsage = defaultUsage | setUsageCPUtime 0.1
+def hashUsage =
+    defaultUsage
+    | setUsageCPUtime 0.1
 target hashcode (f: String): String =
-  def get f = prim "get_hash"
-  def reuse = get f
-  if reuse !=* "" then reuse else
-    def hashPlan cmd  =
-      Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun True Nil (\_ True) hashUsage id id
-    def job = hashPlan ("<hash>", f, Nil) | runJobWith localRunner
-    def hash =
-      job.getJobStdout
-      | getWhenFail ""
-      | extract `(.{64}).*`
-    match job.isJobOk hash
-      True (x, Nil) = x
-      _ _ = "BadHash"
+    def get f =
+        prim "get_hash"
+    def reuse =
+        get f
+    if reuse !=* "" then
+        reuse
+    else
+        def hashPlan cmd  =
+            Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun True Nil (\_ True) hashUsage id id
+        def job =
+            hashPlan ("<hash>", f, Nil)
+            | runJobWith localRunner
+        def hash =
+            job.getJobStdout
+            | getWhenFail ""
+            | extract `(.{64}).*`
+        match job.isJobOk hash
+            True (x, Nil) =
+                x
+            _ _ =
+                "BadHash"
 
 export def getPathHash: Path => String = match _
-  Path    x = hashcode x
-  BadPath _ = "BadHash"
+    Path x =
+        hashcode x
+    BadPath _ =
+        "BadHash"
 
 # Whenever possible, use 'job' if:
 #   cmd can run under FUSE
@@ -633,9 +837,9 @@ export def getPathHash: Path => String = match _
 # If you miss declared visible inputs, your build will fail so you can fix it.
 # If you declare too many visible inputs, cmd execution/replay will wait for unnecessary files.
 export def job (cmd: List String) (visible: List Path): Job =
-  makeExecPlan cmd visible
-  | runJob
+    makeExecPlan cmd visible
+    | runJob
 
 export def shellJob (script: String) (visible: List Path): Job =
-  makeShellPlan script visible
-  | runJob
+    makeShellPlan script visible
+    | runJob

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -60,7 +60,7 @@ tuple Runner =
 # param (Runner _ _ run): base runner that the current runner is built on top of
 #   i.e. localRISCVRunner is built on localRunner.
 
-export def makeRunner name score pre post (Runner _ _ run) =
+export def makeRunner (name: String) (score: Plan => Result Double String) (pre: Result RunnerInput Error => Pair (Result RunnerInput Error) a) (post: Pair (Result RunnerOutput Error) a => Result RunnerOutput Error) (Runner _ _ run: Runner): Runner =
   def doit job preInput = match (pre preInput)
     Pair runInput state =
       def runOutput = run job runInput
@@ -106,13 +106,19 @@ def isShare: Persistence => Boolean = match _
   _     = False
 
 # Convenience accessor methods
-export def getPlanOnce  p = isOnce  (getPlanPersistence p)
-export def getPlanKeep  p = isKeep  (getPlanPersistence p)
-export def getPlanShare p = isShare (getPlanPersistence p)
+export def getPlanOnce (p: Plan): Boolean =
+  isOnce (getPlanPersistence p)
+export def getPlanKeep (p: Plan): Boolean =
+  isKeep (getPlanPersistence p)
+export def getPlanShare (p: Plan): Boolean =
+  isShare (getPlanPersistence p)
 
-export def setPlanOnce  v p = editPlanOnce  (\_ v) p
-export def setPlanKeep  v p = editPlanKeep  (\_ v) p
-export def setPlanShare v p = editPlanShare (\_ v) p
+export def setPlanOnce (v: Boolean) (p: Plan): Plan =
+  editPlanOnce (\_ v) p
+export def setPlanKeep (v: Boolean) (p: Plan): Plan =
+  editPlanKeep (\_ v) p
+export def setPlanShare (v: Boolean) (p: Plan): Plan =
+  editPlanShare (\_ v) p
 
 # Prepend 'value' to the Plan's 'PATH' environment value
 export def prependPlanPath (value: String) (plan: Plan): Plan =
@@ -282,7 +288,7 @@ def runJobImp label cmd env dir stdin res usage finputs foutputs vis pers run (L
   then runOnce   cmd env dir stdin res usage finputs foutputs vis (isKeep pers) run echo stdout stderr label
   else runAlways cmd env dir stdin res usage finputs foutputs vis (isKeep pers) run echo stdout stderr label
 
-export def runJobWith (Runner _ _ run) (Plan label cmd vis env dir stdin stdout stderr echo pers _ res _ usage finputs foutputs) =
+export def runJobWith (Runner _ _ run: Runner) (Plan label cmd vis env dir stdin stdout stderr echo pers _ res _ usage finputs foutputs: Plan): Job =
   runJobImp label cmd env dir stdin res usage finputs foutputs vis pers run echo stdout stderr
 
 data RunnerOption =
@@ -367,12 +373,18 @@ def mapPath = match _
 
 export def killJob (job: Job) (signal: Integer): Unit =
   (\j\s prim "job_kill") job signal # send signal to job
-export def getJobStdout  (job: Job): Result String Error = stdio job 1
-export def getJobStderr  (job: Job): Result String Error = stdio job 2
-export def getJobInputs  (job: Job): List Path = tree job 1 | guardPath job
-export def getJobOutputs (job: Job): List Path = tree job 2 | guardPath job
-export def getJobFailedInputs  (job: Job): List Path = tree job 1 | mapPath
-export def getJobFailedOutputs (job: Job): List Path = tree job 2 | mapPath
+export def getJobStdout (job: Job): Result String Error =
+  stdio job 1
+export def getJobStderr (job: Job): Result String Error =
+  stdio job 2
+export def getJobInputs (job: Job): List Path =
+  tree job 1 | guardPath job
+export def getJobOutputs (job: Job): List Path =
+  tree job 2 | guardPath job
+export def getJobFailedInputs (job: Job): List Path =
+  tree job 1 | mapPath
+export def getJobFailedOutputs (job: Job): List Path =
+  tree job 2 | mapPath
 export def getJobId (job: Job): Integer =
   (\j prim "job_id") job
 export def getJobDescription (job: Job): String =

--- a/share/wake/lib/versions/v0_19.wake
+++ b/share/wake/lib/versions/v0_19.wake
@@ -19,11 +19,16 @@ export def tapLevel (level: LogLevel) (formatFn: a => String) (value: a): a =
     def _ = printlnLevel level (formatFn value)
     value
 
-export def tapError   = tapLevel logError
-export def tapWarn    = tapLevel logWarn
-export def tapNormal  = tapLevel logNormal
-export def tapVerbose = tapLevel logVerbose
-export def tapDebug   = tapLevel logDebug
+export def tapError: (a => String) => a => a =
+    tapLevel logError
+export def tapWarn: (a => String) => a => a =
+    tapLevel logWarn
+export def tapNormal: (a => String) => a => a =
+    tapLevel logNormal
+export def tapVerbose: (a => String) => a => a =
+    tapLevel logVerbose
+export def tapDebug: (a => String) => a => a =
+    tapLevel logDebug
 
 export def installIn (x: String) (y: Path): Path =
     from wake import installIn
@@ -32,9 +37,12 @@ export def installIn (x: String) (y: Path): Path =
 export def makePlan: List String => List Path => Plan =
     makeExecPlan
 
-export def vfoldmap f a g v = vmapReduce g f a v
-export def vfold f a v = vmapReduce (_) f a v
-export def vscanmap f a g v = vmapScan g f a v
+export def vfoldmap (f: accum => accum => accum) (a: accum) (g: element => accum) (v: Vector element): accum =
+    vmapReduce g f a v
+export def vfold (f: a => a => a) (a: a) (v: Vector a): a =
+    vmapReduce (_) f a v
+export def vscanmap (f: b => b => b) (a: b) (g: a => b) (v: Vector a): Vector b =
+    vmapScan g f a v
 
 export def idouble (x: Double): Option Integer = match (dmodf x)
     Pair x 0.0 = Some x


### PR DESCRIPTION
Followup to #710, focusing on bringing `json.wake`, `tree.wake`, and `job.wake` up to parity with the style used elsewhere in the standard library.  If I revisit this again, I'll probably look at following the suggestion in https://github.com/sifive/wake/pull/710#discussion_r707616195 to deconstruct parameters on `def` lines rather than at function arguments, though doing so might align well with improving the comments and giving parameters more descriptive names.

EDIT: Sorry, I didn't realize how big this had gotten.  It probably would have been better to do a file-per-PR style (or otherwise smaller chunks) instead.  Sorry!

EDIT: The Mac failure is weird -- I don't think any of this should trigger duplicate symbol errors in C++ code, or have I done something strange?