### PR TITLE
target: fix a pointer cast warning on newer g++

### DIFF
--- a/src/runtime/target.cpp
+++ b/src/runtime/target.cpp
@@ -75,7 +75,7 @@ template <typename T, T (HeapPointerBase::*memberfn)(T x)>
 T Target::recurse(T arg) {
   arg = Parent::recurse<T, memberfn>(arg);
   arg = (location.*memberfn)(arg);
-  for (auto &x : argnames)
+  for (HeapPointerBase &x : argnames)
     arg = (x.*memberfn)(arg);
   for (auto &x : table)
     arg = x.second.promise.recurse<T, memberfn>(arg);


### PR DESCRIPTION
This warning was printed on recent ubuntu:
```
src/runtime/target.cpp: In instantiation of 'T Target::recurse(T) [with T = PadObject*; T (HeapPointerBase::* memberfn)(T) = &HeapPointerBase::moveto]':
src/runtime/gc.h:356:10:   required from 'Placement GCObject<T, B>::descend(PadObject*) [with T = Target; B = DestroyableObject]'
src/runtime/gc.h:355:11:   required from here
src/runtime/target.cpp:79:24: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
     arg = (x.*memberfn)(arg);
           ~~~~~~~~~~~~~^~~~~
```

I'm baffled why it couldn't lower from HeapPointer<String>& to
HeapPointerBase& on it's own, since it will do it for values.