### PR TITLE
Show DB retry attempts only on a terminal

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -123,7 +123,7 @@ static int schema_cb(void *data, int columns, char **values, char **labels) {
   return -1;
 }
 
-std::string Database::open(bool wait, bool memory) {
+std::string Database::open(bool wait, bool memory, bool tty) {
   if (imp->db) return "";
   // Increment the SCHEMA_VERSION every time the below string changes.
   const char *schema_sql =
@@ -242,11 +242,13 @@ std::string Database::open(bool wait, bool memory) {
       }
       return out;
     } else {
-      if (waiting) {
-        std::cerr << ".";
-      } else {
-        waiting = true;
-        std::cerr << "Database wake.db is busy; waiting .";
+      if (tty) {
+        if (waiting) {
+          std::cerr << ".";
+        } else {
+          waiting = true;
+          std::cerr << "Database wake.db is busy; waiting .";
+        }
       }
       sleep(1);
     }

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -80,7 +80,7 @@ struct Database {
   Database(bool debugdb);
   ~Database();
 
-  std::string open(bool wait, bool memory);
+  std::string open(bool wait, bool memory, bool tty);
   void close();
 
   void entropy(uint64_t *key, int words);

--- a/src/runtime/status.cpp
+++ b/src/runtime/status.cpp
@@ -280,7 +280,7 @@ static void handle_SIGWINCH(int sig)
   resize_detected = true;
 }
 
-void term_init(bool tty_)
+bool term_init(bool tty_)
 {
   tty = tty_;
 
@@ -315,6 +315,8 @@ void term_init(bool tty_)
     sgr0 = tigetstr(sgr0_lit); // optional
     if (sgr0 == (char*)-1) sgr0 = 0;
   }
+
+  return tty;
 }
 
 void status_init()

--- a/src/runtime/status.h
+++ b/src/runtime/status.h
@@ -62,6 +62,6 @@ void status_set_colour(const char *name, int colour);
 void status_set_fd(const char *name, int fd);
 void status_set_bulk_fd(int fd, const char *streams);
 
-void term_init(bool tty);
+bool term_init(bool tty);
 
 #endif

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -266,7 +266,7 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  term_init(tty);
+  tty = term_init(tty);
 
   if (!percents) {
     percents = getenv("WAKE_PERCENT");

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -330,7 +330,7 @@ int main(int argc, char **argv) {
   if (nodb) return 0;
 
   Database db(debugdb);
-  std::string fail = db.open(wait, !workspace);
+  std::string fail = db.open(wait, !workspace, tty);
   if (!fail.empty()) {
     std::cerr << "Failed to open wake.db: " << fail << std::endl;
     return 1;

--- a/vendor/lemon/lemon.wake
+++ b/vendor/lemon/lemon.wake
@@ -31,7 +31,9 @@ def m4 (file: Path): Result Path Error =
         replace `\.m4$` "" file.getPathName
 
     def run =
-        job (which "m4", file.getPathName, Nil) (file, Nil)
+        makeExecPlan (which "m4", file.getPathName, Nil) (file, Nil)
+        | setPlanStdout logNever
+        | runJob
 
     require Pass stdout =
         run.getJobStdout


### PR DESCRIPTION
When wake is run interactively, show the message
```
Database wake.db is busy; waiting ...
```

Otherwise, just wait quietly until the lock is obtained.

This PR also incidentally fixes a bug whereby is_tty detection was not impacting job output batching.