### PR TITLE
wake: record start+stop times for jobs in ns

### DIFF
--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -58,7 +58,8 @@ struct JobReflection {
   std::vector<std::string> environment;
   std::string stack;
   std::string stdin_file;
-  std::string time;
+  std::string starttime;
+  std::string endtime;
   std::string stdout_payload;
   std::string stderr_payload;
   Usage usage;
@@ -121,6 +122,8 @@ struct Database {
     long job,
     const std::string &inputs,  // null separated
     const std::string &outputs, // null separated
+    int64_t starttime,
+    int64_t endtime,
     uint64_t hashcode,
     bool keep,
     Usage reality);

--- a/src/runtime/status.cpp
+++ b/src/runtime/status.cpp
@@ -128,8 +128,8 @@ static int ilog10(int x)
 static void status_redraw(bool idle)
 {
   std::stringstream os;
-  struct timeval now;
-  gettimeofday(&now, 0);
+  struct timespec now;
+  clock_gettime(CLOCK_REALTIME, &now);
 
   refresh_needed = false;
   if (resize_detected) {
@@ -153,7 +153,7 @@ static void status_redraw(bool idle)
 
     double runtime =
       (now.tv_sec  - x.launch.tv_sec) +
-      (now.tv_usec - x.launch.tv_usec) / 1000000.0;
+      (now.tv_nsec - x.launch.tv_nsec) / 1000000000.0;
 
     if (x.budget < MIN_DRAW_TIME && runtime < MIN_DRAW_TIME) {
       --total;

--- a/src/runtime/status.h
+++ b/src/runtime/status.h
@@ -26,8 +26,8 @@ struct Status {
   std::string cmdline;
   double budget;
   bool merged, wait_stdout, wait_stderr;
-  struct timeval launch;
-  Status(const std::string &cmdline_, double budget_, const struct timeval &launch_)
+  struct timespec launch;
+  Status(const std::string &cmdline_, double budget_, const struct timespec &launch_)
    : cmdline(cmdline_), budget(budget_),
      merged(false), wait_stdout(true), wait_stderr(true),
      launch(launch_) { }

--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -65,7 +65,7 @@ static void describe_human(const std::vector<JobReflection> &jobs, bool debug, b
       std::cout << "    " << shell_escape(env) << std::endl;
     std::cout
       << "  Directory: " << job.directory << std::endl
-      << "  Built:     " << job.time << std::endl
+      << "  Built:     " << job.endtime << std::endl
       << "  Runtime:   " << job.usage.runtime << std::endl
       << "  CPUtime:   " << job.usage.cputime << std::endl
       << "  Mem bytes: " << job.usage.membytes << std::endl
@@ -130,7 +130,7 @@ static void describe_shell(const std::vector<JobReflection> &jobs, bool debug, b
     std::cout << "< " << shell_escape(job.stdin_file) << std::endl << std::endl;
     std::cout
       << "# When wake ran this command:" << std::endl
-      << "#   Built:     " << job.time << std::endl
+      << "#   Built:     " << job.endtime << std::endl
       << "#   Runtime:   " << job.usage.runtime << std::endl
       << "#   CPUtime:   " << job.usage.cputime << std::endl
       << "#   Mem bytes: " << job.usage.membytes << std::endl


### PR DESCRIPTION
This required upgrading a lot of types to use timespec (with ns).
Fixes #794