### PR TITLE
Subhash as useful warning

### DIFF
--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -859,12 +859,13 @@ static void dst_def(CSTElement def, DefMap &map, Package *package, Symbols *glob
       FileFragment l = FRAGMENT_CPP_LINE;
 
       Expr *table = new Prim(l, "tnew");
-      for (size_t i = 0; i <= args.size(); ++i)
+      for (size_t i = 0; i < args.size()+2; ++i)
         table = new Lambda(l, "_", table, " ");
 
       std::stringstream s;
       s << defs.front().body->fragment.location();
       table = new App(l, table, new Literal(l, s.str(), &Data::typeString));
+      table = new App(l, table, new Literal(l, std::to_string(tohash), &Data::typeInteger));
 
       for (size_t i = 0; i < args.size(); ++i)
         table = new App(l, table, new Literal(l, std::string(args[i].first), &Data::typeString));

--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -830,17 +830,20 @@ static void dst_def(CSTElement def, DefMap &map, Package *package, Symbols *glob
     if (target) {
       if (tohash == 0) ERROR(fn.location(), "target definition of '" << name << "' must have at least one hashed argument");
       FileFragment bl = body->fragment;
-      Expr *hash = new Prim(bl, "hash");
-      for (size_t i = 0; i < tohash; ++i) hash = new Lambda(bl, "_", hash, " ");
-      for (size_t i = 0; i < tohash; ++i) hash = new App(bl, hash, new VarRef(bl, args[i].first));
-      Expr *subhash = new Prim(bl, "hash");
-      for (size_t i = tohash; i < args.size(); ++i) subhash = new Lambda(bl, "_", subhash, " ");
-      for (size_t i = tohash; i < args.size(); ++i) subhash = new App(bl, subhash, new VarRef(bl, args[i].first));
-      Lambda *gen = new Lambda(bl, "_", body, " ");
-      Lambda *tget = new Lambda(bl, "_fn", new Prim(bl, "tget"), " ");
-      body = new App(bl, new App(bl, new App(bl, new App(bl,
-        new Lambda(bl, "_target", new Lambda(bl, "_hash", new Lambda(bl, "_subhash", tget))),
-        new VarRef(bl, "table " + name)), hash), subhash), gen);
+
+      Expr *tget = new Prim(bl, "tget");
+      for (size_t i = 0; i < args.size(); ++i)
+        tget = new Lambda(bl, "_", tget, " ");
+
+      tget = new App(bl, new App(bl,
+        new Lambda(bl, "_ target", new Lambda(bl, "_ body", tget)),
+        new VarRef(bl, "table " + name)),
+        new Lambda(bl, "_", body, " "));
+
+      for (size_t i = 0; i < args.size(); ++i)
+        tget = new App(bl, tget, new VarRef(bl, args[i].first));
+
+      body = tget;
     }
 
     if (publish && !args.empty()) {

--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -866,7 +866,7 @@ static void dst_def(CSTElement def, DefMap &map, Package *package, Symbols *glob
         table = new Lambda(l, "_", table, " ");
 
       std::stringstream s;
-      s << defs.front().body->fragment.location();
+      s << "'" << name << "' <" << defs.front().body->fragment.location() << ">";
       table = new App(l, table, new Literal(l, s.str(), &Data::typeString));
       table = new App(l, table, new Literal(l, std::to_string(tohash), &Data::typeInteger));
 

--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -856,14 +856,20 @@ static void dst_def(CSTElement def, DefMap &map, Package *package, Symbols *glob
     defs.emplace_back(name, ast.token, body, std::move(typeVars));
 
     if (target) {
-      auto &def = defs.front();
-      std::stringstream s;
-      s << def.body->fragment.location();
       FileFragment l = FRAGMENT_CPP_LINE;
-      bind_def(map, Definition("table " + name, l,
-          new App(l, new Lambda(l, "_", new Prim(l, "tnew"), " "),
-          new Literal(l, s.str(), &Data::typeString))),
-        nullptr, nullptr);
+
+      Expr *table = new Prim(l, "tnew");
+      for (size_t i = 0; i <= args.size(); ++i)
+        table = new Lambda(l, "_", table, " ");
+
+      std::stringstream s;
+      s << defs.front().body->fragment.location();
+      table = new App(l, table, new Literal(l, s.str(), &Data::typeString));
+
+      for (size_t i = 0; i < args.size(); ++i)
+        table = new App(l, table, new Literal(l, std::string(args[i].first), &Data::typeString));
+
+      bind_def(map, Definition("table " + name, l, table), nullptr, nullptr);
     }
   }
 

--- a/src/optimizer/purity.cpp
+++ b/src/optimizer/purity.cpp
@@ -61,7 +61,7 @@ void RPrim::pass_purity(PassPurity &p) {
   meta = (pflags & p.pflag) == 0;
   // Special-case for tget (purity depends on purity of fn arg)
   if ((pflags & PRIM_FNARG))
-    meta = p.scope[args[3]]->meta >> 1;
+    meta = p.scope[args[1]]->meta >> 1;
   set(p.sflag, !(meta & 1));
 }
 

--- a/src/runtime/prim.cpp
+++ b/src/runtime/prim.cpp
@@ -179,14 +179,6 @@ void CHash::execute(Runtime &runtime) {
     next = nullptr; // reschedule
     hash.broken->await(runtime, this);
   } else {
-    Hash &h = hash.code;
-    mpz_import(out.value, sizeof(h.data)/sizeof(h.data[0]), 1, sizeof(h.data[0]), 0, 0, &h.data[0]);
-    if (runtime.debug_hash && h.data[0] == runtime.debug_hash) {
-      runtime.debug_hash = 0;
-      std::stringstream ss;
-      ss << "Debug-target hash input was: " << obj.get() << std::endl;
-      status_write(STREAM_ERROR, ss.str());
-    }
     cont->resume(runtime, Integer::claim(runtime.heap, out));
   }
 }

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -50,10 +50,9 @@ Category Work::category() const {
   return WORK;
 }
 
-Runtime::Runtime(Profile *profile_, int profile_heap, double heap_factor, uint64_t debug_hash_)
+Runtime::Runtime(Profile *profile_, int profile_heap, double heap_factor)
  : abort(false),
    profile(profile_),
-   debug_hash(debug_hash_),
    heap(profile_heap, heap_factor),
    stack(heap.root<Work>(nullptr)),
    output(heap.root<HeapObject>(nullptr)),

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -46,13 +46,12 @@ struct Profile;
 struct Runtime {
   bool abort;
   Profile *profile;
-  uint64_t debug_hash;
   Heap heap;
   RootPointer<Work> stack;
   RootPointer<HeapObject> output;
   RootPointer<Record> sources; // Vector String
 
-  Runtime(Profile *profile_, int profile_heap, double heap_factor, uint64_t debug_hash_);
+  Runtime(Profile *profile_, int profile_heap, double heap_factor);
   ~Runtime();
   void run();
 

--- a/src/runtime/target.cpp
+++ b/src/runtime/target.cpp
@@ -147,11 +147,11 @@ static PRIMFN(prim_tnew) {
   RETURN(t);
 }
 
-struct CTarget final : public GCObject<CTarget, Continuation> {
+struct CTargetFill final : public GCObject<CTargetFill, Continuation> {
   HeapPointer<Target> target;
   Hash hash;
 
-  CTarget(Target *target_, Hash hash_)
+  CTargetFill(Target *target_, Hash hash_)
    : target(target_), hash(hash_) { }
 
   template <typename T, T (HeapPointerBase::*memberfn)(T x)>
@@ -164,35 +164,60 @@ struct CTarget final : public GCObject<CTarget, Continuation> {
   void execute(Runtime &runtime) override;
 };
 
-void CTarget::execute(Runtime &runtime) {
+void CTargetFill::execute(Runtime &runtime) {
   target->table[hash].promise.fulfill(runtime, value.get());
 }
 
-static PRIMFN(prim_tget) {
-  EXPECT(4);
-  TARGET(target, 0);
-  INTEGER_MPZ(key, 1);
-  INTEGER_MPZ(subkey, 2);
-  CLOSURE(body, 3);
+struct CTargetArgs final : public GCObject<CTargetArgs, Continuation> {
+  HeapPointer<Target> target;
+  HeapPointer<Closure> body;
+  HeapPointer<Value> list;
+  HeapPointer<Scope> caller;
+  HeapPointer<Continuation> cont;
 
-  runtime.heap.reserve(Tuple::fulfiller_pads + Runtime::reserve_apply(body->fun) + CTarget::reserve());
-  Continuation *continuation = scope->claim_fulfiller(runtime, output);
+  CTargetArgs(Target *target_, Closure *body_, Value *list_, Scope *caller_, Continuation *cont_)
+   : target(target_), body(body_), list(list_), caller(caller_), cont(cont_) { }
 
-  Hash hash;
-  REQUIRE(mpz_sizeinbase(key, 2) <= 8*sizeof(hash.data));
-  mpz_export(&hash.data[0], 0, 1, sizeof(hash.data[0]), 0, 0, key);
+  template <typename T, T (HeapPointerBase::*memberfn)(T x)>
+  T recurse(T arg) {
+    arg = Continuation::recurse<T, memberfn>(arg);
+    arg = (target.*memberfn)(arg);
+    arg = (body.*memberfn)(arg);
+    arg = (list.*memberfn)(arg);
+    arg = (caller.*memberfn)(arg);
+    arg = (cont.*memberfn)(arg);
+    return arg;
+  }
 
-  Hash subhash;
-  REQUIRE(mpz_sizeinbase(subkey, 2) <= 8*sizeof(subhash.data));
-  mpz_export(&subhash.data[0], 0, 1, sizeof(subhash.data[0]), 0, 0, subkey);
+  void execute(Runtime &runtime) override;
+};
+
+void CTargetArgs::execute(Runtime &runtime) {
+  // value = hash(list) ... which we will ignore
+
+  runtime.heap.reserve(Runtime::reserve_apply(body->fun) + CTargetFill::reserve());
+
+  long i = 0;
+  std::vector<uint64_t> hashes, subhashes;
+
+  for (Record *item = static_cast<Record*>(list.get()); item->size() == 2; item = item->at(1)->coerce<Record>()) {
+    Hash h = item->at(0)->coerce<Value>()->deep_hash(runtime.heap);
+    if (++i <= target->keyargs) {
+      h.push(hashes);
+    } else {
+      h.push(subhashes);
+    }
+  }
+
+  Hash hash(hashes), subhash(subhashes);
 
   auto ref = target->table.insert(std::make_pair(hash, TargetValue(subhash)));
-  ref.first->second.promise.await(runtime, continuation);
+  ref.first->second.promise.await(runtime, cont.get());
 
   if (!(ref.first->second.subhash == subhash)) {
     std::stringstream ss;
     ss << "ERROR: Target subkey mismatch for " << target->location->c_str() << std::endl;
-    for (auto &x : scope->stack_trace())
+    for (auto &x : caller->stack_trace())
       ss << "  from " << x << std::endl;
     ss << "To debug, rerun your wake command with these additional options:" << std::endl;
     ss << "  --debug-target=" << hash.data[0] << " to see the unique target arguments (before the '\\')" << std::endl;
@@ -203,7 +228,27 @@ static PRIMFN(prim_tget) {
   }
 
   if (ref.second)
-    runtime.claim_apply(body, args[1], CTarget::claim(runtime.heap, target, hash), scope);
+    runtime.claim_apply(body.get(), target.get(),
+      CTargetFill::claim(runtime.heap, target.get(), hash), caller.get());
+}
+
+static PRIMFN(prim_tget) {
+  REQUIRE(nargs >= 2);
+  TARGET(target, 0);
+  CLOSURE(body, 1);
+  REQUIRE(nargs == target->argnames.size() + 2);
+
+  runtime.heap.reserve(
+    Tuple::fulfiller_pads
+    + reserve_list(target->argnames.size())
+    + reserve_hash()
+    + CTargetArgs::reserve());
+
+  Continuation *cont = scope->claim_fulfiller(runtime, output);
+  Value *list = claim_list(runtime.heap, target->argnames.size(), args+2);
+
+  runtime.schedule(claim_hash(runtime.heap, list,
+    CTargetArgs::claim(runtime.heap, target, body, list, scope, cont)));
 }
 
 void prim_register_target(PrimMap &pmap) {

--- a/src/types/internal.cpp
+++ b/src/types/internal.cpp
@@ -64,13 +64,11 @@ PRIMTYPE(type_cmp_nan_lt) {
 }
 
 PRIMTYPE(type_tget) {
-  return args.size() == 4 &&
+  return args.size() >= 2 &&
     args[0]->unify(Data::typeTarget) &&
-    args[1]->unify(Data::typeInteger) &&
-    args[2]->unify(Data::typeInteger) &&
-    args[3]->unify(TypeVar(FN, 2)) &&
-    (*args[3])[0].unify(Data::typeInteger) &&
-    out->unify((*args[3])[1]);
+    args[1]->unify(TypeVar(FN, 2)) &&
+    (*args[1])[0].unify(Data::typeTarget) &&
+    out->unify((*args[1])[1]);
 }
 
 void prim_register(PrimMap &pmap, const char *key, PrimFn fn, PrimType type, int flags, void *data) {

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -168,7 +168,6 @@ int main(int argc, char **argv) {
     { 0,   "html",                  GOPT_ARGUMENT_FORBIDDEN },
     { 'h', "help",                  GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "debug-db",              GOPT_ARGUMENT_FORBIDDEN },
-    { 0,   "debug-target",          GOPT_ARGUMENT_REQUIRED  },
     { 0,   "stop-after-parse",      GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "stop-after-type-check", GOPT_ARGUMENT_FORBIDDEN },
     { 0,   "stop-after-ssa",        GOPT_ARGUMENT_FORBIDDEN },
@@ -223,7 +222,6 @@ int main(int argc, char **argv) {
   const char *heapf   = arg(options, "heap-factor")->argument;
   const char *profile = arg(options, "profile")->argument;
   const char *init    = arg(options, "init")->argument;
-  const char *hash    = arg(options, "debug-target")->argument;
   const char *chdir   = arg(options, "chdir")->argument;
   const char *in      = arg(options, "in")->argument;
   const char *exec    = arg(options, "exec")->argument;
@@ -429,18 +427,8 @@ int main(int argc, char **argv) {
     // The unreadable location might be irrelevant to the build
   }
 
-  uint64_t target_hash = 0;
-  if (hash) {
-    char *tail;
-    target_hash = strtoull(hash, &tail, 0);
-    if (*tail) {
-      std::cerr << "Cannot run with debug-target=" << hash << "  (must be a number)!" << std::endl;
-      return 1;
-    }
-  }
-
   Profile tree;
-  Runtime runtime(profile ? &tree : nullptr, profileh, heap_factor, target_hash);
+  Runtime runtime(profile ? &tree : nullptr, profileh, heap_factor);
   bool sources = find_all_sources(runtime, workspace);
   if (!sources) {
     if (verbose) std::cerr << "Source file enumeration failed" << std::endl;


### PR DESCRIPTION
Rework how target subkeys are treated in wake. By definition, these keys are not supposed to matter. So, if they are used inconsistently, this should not trigger an error, just a warning. Furthermore, the old error messages were exceedingly unhelpful.

Consider this bad program:
```
export def broken _ =
    require Pass job1 =
        "ls"
        | makePlan "job1" Nil
        | setPlanStdout logError
        | runJob
        | getJobStdout
    require Pass job2 =
        "ls"
        | makePlan "job2" Nil
        | setPlanStdout logWarning
        | runJob
        | getJobStdout
    Pass "{job1}{job2}"
```

The old ERROR message:
```
ERROR: Target subkey mismatch for share/wake/lib/system/job.wake:273:[8-32]
To debug, rerun your wake command with these additional options:
  --debug-target=945013996097089732 to see the unique target arguments (before the '\')
  --debug-target=18216666221716652470 to see the first invocation's extra arguments
  --debug-target=3239709073642377762 to see the second invocation's extra arguments
```

The new WARNING message:
```
Target 'runOnce' <share/wake/lib/system/job.wake:273:[8-32]> was called with inconsistent auxiliary arguments
  It was passed these identical primary key arguments:
    cmd = "/opt/local/bin/dash", "-c", "ls", Nil
    env = "PATH=/opt/local/bin:/usr/local/bin:/usr/bin:/bin", Nil
    dir = "."
    stdin = ""
  It was passed these auxiliary arguments (after the '\') which should also be identical:
    res = Nil
    usage = Usage 0 0.00000000000000000e+00 1e0 0 0 0
    finputs = <share/wake/lib/system/job.wake:472:43>
    foutputs = <share/wake/lib/system/job.wake:472:43>
    vis = Nil
    keep = True
    run = <share/wake/lib/system/job.wake:64:[7-23]>
    echo = "echo"
    (INCONSISTENT) stdout = "warning"
    stderr = "warning"
    (INCONSISTENT) label = "job2"
Pass ""
```

Fixes #385
Fixes #570