### PR TITLE
bind: fix a bug wasting nearly 1s on wake start-up

### DIFF
--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -1514,7 +1514,7 @@ static bool contract(const Contractor &con, SymbolSource &sym) {
     }
     return false;
   } else {
-    auto map = con.member(ip->second->exports);
+    auto &map = con.member(ip->second->exports);
     auto ie = map.find(def);
     if (ie == map.end()) {
       if (con.warn) {


### PR DESCRIPTION
Without the '&', auto causes us to copy the map on every lookup!
This leads to a high-constant quadratic time algorithm. Oops.