### PR TITLE
{get,edit}Environment: fix value extraction

### DIFF
--- a/share/wake/lib/system/environment.wake
+++ b/share/wake/lib/system/environment.wake
@@ -67,7 +67,7 @@ export def getenv (key: String): Option String =
     head (p key)
 
 def test key = replace `=.*` "" _ ==* key
-def value pair = replace `[^=]*=` "" pair
+def value pair = replace `^[^=]*=` "" pair
 
 # Retrieve the value for 'key' from a KEY=VALUE environment list
 export def getEnvironment (key: String) (environment: List String): Option String =


### PR DESCRIPTION
If the value of an environment variable includes an `=` it gets cut.
ie: `getEnvironment "a" ("a=b=c", Nil) == "c"` (should be: "b=c")