### PR TITLE
wake: don't replace bootstrap gz files by default

### DIFF
--- a/vendor/lemon/lemon.wake
+++ b/vendor/lemon/lemon.wake
@@ -78,6 +78,11 @@ def lemon variant (file: Path): Result (Pair Path Path) Error =
     def cppfile =
         installAs (replace `\.c$` ".cpp" cfile.getPathName) cfile
 
+    require Some "1" =
+        getenv "UPGRADE_GENERATED"
+    else
+        Pass (Pair cppfile hfile)
+
     def compress =
         which "gzip", "-nk9", cppfile.getPathName, hfile.getPathName, Nil
 

--- a/vendor/re2c.wake
+++ b/vendor/re2c.wake
@@ -47,6 +47,11 @@ def re2cReal file =
         | getJobOutput
         | getPathResult
 
+    require Some "1" =
+        getenv "UPGRADE_GENERATED"
+    else
+        Pass result
+
     def compress =
         which "gzip", "-nk9", result.getPathName, Nil
 


### PR DESCRIPTION
For systems without re2c and for the pre-wake bootstrap, we need
copies of the generated parser/lexer files.  When the actual
origin of these files change, the generated code is committed to git.
However, gzip on different systems produces different output.
Therefore, to prevent dirty trees and ping-pong'ing the contents,
only recreate the generated files if UPGRADE_GENERATED=1.