### PR TITLE
Workaround for building wake (x86_64) on MacOS ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION	:= $(shell if test -f manifest.wake; then sed -n "/publish releaseAs/ s/
 
 CC	:= cc -std=c11
 CXX	:= c++ -std=c++11
-CFLAGS	:= -Wall -O2 -DVERSION=$(VERSION)
+CFLAGS	:= -target x86_64-apple-darwin-macho -Wall -O2 -DVERSION=$(VERSION)
 LDFLAGS	:=
 DESTDIR ?= /usr/local
 
@@ -12,12 +12,12 @@ LOCAL_CFLAGS :=	-Ivendor -Isrc
 FUSE_CFLAGS  :=	$(shell pkg-config --silence-errors --cflags fuse)
 CORE_CFLAGS  := $(shell pkg-config --silence-errors --cflags sqlite3)	\
 		$(shell pkg-config --silence-errors --cflags gmp-6)	\
-		$(shell pkg-config --silence-errors --cflags re2)	\
+		-pthread -I/usr/local/opt/re2/include/	\
 		$(shell pkg-config --silence-errors --cflags-only-I ncurses)
 FUSE_LDFLAGS := $(shell pkg-config --silence-errors --libs fuse    || echo -lfuse)
 CORE_LDFLAGS :=	$(shell pkg-config --silence-errors --libs sqlite3 || echo -lsqlite3)	\
 		$(shell pkg-config --silence-errors --libs gmp-6   || echo -lgmp)	\
-		$(shell pkg-config --silence-errors --libs re2     || echo -lre2)	\
+		-L/usr/local/opt/homebrew/Cellar/re2/lib -pthread -lre2	\
 		$(shell pkg-config --silence-errors --libs ncurses tinfo || pkg-config --silence-errors --libs ncurses || echo -lncurses)
 
 COMMON_DIRS := src/compat src/util src/json


### PR DESCRIPTION
Steps I took to achieve this

1. Run `arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"` to install the x86_64 version of homebrew.
2. If a permissions error [occurs like this](https://github.com/Homebrew/discussions/discussions/600) then run `sudo chown -R $(whoami): /usr/local/share/zsh` to fix the permissions and then repeat step 1.
3. Optionally create a alias for the x86_64 version of Homebrew with `alias brow='arch --x86_64 /usr/local/Homebrew/bin/brew'` I picked brow where the o stands for old [like this person did](https://stackoverflow.com/a/64951025).
4. Run `arch --x86_64 /usr/local/Homebrew/bin/brew install gmp re2 pkgconfig dash` to get x86_64 versions of the required non cask packages.
5. Run `arch --x86_64 /usr/local/Homebrew/bin/brew install --cask macfuse` and reboot
6. Modified the Makefile to target x86_64 and then also figured out where the x86_64 version of re2 lived on my drive and modified the relevant portions of the Makefile to suit that as well.