### PR TITLE
add truncate string function

### DIFF
--- a/share/wake/lib/core/string.wake
+++ b/share/wake/lib/core/string.wake
@@ -56,6 +56,15 @@ export def explode (string: String): List String =
     def p s = prim "explode"
     p string
 
+# truncate: return only the first N Unicode code points from a given string.
+#
+#   truncate 7 "hello world" = "hello w"
+export def truncate (num: Integer) (string: String) : String =
+    string
+    | explode
+    | take num
+    | cat
+
 # strbase: convert an Integer into a String using a given base.
 #
 # For 2 <= base <= 36, the characters used for the encoding are:


### PR DESCRIPTION
Sometimes its nice to shorten a string, for example when printing a log line.

It feels inefficient to explode the string, is there a better way?