### PR TITLE
LSP: fix type hover corner cases

### DIFF
--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -756,20 +756,20 @@ struct SymMover {
       if (unary != from.end()) {
         to.insert(std::make_pair(
           "unary " + sym.first.substr(3),
-          sym.second.clone(unary->second.qualified)));
+          sym.second.qualify(unary->second)));
         warn = false;
       }
       auto binary = from.find("binary " + def.substr(3));
       if (binary != from.end()) {
         to.insert(std::make_pair(
           "binary " + sym.first.substr(3),
-          sym.second.clone(binary->second.qualified)));
+          sym.second.qualify(binary->second)));
         warn = false;
       }
     } else {
       auto it = from.find(def);
       if (it != from.end()) {
-        to.insert(std::make_pair(sym.first, sym.second.clone(it->second.qualified)));
+        to.insert(std::make_pair(sym.first, sym.second.qualify(it->second)));
         warn = false;
       }
     }

--- a/src/dst/expr.h
+++ b/src/dst/expr.h
@@ -189,9 +189,11 @@ struct SymbolSource {
    : fragment(fragment_), origin(fragment_), qualified(), flags(flags_) { }
   SymbolSource(const FileFragment &fragment_, const std::string &qualified_, long flags_ = 0)
    : fragment(fragment_), origin(fragment_), qualified(qualified_), flags(flags_) { }
+  SymbolSource(const FileFragment &fragment_, const FileFragment &origin_, const std::string &qualified_, long flags_ = 0)
+   : fragment(fragment_), origin(origin_), qualified(qualified_), flags(flags_) { }
 
-  SymbolSource clone(const std::string &qualified) const {
-    return SymbolSource(fragment, qualified, flags);
+  SymbolSource qualify(const SymbolSource &source) const {
+    return SymbolSource(fragment, source.origin, source.qualified, flags);
   }
 };
 

--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -1376,7 +1376,9 @@ const char *dst_top(CSTElement root, Top &top) {
       if (it.first->second.qualified == name) {
         it.first->second.fragment = def.second.fragment;
         it.first->second.flags |= SYM_LEAF;
-        package->exports.defs.find(def.first)->second.flags |= SYM_LEAF;
+        auto jt = package->exports.defs.find(def.first);
+        jt->second.flags |= SYM_LEAF;
+        it.first->second.origin = jt->second.origin = def.second.fragment;
       } else {
         ERROR(def.second.fragment.location(),
           "definition '" << def.first
@@ -1394,7 +1396,9 @@ const char *dst_top(CSTElement root, Top &top) {
       if (it.first->second.qualified == name) {
         it.first->second.fragment = topic.second.fragment;
         it.first->second.flags |= SYM_LEAF;
-        package->exports.topics.find(topic.first)->second.flags |= SYM_LEAF;
+        auto jt = package->exports.topics.find(topic.first);
+        jt->second.flags |= SYM_LEAF;
+        it.first->second.origin = jt->second.origin = topic.second.fragment;
       } else {
         ERROR(topic.second.fragment.location(),
           "topic '" << topic.first
@@ -1411,7 +1415,9 @@ const char *dst_top(CSTElement root, Top &top) {
       if (it.first->second.qualified == name) {
         it.first->second.fragment = type.second.fragment;
         it.first->second.flags |= SYM_LEAF;
-        package->exports.types.find(type.first)->second.flags |= SYM_LEAF;
+        auto jt = package->exports.types.find(type.first);
+        jt->second.flags |= SYM_LEAF;
+        it.first->second.origin = jt->second.origin = type.second.fragment;
       } else {
         ERROR(type.second.fragment.location(),
           "type '" << type.first

--- a/tools/lsp-wake/astree.cpp
+++ b/tools/lsp-wake/astree.cpp
@@ -318,6 +318,16 @@ void ASTree::explore(Expr *expr, bool isGlobal) {
     Construct *construct = dynamic_cast<Construct*>(expr);
     if (construct->sum->scoped) {
       construct->sum->scoped = false;
+
+      if (types.insert(construct->sum->token.location()).second) {
+        definitions.emplace_back(
+          /* name */     construct->sum->name,
+          /* location */ construct->sum->token.location(),
+          /* type */     "type",
+          /* kind */     KIND_CLASS,
+          /* global */   true);
+      }
+
       for (auto &mem : construct->sum->members) {
         explore_type(mem.ast);
       }


### PR DESCRIPTION
Fix some type hover bugs discovered by @elena-pudovkina 

```
 # Some comment
 data Foo = Bar
```

Mouse-over of `Foo` should still show the comment, even before
`Foo` is used in a type signature.


```
from wake import type Hax=List
def foo (x: Hax Integer) = sum2 (x: List Integer)
```

In the LSP, Hax and List should be the same.
```
data Foo = Bar
from my_pkg export type Foo
```

The definition of `Foo` should be bound to the `data`, not the export.