### PR TITLE
wake: report location of bad import all

### DIFF
--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -802,10 +802,10 @@ static std::vector<Symbols*> process_import(Top &top, Imports &imports, FileFrag
 
   std::vector<Symbols*> out;
   for (auto &p : imports.import_all) {
-    auto it = top.packages.find(p);
+    auto it = top.packages.find(p.first);
     if (it == top.packages.end()) {
-      WARNING(fragment.location(),
-        "full import from non-existent package '" << p << "'");
+      WARNING(p.second.location(),
+        "full import from non-existent package '" << p.first << "'");
     } else {
       out.push_back(&it->second->exports);
     }
@@ -1081,7 +1081,7 @@ static std::unique_ptr<Expr> fracture(std::unique_ptr<Top> top) {
     std::set<std::string> imports;
     for (auto &file : defp->files)
       for (auto &bulk : file.content->imports.import_all)
-        imports.insert(bulk);
+        imports.insert(bulk.first);
     for (auto &imp : imports) {
       auto it = top->packages.find(imp);
       if (it != top->packages.end())

--- a/src/dst/expr.h
+++ b/src/dst/expr.h
@@ -207,7 +207,7 @@ struct Symbols {
 
 struct Imports : public Symbols {
   SymbolMap mixed;
-  std::vector<std::string> import_all;
+  std::vector<std::pair<std::string, FileFragment>> import_all;
   bool empty() const { return import_all.empty() && mixed.empty() && defs.empty() && types.empty() && topics.empty(); }
 };
 

--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -114,7 +114,7 @@ static void dst_import(CSTElement topdef, DefMap &map) {
 
   // Special case for wildcard import
   if (child.empty()) {
-    map.imports.import_all.emplace_back(pkgname);
+    map.imports.import_all.emplace_back(pkgname, topdef.fragment());
     return;
   }
 
@@ -1332,7 +1332,7 @@ const char *dst_top(CSTElement root, Top &top) {
 
   // Set a default import
   if (file.content->imports.empty())
-    file.content->imports.import_all.push_back("wake");
+    file.content->imports.import_all.emplace_back("wake", file.content->fragment);
 
   // Set a default package name
   if (package->name.empty()) {


### PR DESCRIPTION
Fixes #752.

When reporting an error for

```
from nonexistent import _
```

now report the location of the import instead of the whole file.