### PR TITLE
Improve user error messages of guard statements

### DIFF
--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -549,25 +549,25 @@ static std::unique_ptr<Expr> expand_patterns(const std::string &fnname, std::vec
       std::unique_ptr<Expr> guard_false(expand_patterns(fnname, patterns));
       patterns.emplace(patterns.begin()+1, std::move(save));
       if (!guard_false) return nullptr;
-      std::unique_ptr<DefMap> fmap(new DefMap(FRAGMENT_CPP_LINE));
-      fmap->defs.insert(std::make_pair("_ guardpair", DefValue(FRAGMENT_CPP_LINE, std::unique_ptr<Expr>(
+      std::unique_ptr<DefMap> fmap(new DefMap(p.fragment));
+      fmap->defs.insert(std::make_pair("_ guardpair", DefValue(p.fragment, std::unique_ptr<Expr>(
         fill_pattern(
           new VarRef(p.fragment, "_ f" + std::to_string(p.index)),
           prototype.tree, p.tree)))));
-      fmap->defs.insert(std::make_pair("_ rhs", DefValue(FRAGMENT_CPP_LINE, std::unique_ptr<Expr>(
-        new App(FRAGMENT_CPP_LINE,
-          new VarRef(FRAGMENT_CPP_LINE, "getPairFirst@wake"),
-          new VarRef(FRAGMENT_CPP_LINE, "_ guardpair"))))));
-      fmap->defs.insert(std::make_pair("_ guard", DefValue(FRAGMENT_CPP_LINE, std::unique_ptr<Expr>(
-        new App(FRAGMENT_CPP_LINE,
-          new VarRef(FRAGMENT_CPP_LINE, "getPairSecond@wake"),
-          new VarRef(FRAGMENT_CPP_LINE, "_ guardpair"))))));
-      std::unique_ptr<Expr> guard_true(new App(FRAGMENT_CPP_LINE,
-        new VarRef(FRAGMENT_CPP_LINE, "_ rhs"),
-        new VarRef(FRAGMENT_CPP_LINE, "Unit@wake")));
-      std::unique_ptr<Destruct> des(new Destruct(fragment, Boolean, new App(FRAGMENT_CPP_LINE,
-        new VarRef(FRAGMENT_CPP_LINE, "_ guard"),
-        new VarRef(FRAGMENT_CPP_LINE, "Unit@wake"))));
+      fmap->defs.insert(std::make_pair("_ rhs", DefValue(p.fragment, std::unique_ptr<Expr>(
+        new App(p.fragment,
+          new VarRef(p.fragment, "getPairFirst@wake"),
+          new VarRef(p.fragment, "_ guardpair"))))));
+      fmap->defs.insert(std::make_pair("_ guard", DefValue(p.fragment, std::unique_ptr<Expr>(
+        new App(p.fragment,
+          new VarRef(p.fragment, "getPairSecond@wake"),
+          new VarRef(p.fragment, "_ guardpair"))))));
+      std::unique_ptr<Expr> guard_true(new App(p.fragment,
+        new VarRef(p.fragment, "_ rhs"),
+        new VarRef(p.fragment, "Unit@wake")));
+      std::unique_ptr<Destruct> des(new Destruct(fragment, Boolean, new App(p.fragment,
+        new VarRef(p.fragment, "_ guard"),
+        new VarRef(p.fragment, "Unit@wake"))));
       des->cases.emplace_back(new Lambda(guard_true->fragment, "_", guard_true.release()));
       des->cases.emplace_back(new Lambda(guard_false->fragment, "_", guard_false.release()));
       des->fragment = des->cases.front()->fragment;


### PR DESCRIPTION
This change alters the type checking error message revived for so called "guard" statements in wake's pattern matching. This would be anything after an `if` in a pattern. We also use guards to implement literal pattern matching so if you have something like 0 or "foo" in a pattern we wind up use a guard for that.

Currently we do not type check code before transforming it this way which means that the type checker can wind up type checking generated code. Wes had previously used the C++ source location for the source location of the generated code. Most of the time when this technique is used the code is known to be correct in form ahead of time. When it is not known to be correct in form ahead of time we should (and often already do) prefer to use the fragment from the code that we're transforming/expanding instead.

This makes it slightly harder for wake devs to figure out what bit of C++ code generated an error message but it makes it easier for people using wake to solve their own problems. Frankly the correctness of this code has been quite stable though so I'm not overly concerned with debugging it as a likely cost. A user recently hit this error message and it took me 45 minutes just to figure out what part of the user's code was triggering the message. It would have likely been essentially impossible for a typical wake user to have found this issue in a non-trivial change. On the other hand I can probably find the correct C++ code if we omit the C++ location in a couple hours even if I forget about this PR.

So given the expectation of where we expect to find the errors, the developer time cost, and how much developer time we'd lose in each case, I claim this is a better error message even if it throws out useful information.

