### PR TITLE
stdlib: export basename and dirname

### DIFF
--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -131,3 +131,37 @@ export def write (path: String) (content: String): Path =
     def spath = simplify path
     def parent = simplify "{spath}/.."
     writeImp (mkdir parent, Nil) 0644 spath content
+
+# Remove any leading directories from `file`.
+#
+# Parameters:
+#  - `file`: The filename to simplify
+#
+# Guarantees:
+#  - The resulting String contains no '/'s
+#
+# ```
+# basename "abc/def"  = "def"
+# basename "/foo/bar" = "bar"
+# basename "/foo"     = "foo"
+# basename "foo-bar"  = "foo-bar"
+# ```
+export def basename (file: String): String =
+    replace `^.*/` '' file
+
+# Extract the directory name from `file`.
+#
+# Parameters:
+#  - `file`: The filename to simplify
+#
+# Guarantees:
+#  - The resulting String is non-empty
+#
+# ```
+# dirname "foo/bar"  = "foo"
+# dirname "bar"      = "."
+# dirname "/bar"     = "/"
+# dirname "/foo/bar" = /foo"
+# ```
+export def dirname (file: String): String =
+    simplify "{file}/.."

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -48,12 +48,6 @@ def raw_source file =
         | runJobWith virtualRunner
         | getJobOutput
 
-export def basename (file: String): String =
-    replace `^.*/` '' file
-
-export def dirname (file: String): String =
-    simplify "{file}/.."
-
 export def source (file: String): Path =
     def base = basename file
     def dir = dirname file


### PR DESCRIPTION
These functions are generally useful.

Fixes #774.