### PR TITLE
CI: remove older linux distros

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,28 +60,6 @@ jobs:
           paths:
             - release/alpine
 
-  debian_jessie:
-    machine:
-      image: ubuntu-2004:202201-02
-#      docker_layer_caching: true
-#    resource_class: large
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - run: docker build -f /tmp/workspace/.circleci/dockerfiles/debian-jessie -t wake-debian-jessie .
-      - run: |
-          x=(/tmp/workspace/wake_*.tar.xz); y=${x%.tar.xz}; cp "$x" "${y##*/}.orig.tar.xz" && \
-          tar xJf wake_*.orig.tar.xz && \
-          cp -a /tmp/workspace/debian wake-* && \
-          cp -a /tmp/workspace/tests . && \
-          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build -w /build/$(ls -d wake-*) wake-debian-jessie debuild -us -uc && \
-          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build wake-debian-jessie /bin/sh -c "dpkg -i *.deb && cd tests && wake runTests" && \
-          install -D -t release/debian_jessie *.deb *.xz *.changes *.dsc
-      - persist_to_workspace:
-          root: .
-          paths:
-            - release/debian_jessie
-
   debian_bullseye:
     machine:
       image: ubuntu-2004:202201-02
@@ -141,50 +119,6 @@ jobs:
           root: .
           paths:
             - release/rocky_8
-
-  ubuntu_14_04:
-    machine:
-      image: ubuntu-2004:202201-02
-#      docker_layer_caching: true
-#    resource_class: large
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - run: docker build -f /tmp/workspace/.circleci/dockerfiles/ubuntu-14.04 -t wake-ubuntu-14.04 .
-      - run: |
-          x=(/tmp/workspace/wake_*.tar.xz); y=${x%.tar.xz}; cp "$x" "${y##*/}.orig.tar.xz" && \
-          tar xJf wake_*.orig.tar.xz && \
-          cp -a /tmp/workspace/debian wake-* && \
-          cp -a /tmp/workspace/tests . && \
-          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build -w /build/$(ls -d wake-*) wake-ubuntu-14.04 debuild -us -uc && \
-          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build wake-ubuntu-14.04 /bin/sh -c "dpkg -i *.deb && cd tests && wake runTests" && \
-          install -D -t release/ubuntu_14_04 *.deb *.gz *.xz *.changes *.dsc
-      - persist_to_workspace:
-          root: .
-          paths:
-            - release/ubuntu_14_04
-
-  ubuntu_16_04:
-    machine:
-      image: ubuntu-2004:202201-02
-#      docker_layer_caching: true
-#    resource_class: large
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - run: docker build -f /tmp/workspace/.circleci/dockerfiles/ubuntu-16.04 -t wake-ubuntu-16.04 .
-      - run: |
-          x=(/tmp/workspace/wake_*.tar.xz); y=${x%.tar.xz}; cp "$x" "${y##*/}.orig.tar.xz" && \
-          tar xJf wake_*.orig.tar.xz && \
-          cp -a /tmp/workspace/debian wake-* && \
-          cp -a /tmp/workspace/tests . && \
-          docker run --rm --mount type=bind,source=$PWD,target=/build --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -w /build/$(ls -d wake-*) wake-ubuntu-16.04 debuild -us -uc && \
-          docker run --rm --mount type=bind,source=$PWD,target=/build --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined wake-ubuntu-16.04 /bin/sh -c "dpkg -i *.deb && cd tests && wake runTests" && \
-          install -D -t release/ubuntu_16_04 *.deb *.xz *.changes *.dsc
-      - persist_to_workspace:
-          root: .
-          paths:
-            - release/ubuntu_16_04
 
   ubuntu_18_04:
     machine:
@@ -249,19 +183,10 @@ workflows:
       - debian_bullseye:
           requires:
             - tarball
-      - debian_jessie:
-          requires:
-            - tarball
       - centos_7_6:
           requires:
             - tarball
       - rocky_8:
-          requires:
-            - tarball
-      - ubuntu_14_04:
-          requires:
-            - tarball
-      - ubuntu_16_04:
           requires:
             - tarball
       - ubuntu_18_04:
@@ -274,11 +199,8 @@ workflows:
           requires:
             - alpine
             - debian_bullseye
-            - debian_jessie  # Oldest supported compiler
             - centos_7_6
             - rocky_8
-            - ubuntu_14_04   # LTS
-            - ubuntu_16_04   # LTS
             - ubuntu_18_04   # LTS
             - vscode
       - docs_deploy:

--- a/.circleci/dockerfiles/debian-jessie
+++ b/.circleci/dockerfiles/debian-jessie
@@ -1,7 +1,0 @@
-FROM debian:jessie
-
-RUN apt-get update && apt-get install -y build-essential m4 devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libsqlite3-dev pkg-config curl
-RUN curl -LO https://github.com/sifive/wake/releases/download/v0.17.2/libre2-1_20140304+dfsg-2_amd64.deb && dpkg -i libre2-1_20140304+dfsg-2_amd64.deb
-RUN curl -LO https://github.com/sifive/wake/releases/download/v0.17.2/libre2-dev_20140304+dfsg-2_amd64.deb && dpkg -i libre2-dev_20140304+dfsg-2_amd64.deb
-
-WORKDIR /build

--- a/.circleci/dockerfiles/ubuntu-14.04
+++ b/.circleci/dockerfiles/ubuntu-14.04
@@ -1,7 +1,0 @@
-FROM ubuntu:14.04
-
-RUN apt-get update && apt-get install -y build-essential m4 debhelper devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libsqlite3-dev pkg-config wget
-RUN wget -q https://github.com/sifive/wake/releases/download/v0.17.2/libre2-1_20140304+dfsg-2_amd64.deb && dpkg -i libre2-1_20140304+dfsg-2_amd64.deb
-RUN wget -q https://github.com/sifive/wake/releases/download/v0.17.2/libre2-dev_20140304+dfsg-2_amd64.deb && dpkg -i libre2-dev_20140304+dfsg-2_amd64.deb
-
-WORKDIR /build

--- a/.circleci/dockerfiles/ubuntu-16.04
+++ b/.circleci/dockerfiles/ubuntu-16.04
@@ -1,5 +1,0 @@
-FROM ubuntu:16.04
-
-RUN apt-get update && apt-get install -y build-essential m4 debhelper devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse
-
-WORKDIR /build


### PR DESCRIPTION
We've carried some older linux distributions in CI for a while, it may be time to remove them.

Debian Jessie ends extended LTS support in few months, and has already ended regular LTS.
Ubuntu 14.04 & 16.04 are also outside LTS, though it's possible to pay for extended support.

If desired, we could add some newer distros to CI in a separate PR