### PR TITLE
Deliberately fail in such a way to break the LSP

### DIFF
--- a/extensions/vscode/vscode.wake
+++ b/extensions/vscode/vscode.wake
@@ -34,7 +34,7 @@ export def vscode _: Result Path Error =
     require wasm, Nil =
         filter (matches `.*\.wasm` _.getPathName) files
     else
-        failWithError "Did not find empscripten wasm output file; got: {format files}"
+        "Did not find empscripten wasm output file; got: {format files}"
 
     require js, Nil =
         filter (matches `.*\.wasm-.*` _.getPathName) files


### PR DESCRIPTION
This changes the result type enough to throw an error which is given the wrong source location (`bind.cpp:444`).

This PR is *not* meant to be merged, but simply as an easy minimal bug reproduction.