### PR TITLE
database: add a missing index for foreign key constraint

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -173,6 +173,7 @@ std::string Database::open(bool wait, bool memory, bool tty) {
     "  endtime     text    not null default '',"
     "  keep        integer not null default 0);"       // 0=false, 1=true
     "create index if not exists job on jobs(directory, commandline, environment, stdin, signature, keep, job_id, stat_id);"
+    "create index if not exists jobstats on jobs(stat_id);"
     "create table if not exists filetree("
     "  tree_id  integer primary key autoincrement,"
     "  access   integer not null," // 0=visible, 1=input, 2=output


### PR DESCRIPTION
When a 'stats' table entry is deleted, the jobs table must be checked to
confirm it is unreferenced to ensures the references() is not broken.

Unfortuntely, there was no index, which meant this required a jobs scan.
As the number of stats is O(jobs) and the clean-up phase of a rebuild often
refreshes many of the statistics, this could become O(jobs^2) cost.

By adding this index, deleting a stats row is now O(1).