### PR TITLE
use isolate-retcode when running Jobs

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -504,7 +504,7 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
             Fail f = Pair (Fail (makeError f)) ""
             Pass inFile =
               def outFile = "{build}/{prefix}.out.json"
-              def cmd = script, "-p", inFile, "-o", outFile, extraArgs
+              def cmd = script, "-I", "-p", inFile, "-o", outFile, extraArgs
               def proxy = RunnerInput label cmd Nil (extraEnv ++ environment) "." "" Nil prefix (estimate record)
               Pair (Pass proxy) inFile
   def post = match _


### PR DESCRIPTION
The fuse-wake executable would default to not returning the exit code of the process as its own.
Wakebox does by default, but has a cli flag to use the other behavior.

When we removed the fuse-wake executable, it was missed to add the `-I` to isolate the return code so that wakelang runners would only observe the jobs return code via the output json