### PR TITLE
.gitignore: wake.db-shm and wake.db-wal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ manifest.wake
 .build
 .fuse*
 /.vscode/*.log
-/**/wake.db
-/wake.db
+/**/wake.db*
+/wake.db*
 /wake.spec
 /src/parser/lexer.cpp
 /src/parser/parser.y


### PR DESCRIPTION
`wake.db-shm` and `wake.db-wal` shouldn't be tracked by git