### PR TITLE
wake.db: keep a record for jobs with stale inputs

### DIFF
--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -51,6 +51,7 @@ struct JobTag {
 
 struct JobReflection {
   long job;
+  bool stale;
   std::string label;
   std::string directory;
   std::vector<std::string> commandline;

--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -44,6 +44,12 @@ static void indent(const std::string& tab, const std::string& body) {
   std::cout << std::endl;
 }
 
+static std::string describe_hash(const std::string &hash, bool verbose, bool stale) {
+  if (stale) return "<out-of-date>";
+  if (verbose) return hash;
+  return hash.substr(0, SHORT_HASH);
+}
+
 static void describe_human(const std::vector<JobReflection> &jobs, bool debug, bool verbose) {
   for (auto &job : jobs) {
     std::cout << "Job " << job.job;
@@ -70,16 +76,16 @@ static void describe_human(const std::vector<JobReflection> &jobs, bool debug, b
     if (verbose) {
       std::cout << "Visible:" << std::endl;
       for (auto &in : job.visible)
-        std::cout << "  " << in.hash.substr(0, verbose?std::string::npos:SHORT_HASH)
+        std::cout << "  " << describe_hash(in.hash, verbose, job.stale)
                   << " " << in.path << std::endl;
     }
     std::cout << "Inputs:" << std::endl;
     for (auto &in : job.inputs)
-      std::cout << "  " << in.hash.substr(0, verbose?std::string::npos:SHORT_HASH)
+      std::cout << "  " << describe_hash(in.hash, verbose, job.stale)
                 << " " << in.path << std::endl;
     std::cout << "Outputs:" << std::endl;
     for (auto &out : job.outputs)
-      std::cout << "  " << out.hash.substr(0, verbose?std::string::npos:SHORT_HASH)
+      std::cout << "  " << describe_hash(out.hash, verbose, false)
                 << " " << out.path << std::endl;
     if (debug) {
       std::cout << "Stack:";
@@ -134,17 +140,17 @@ static void describe_shell(const std::vector<JobReflection> &jobs, bool debug, b
     if (verbose) {
       std::cout << "# Visible:" << std::endl;
       for (auto &in : job.visible)
-        std::cout << "#  " << in.hash.substr(0, verbose?std::string::npos:SHORT_HASH)
+        std::cout << "#  " << describe_hash(in.hash, verbose, job.stale)
                   << " " << in.path << std::endl;
     }
     std::cout
       << "# Inputs:" << std::endl;
     for (auto &in : job.inputs)
-      std::cout << "#  " << in.hash.substr(0, verbose?std::string::npos:SHORT_HASH)
+      std::cout << "#  " << describe_hash(in.hash, verbose, job.stale)
                 << " " << in.path << std::endl;
     std::cout << "# Outputs:" << std::endl;
     for (auto &out : job.outputs)
-      std::cout << "#  " << out.hash.substr(0, verbose?std::string::npos:SHORT_HASH)
+      std::cout << "#  " << describe_hash(out.hash, verbose, false)
                 << " " << out.path << std::endl;
     if (debug) {
       std::cout << "# Stack:";


### PR DESCRIPTION
Even if a previous job's inputs have changed (and thus the outputs
are stale), users may still wish to inspect which job produced the
file.

This PR helps wake remember jobs for all output files, by not erasing
a stale job the moment it is out-of-date.

Now, you will see something like this:
```
Job 1086 (compile c++ src/runtime/job.native-cpp11-release.o):
  Command-line: /usr/bin/c++ -std=c++11 -Wall -O2 -Isrc -Ivendor -std=c++11 -pthread -c src/runtime/job.cpp -frandom-seed=src/runtime/job.native-cpp11-release.o -o src/runtime/job.native-cpp11-release.o
  Environment:
    PATH=/usr/bin:/bin
  Directory: .
  Built:     2021-11-09 01:06:50
  Runtime:   1.91766
  CPUtime:   1.89431
  Mem bytes: 169934848
  In  bytes: 246256
  Out bytes: 184790
  Status:    0
  Stdin:     /dev/null
Inputs:
  <out-of-date> src/compat/mtime.h
  <out-of-date> src/compat/physmem.h
  <out-of-date> src/compat/rusage.h
  <out-of-date> src/compat/sigwinch.h
```

Fixes: #779