### PR TITLE
[wcl] Introduce the Wake Core Library

### DIFF
--- a/src/wcl/optional.h
+++ b/src/wcl/optional.h
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <utility>
+
+namespace wcl {
+
+struct in_place_t {
+  explicit in_place_t() = default;
+};
+
+template <class T, bool copy, bool move>
+class optional_base {};
+
+template <class T>
+class alignas(T) optional_base<T, true, true> {
+ protected:
+  union {
+    in_place_t null_value;
+    T value;
+  };
+  bool none = true;
+
+ public:
+  ~optional_base() {
+    if (!none) value.~T();
+  }
+  optional_base() : null_value(), none(true) {}
+  optional_base(const optional_base& other) : null_value(), none(other.none) {
+    if (!none) new (&value) T(other.value);
+  }
+  optional_base(optional_base&& other) : null_value(), none(other.none) {
+    if (!none) {
+      new (&value) T(std::move(other.value));
+      other.value.~T();
+      other.none = true;
+    }
+  }
+
+  optional_base& operator=(const optional_base& other) {
+    if (!none) value.~T();
+    none = other.none;
+    if (none) return *this;
+    new (&value) T(other.value);
+    return *this;
+  }
+
+  optional_base& operator=(optional_base&& other) {
+    if (!none) value.~T();
+    none = other.none;
+    if (none) return *this;
+    new (&value) T(std::move(other.value));
+    other.value.~T();
+    other.none = true;
+    return *this;
+  }
+
+  template <class... Args>
+  optional_base(in_place_t, Args&&... args) : value(std::forward<Args>(args)...), none(false) {}
+};
+
+template <class T>
+class alignas(T) optional_base<T, true, false> {
+ protected:
+  union {
+    uint8_t null_value;
+    T value;
+  };
+  bool none = true;
+
+ public:
+  ~optional_base() {
+    if (!none) value.~T();
+  }
+  optional_base() : null_value(), none(true) {}
+  optional_base(const optional_base& other) : null_value(), none(other.none) {
+    if (!none) new (&value) T(other.value);
+  }
+  optional_base(optional_base&&) = delete;
+
+  optional_base& operator=(const optional_base& other) {
+    if (!none) value.~T();
+    none = other.none;
+    if (none) return *this;
+    new (&value) T(other.value);
+    return *this;
+  }
+
+  optional_base& operator=(optional_base&& other) = delete;
+
+  template <class... Args>
+  optional_base(in_place_t, Args&&... args) : value(std::forward<Args>(args)...), none(false) {}
+};
+
+template <class T>
+class alignas(T) optional_base<T, false, true> {
+ protected:
+  union {
+    in_place_t null_value;
+    T value;
+  };
+  bool none = true;
+
+ public:
+  ~optional_base() {
+    if (!none) value.~T();
+  }
+  optional_base() : null_value(), none(true) {}
+
+  optional_base(optional_base&& other) : null_value(), none(other.none) {
+    if (!none) {
+      new (&value) T(std::move(other.value));
+      other.value.~T();
+      other.none = true;
+    }
+  }
+  optional_base(const optional_base&) = delete;
+
+  optional_base& operator=(optional_base&& other) {
+    if (!none) value.~T();
+    none = other.none;
+    if (none) return *this;
+    new (&value) T(std::move(other.value));
+    other.value.~T();
+    other.none = true;
+    return *this;
+  }
+
+  template <class... Args>
+  optional_base(in_place_t, Args&&... args) : value(std::forward<Args>(args)...), none(false) {}
+};
+
+template <class T>
+class alignas(T) optional_base<T, false, false> {
+ protected:
+  union {
+    uint8_t null_value;
+    T value;
+  };
+  bool none = true;
+
+ public:
+  ~optional_base() {
+    if (!none) value.~T();
+  }
+  optional_base() : null_value(), none(true) {}
+  optional_base(const optional_base&) = delete;
+  optional_base(optional_base&&) = delete;
+
+  template <class... Args>
+  optional_base(in_place_t, Args&&... args) : value(std::forward<Args>(args)...), none(false) {}
+};
+
+template <class T>
+using optional_base_t = optional_base<
+    T,
+    std::is_copy_constructible<T>::value,
+    std::is_move_constructible<T>::value>;
+
+template <class T>
+class optional
+  : public optional_base_t<T>
+{
+ public:
+  template <class... Args>
+  optional(in_place_t x, Args&&... args) : optional_base_t<T>(x, std::forward<Args>(args)...) {}
+
+  optional() = default;
+  optional(const optional&) = default;
+  optional(optional&&) = default;
+  ~optional() = default;
+
+  optional& operator=(const optional&) = default;
+  optional& operator=(optional&&) = default;
+
+  explicit operator bool() const { return !this->none; }
+
+  T& operator*() { return this->value; }
+
+  const T& operator*() const { return this->value; }
+
+  T* operator->() { return &this->value; }
+
+  const T* operator->() const { return &this->value; }
+};
+
+}  // namespace wcl

--- a/src/wcl/optional.h
+++ b/src/wcl/optional.h
@@ -167,15 +167,11 @@ class alignas(T) optional_base<T, false, false> {
 };
 
 template <class T>
-using optional_base_t = optional_base<
-    T,
-    std::is_copy_constructible<T>::value,
-    std::is_move_constructible<T>::value>;
+using optional_base_t =
+    optional_base<T, std::is_copy_constructible<T>::value, std::is_move_constructible<T>::value>;
 
 template <class T>
-class optional
-  : public optional_base_t<T>
-{
+class optional : public optional_base_t<T> {
  public:
   template <class... Args>
   optional(in_place_t x, Args&&... args) : optional_base_t<T>(x, std::forward<Args>(args)...) {}

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -43,7 +43,7 @@ def wakeToTest Unit = match (subscribe wakeTestBinary)
 def wakeUnitToTest Unit =
     require buildWakeUnit, Nil = subscribe wakeUnitTestBinary
     else failWithError "wake-unit binary not found"
-    require Pass wakeUnitLst = buildWakeUnit (Pair "native-cpp11-release" "native-c11-release")
+    require Pass wakeUnitLst = buildWakeUnit (Pair "native-cpp14-release" "native-c11-release")
     require Some result = head wakeUnitLst
     else failWithError "wake-unit binary not found"
     Pass result

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -1,4 +1,14 @@
 PASSED:
+  option_assign1
+  option_assign2
+  option_copy
+  option_destructs
+  option_forward
+  option_inplace
+  option_move
+  option_no_construct
+  option_none_is_none
+  option_some
   sanity_check1
   sanity_check2
 

--- a/tools/wake-unit/optional.cpp
+++ b/tools/wake-unit/optional.cpp
@@ -69,7 +69,7 @@ TEST(option_move) {
   // We want to make sure we can make optional move only things.
   wcl::optional<std::unique_ptr<int>> move_only1(wcl::in_place_t{}, std::make_unique<int>(10));
   wcl::optional<std::unique_ptr<int>> move_only2(std::move(move_only1));
-  //move_only1 = move_only2;
+  // move_only1 = move_only2;
   EXPECT_FALSE((bool)move_only1);
   ASSERT_TRUE((bool)move_only2);
   EXPECT_FALSE(move_only2->get() == nullptr);
@@ -104,25 +104,22 @@ TEST(option_no_construct) {
 }
 
 struct SetOnDestruct {
-  const char* &msg;
+  const char*& msg;
   const char* on_destruct = nullptr;
 
   SetOnDestruct() = delete;
-  SetOnDestruct(const char *&msg, const char* on_destruct) : msg(msg), on_destruct(on_destruct) {}
+  SetOnDestruct(const char*& msg, const char* on_destruct) : msg(msg), on_destruct(on_destruct) {}
 
-  ~SetOnDestruct() {
-    msg = on_destruct;
-  }
+  ~SetOnDestruct() { msg = on_destruct; }
 };
 
 class ConstructDestructCount {
  private:
-  int *count = nullptr;
+  int* count = nullptr;
+
  public:
   ConstructDestructCount() = default;
-  ConstructDestructCount(int &count) : count(&count) {
-    ++*this->count;
-  }
+  ConstructDestructCount(int& count) : count(&count) { ++*this->count; }
   ConstructDestructCount(const ConstructDestructCount& other) : count(other.count) {
     ++*this->count;
   }
@@ -144,9 +141,7 @@ class ConstructDestructCount {
   ~ConstructDestructCount() {
     if (count) --*count;
   }
-  void swap(ConstructDestructCount& other) {
-    std::swap(count, other.count);
-  }
+  void swap(ConstructDestructCount& other) { std::swap(count, other.count); }
 };
 
 TEST(option_destructs) {
@@ -188,8 +183,7 @@ TEST(option_destructs) {
     }
     EXPECT_EQUAL(1000, counter);
     std::mt19937 gen;
-    for (int i = 0; i < 10; ++i)
-      std::shuffle(counters.begin(), counters.end(), gen);
+    for (int i = 0; i < 10; ++i) std::shuffle(counters.begin(), counters.end(), gen);
     EXPECT_EQUAL(1000, counter);
   }
   ASSERT_EQUAL(0, counter);

--- a/tools/wake-unit/optional.cpp
+++ b/tools/wake-unit/optional.cpp
@@ -35,9 +35,9 @@ TEST(option_some) {
 }
 
 TEST(option_inplace) {
-  wcl::optional<int> some(wcl::in_place_t{}, 10);
+  wcl::optional<std::pair<int, int>> some(wcl::in_place_t{}, 10, 10);
   ASSERT_TRUE((bool)some);
-  EXPECT_EQUAL(10, *some);
+  EXPECT_EQUAL(std::make_pair(10, 10), *some);
 }
 
 TEST(option_copy) {

--- a/tools/wake-unit/optional.cpp
+++ b/tools/wake-unit/optional.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <wcl/optional.h>
+
+#include <algorithm>
+#include <memory>
+#include <random>
+
+#include "unit.h"
+
+TEST(option_none_is_none) {
+  wcl::optional<int> none;
+  EXPECT_FALSE((bool)none);
+}
+
+TEST(option_some) {
+  wcl::optional<int> some(wcl::in_place_t{}, 10);
+  ASSERT_TRUE((bool)some);
+  EXPECT_EQUAL(10, *some);
+}
+
+TEST(option_inplace) {
+  wcl::optional<int> some(wcl::in_place_t{}, 10);
+  ASSERT_TRUE((bool)some);
+  EXPECT_EQUAL(10, *some);
+}
+
+TEST(option_copy) {
+  wcl::optional<int> none1;
+  wcl::optional<int> none2(none1);
+  EXPECT_FALSE((bool)none1);
+  EXPECT_FALSE((bool)none2);
+
+  wcl::optional<int> some1(wcl::in_place_t{}, 10);
+  wcl::optional<int> some2(some1);
+  ASSERT_TRUE((bool)some1);
+  EXPECT_EQUAL(10, *some1);
+  ASSERT_TRUE((bool)some2);
+  EXPECT_EQUAL(10, *some2);
+}
+
+TEST(option_move) {
+  wcl::optional<int> none1;
+  wcl::optional<int> none2(std::move(none1));
+  EXPECT_FALSE((bool)none1);
+  EXPECT_FALSE((bool)none2);
+
+  wcl::optional<int> some1(wcl::in_place_t{}, 10);
+  wcl::optional<int> some2(std::move(some1));
+  EXPECT_FALSE((bool)some1);
+  ASSERT_TRUE((bool)some2);
+  EXPECT_EQUAL(10, *some2);
+
+  // We want to make sure we can make optional move only things.
+  wcl::optional<std::unique_ptr<int>> move_only1(wcl::in_place_t{}, std::make_unique<int>(10));
+  wcl::optional<std::unique_ptr<int>> move_only2(std::move(move_only1));
+  //move_only1 = move_only2;
+  EXPECT_FALSE((bool)move_only1);
+  ASSERT_TRUE((bool)move_only2);
+  EXPECT_FALSE(move_only2->get() == nullptr);
+  EXPECT_FALSE((*move_only2).get() == nullptr);
+  const auto& ref = move_only2;
+  EXPECT_FALSE(move_only2->get() == nullptr);
+  EXPECT_FALSE((*move_only2).get() == nullptr);
+  (void)ref;
+}
+
+TEST(option_forward) {
+  wcl::optional<std::pair<int, int>> opair(wcl::in_place_t{}, 10, 10);
+  EXPECT_TRUE((bool)opair);
+  EXPECT_EQUAL(std::make_pair(10, 10), *opair);
+}
+
+struct NoConstruct {
+  NoConstruct() = delete;
+  NoConstruct(const NoConstruct&) = delete;
+  NoConstruct(NoConstruct&&) = delete;
+  ~NoConstruct() {
+    std::cerr << "You weren't ever supposed to be able to construct such a thing!!!" << std::endl;
+    exit(1);
+  }
+};
+
+TEST(option_no_construct) {
+  wcl::optional<NoConstruct> none1;
+  wcl::optional<NoConstruct> none2;
+  EXPECT_FALSE((bool)none1);
+  EXPECT_FALSE((bool)none2);
+}
+
+struct SetOnDestruct {
+  const char* &msg;
+  const char* on_destruct = nullptr;
+
+  SetOnDestruct() = delete;
+  SetOnDestruct(const char *&msg, const char* on_destruct) : msg(msg), on_destruct(on_destruct) {}
+
+  ~SetOnDestruct() {
+    msg = on_destruct;
+  }
+};
+
+class ConstructDestructCount {
+ private:
+  int *count = nullptr;
+ public:
+  ConstructDestructCount() = default;
+  ConstructDestructCount(int &count) : count(&count) {
+    ++*this->count;
+  }
+  ConstructDestructCount(const ConstructDestructCount& other) : count(other.count) {
+    ++*this->count;
+  }
+  ConstructDestructCount(ConstructDestructCount&& other) : count(other.count) {
+    other.count = nullptr;
+  }
+  ConstructDestructCount& operator=(const ConstructDestructCount& other) {
+    if (count) --*count;
+    count = other.count;
+    ++*count;
+    return *this;
+  }
+  ConstructDestructCount& operator=(ConstructDestructCount&& other) {
+    if (count) --*count;
+    count = other.count;
+    other.count = nullptr;
+    return *this;
+  }
+  ~ConstructDestructCount() {
+    if (count) --*count;
+  }
+  void swap(ConstructDestructCount& other) {
+    std::swap(count, other.count);
+  }
+};
+
+TEST(option_destructs) {
+  const char* msg;
+  const char* expected = "this is the expected string";
+  int counter = 0;
+
+  // First some really basic tests
+  {
+    wcl::optional<SetOnDestruct> msg_setter(wcl::in_place_t{}, msg, expected);
+    wcl::optional<ConstructDestructCount> ocounter(wcl::in_place_t{}, counter);
+  }
+  EXPECT_EQUAL(msg, expected);
+  ASSERT_EQUAL(0, counter);
+
+  // Now some basic assignment tests.
+  {
+    wcl::optional<ConstructDestructCount> counter1(wcl::in_place_t{}, counter);
+    EXPECT_EQUAL(1, counter);
+    wcl::optional<ConstructDestructCount> counter2;
+    counter2 = counter1;
+    EXPECT_EQUAL(2, counter);
+  }
+  ASSERT_EQUAL(0, counter);
+  {
+    wcl::optional<ConstructDestructCount> counter1(wcl::in_place_t{}, counter);
+    EXPECT_EQUAL(1, counter);
+    wcl::optional<ConstructDestructCount> counter2;
+    counter2 = std::move(counter1);
+    EXPECT_EQUAL(1, counter);
+  }
+  ASSERT_EQUAL(0, counter);
+
+  // Now do something complicated to really stress the counter.
+  {
+    std::vector<wcl::optional<ConstructDestructCount>> counters;
+    for (int i = 0; i < 1000; ++i) {
+      counters.emplace_back(wcl::in_place_t{}, counter);
+    }
+    EXPECT_EQUAL(1000, counter);
+    std::mt19937 gen;
+    for (int i = 0; i < 10; ++i)
+      std::shuffle(counters.begin(), counters.end(), gen);
+    EXPECT_EQUAL(1000, counter);
+  }
+  ASSERT_EQUAL(0, counter);
+}
+
+TEST(option_assign1) {
+  // Basic copy
+  wcl::optional<int> some1(wcl::in_place_t{}, 10);
+  wcl::optional<int> some2;
+  EXPECT_FALSE((bool)some2);
+  some2 = some1;
+  ASSERT_TRUE((bool)some1);
+  ASSERT_TRUE((bool)some2);
+  EXPECT_EQUAL(*some1, *some2);
+}
+
+TEST(option_assign2) {
+  // Basic copy
+  int counter = 0;
+  {
+    wcl::optional<ConstructDestructCount> some1(wcl::in_place_t{}, counter);
+    wcl::optional<ConstructDestructCount> some2;
+
+    EXPECT_TRUE((bool)some1);
+    EXPECT_FALSE((bool)some2);
+    EXPECT_EQUAL(1, counter);
+
+    some2 = some1;
+    EXPECT_TRUE((bool)some1);
+    EXPECT_TRUE((bool)some2);
+    EXPECT_EQUAL(2, counter);
+
+    some1 = some2;
+    EXPECT_TRUE((bool)some1);
+    EXPECT_TRUE((bool)some2);
+    EXPECT_EQUAL(2, counter);
+
+    some1 = wcl::optional<ConstructDestructCount>();
+    EXPECT_TRUE((bool)some2);
+    EXPECT_FALSE((bool)some1);
+    EXPECT_EQUAL(1, counter);
+  }
+  EXPECT_EQUAL(0, counter);
+}

--- a/tools/wake-unit/unit.cpp
+++ b/tools/wake-unit/unit.cpp
@@ -33,11 +33,16 @@ struct Test {
 
 // A global list of all the tests to run. Its kept static so that
 // nothing can interfear with it except things in this file, which
-// is only TestRegister and main itself.
-static std::vector<Test> tests;
+// is only TestRegister and main itself. We have to make it static
+// local so that it can be initied before anything else no matter
+// what order things are linked in.
+static std::vector<Test>* get_tests() {
+  static std::vector<Test> tests;
+  return &tests;
+}
 
 TestRegister::TestRegister(const char* test_name, TestFunc test) {
-  tests.emplace_back(test_name, test);
+  get_tests()->emplace_back(test_name, test);
 }
 
 int main(int argc, char** argv) {
@@ -59,7 +64,7 @@ int main(int argc, char** argv) {
   TestLogger logger;
   std::set<std::string> failed_tests;
   std::set<std::string> passing_tests;
-  for (auto& test : tests) {
+  for (auto& test : *get_tests()) {
     // Set this logjump in case this test fails
     size_t num_errors = logger.errors.size();
     logger.test_name = test.test_name;

--- a/tools/wake-unit/unit.h
+++ b/tools/wake-unit/unit.h
@@ -93,9 +93,8 @@ struct TestLogger {
     return fail(*err, assert);
   }
 
-  TestStream expect_equal(bool assert, int expected, int actual,
-                          const char* expected_str, const char* actual_str, int line,
-                          const char* file) {
+  TestStream expect_equal(bool assert, int expected, int actual, const char* expected_str,
+                          const char* actual_str, int line, const char* file) {
     if (expected == actual) return TestStream(nullptr, nullptr);
     errors.emplace_back(new ErrorMessage);
     auto& err = errors.back();


### PR DESCRIPTION
This change just adds an optional type that functions the same way as std::optional more or less.
It doesn't respect assignment quite the same way right now which means that wcl::optional<std::vector<T>>
isn't as efficen't as it could be since if you assign one vector to another that already has capacity,
the current implementation deallocates the first one and reallocates this one despite that not being
needed.