### PR TITLE
CI: switch from debian testing to bullseye

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           paths:
             - release/debian_jessie
 
-  debian_testing:
+  debian_bullseye:
     machine:
       image: ubuntu-1604:202007-01
 #      docker_layer_caching: true
@@ -90,19 +90,19 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run: docker build -f /tmp/workspace/.circleci/dockerfiles/debian-testing -t wake-debian-testing .
+      - run: docker build -f /tmp/workspace/.circleci/dockerfiles/debian-bullseye -t wake-debian-bullseye .
       - run: |
           x=(/tmp/workspace/wake_*.tar.xz); y=${x%.tar.xz}; cp "$x" "${y##*/}.orig.tar.xz" && \
           tar xJf wake_*.orig.tar.xz && \
           cp -a /tmp/workspace/debian wake-* && \
           cp -a /tmp/workspace/tests . && \
-          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build -w /build/$(ls -d wake-*) wake-debian-testing debuild -us -uc && \
-          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build wake-debian-testing /bin/sh -c "dpkg -i *.deb && cd tests && wake runTests" && \
-          install -D -t release/debian_testing *.deb *.xz *.changes *.dsc
+          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build -w /build/$(ls -d wake-*) wake-debian-bullseye debuild -us -uc && \
+          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build wake-debian-bullseye /bin/sh -c "dpkg -i *.deb && cd tests && wake runTests" && \
+          install -D -t release/debian_bullseye *.deb *.xz *.changes *.dsc
       - persist_to_workspace:
           root: .
           paths:
-            - release/debian_testing
+            - release/debian_bullseye
 
   centos_7_6:
     machine:
@@ -246,7 +246,7 @@ workflows:
       - alpine:
           requires:
             - tarball
-      - debian_testing:
+      - debian_bullseye:
           requires:
             - tarball
       - debian_jessie:
@@ -273,7 +273,7 @@ workflows:
       - release:
           requires:
             - alpine
-            - debian_testing # Newest everything
+            - debian_bullseye
             - debian_jessie  # Oldest supported compiler
             - centos_7_6
             - centos_8_3

--- a/.circleci/dockerfiles/debian-bullseye
+++ b/.circleci/dockerfiles/debian-bullseye
@@ -1,4 +1,4 @@
-FROM debian:testing
+FROM debian:bullseye
 
 RUN apt-get update && apt-get install -y build-essential m4 devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse
 

--- a/scripts/fetch
+++ b/scripts/fetch
@@ -6,13 +6,13 @@ url="$1"
 # eg: 0.18.1
 version="$2"
 
-curl -L -o wake_${version}.tar.xz                    ${url}/wake_${version}.tar.xz
-curl -L -o wake-${version}.vsix                      ${url}/vscode/wake-${version}.vsix
-curl -L -o wake-static_${version}.tar.xz             ${url}/alpine/wake-static_${version}.tar.xz
-curl -L -o centos-7-6-wake-${version}-1.x86_64.rpm   ${url}/centos_7_6/wake-${version}-1.x86_64.rpm
-curl -L -o centos-8-3-wake-${version}-1.x86_64.rpm   ${url}/centos_8_3/wake-${version}-1.x86_64.rpm
-curl -L -o debian-sarge-wake_${version}-1_amd64.deb  ${url}/debian_testing/wake_${version}-1_amd64.deb
-curl -L -o debian-jessie-wake_${version}-1_amd64.deb ${url}/debian_jessie/wake_${version}-1_amd64.deb
-curl -L -o ubuntu-14-04-wake_${version}-1_amd64.deb  ${url}/ubuntu_14_04/wake_${version}-1_amd64.deb
-curl -L -o ubuntu-16-04-wake_${version}-1_amd64.deb  ${url}/ubuntu_16_04/wake_${version}-1_amd64.deb
-curl -L -o ubuntu-18-04-wake_${version}-1_amd64.deb  ${url}/ubuntu_18_04/wake_${version}-1_amd64.deb
+curl -L -o wake_${version}.tar.xz                      ${url}/wake_${version}.tar.xz
+curl -L -o wake-${version}.vsix                        ${url}/vscode/wake-${version}.vsix
+curl -L -o wake-static_${version}.tar.xz               ${url}/alpine/wake-static_${version}.tar.xz
+curl -L -o centos-7-6-wake-${version}-1.x86_64.rpm     ${url}/centos_7_6/wake-${version}-1.x86_64.rpm
+curl -L -o centos-8-3-wake-${version}-1.x86_64.rpm     ${url}/centos_8_3/wake-${version}-1.x86_64.rpm
+curl -L -o debian-bullseye-wake_${version}-1_amd64.deb ${url}/debian_bullseye/wake_${version}-1_amd64.deb
+curl -L -o debian-jessie-wake_${version}-1_amd64.deb   ${url}/debian_jessie/wake_${version}-1_amd64.deb
+curl -L -o ubuntu-14-04-wake_${version}-1_amd64.deb    ${url}/ubuntu_14_04/wake_${version}-1_amd64.deb
+curl -L -o ubuntu-16-04-wake_${version}-1_amd64.deb    ${url}/ubuntu_16_04/wake_${version}-1_amd64.deb
+curl -L -o ubuntu-18-04-wake_${version}-1_amd64.deb    ${url}/ubuntu_18_04/wake_${version}-1_amd64.deb


### PR DESCRIPTION
Bullseye was recently released and debian/testing currently has major breaking changes in how apt works. Let's avoid that for now.
