### PR TITLE
match: report an error for multiarg match with singleton pattern

### DIFF
--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -669,6 +669,10 @@ static std::unique_ptr<Expr> rebind_match(const std::string &fnname, ResolveBind
   int f = 0;
   bool ok = true;
   for (auto &p : match->patterns) {
+    if (p.pattern.args.empty() && multiarg) {
+      ERROR(p.pattern.region.location(), "multi-argument match requires a multi-argument pattern");
+      continue;
+    }
     patterns.emplace_back(p.expr->fragment);
     patterns.back().index = f;
     patterns.back().guard = static_cast<bool>(p.guard);


### PR DESCRIPTION
Fixes #739.

This program:
```
def _ =
    match a.b a.c
            (Pass _) (Pass _) = ""
            _                 = Unit
```

Now produces:
```
demo.wake:4:13: multi-argument match requires a multi-argument pattern
demo.wake:2:[11-13]: non-exhaustive match; missing:  (Pass _) (Fail _)
>>> Aborting without execution <<<
```

Instead of just:
```
>>> Aborting without execution <<<
```