### PR TITLE
CI: Ubuntu 22.04 LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,26 @@ jobs:
           paths:
             - release/ubuntu_18_04
 
+  ubuntu_22_04:
+    machine:
+      image: ubuntu-2004:202201-02
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: docker build -f /tmp/workspace/.circleci/dockerfiles/ubuntu-22.04 -t wake-ubuntu-22.04 .
+      - run: |
+          x=(/tmp/workspace/wake_*.tar.xz); y=${x%.tar.xz}; cp "$x" "${y##*/}.orig.tar.xz" && \
+          tar xJf wake_*.orig.tar.xz && \
+          cp -a /tmp/workspace/debian wake-* && \
+          cp -a /tmp/workspace/tests . && \
+          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build -w /build/$(ls -d wake-*) wake-ubuntu-22.04 debuild -us -uc && \
+          docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --mount type=bind,source=$PWD,target=/build wake-ubuntu-22.04 /bin/sh -c "dpkg -i *.deb && cd tests && wake runTests" && \
+          install -D -t release/ubuntu_22_04 *.deb *.xz *.changes *.dsc
+      - persist_to_workspace:
+          root: .
+          paths:
+            - release/ubuntu_22_04
+
   release:
     docker:
       - image: circleci/buildpack-deps:stretch
@@ -192,6 +212,9 @@ workflows:
       - ubuntu_18_04:
           requires:
             - tarball
+      - ubuntu_22_04:
+          requires:
+            - tarball
       - vscode:
           requires:
             - tarball
@@ -199,9 +222,10 @@ workflows:
           requires:
             - alpine
             - debian_bullseye
-            - centos_7_6
-            - rocky_8
+            - centos_7_6     # RHEL7-compatible, oldest gcc
+            - rocky_8        # RHEL8-compatible
             - ubuntu_18_04   # LTS
+            - ubuntu_22_04   # LTS
             - vscode
       - docs_deploy:
           requires:

--- a/.circleci/dockerfiles/ubuntu-22.04
+++ b/.circleci/dockerfiles/ubuntu-22.04
@@ -1,0 +1,5 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y build-essential m4 debhelper devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse
+
+WORKDIR /build


### PR DESCRIPTION
Adds Ubuntu 22.04 as a supported build target in CI

Follows on from the removals of older distros in https://github.com/sifive/wake/pull/869

Ubuntu 22.04 isn't actually officially released yet, but this is pointing at the docker image _tag_ that will become the official image in a few weeks (April 23). It's unlikely that much would change between now and then that would impact us