### PR TITLE
LSP: fix documentation hover for `tuple` and `data`

### DIFF
--- a/src/util/location.h
+++ b/src/util/location.h
@@ -55,8 +55,17 @@ struct Location {
   }
 
   bool operator < (const Location &l) const {
-    if (filename == l.filename) { return start < l.start; }
+    if (filename == l.filename) {
+      if (start == l.start) {
+        return end < l.end;
+      }
+      return start < l.start;
+    }
     return filename < l.filename;
+  }
+
+  bool operator == (const Location &l) const {
+    return this->contains(l) && l.contains(*this);
   }
 };
 

--- a/src/util/location.h
+++ b/src/util/location.h
@@ -55,17 +55,17 @@ struct Location {
   }
 
   bool operator < (const Location &l) const {
-    if (filename == l.filename) {
-      if (start == l.start) {
-        return end < l.end;
-      }
-      return start < l.start;
-    }
-    return filename < l.filename;
+    if (filename != l.filename) return filename < l.filename;
+    if (start != l.start) return start < l.start;
+    return end < l.end;
   }
 
   bool operator == (const Location &l) const {
     return this->contains(l) && l.contains(*this);
+  }
+
+  bool operator != (const Location &l) const {
+    return !(*this == l);
   }
 };
 

--- a/tools/lsp-wake/astree.cpp
+++ b/tools/lsp-wake/astree.cpp
@@ -501,9 +501,7 @@ void ASTree::emplaceComment(std::vector<std::pair<std::string, int>> &comment, c
 ASTree::SymbolUsage::SymbolUsage(Location _usage, Location _definition) : usage(std::move(_usage)), definition(std::move(_definition)) {}
 
 ASTree::Comment::Comment(std::string _comment_text, Location _location, int _level)
-: comment_text(std::move(_comment_text)), location(std::move(_location)) {
-  level = _level;
-}
+: comment_text(std::move(_comment_text)), location(std::move(_location)), level(_level) {}
 
 void ASTree::LSPReporter::report(Diagnostic diagnostic) {
   diagnostics[diagnostic.getFilename()].push_back(diagnostic);

--- a/tools/lsp-wake/astree.h
+++ b/tools/lsp-wake/astree.h
@@ -66,10 +66,11 @@ private:
     };
 
     struct Comment {
-        Comment(std::string _comment_text, Location _location);
+        Comment(std::string _comment_text, Location _location, int level);
 
         std::string comment_text;
         Location location;
+        int level; // level of nestedness in the tree
     };
 
     std::set<Location> types;
@@ -92,10 +93,14 @@ private:
 
     static SymbolKind getSymbolKind(const char *name, const std::string& type);
 
-    void recordComments(CSTElement def);
+    void recordComments(CSTElement def, int level);
 
     void fillDefinitionDocumentationFields();
 
     static std::string sanitizeComment(std::string comment);
+
+    static std::string composeComment(std::vector<std::pair<std::string, int>> comment);
+
+    static void emplaceComment(std::vector<std::pair<std::string, int>> &comment, const std::string &text, int level);
 };
 #endif

--- a/tools/lsp-wake/astree.h
+++ b/tools/lsp-wake/astree.h
@@ -24,6 +24,7 @@
 #include <set>
 #include <vector>
 #include <functional>
+#include <parser/cst.h>
 
 #include "dst/expr.h"
 #include "util/diagnostic.h"
@@ -90,6 +91,8 @@ private:
     void explore_type(const AST &ast);
 
     static SymbolKind getSymbolKind(const char *name, const std::string& type);
+
+    void recordComments(CSTElement def);
 
     void fillDefinitionDocumentationFields();
 

--- a/tools/lsp-wake/astree.h
+++ b/tools/lsp-wake/astree.h
@@ -99,8 +99,10 @@ private:
 
     static std::string sanitizeComment(std::string comment);
 
-    static std::string composeComment(std::vector<std::pair<std::string, int>> comment);
+    static std::string composeOuterComment(std::vector<std::pair<std::string, int>> comment);
 
     static void emplaceComment(std::vector<std::pair<std::string, int>> &comment, const std::string &text, int level);
+
+    void recordSameLocationDefinition(std::vector<SymbolDefinition>::iterator &definitions_iterator);
 };
 #endif

--- a/tools/lsp-wake/json_converter.cpp
+++ b/tools/lsp-wake/json_converter.cpp
@@ -279,6 +279,13 @@ namespace JSONConverter {
       for (const SymbolDefinition& def: hoverInfoPieces) {
         value += "**" + def.name + ": " + def.type + "**\n\n";
         value += def.documentation + "\n\n";
+        if (!def.introduces.empty()) {
+          value += "Introduces:\n\n";
+          for (auto introduced: def.introduces) {
+            value += "**" + introduced.first + ": " + introduced.second + "**\n\n";
+          }
+        }
+        value += def.outerDocumentation + "\n\n";
       }
       if (!value.empty()) {
         JAST &contents = result.add("contents",JSON_OBJECT);

--- a/tools/lsp-wake/symbol_definition.h
+++ b/tools/lsp-wake/symbol_definition.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <utility>
+#include <vector>
 
 enum SymbolKind {
   KIND_PACKAGE     = 4,
@@ -43,12 +44,20 @@ struct SymbolDefinition {
     SymbolKind symbolKind;
     bool isGlobal;
     std::string documentation;
+    std::string outerDocumentation;
+    std::vector<std::pair<std::string, std::string>> introduces;
 
     SymbolDefinition(std::string _name, Location _location, std::string _type, SymbolKind _symbolKind, bool _isGlobal) :
     name(std::move(_name)), location(std::move(_location)), type(std::move(_type)), symbolKind(_symbolKind),
     isGlobal(_isGlobal) {}
 
     bool operator < (const SymbolDefinition &def) const {
+      if (!(this->location < def.location) && !(def.location < this->location)) {
+        if (this->name == def.name) {
+          return this->type < def.type;
+        }
+        return this->name < def.name;
+      }
       return location < def.location;
     }
 };

--- a/tools/lsp-wake/symbol_definition.h
+++ b/tools/lsp-wake/symbol_definition.h
@@ -52,13 +52,9 @@ struct SymbolDefinition {
     isGlobal(_isGlobal) {}
 
     bool operator < (const SymbolDefinition &def) const {
-      if (!(this->location < def.location) && !(def.location < this->location)) {
-        if (this->name == def.name) {
-          return this->type < def.type;
-        }
-        return this->name < def.name;
-      }
-      return location < def.location;
+      if (location != def.location) return location < def.location;
+      if (name != def.name) return name < def.name;
+      return type < def.type;
     }
 };
 


### PR DESCRIPTION
Outer comments are now also bound to symbols introduced in a `tuple` or `data` definition. They appear after the inner comment:
![image](https://user-images.githubusercontent.com/85900066/145812838-394c042f-e9b4-462b-b4d7-547a59e36939.png)

Definitions which have the same location are now merged into a single definition with the documentation containing:
- Name and type of the symbol
- Inner documentation of the symbol
- List of definitions introduced at this location
- Outer documentation

![image](https://user-images.githubusercontent.com/85900066/145814442-746c474c-6db6-42a6-9024-2e025a55881f.png)

![image](https://user-images.githubusercontent.com/85900066/145814327-47881269-2788-4154-bdce-ba75c697606f.png)

Fixes #820.