### PR TITLE
wake: allow independent control of memory and CPU usage

### DIFF
--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -31,6 +31,7 @@
 #include <fcntl.h>
 #include <math.h>
 #include <limits.h>
+#include <stdlib.h>
 
 #include <sstream>
 #include <iostream>
@@ -304,6 +305,48 @@ CriticalJob JobTable::detail::critJob(double nexttime) const {
   return out;
 }
 
+const char *ResourceBudget::parse(const char *str, ResourceBudget &output) {
+  char *dtail;
+  double percentage = strtod(str, &dtail);
+
+  if (dtail[0] == '%' && dtail[1] == 0) {
+    if (percentage < 1) {
+      return "percentage must be >= 1%";
+    } else {
+      output.percentage = percentage / 100.0;
+      output.fixed = 0;
+      return nullptr;
+    }
+  }
+
+  char *ltail;
+  long long val = strtoll(str, &ltail, 0);
+
+  if (val <= 0) {
+    return "value must be > 0";
+  }
+
+  output.percentage = 0;
+  output.fixed = val;
+
+  if (ltail[0] == 0) return nullptr;
+  output.fixed *= 1024;
+  if (ltail[0] == 'k' && ltail[1] == 0) return nullptr;
+  output.fixed *= 1024;
+  if (ltail[0] == 'M' && ltail[1] == 0) return nullptr;
+  output.fixed *= 1024;
+  if (ltail[0] == 'G' && ltail[1] == 0) return nullptr;
+  output.fixed *= 1024;
+  if (ltail[0] == 'T' && ltail[1] == 0) return nullptr;
+
+  // Error reporting
+  if (ltail == dtail) {
+    return "integer value must be followed by nothing or one of [kMGT]";
+  } else {
+    return "percentage value must be followed by a '%'";
+  }
+}
+
 static volatile bool child_ready = false;
 static volatile bool exit_asap = false;
 
@@ -321,7 +364,7 @@ bool JobTable::exit_now() {
   return exit_asap;
 }
 
-JobTable::JobTable(Database *db, double percent, bool debug, bool verbose, bool quiet, bool check, bool batch) : imp(new JobTable::detail) {
+JobTable::JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool debug, bool verbose, bool quiet, bool check, bool batch) : imp(new JobTable::detail) {
   imp->debug = debug;
   imp->verbose = verbose;
   imp->quiet = quiet;
@@ -329,9 +372,9 @@ JobTable::JobTable(Database *db, double percent, bool debug, bool verbose, bool 
   imp->batch = batch;
   imp->db = db;
   imp->active = 0;
-  imp->limit = std::thread::hardware_concurrency() * percent;
+  imp->limit = cpu.get(std::thread::hardware_concurrency());
   imp->phys_active = 0;
-  imp->phys_limit = get_physical_memory() * percent;
+  imp->phys_limit = memory.get(get_physical_memory());
   memset(&imp->childrenUsage, 0, sizeof(struct RUsage));
 
   sigemptyset(&imp->block);

--- a/src/runtime/job.h
+++ b/src/runtime/job.h
@@ -19,15 +19,34 @@
 #define JOB_H
 
 #include <memory>
+#include <string>
 
 struct Database;
 struct Runtime;
+
+struct ResourceBudget {
+  double percentage;
+  uint64_t fixed;
+
+  static const char *parse(const char *str, ResourceBudget &output);
+
+  ResourceBudget() : percentage(0), fixed(0) { }
+  ResourceBudget(double percentage_) : percentage(percentage_), fixed(0) { }
+
+  uint64_t get(uint64_t max_available) const {
+    if (fixed) {
+      return fixed;
+    } else {
+      return max_available * percentage;
+    }
+  }
+};
 
 struct JobTable {
   struct detail;
   std::unique_ptr<detail> imp;
 
-  JobTable(Database *db, double percent, bool debug, bool verbose, bool quiet, bool check, bool batch);
+  JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool debug, bool verbose, bool quiet, bool check, bool batch);
   ~JobTable();
 
   // Wait for a job to complete; false -> no more active jobs


### PR DESCRIPTION
This will hopefully help fitting wake jobs into container slices.

Fixes #591.
