### PR TITLE
dst: include the uses of destructors in patterns

### DIFF
--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -473,6 +473,7 @@ static std::unique_ptr<Expr> expand_patterns(const std::string &fnname, std::vec
       std::vector<std::unique_ptr<Expr> > gets;
       for (int i = 0; i < args; ++i)
         gets.emplace_back(new Get(FRAGMENT_CPP_LINE, sum, &cons, i));
+      des->uses.resize(des->uses.size()+1);
       for (auto p = patterns.begin(); p != patterns.end(); ++p) {
         PatternTree *t = get_expansion(&p->tree, expand);
         if (!t->sum) {
@@ -491,6 +492,7 @@ static std::unique_ptr<Expr> expand_patterns(const std::string &fnname, std::vec
             << "', but is not a member of this type");
           return nullptr;
         } else if (t->sum && t->cons == (int)c) {
+          des->uses.back().emplace_back(t->fragment);
           // Put any supplied type constraints on the object
           assert (args == (int)t->children.size());
           for (int i = 0; i < args; ++i) {

--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -567,6 +567,7 @@ static std::unique_ptr<Expr> expand_patterns(const std::string &fnname, std::vec
       des->cases.emplace_back(new Lambda(guard_true->fragment, "_", guard_true.release()));
       des->cases.emplace_back(new Lambda(guard_false->fragment, "_", guard_false.release()));
       des->fragment = des->cases.front()->fragment;
+      des->uses.resize(2);
       fmap->body = std::move(des);
       return std::unique_ptr<Expr>(std::move(fmap));
     }

--- a/src/dst/expr.h
+++ b/src/dst/expr.h
@@ -319,6 +319,7 @@ struct Destruct : public Expr {
   std::shared_ptr<Sum> sum;
   std::unique_ptr<Expr> arg;
   DefBinding::Values cases;
+  std::vector<std::vector<FileFragment> > uses;
 
   static const TypeDescriptor type;
   Destruct(const FileFragment &fragment_, const std::shared_ptr<Sum> &sum_, Expr *arg_)

--- a/tools/lsp-wake/astree.cpp
+++ b/tools/lsp-wake/astree.cpp
@@ -293,6 +293,22 @@ void ASTree::explore(Expr *expr, bool isGlobal) {
       }
     }
     explore(defbinding->body.get(), isGlobal);
+  } else if (expr->type == &Destruct::type) {
+    Destruct *destruct = dynamic_cast<Destruct*>(expr);
+    std::shared_ptr<Sum> sum = destruct->sum;
+
+    for (size_t i = 0; i < sum->members.size(); i++) {
+      FileFragment token = sum->members[i].ast.token;
+      if (!token.empty()) {
+        Location definitionLocation = token.location();
+        for (FileFragment use: destruct->uses[i]) {
+          usages.emplace_back(
+            use.location(),
+            definitionLocation
+            );
+        }
+      }
+    }
   }
 }
 

--- a/tools/lsp-wake/astree.cpp
+++ b/tools/lsp-wake/astree.cpp
@@ -309,6 +309,9 @@ void ASTree::explore(Expr *expr, bool isGlobal) {
         }
       }
     }
+
+    explore(destruct->arg.get(), false);
+    for (auto &c : destruct->cases) explore(c.get(), false);
   }
 }
 


### PR DESCRIPTION
Adds support for goto-definition and hover for destructors in patterns.
![Screen Shot 2021-11-19 at 10 06 16 AM](https://user-images.githubusercontent.com/1101706/142670453-47a60b01-cae9-42b5-9d22-e0373e15107d.png)


