### PR TITLE
[wcl] Introduce the Wake Core Library

### DIFF
--- a/src/wcl/optional.h
+++ b/src/wcl/optional.h
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+#include <utility>
+#include <cstdint>
+
 namespace wcl {
 
 template <class T>
@@ -25,27 +28,27 @@ class alignas(T) optional {
 
  public:
   // Default construct is none
-  Optional() = default;
+  optional() = default;
 
-  Optional(const Optional& other) : none(other.none) {
+  optional(const optional& other) : none(other.none) {
     if (other.none) return;
     new (reinterpret_cast<T*>(data)) T(*other);
   }
 
-  Optional(Optional&& other) : none(other.none) {
+  optional(optional&& other) : none(other.none) {
     if (other.none) return;
     new (reinterpret_cast<T*>(data)) T(std::move(*other));
   }
 
   // Placement new, perfect forwarding construction
   template <class... Args>
-  Optional(Args&&... args) : none(false) {
+  optional(Args&&... args) : none(false) {
     new (reinterpret_cast<T*>(data)) T(std::forward<Args>(args)...);
   }
 
-  ~Optional() { reinterpret_cast<T*>(data)->~T(); }
+  ~optional() { reinterpret_cast<T*>(data)->~T(); }
 
-  Optional& operator=(const Optional& other) {
+  optional& operator=(const optional& other) {
     if (!none) reinterpret_cast<T*>(data)->~T();
     none = other.none;
     if (none) return *this;
@@ -53,7 +56,7 @@ class alignas(T) optional {
     return *this;
   }
 
-  Optional& operator=(Optional&& other) {
+  optional& operator=(optional&& other) {
     if (!none) reinterpret_cast<T*>(data)->~T();
     none = other.none;
     if (none) return *this;

--- a/src/wcl/optional.h
+++ b/src/wcl/optional.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace wcl {
+
+template <class T>
+class alignas(T) optional {
+ private:
+  uint8_t data[sizeof(T)];
+  bool none = true;
+
+ public:
+  // Default construct is none
+  Optional() = default;
+
+  Optional(const Optional& other) : none(other.none) {
+    if (other.none) return;
+    new (reinterpret_cast<T*>(data)) T(*other);
+  }
+
+  Optional(Optional&& other) : none(other.none) {
+    if (other.none) return;
+    new (reinterpret_cast<T*>(data)) T(std::move(*other));
+  }
+
+  // Placement new, perfect forwarding construction
+  template <class... Args>
+  Optional(Args&&... args) : none(false) {
+    new (reinterpret_cast<T*>(data)) T(std::forward<Args>(args)...);
+  }
+
+  ~Optional() { reinterpret_cast<T*>(data)->~T(); }
+
+  Optional& operator=(const Optional& other) {
+    if (!none) reinterpret_cast<T*>(data)->~T();
+    none = other.none;
+    if (none) return *this;
+    new (reinterpret_cast<T*>(data)) T(*other);
+    return *this;
+  }
+
+  Optional& operator=(Optional&& other) {
+    if (!none) reinterpret_cast<T*>(data)->~T();
+    none = other.none;
+    if (none) return *this;
+    new (reinterpret_cast<T*>(data)) T(std::move(*other));
+    return *this;
+  }
+
+  explicit operator bool() const { return !none; }
+
+  T& operator*() { return *reinterpret_cast<T*>(data); }
+
+  const T& operator*() const { return *reinterpret_cast<const T*>(data); }
+
+  T* operator->() { return reinterpret_cast<const T*>(data); }
+
+  const T* operator->() const { return reinterpret_cast<const T*>(data); }
+};
+
+}  // namespace wcl

--- a/src/wcl/result.h
+++ b/src/wcl/result.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cstdint>
+
+namespace wcl {
+
+template <class Value, class Error>
+class alignas(std::max(alignof(Value), alignof(Error))) result {
+ private:
+  uint8_t data[std::max(sizeof(Value), sizeof(Error))];
+  bool is_error = false;
+
+  // we need a default constructor but only because
+  // we need static functions to act as our primary
+  // constructors and those need to be able to construct.
+  // something to a default state. From a user's perspective
+  // however this function is *very* dangerous.
+  result() = default;
+
+  // We commonly need to revert to an unconstructed state
+  // while implementing these functions but it would
+  // be dangerous for the user to do this. So we make it
+  // private. This is really just a convient name for the
+  // destructor.
+  void clear() {
+    if (is_error) {
+      reinterpret_cast<Error*>(data)->~Error();
+    } else {
+      reinterpret_cast<Value*>(data)->~Value();
+    }
+  }
+
+ public:
+  result(const result& other) : is_error(other.is_error) {
+    if (other.is_error) {
+      Error* other_ptr = reinterpret_cast<const Error*>(other.data);
+      new (reinterpret_cast<Error*>(data)) Error(*other_ptr);
+    } else {
+      Value* other_ptr = reinterpret_cast<const Value*>(other.data);
+      new (reinterpret_cast<Value*>(data)) Value(*other_ptr);
+    }
+  }
+
+  result(result&& other) : is_error(other.is_error) {
+    if (other.is_error) {
+      Error* other_ptr = reinterpret_cast<const Error*>(other.data);
+      new (reinterpret_cast<Error*>(data)) Error(std::move(*other_ptr));
+    } else {
+      Value* other_ptr = reinterpret_cast<const Value*>(other.data);
+      new (reinterpret_cast<Value*>(data)) Value(std::move(*other_ptr));
+    }
+  }
+
+  template <class... Args>
+  static result make_result(Args&&... args) {
+    result out;
+    out.is_error = false;
+    new (reinterpret_cast<Value*>(out.data)) Value(std::forward<Args>(args)...);
+    return out;
+  }
+
+  template <class... Args>
+  static result make_error(Args&&... args) {
+    result out;
+    out.is_error = true;
+    new (reinterpret_cast<Error*>(out.data)) Error(std::forward<Args>(args)...);
+    return out;
+  }
+
+  ~result() { clear(); }
+
+  result& operator=(const result& other) {
+    clear();
+    new (this) result(other);
+    return *this;
+  }
+
+  result& operator=(result&& other) {
+    clear();
+    new (this) result(std::move(other));
+    return *this;
+  }
+
+  explicit operator bool() const { return !is_error; }
+
+  Value& operator*() {
+    assert(!is_error);
+    return *reinterpret_cast<Value*>(data);
+  }
+
+  const Value& operator*() const {
+    assert(!is_error);
+    return *reinterpret_cast<const Value*>(data);
+  }
+
+  Value* operator->() {
+    assert(!is_error);
+    return reinterpret_cast<const Value*>(data);
+  }
+
+  const Value* operator->() const {
+    assert(!is_error);
+    return reinterpret_cast<const Value*>(data);
+  }
+
+  Error& error() {
+    assert(is_error);
+    return *reinterpret_cast<Error*>(data);
+  }
+
+  const Error& error() const {
+    assert(is_error);
+    return *reinterpret_cast<const Error*>(data);
+  }
+};
+
+template <class Value, class Error, class... Args>
+static inline result<Value, Error> make_result(Args&&... args) {
+  return result<Value, Error>::make_result(std::forward<Args>(args)...);
+}
+
+template <class Value, class Error, class... Args>
+static inline result<Value, Error> make_error(Args&&... args) {
+  return result<Value, Error>::make_error(std::forward<Args>(args)...);
+}
+
+}  // namespace wcl

--- a/src/wcl/small_vector.h
+++ b/src/wcl/small_vector.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <vector>
+
+namespace wcl {
+
+// TODO: Use type traits to check if we can use realloc
+template <class T, size_t small_size>
+class alignas(T) small_vector {
+ private:
+  // We don't need _cap when _size <= small_size so we
+  // put it in a vector and use that space for small
+  // elements. This means that if your small vector items
+  // take up less than 16-bytes the small vector is spaace free.
+  // it does however take up additional computational resoruces.
+  struct dynamic_vector {
+    T* _data = nullptr;
+    size_t _cap = 0;
+  };
+
+  uint8_t _data[std::max(sizeof(dynamic_vector), small_size * sizeof(T))];
+  size_t _size = 0;
+
+  dynamic_vector& dyn() { return *reinterpret_cast<dynamic_vector*>((uint8_t*)_data); }
+
+  size_t cap() {
+    if (_size > small_size) return dyn()._cap;
+    return small_size;
+  }
+
+  T* get_data() {
+    if (_size > _small_size) return dyn()._data;
+    return reinterpret_cast<T(&)[_small_size]>(_data);
+  }
+
+  const T* get_data() const {
+    if (_size > _small_size) return dyn()._data;
+    return reinterpret_cast<const T(&)[_small_size]>(_data);
+  }
+
+  inline void grow() {
+    // Figure out the old and new caps
+    size_t old_cap = cap();
+    size_t new_cap = old_cap * 2;
+
+    // Get the new space.
+    T* new_data = reinterpret_cast<T>(malloc(new_cap * sizeof(T)));
+    T* new_end = new_data + _size;
+
+    // Move the data from the constructed space, over to the unconstructed space.
+    // Since the object is still constructed we also have to *destruct* it.
+    for (T *new_iter = new_data, *old_iter = get_data(); new_iter < new_end;
+         ++new_iter, ++old_iter) {
+      new (new_iter) T(std::move(*old_iter));
+      old_iter->~T();
+    }
+
+    // Now we might need to free and we might not.
+    if (_size > small_size) {
+      free(get_data());
+      dyn()._data = new_data;
+      dyn()._cap = new_cap;
+    }
+  }
+
+ public:
+  T* data() { return get_data(); }
+
+  const T* data() const { return get_data(); }
+
+  size_t size() const { return _size; }
+
+  T& operator[](size_t index) { return data()[index]; }
+
+  const T& operator[](size_t index) const { return data()[index]; }
+
+  T& front() { return *data(); }
+
+  const T& front() const { return *data(); }
+
+  T& back() { return (*this)[_size - 1]; }
+
+  const T& back() const { return (*this)[_size - 1]; }
+
+  T* begin() { return data(); }
+
+  const T* begin() const { return data(); }
+
+  T* end() { return data() + _size; }
+
+  const T* end() const { return data() + _size; }
+
+  bool empty() { return _size == 0; }
+
+  template <class... Args>
+  void emplace_back(Args&&... args) {
+    if (_size == cap()) {
+      grow();
+    }
+    new (data()[_size++]) T(std::forward<Args>(args)...);
+  }
+
+  // push_back is just an alias for copy construct emplace_back
+  void push_back(const T& value) { emplace_back(value); }
+
+  // TODO: Implement clear, pop_back, emplace(like insert)
+};
+
+}  // namespace wcl

--- a/src/wcl/span.h
+++ b/src/wcl/span.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace wcl {
+
+// behave's like std::span or llvm's ArrayRef
+template <class T>
+class span {
+ private:
+  const T* _begin = nullptr;
+  const T* _end = nullptr;
+
+ public:
+  // Constructors
+  span() = default;
+  span(const span&) = default;
+  span(span&&) = deafult;
+  span(const T& elem) : _begin(&elem), _end(&elem + 1) {}
+  span(const T* begin, const T* end) : _begin(begin), _end(end) {}
+  span(const T* data, size_t size) : _begin(data), _end(data + size) {}
+  span(const std::vector<T>& vec) : _begin(vec.data()), _end(vec.data() + vec.size()) {}
+  template <size_t small_size>
+  span(const small_vector<T, small_size>& vec)
+      : _begin(vec.data()), _end(vec.data() + vec.size()) {}
+  template <size_t size>
+  span(const T (&arr)[size]) : _begin(arr), _end(arr + size) {}
+  span(const std::initializer_list<T>& init_list)
+      : _begin(init_list.begin()), _end(init_list.end()) {}
+
+  // assignment
+  span& operator=(const span&) = default;
+  span& operator=(span&&) = default;
+  span& operator=(const std::vector<T>& vec) {
+    span<T> new_ref(vec);
+    return *this = new_ref;
+  }
+  template <size_t size>
+  span& operator=(const T (&arr)[size]) {
+    span<T> new_ref(arr);
+    return *this = new_ref;
+  }
+
+  // standard accessors
+  size_t size() const { return _end - _begin; }
+
+  const T& operator[](size_t index) { return _begin[index]; }
+
+  const T* begin() const { return _begin; }
+
+  const T* end() const { return _end; }
+
+  const T& front() const { return *_begin; }
+
+  const T& back() const { return *(_end - 1); }
+
+  // sub views
+  span<T> sub(size_t start, size_t size) const {
+    return span<T>(_begin + start, _begin + start + size);
+  }
+
+  span<T> remove_prefix(size_t num = 1) const { return span<T>(_begin + num, _end); }
+
+  span<T> remove_suffix(size_t num = 1) const { return span<T>(_begin, _end - num); }
+
+  span<T> first(size_t num = 1) const { return span<T>(_begin, _begin + num); }
+
+  span<T> last(size_t num = 1) const { return span<T>(_end - num, _end); }
+};
+
+}  // namespace wcl

--- a/src/wcl/string_view.h
+++ b/src/wcl/string_view.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+
+namespace wcl {
+
+// behave's like std::string_view or llvm's StringRef
+class string_view {
+ private:
+  const char* _begin = nullptr;
+  const char* _end = nullptr;
+
+ public:
+  // Constructors
+  string_view() = default;
+  string_view(const string_view&) = default;
+  string_view(string_view&&) = default;
+  string_view(const char& elem) : _begin(&elem), _end(&elem + 1) {}
+  string_view(const char* begin, const char* end) : _begin(begin), _end(end) {}
+  string_view(const char* data, size_t size) : _begin(data), _end(data + size) {}
+  string_view(const std::string& str) : _begin(str.data()), _end(str.data() + str.size()) {}
+  template <size_t size>
+  string_view(const char (&arr)[size]) : _begin(arr), _end(arr + size) {}
+  string_view(const std::initializer_list<char>& init_list)
+      : _begin(init_list.begin()), _end(init_list.end()) {}
+
+  // assignment
+  string_view& operator=(const string_view&) = default;
+  string_view& operator=(string_view&&) = default;
+  string_view& operator=(const std::string& str) {
+    string_view new_ref(str);
+    return *this = new_ref;
+  }
+  template <size_t size>
+  string_view& operator=(const char (&arr)[size]) {
+    string_view<T> new_ref(arr);
+    return *this = new_ref;
+  }
+
+  // standard accessors
+  size_t size() const { return _end - _begin; }
+
+  const char& operator[](size_t index) const { return _begin[index]; }
+
+  const char* begin() const { return _begin; }
+
+  const char* end() const { return _end; }
+
+  const char& front() const { return *_begin; }
+
+  const char& back() const { return *(_end - 1); }
+
+  // sub views
+  string_view sub(size_t start, size_t size) const {
+    return string_view(_begin + start, _begin + start + size);
+  }
+
+  string_view remove_prefix(size_t num = 1) const { return string_view(_begin + num, _end); }
+
+  string_view remove_suffix(size_t num = 1) const { return string_view(_begin, _end - num); }
+
+  string_view first(size_t num = 1) const { return string_view(_begin, _begin + num); }
+
+  string_view last(size_t num = 1) const { return string_view(_end - num, _end); }
+
+  // convert to string
+  std::string str() const { return std::string(_begin, _end); }
+};
+
+}  // namespace wcl

--- a/src/wcl/trie.h
+++ b/src/wcl/trie.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optional.h"
+#include "small_vector.h"
+
+namespace wcl {
+
+template <class Key, class Value>
+class trie {
+ private:
+  struct trie_node {
+    small_vector<size_t, 2> child_indexes;
+    Key key;
+    optional<Value> value;
+
+    trie_node(trie_node&&) = default;
+    trie_node(const trie_node&) = default;
+    explicit trie_node(Key&& k) : child_indexes(), key(std::move(v)), value() {}
+    explicit trie_node(const Key& k) : child_indexes(), key(v), value() {}
+  };
+  std::vector<trie_node> nodes;
+
+  optional<size_t> matching_child(size_t pindex, const Key& value) {
+    if (nodes.size() <= pindex) return optional<size_t>();
+    trie_node* node = &nodes[pindex];
+    for (size_t child_index : node->child_indexes) {
+      if (value == nodes[child_index].value) return child_index;
+    }
+    return optional<size_t>();
+  }
+
+ public:
+  template <class KeyIter>
+  void move_insert(Value&& value, KeyIter begin, KeyIter end) {
+    size_t root = 0;
+    while (begin != end) {
+      // Check if there's a matching child already
+      optional<size_t> child = matching_child(root, *begin);
+      if (child) {
+        root = *child;
+        ++begin;
+        continue;
+      }
+
+      // If not that just means we have to allocate a node
+      size_t new_node = nodes.size();
+      nodes.emplace_back(std::move(*begin++));
+      if (new_node) nodes[root].child_indexes(new_node);
+      root = new_node;
+    }
+    nodes[root].value = value;
+  }
+
+  template <class KeyIter>
+  void move_insert(const Value& value, KeyIter begin, KeyIter end) {
+    Value copy(value);
+    move_insert(std::move(copy), begin, end);
+  }
+};
+
+}  // namespace wcl

--- a/src/wcl/unique_fd.h
+++ b/src/wcl/unique_fd.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Open Group Base Specifications Issue 7
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
+#include "result.h"
+
+namespace wcl {
+
+class unique_fd {
+ private:
+  int fd = -1;
+
+  // We don't want user's to be able to construct like
+  // this directly but we need to be able to do this.
+  explicit unique_fd(int fd) : fd(fd) {}
+
+ public:
+  unique_fd() = default;
+  unique_fd(const unique_fd&) = delete;
+
+  unique_fd& operator=(unique_fd&& f) {
+    fd = f.fd;
+    f.fd = -1;
+    return *this;
+  }
+  unique_fd(unique_fd&& f) : fd(f.fd) { f.fd = -1; }
+
+  ~unique_fd() {
+    if (fd > 0) {
+      // It's a bit annoying but we aren't allowed to
+      // error handle in anyway here. We add an assert
+      // so that we are likely to catch this issue.
+      assert(close(fd) > -1);
+    }
+  }
+
+  int get() const { return fd; }
+
+  // Opens a file just as posix's open would, returning
+  // either a unique_fd or the errno value.
+  static result<unique_fd, int> open(const char* str, int flags) {
+    int fd = ::open(str, flags);
+    if (fd == -1) {
+      return make_error<unique_fd, int>(errno);
+    }
+    return make_result<unique_fd, int>(unique_fd(fd));
+  }
+
+  // Opens a file just as posix's open would, returning
+  // either a unique_fd or the errno value.
+  static result<unique_fd, int> open(const char* str, int flags, mode_t mode) {
+    int fd = ::open(str, flags, mode);
+    if (fd == -1) {
+      return make_error<unique_fd, int>(errno);
+    }
+    return make_result<unique_fd, int>(unique_fd(fd));
+  }
+};
+
+}  // namespace wcl

--- a/tools/wake-unit/optional.cpp
+++ b/tools/wake-unit/optional.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <wcl/optional.h>
+
+#include <memory>
+#include <algorithm>
+#include <random>
+
+#include "unit.h"
+
+TEST(option_none_is_none) {
+  wcl::optional<int> none;
+  EXPECT_FALSE((bool)none);
+}
+
+TEST(option_some) {
+  wcl::optional<int> some(10);
+  ASSERT_TRUE((bool)some);
+  EXPECT_EQUAL(10, *some);
+}
+
+TEST(option_copy) {
+  wcl::optional<int> none1;
+  wcl::optional<int> none2(none1);
+  EXPECT_FALSE((bool)none1);
+  EXPECT_FALSE((bool)none2);
+
+  wcl::optional<int> some1(10);
+  wcl::optional<int> some2(some1);
+  ASSERT_TRUE((bool)some1);
+  EXPECT_EQUAL(10, *some1);
+  ASSERT_TRUE((bool)some2);
+  EXPECT_EQUAL(10, *some2);
+}
+
+TEST(option_move) {
+  wcl::optional<int> none1;
+  wcl::optional<int> none2(std::move(none1));
+  EXPECT_FALSE((bool)none1);
+  EXPECT_FALSE((bool)none2);
+
+  wcl::optional<int> some1(10);
+  wcl::optional<int> some2(std::move(some1));
+  EXPECT_FALSE((bool)some1);
+  ASSERT_TRUE((bool)some2);
+  EXPECT_EQUAL(10, *some2);
+
+  // We want to make sure we can make optional move only things.
+  wcl::optional<std::unique_ptr<int>> move_only1(std::make_unique<int>(10));
+  wcl::optional<std::unique_ptr<int>> move_only2(std::move(move_only1));
+  EXPECT_FALSE((bool)move_only1);
+  ASSERT_TRUE((bool)move_only2);
+  EXPECT_FALSE(move_only2->get() == nullptr);
+  EXPECT_FALSE((*move_only2).get() == nullptr);
+  const auto& ref = move_only2;
+  EXPECT_FALSE(move_only2->get() == nullptr);
+  EXPECT_FALSE((*move_only2).get() == nullptr);
+}
+
+TEST(option_forward) {
+  wcl::optional<std::pair<int, int>> opair(10, 10);
+  EXPECT_TRUE((bool)opair);
+  EXPECT_EQUAL(std::make_pair(10, 10), *opair);
+}
+
+struct NoConstruct {
+  NoConstruct() = delete;
+  NoConstruct(const NoConstruct&) = delete;
+  NoConstruct(const NoConstruct&&) = delete;
+  ~NoConstruct() {
+    std::cerr << "You weren't ever supposed to be able to construct such a thing!!!" << std::endl;
+    exit(1);
+  }
+};
+
+TEST(option_no_construct) {
+  wcl::optional<NoConstruct> none1;
+  wcl::optional<NoConstruct> none2;
+  EXPECT_FALSE((bool)none1);
+  EXPECT_FALSE((bool)none2);
+  none1 = none2;
+  none2 = std::move(none1);
+}
+
+struct SetOnDestruct {
+  const char* &msg;
+  const char* on_destruct = nullptr;
+
+  SetOnDestruct() = delete;
+  SetOnDestruct(const char *&msg, const char* on_destruct) : msg(msg), on_destruct(on_destruct) {}
+
+  ~SetOnDestruct() {
+    msg = on_destruct;
+  }
+};
+
+class ConstructDestructCount {
+ private:
+  int *count = nullptr;
+ public:
+  ConstructDestructCount() = default;
+  ConstructDestructCount(int &count) : count(&count) {
+    ++*this->count;
+  }
+  ConstructDestructCount(const ConstructDestructCount& other) : count(other.count) {
+    ++*this->count;
+  }
+  ConstructDestructCount(ConstructDestructCount&& other) : count(other.count) {
+    other.count = nullptr;
+  }
+  ~ConstructDestructCount() {
+    if (count) --*count;
+  }
+};
+
+TEST(option_destructs) {
+  const char* msg;
+  const char* expected = "this is the expected string";
+  int counter = 0;
+
+  // First some really basic tests
+  {
+    wcl::optional<SetOnDestruct> msg_setter(msg, expected);
+    wcl::optional<ConstructDestructCount> counter(counter);
+  }
+  EXPECT_EQUAL(msg, expected);
+  ASSERT_EQUAL(0, counter);
+
+  // Now some basic assignment tests.
+  {
+    wcl::optional<ConstructDestructCount> counter1(counter);
+    EXPECT_EQUAL(1, counter);
+    wcl::optional<ConstructDestructCount> counter2;
+    counter2 = counter1;
+    EXPECT_EQUAL(2, counter);
+  }
+  ASSERT_EQUAL(0, counter);
+  {
+    wcl::optional<ConstructDestructCount> counter1(counter);
+    EXPECT_EQUAL(1, counter);
+    wcl::optional<ConstructDestructCount> counter2;
+    counter2 = std::move(counter1);
+    EXPECT_EQUAL(1, counter);
+  }
+  ASSERT_EQUAL(0, counter);
+
+  // Now do something complicated to really stress the counter.
+  {
+    std::vector<wcl::optional<ConstructDestructCount>> counters;
+    for (int i = 0; i < 1000; ++i) {
+      counters.emplace_back(counter);
+    }
+    EXPECT_EQUAL(1000, counter);
+    std::random_device rd;
+    std::mt19937 g(rd());
+    for (int i = 0; i < 10; ++i)
+      std::random_shuffle(counters.begin(), counters.end(), g);
+    EXPECT_EQUAL(1000, counter);
+  }
+  ASSERT_EQUAL(0, counter);
+}

--- a/tools/wake-unit/unit.h
+++ b/tools/wake-unit/unit.h
@@ -109,8 +109,8 @@ struct TestLogger {
     return fail(*err, assert);
   }
 
-  template <class T>
-  TestStream expect_equal(bool assert, T&& expected, T&& actual, const char* expected_str,
+  template <class T1, class T2>
+  TestStream expect_equal(bool assert, T1&& expected, T2&& actual, const char* expected_str,
                           const char* actual_str, int line, const char* file) {
     if (expected == actual) return TestStream(nullptr, nullptr);
     errors.emplace_back(new ErrorMessage);


### PR DESCRIPTION
We've updated wake to use C++14 but we've decided we won't be updating to C++17 for quite some time. In the mean time however we want to be able to use modern looking C++ with proper error handling, and modern libraries. This library is the start of a modern set of useful tools and data structures that we can use to write highly optimized C++ that looks and feels a lot like real modern C++.

This library's interface is inspired by the current C++ standard library, absl, and llvm's library. Where possible we've chosen names that come from the C++ standard library so that migration to C++17 will be slightly eased in the future.