### PR TITLE
file: compute the correct column when a token ENDS with utf8

### DIFF
--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -81,6 +81,8 @@ Coordinates FileContent::coordinates(const uint8_t *position) const
         auto it = std::upper_bound(newlines.begin(), newlines.end(), offset);
         --it; // always works, because newlines includes 0
         size_t row = 1 + (it - newlines.begin());
+        // If position points to the first byte of a codepoint, position+1 increases col to include it
+        // If position points to any other byte of a codepoint, position+1 includes an ignored '10xx xxxx'
         size_t col = utf8_tokens(ss.start + *it, position+1);
         return Coordinates(row, col);
     }

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -33,7 +33,9 @@ public:
     FileContent(FileContent &&o);
     FileContent &operator = (FileContent &&o);
 
+    // position points to any byte of the codepoint
     Coordinates coordinates(const uint8_t *position) const;
+
     void clearNewLines();
     void addNewline(const uint8_t *first_column);
 

--- a/src/util/fragment.cpp
+++ b/src/util/fragment.cpp
@@ -18,6 +18,7 @@
 #include "fragment.h"
 
 Location FileFragment::location() const {
+    // end-1 puts end1 on a byte within the last included codepoint
     uint32_t end1 = end!=start?end-1:end;
     return Location(
         content->filename(),


### PR DESCRIPTION
The position passed to 'coordinates' includes the pointed-at byte.

Follow-up fix to #770 and #784.