### PR TITLE
Added claim function for using edited files

### DIFF
--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -66,7 +66,7 @@ export def source (file: String): Result Path Error =
 # all paths be produced by exactly one job, virtual or
 # otherwise.
 #
-# For source files please use `soruce`. For files outside
+# For source files please use `source`. For files outside
 # of wakeroot please use `claimFileAsPath` or `claimFileAsPathIn`.
 # `claim` is good for claiming files of previous builds that
 # are not being used again this build.

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -58,6 +58,42 @@ export def source (file: String): Result Path Error =
         x, Nil = Pass x
         _      = unreachable "a quoted RegExp can never match more than one distinct String"
 
+# Allows claiming of a file so long as the file is within
+# wakeroot. Keep in mind that if another job produces this
+# file, claim will fail. Likewise if you claim a file then
+# any job that produces this file will fail. Claim should
+# be thought of as a "virtual" job and wake demands that
+# all paths be produced by exactly one job, virtual or
+# otherwise.
+#
+# For source files please use `soruce`. For files outside
+# of wakeroot please use `claimFileAsPath` or `claimFileAsPathIn`.
+# `claim` is good for claiming files of previous builds that
+# are not being used again this build.
+#
+# Parameters:
+#  - `file`: The string giving the path to the file to be claimed
+#
+# Example:
+# ```
+#   claim "build/my_flow/my_step/previous-output.txt" # Claims the file
+# ```
+export def claim (file: String): Result Path Error =
+    def claimRel relpath =
+        def isOutsideRoot = matches `\.\..*` relpath
+        if isOutsideRoot then
+            failWithError "claim cannot be used on files outside of wake's root. Consider using claimFileAsPath instead."
+        else
+            raw_source relpath
+
+    def simplePath = simplify file
+    def isAbs = matches `/.*` simplePath
+    require True = isAbs else claimRel simplePath
+
+    relative workspace file
+    | simplify
+    | claimRel
+
 # Find sources files
 export def sources (dir: String) (filterRegexp: RegExp): Result (List Path) Error =
     def scan dir regexp = prim "sources"

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -84,7 +84,7 @@ export def claim (file: String): Result Path Error =
         def get_modtime file = prim "get_modtime"
         def time = get_modtime file
         if time == -1 then
-            failWithError "{file}: files does not exist. Maybe you haven't previouslly built this file?"
+            failWithError "{file}: files does not exist. Maybe you haven't previously built this file?"
         else
             # Its important that the command here is distinct from what `source` would use
             # so that claim and source do not overlap.

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -105,10 +105,19 @@ export def claim (file: String): Result Path Error =
 
     # Fail if we're outside of wakeroot (relPath must be simplified)
     def isOutsideRoot = matches `\.\..*/.*` relPath
-    if isOutsideRoot then
-        failWithError "claim cannot be used on files outside of wake's root. Consider using claimFileAsPath instead."
-    else
-        raw_claim relPath
+    require False = isOutsideRoot
+    else failWithError "claim cannot be used on files outside of wake's root. Consider using claimFileAsPath instead."
+
+    # Now that our path is uniform check if it could have been fetched with `source`
+    def base = basename relPath
+    def dir = dirname relPath
+    def scan dir regexp = prim "sources"
+    def canBeSourced = exists (_==~relPath) (scan dir base.quote)
+    require False = canBeSourced
+    else failWithError "{file}: Is a source file, please use `source` or `sources` instead of `claim`"
+
+    # Finally if the file is inside of wakeroot and can't be sourced we're in the clear
+    raw_claim relPath
 
 # Find sources files
 export def sources (dir: String) (filterRegexp: RegExp): Result (List Path) Error =

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -79,20 +79,36 @@ export def source (file: String): Result Path Error =
 #   claim "build/my_flow/my_step/previous-output.txt" # Claims the file
 # ```
 export def claim (file: String): Result Path Error =
-    def claimRel relpath =
-        def isOutsideRoot = matches `\.\..*` relpath
-        if isOutsideRoot then
-            failWithError "claim cannot be used on files outside of wake's root. Consider using claimFileAsPath instead."
+    # Define the actual virtual job that produces the Path
+    def raw_claim file =
+        def get_modtime file = prim "get_modtime"
+        def time = get_modtime file
+        if time == -1 then
+            failWithError "{file}: files does not exist. Maybe you haven't previouslly built this file?"
         else
-            raw_source relpath
+            # Its important that the command here is distinct from what `source` would use
+            # so that claim and source do not overlap.
+            makeExecPlan ("<claim>", str time, file, Nil) Nil
+            | setPlanShare       False
+            | setPlanEcho        logDebug
+            | setPlanEnvironment Nil
+            | setPlanFnOutputs   (file, _)
+            | runJobWith virtualRunner
+            | getJobOutput
 
-    def simplePath = simplify file
-    def isAbs = matches `/.*` simplePath
-    require True = isAbs else claimRel simplePath
+    # Compute the relative path in simplist form
+    def isAbs = matches `/.*` file
+    def relPath = if isAbs then
+        relative workspace file
+    else
+        simplify file
 
-    relative workspace file
-    | simplify
-    | claimRel
+    # Fail if we're outside of wakeroot (relPath must be simplified)
+    def isOutsideRoot = matches `\.\..*/.*` relPath
+    if isOutsideRoot then
+        failWithError "claim cannot be used on files outside of wake's root. Consider using claimFileAsPath instead."
+    else
+        raw_claim relPath
 
 # Find sources files
 export def sources (dir: String) (filterRegexp: RegExp): Result (List Path) Error =

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -59,17 +59,18 @@ export def source (file: String): Result Path Error =
         _      = unreachable "a quoted RegExp can never match more than one distinct String"
 
 # Allows claiming of a file so long as the file is within
-# wakeroot. Keep in mind that if another job produces this
-# file, claim will fail. Likewise if you claim a file then
-# any job that produces this file will fail. Claim should
-# be thought of as a "virtual" job and wake demands that
-# all paths be produced by exactly one job, virtual or
-# otherwise.
+# wake's workspace. Keep in mind that if another job
+# produced this file in the same run of wake, claim will
+# fail. Likewise if you claim a file then any job that
+# produces this file will fail. Claim should be thought
+# of as a "virtual" job and wake demands that all paths
+# be produced by exactly one job, virtual or otherwise.
 #
 # For source files please use `source`. For files outside
-# of wakeroot please use `claimFileAsPath` or `claimFileAsPathIn`.
-# `claim` is good for claiming files of previous builds that
-# are not being used again this build.
+# of wake's workspace please use `claimFileAsPath` or
+# `claimFileAsPathIn`. `claim` is good for claiming
+# artifacts of previous builds that should not be rebuilt
+# during this run.
 #
 # Parameters:
 #  - `file`: The string giving the path to the file to be claimed
@@ -84,7 +85,7 @@ export def claim (file: String): Result Path Error =
         def get_modtime file = prim "get_modtime"
         def time = get_modtime file
         if time == -1 then
-            failWithError "{file}: files does not exist. Maybe you haven't previously built this file?"
+            failWithError "{file}: file does not exist. Maybe you haven't previously built this file?"
         else
             # Its important that the command here is distinct from what `source` would use
             # so that claim and source do not overlap.
@@ -96,17 +97,17 @@ export def claim (file: String): Result Path Error =
             | runJobWith virtualRunner
             | getJobOutput
 
-    # Compute the relative path in simplist form
+    # Compute the relative path in simplest form
     def isAbs = matches `/.*` file
     def relPath = if isAbs then
         relative workspace file
     else
         simplify file
 
-    # Fail if we're outside of wakeroot (relPath must be simplified)
+    # Fail if we're outside of wake's workspace (relPath must be simplified)
     def isOutsideRoot = matches `\.\..*/.*` relPath
     require False = isOutsideRoot
-    else failWithError "claim cannot be used on files outside of wake's root. Consider using claimFileAsPath instead."
+    else failWithError "{file}: claim cannot be used on files outside of wake's workspace. Consider using claimFileAsPath instead."
 
     # Now that our path is uniform check if it could have been fetched with `source`
     def base = basename relPath
@@ -116,7 +117,7 @@ export def claim (file: String): Result Path Error =
     require False = canBeSourced
     else failWithError "{file}: Is a source file, please use `source` or `sources` instead of `claim`"
 
-    # Finally if the file is inside of wakeroot and can't be sourced we're in the clear
+    # Finally if the file is inside of wake's workspace and can't be sourced we're in the clear
     raw_claim relPath
 
 # Find sources files

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -372,6 +372,7 @@ std::string Database::open(bool wait, bool memory, bool tty) {
     "select j.job_id, j.label, j.directory, j.commandline, j.environment, j.stack, j.stdin, j.starttime, j.endtime, j.stale, r.time, r.cmdline, s.status, s.runtime, s.cputime, s.membytes, s.ibytes, s.obytes"
     " from  jobs j left join stats s on j.stat_id=s.stat_id join runs r on j.run_id=r.run_id"
     " where substr(cast(j.commandline as varchar), 1, 8) != '<source>'"
+    " and substr(cast(j.commandline as varchar), 1, 7) != '<claim>'"
     " and substr(cast(j.commandline as varchar), 1, 7) != '<mkdir>'"
     " and substr(cast(j.commandline as varchar), 1, 7) != '<write>'"
     " and substr(cast(j.commandline as varchar), 1, 6) != '<hash>'";


### PR DESCRIPTION
This change adds add_claim to the standard library where we have access to things like raw_sources. If we're happy with this I'll also use this as an excuse to do a minor release so I can learn that process.

The specific semantics I chose are to restrict `claim` to operating within wakeroot to limit its effectiveness. I couldn't think of a way to prevent people from using it instead of `source` but added that `source` is preferred in the documentation.