### PR TITLE
todst: check unused pattern expansions

### DIFF
--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -709,6 +709,12 @@ static Expr *relabel_anon(Expr *out) {
 static void extract_def(std::vector<Definition> &out, long index, AST &&ast, const std::vector<ScopedTypeVar> &typeVars, Expr *body) {
   std::string key = "_ extract " + std::to_string(++index);
   out.emplace_back(key, ast.token, body, std::vector<ScopedTypeVar>(typeVars));
+  if (ast.args.empty()) {
+    Match *match = new Match(ast.token);
+    match->args.emplace_back(new VarRef(body->fragment, key));
+    match->patterns.emplace_back(AST(ast.region, std::string(ast.name)), new VarRef(body->fragment, key), nullptr);
+    out.emplace_back("_ discard " + std::to_string(index), ast.token, match, std::vector<ScopedTypeVar>(typeVars));
+  }
   for (auto &m : ast.args) {
     AST pattern(ast.region, std::string(ast.name));
     pattern.type = std::move(ast.type);


### PR DESCRIPTION
This code is fine:
```
def ok _ =
  def Unit = println "Hello"
  4
```

This code is not fine:
```
def bad _ =
  def Unit = 44
  4
```

This code is also not fine:
```
def bad _ =
  def None = Some 10
  4
```

Previously, both of the bad examples were accepted by wake.