### PR TITLE
job: report how many resources wake will use in the build

### DIFF
--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -397,6 +397,11 @@ JobTable::JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool
   imp->phys_limit = memory.get(get_physical_memory());
   memset(&imp->childrenUsage, 0, sizeof(struct RUsage));
 
+  std::stringstream s;
+  s << "wake: targeting utilization for " << imp->limit << " threads and " << imp->phys_limit << " bytes of memory." << std::endl;
+  std::string out = s.str();
+  status_write("echo", out.data(), out.size());
+
   sigemptyset(&imp->block);
 
   struct sigaction sa;


### PR DESCRIPTION
Do you guys think this would be useful to see in CI logs?

```
terpstra@peach:~/wake$ ./bin/wake --no-tty build default
wake: targeting utilization for 7 threads and 15461882265 bytes of memory.
'<mkdir>' -m 0775 lib
'<mkdir>' -m 0775 lib/wake
...
```