### PR TITLE
Don't restart IO operations after exit is scheduled

### DIFF
--- a/tools/fuse-waked/fuse-waked.cpp
+++ b/tools/fuse-waked/fuse-waked.cpp
@@ -1412,6 +1412,13 @@ static void handle_exit(int sig)
 	static pid_t pid = -1;
 	struct timeval now;
 
+	// Ensure that future SIGALRM will interrupt the main loop's blocking read
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = handle_exit;
+	sa.sa_flags = 0; // not SA_RESTART
+	sigaction(SIGALRM, &sa, 0);
+
 	// Unfortunately, fuse_unmount can fail if the filesystem is still in use.
 	// Yes, this can even happen on linux with MNT_DETACH / lazy umount.
 	// Worse, fuse_unmount closes descriptors and frees memory, so can only be called once.

--- a/tools/fuse-waked/fuse-waked.cpp
+++ b/tools/fuse-waked/fuse-waked.cpp
@@ -1080,77 +1080,6 @@ static int wakefuse_utimens_trace(const char *path, const struct timespec ts[2])
 	return out;
 }
 
-static int wakefuse_opendir(const char *path, struct fuse_file_info *fi)
-{
-	if (is_special(path))
-		return -ENOTDIR;
-
-	auto key = split_key(path);
-	if (key.first.empty()) {
-		++context.uses;
-		return 0;
-	}
-
-	auto it = context.jobs.find(key.first);
-	if (it == context.jobs.end())
-		return -ENOENT;
-
-	int dfd;
-	if (key.second == ".") {
-		dfd = dup(context.rootfd);
-	} else if (!it->second.is_readable(key.second)) {
-		return -ENOENT;
-	} else {
-		dfd = openat(context.rootfd, key.second.c_str(), O_RDONLY | O_NOFOLLOW | O_DIRECTORY);
-	}
-
-	if (dfd == -1)
-		return -errno;
-
-	fi->fh = dfd;
-	++it->second.uses;
-	return 0;
-}
-
-static int wakefuse_opendir_trace(const char *path, struct fuse_file_info *fi)
-{
-	int out = wakefuse_opendir(path, fi);
-	fprintf(stderr, "opendir(%s) = %s\n", path, trace_out(out));
-	return out;
-}
-
-static int wakefuse_releasedir(const char *path, struct fuse_file_info *fi)
-{
-	auto key = split_key(path);
-	if (key.first.empty()) {
-		--context.uses;
-		return 0;
-	}
-
-	auto it = context.jobs.find(key.first);
-	if (it == context.jobs.end())
-		return -ENOENT;
-
-	--it->second.uses;
-	if (-1 == close(fi->fh))
-		return -errno;
-
-	if (it->second.should_erase())
-		context.jobs.erase(it);
-
-	if (context.should_exit())
-		schedule_exit();
-
-	return 0;
-}
-
-static int wakefuse_releasedir_trace(const char *path, struct fuse_file_info *fi)
-{
-	int out = wakefuse_releasedir(path, fi);
-	fprintf(stderr, "releasedir(%s) = %s\n", path, trace_out(out));
-	return out;
-}
-
 static int wakefuse_open(const char *path, struct fuse_file_info *fi)
 {
 	if (auto s = is_special(path)) {
@@ -1553,8 +1482,6 @@ int main(int argc, char *argv[])
 	wakefuse_ops.statfs		= enable_trace ? wakefuse_statfs_trace   : wakefuse_statfs;
 	wakefuse_ops.release		= enable_trace ? wakefuse_release_trace  : wakefuse_release;
 	wakefuse_ops.fsync		= enable_trace ? wakefuse_fsync_trace    : wakefuse_fsync;
-	wakefuse_ops.opendir		= enable_trace ? wakefuse_opendir_trace  : wakefuse_opendir;
-	wakefuse_ops.releasedir		= enable_trace ? wakefuse_releasedir_trace : wakefuse_releasedir;
 
 	// xattr were removed because they are not hashed!
 #ifdef HAVE_FALLOCATE


### PR DESCRIPTION
The fuse_loop calls blocking read.
If the arrival of SIGALRM never interrupts this read, the daemon never exits cleanly.
