### PR TITLE
Check version in .wakeroot before parsing a repository

### DIFF
--- a/src/runtime/sources.cpp
+++ b/src/runtime/sources.cpp
@@ -155,6 +155,10 @@ bool chdir_workspace(const char *chdirto, std::string &wake_cwd, std::string &sr
   return true;
 }
 
+std::string check_version(bool workspace) {
+  if (!workspace) return "";
+}
+
 static std::string slurp(int dirfd, const char * const * argv, bool &fail) {
   std::stringstream str;
   char buf[4096];

--- a/src/runtime/sources.h
+++ b/src/runtime/sources.h
@@ -26,7 +26,7 @@ struct Runtime;
 bool chdir_workspace(const char *chdirto, std::string &wake_cwd, std::string &src_dir);
 bool make_workspace(const std::string &dir);
 
-std::string check_version(bool workspace);
+std::string check_version(bool workspace, const char *wake_version);
 bool find_all_sources(Runtime &runtime, bool workspace);
 
 #endif

--- a/src/runtime/sources.h
+++ b/src/runtime/sources.h
@@ -26,6 +26,7 @@ struct Runtime;
 bool chdir_workspace(const char *chdirto, std::string &wake_cwd, std::string &src_dir);
 bool make_workspace(const std::string &dir);
 
+std::string check_version(bool workspace);
 bool find_all_sources(Runtime &runtime, bool workspace);
 
 #endif

--- a/tools/lsp-wake/lsp.cpp
+++ b/tools/lsp-wake/lsp.cpp
@@ -42,14 +42,6 @@
 #include "json_converter.h"
 #include "astree.h"
 
-#ifndef VERSION
-#include "../src/version.h"
-#endif
-
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
-#define VERSION_STR TOSTRING(VERSION)
-
 #ifdef __EMSCRIPTEN__
 #define CERR_DEBUG
 #include <emscripten/emscripten.h>

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -364,6 +364,13 @@ int main(int argc, char **argv) {
 
   if (nodb) return 0;
 
+  // check that the .wakeroot is compatible with the wake version
+  std::string version_check = check_version(workspace);
+  if (!version_check.empty()) {
+    std::cerr << version_check << std::endl;
+    return 1;
+  }
+
   Database db(debugdb);
   std::string fail = db.open(wait, !workspace, tty);
   if (!fail.empty()) {

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -365,9 +365,9 @@ int main(int argc, char **argv) {
   if (nodb) return 0;
 
   // check that the .wakeroot is compatible with the wake version
-  std::string version_check = check_version(workspace);
+  std::string version_check = check_version(workspace, VERSION_STR);
   if (!version_check.empty()) {
-    std::cerr << version_check << std::endl;
+    std::cerr << ".wakeroot: " << version_check << std::endl;
     return 1;
   }
 


### PR DESCRIPTION
If you run an older wake on a newer repository, you often get spurious errors from the wake files.
This is confusing to users.

In order to report a more useful error message, allow the `.wakeroot` file to include a version number on the first line of the file. This is then compared against the wake version, potentially resulting in an error message like:
```
.wakeroot: minor version is not a number (0.a23.9)
.wakeroot: excess text after the patch version number (0.23.9.k)
.wakeroot: minor version not followed by a '.' (0.23-9)
.wakeroot: repository requires wake v1.x.y, but this is wake v0.24.0-alpha-75-gdd46370-dirty
.wakeroot: repository requires wake >= v0.200.3, but this is wake v0.24.0-alpha-75-gdd46370-dirty
```

A repository version `x.y.z` is compatible with a wake version `a.b.c` if and only if `a == x && (b > y || (b == y && c > z))`.

Fixes #657 