### PR TITLE
release fetch: use rocky8

### DIFF
--- a/scripts/fetch
+++ b/scripts/fetch
@@ -1,4 +1,5 @@
 #! /bin/sh
+set -xe
 
 # eg: https://6075-148184315-gh.circle-artifacts.com/0/tmp/workspace/release
 url="$1"
@@ -10,7 +11,7 @@ curl -L -o wake_${version}.tar.xz                      ${url}/wake_${version}.ta
 curl -L -o wake-${version}.vsix                        ${url}/vscode/wake-${version}.vsix
 curl -L -o wake-static_${version}.tar.xz               ${url}/alpine/wake-static_${version}.tar.xz
 curl -L -o centos-7-6-wake-${version}-1.x86_64.rpm     ${url}/centos_7_6/wake-${version}-1.x86_64.rpm
-curl -L -o centos-8-3-wake-${version}-1.x86_64.rpm     ${url}/centos_8_3/wake-${version}-1.x86_64.rpm
+curl -L -o rocky_8-wake-${version}-1.x86_64.rpm        ${url}/rocky_8/wake-${version}-1.x86_64.rpm
 curl -L -o debian-bullseye-wake_${version}-1_amd64.deb ${url}/debian_bullseye/wake_${version}-1_amd64.deb
 curl -L -o debian-jessie-wake_${version}-1_amd64.deb   ${url}/debian_jessie/wake_${version}-1_amd64.deb
 curl -L -o ubuntu-14-04-wake_${version}-1_amd64.deb    ${url}/ubuntu_14_04/wake_${version}-1_amd64.deb


### PR DESCRIPTION
The fetch script for releases also needs to know about the `s/centos_8_3/rocky_8/`