### PR TITLE
system job labels

### DIFF
--- a/share/wake/lib/system/incremental.wake
+++ b/share/wake/lib/system/incremental.wake
@@ -27,6 +27,7 @@ def targz output paths =
     makeExecPlan cmd paths
     | setPlanLocalOnly True
     | setPlanFnOutputs (\_ output, Nil)
+    | setPlanLabel "tar-gz: {output}"
     | runJobWith       localRunner
     | getJobOutput
 

--- a/share/wake/lib/system/incremental.wake
+++ b/share/wake/lib/system/incremental.wake
@@ -27,7 +27,7 @@ def targz output paths =
     makeExecPlan cmd paths
     | setPlanLocalOnly True
     | setPlanFnOutputs (\_ output, Nil)
-    | setPlanLabel "tar-gz: {output}"
+    | setPlanLabel "tar-gz: {output}" # test
     | runJobWith       localRunner
     | getJobOutput
 

--- a/share/wake/lib/system/incremental.wake
+++ b/share/wake/lib/system/incremental.wake
@@ -27,7 +27,7 @@ def targz output paths =
     makeExecPlan cmd paths
     | setPlanLocalOnly True
     | setPlanFnOutputs (\_ output, Nil)
-    | setPlanLabel "tar-gz: {output}" # test
+    | setPlanLabel "tar-gz: {output}"
     | runJobWith       localRunner
     | getJobOutput
 

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -37,6 +37,7 @@ target writeImp inputs mode path content =
         makeRunner "write" (\_ Pass 0.0) pre post virtualRunner
     makeExecPlan ("<write>", str mode, path, Nil) inputs
     | setPlanOnce        False
+    | setPlanLabel "write: {path}"
     | setPlanEnvironment Nil
     | runJobWith writeRunner
     | getJobOutput
@@ -68,6 +69,7 @@ export def installAs (dest: String) (file: Path): Result Path Error =
         sdest, Nil
     makeExecPlan cmd inputs
     | setPlanEnvironment Nil
+    | setPlanLabel "installAs: {dest}"
     | setPlanLocalOnly True
     | setPlanFnOutputs foutputs
     | runJob
@@ -115,6 +117,7 @@ def mkdirRunner: Runner =
 def mkdirImp inputs mode path =
     makeExecPlan ("<mkdir>", "-m", "0{strOctal mode}", path, Nil) inputs
     | setPlanKeep        False
+    | setPlanLabel "mkdir: {path}"
     | setPlanEnvironment Nil
     | runJobWith mkdirRunner
     | getJobOutput

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -124,7 +124,7 @@ target hashcode (f: String): String =
   if reuse !=* "" then reuse else
     def hashPlan cmd  =
       Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun True Nil (\_ True) hashUsage id id
-    def job = hashPlan ("<hash>", f, Nil) | runJobWith localRunner
+    def job = hashPlan ("<hash>", f, Nil) | setPlanLabel "hash: {f}" | runJobWith localRunner
     def hash =
       job.getJobStdout
       | getWhenFail ""

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -44,6 +44,7 @@ def raw_source file =
         | setPlanShare       False
         | setPlanEcho        logDebug
         | setPlanEnvironment Nil
+        | setPlanLabel "source: {file}"
         | setPlanFnOutputs   (file, _)
         | runJobWith virtualRunner
         | getJobOutput
@@ -93,6 +94,7 @@ export def claim (file: String): Result Path Error =
             | setPlanShare       False
             | setPlanEcho        logDebug
             | setPlanEnvironment Nil
+            | setPlanLabel "claim: {file}"
             | setPlanFnOutputs   (file, _)
             | runJobWith virtualRunner
             | getJobOutput
@@ -155,5 +157,6 @@ export def claimFileAsPathIn (outputDirectory: Path) (existingFile: String) (des
         | setPlanLocalOnly   True
         | setPlanPersistence Once
         | setPlanFnOutputs   (\_ desiredWorkspacePath, Nil)
+        | setPlanLabel "claim-in: {existingFile}"
         | runJobWith localRunner
         | getJobOutput


### PR DESCRIPTION
This adds some `Plan` `Label`s to some of the `Job`s in `share/wake/lib/system`.
It's somewhat useful when making manual SQL queries on `wake.db`