### PR TITLE
wake: switch from select() to poll() wherever possible

### DIFF
--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -277,7 +277,7 @@ struct CriticalJob {
 // Implementation details for a JobTable
 struct JobTable::detail {
   Poll poll;
-  int num_running;
+  long num_running;
   std::map<pid_t, std::shared_ptr<JobEntry> > pidmap;
   std::map<int, std::shared_ptr<JobEntry> > pipes;
   std::vector<std::unique_ptr<Task> > pending;
@@ -687,7 +687,7 @@ static void launch(JobTable *jobtable) {
   //   - even if a job uses more memory than the system has, eventually attempt it anyway (progress)
   auto &heap = jobtable->imp->pending;
   while (!heap.empty()
-      && jobtable->imp->num_running < (size_t)jobtable->imp->max_children
+      && jobtable->imp->num_running < jobtable->imp->max_children
       && jobtable->imp->active < jobtable->imp->limit
       && (jobtable->imp->phys_active == 0 || jobtable->imp->phys_active + heap.front()->job->memory() < jobtable->imp->phys_limit)) {
     Task &task = *heap.front();

--- a/src/runtime/poll.cpp
+++ b/src/runtime/poll.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include "poll.h"
+
+#ifdef __APPLE__
+#define USE_PSELECT 1
+#else
+#define USE_PPOLL 1
+#endif
+
+#ifdef USE_PSELECT
+
+struct Poll::detail {
+  std::vector<int> fds;
+};
+
+Poll::Poll() : imp(new Poll::detail) {
+}
+
+Poll::~Poll() {
+}
+
+void Poll::add(int fd) {
+  imp->fds.push_back(fd);
+}
+
+void Poll::remove(int fd) {
+  imp->fds.resize(
+    std::remove(imp->fds.begin(), imp->fds.end(), fd)
+    - imp->fds.begin());
+}
+
+void Poll::clear() {
+  imp->fds.clear();
+}
+
+std::vector<int> Poll::wait(struct timespec *timeout, sigset_t *saved) {
+  fd_set set;
+  int nfds = 0;
+
+  FD_ZERO(&set);
+  for (auto fd : imp->fds) {
+    if (fd >= nfds) nfds = fd + 1;
+    FD_SET(fd, &set);
+  }
+
+  int retval = pselect(nfds, &set, 0, 0, timeout, saved);
+  if (retval == -1 && errno != EINTR) {
+    perror("pselect");
+    exit(1);
+  }
+
+  std::vector<int> ready;
+  if (retval > 0) {
+    for (auto fd : imp->fds) {
+      if (FD_ISSET(fd, &set)) {
+        ready.push_back(fd);
+      }
+    }
+  }
+
+  return ready;
+}
+
+int Poll::max_fds() const {
+  return 1024;
+}
+
+#endif
+
+#ifdef USE_PPOLL
+
+struct Poll::detail {
+};
+
+Poll::Poll() : imp(new Poll::detail) {
+}
+
+Poll::~Poll() {
+}
+
+void Poll::add(int fd) {
+}
+
+void Poll::remove(int fd) {
+}
+
+void Poll::clear() {
+}
+
+std::vector<int> Poll::wait(struct timespec *timeout, sigset_t *saved) {
+}
+
+int Poll::max_fds() const {
+}
+
+#endif

--- a/src/runtime/poll.cpp
+++ b/src/runtime/poll.cpp
@@ -19,6 +19,8 @@
 #include <stdio.h>
 #include <errno.h>
 #include <poll.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 
 #include <algorithm>
 
@@ -109,7 +111,19 @@ std::vector<int> Poll::wait(struct timespec *timeout, sigset_t *saved) {
 }
 
 int Poll::max_fds() const {
-  return 1024;
+  struct rlimit nfd;
+  if (getrlimit(RLIMIT_NOFILE, &nfd) == -1) {
+    perror("getrlimit(RLIMIT_NOFILE)");
+    exit(1);
+  }
+  if (nfd.rlim_cur != nfd.rlim_max) {
+    nfd.rlim_cur = nfd.rlim_max;
+    if (setrlimit(RLIMIT_NOFILE, &nfd) == -1) {
+      perror("setrlimit(RLIMIT_NOFILE)");
+      exit(1);
+    }
+  }
+  return nfd.rlim_max;
 }
 
 #endif
@@ -169,7 +183,22 @@ std::vector<int> Poll::wait(struct timespec *timeout, sigset_t *saved) {
 }
 
 int Poll::max_fds() const {
-  return 1024;
+  struct rlimit nfd;
+  if (getrlimit(RLIMIT_NOFILE, &nfd) == -1) {
+    perror("getrlimit(RLIMIT_NOFILE)");
+    exit(1);
+  }
+  rlim_t set = FD_SETSIZE;
+  if (set > nfd.rlim_max && nfd.rlim_max != RLIM_INFINITY)
+    set = nfd.rlim_max;
+  if (nfd.rlim_cur != set) {
+    nfd.rlim_cur = set;
+    if (setrlimit(RLIMIT_NOFILE, &nfd) == -1) {
+      perror("setrlimit(RLIMIT_NOFILE)");
+      exit(1);
+    }
+  }
+  return set;
 }
 
 #endif
@@ -230,7 +259,19 @@ std::vector<int> Poll::wait(struct timespec *timeout, sigset_t *saved) {
 }
 
 int Poll::max_fds() const {
-  return 1024;
+  struct rlimit nfd;
+  if (getrlimit(RLIMIT_NOFILE, &nfd) == -1) {
+    perror("getrlimit(RLIMIT_NOFILE)");
+    exit(1);
+  }
+  if (nfd.rlim_cur != nfd.rlim_max) {
+    nfd.rlim_cur = nfd.rlim_max;
+    if (setrlimit(RLIMIT_NOFILE, &nfd) == -1) {
+      perror("setrlimit(RLIMIT_NOFILE)");
+      exit(1);
+    }
+  }
+  return nfd.rlim_max;
 }
 
 #endif

--- a/src/runtime/poll.h
+++ b/src/runtime/poll.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef POLL_H
+#define POLL_H
+
+#include <sys/select.h>
+
+#include <vector>
+#include <memory>
+
+struct Poll {
+  struct detail;
+  std::unique_ptr<detail> imp;
+
+  Poll();
+  ~Poll();
+
+  void add(int fd);
+  void remove(int fd);
+  void clear();
+
+  std::vector<int> wait(struct timespec *timeout, sigset_t *saved);
+
+  int max_fds() const;
+};
+
+#endif

--- a/src/runtime/status.cpp
+++ b/src/runtime/status.cpp
@@ -327,7 +327,7 @@ void status_init()
 
     // watch for resize events
     sa.sa_handler = handle_SIGWINCH;
-    sa.sa_flags = SA_RESTART; // interrupting pselect() is not critical for this
+    sa.sa_flags = SA_RESTART; // we don't interrupt the main loop for this
     sigaction(wake_SIGWINCH, &sa, 0);
     handle_SIGWINCH(wake_SIGWINCH);
 


### PR DESCRIPTION
This PR reworks how wake manages file descriptor monitoring:
- We can use > 1024 file descriptors (up to the hard ulimit)
- This means we can have a lot more child processes
- On linux, we now use epoll() to avoid scaling issues with many children
- We regularize / sanitize the soft descriptor limit for our children

Fixes #776.