### PR TITLE
vscode: peg vsce at older version

### DIFF
--- a/extensions/vscode/vscode.wake
+++ b/extensions/vscode/vscode.wake
@@ -82,7 +82,7 @@ export def vscode _: Result Path Error =
         nodeModules
 
     require Pass outputs =
-        makeExecPlan (which "npx", "vsce", "package", Nil) vsceFiles
+        makeExecPlan (which "npx", "vsce@1.103.1", "package", Nil) vsceFiles
         | setPlanDirectory here
         | runJob
         | getJobOutputs


### PR DESCRIPTION
This is necessary because node in the emsdk image is too old.