### PR TITLE
Allow visibility of . and .. in directory listings

### DIFF
--- a/tools/fuse-waked/fuse-waked.cpp
+++ b/tools/fuse-waked/fuse-waked.cpp
@@ -467,8 +467,14 @@ static int wakefuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 		}
 		file += de->d_name;
 
-		if (!it->second.is_readable(file))
-			continue;
+		if (!it->second.is_readable(file)) {
+			// Allow '.' and '..' links in this directory.
+			// This directory was earlier checked as visible (for '.') and
+			// the parent of a readable directory should also be visible (for '..').
+			std::string name(de->d_name);
+			if (!(name == "." || name == ".."))
+				continue;
+		}
 
 		if (filler(buf, de->d_name, &st, 0))
 			break;


### PR DESCRIPTION
When using the fuse daemon, running `ls -laR` in the root of the workspace we would see
```
.:
total 8
-rw-rw-r--. 1 root root   19 Feb 14 18:57 bar.sv
drwxrwxr-x. 2 root root 4096 Feb 14 19:00 foo

./foo:
total 4
-rw-rw-r--. 1 root root 26 Feb 14 18:27 beef.sv
```
instead of the expected
```
.:
total 16
drwxrwxrwx.  1 root   root   4096 Feb 15 00:04 .
dr-xr-xr-x. 27 nobody nobody 4096 Feb  3 20:47 ..
-rw-rw-r--.  1 root   root     19 Feb 14 18:57 bar.sv
drwxrwxr-x.  2 root   root   4096 Feb 14 19:00 foo

./foo:
total 12
drwxrwxr-x. 2 root root 4096 Feb 14 19:00 .
drwxrwxrwx. 1 root root 4096 Feb 15 00:04 ..
-rw-rw-r--. 1 root root   26 Feb 14 18:27 beef.sv
```



If `dir1` is visible `dir1/.` should be visible.
If `dir1/dir2` is visible, `dir1/dir2/..` should be visible, and so should `dir1`.

This PR removes `/.` and `/..` suffixes when comparing to the visible list.
After `/.` and `/..` is removed, it checks if there is an exact match with the visible list, or (if I'm reading it correctly) if the path was a parent of something in the visible list.