### PR TITLE
Move Xoshiro256 to wcl

### DIFF
--- a/src/wcl/xoshiro256.h
+++ b/src/wcl/xoshiro256.h
@@ -35,6 +35,17 @@ static std::string to_hex(const T *value) {
   return name;
 }
 
+// Use /dev/urandom to get a good seed
+static std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> get_rng_seed() {
+  auto rng_fd = UniqueFd::open("/dev/urandom", O_RDONLY, 0644);
+  uint8_t seed_data[32] = {0};
+  if (read(rng_fd.get(), seed_data, sizeof(seed_data)) < 0) {
+    log_fatal("read(/dev/urandom): %s", strerror(errno));
+  }
+  uint64_t *data = reinterpret_cast<uint64_t *>(seed_data);
+  return std::make_tuple(data[0], data[1], data[2], data[3]);
+}
+
 // Adapted from wikipedia's code, which was adapted from
 // the code included on Sebastiano Vigna's website for
 // Xoshiro256**. Xoshiro256** is a modern, efficent, and

--- a/src/wcl/xoshiro256.h
+++ b/src/wcl/xoshiro256.h
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <tuple>
 
-#pragma once
+namespace wcl {
 
 template <class T>
 static std::string to_hex(const T *value) {
@@ -86,3 +86,5 @@ class Xoshiro256 {
     return to_hex<uint8_t[16]>(&data);
   }
 };
+
+}  // namespace wcl

--- a/src/wcl/xoshiro_256.h
+++ b/src/wcl/xoshiro_256.h
@@ -37,11 +37,23 @@ static std::string to_hex(const T *value) {
 
 // Use /dev/urandom to get a good seed
 static std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> get_rng_seed() {
-  auto rng_fd = UniqueFd::open("/dev/urandom", O_RDONLY, 0644);
-  uint8_t seed_data[32] = {0};
-  if (read(rng_fd.get(), seed_data, sizeof(seed_data)) < 0) {
-    log_fatal("read(/dev/urandom): %s", strerror(errno));
+  // TODO: This really needs to be using a unique_fd/return a result
+  // That is currently blocked by landing wcl. Update this once
+  // unique_fd and result land.
+
+  int rng_fd = open("/dev/urandom", O_RDONLY, 0644);
+  if (rng_fd == -1) {
+    std::cerr << "Failed to open /dev/urandom" << std::endl;
+    exit(1);
   }
+
+  uint8_t seed_data[32] = {0};
+  if (read(rng_fd, seed_data, sizeof(seed_data)) < 0) {
+    std::cerr << "Failed to read /dev/urandom" << std::endl;
+    exit(1);
+  }
+  close(rng_fd);
+
   uint64_t *data = reinterpret_cast<uint64_t *>(seed_data);
   return std::make_tuple(data[0], data[1], data[2], data[3]);
 }
@@ -52,15 +64,15 @@ static std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> get_rng_seed() {
 // highly robust psuedo random number generator. It uses
 // a small amount of state for its period and passes the
 // CRUSH suite of statistical tests.
-class Xoshiro256 {
+class xoshiro_256 {
   uint64_t state[4];
 
   static uint64_t rol64(uint64_t x, int k) { return (x << k) | (x >> (64 - k)); }
 
  public:
-  Xoshiro256() = delete;
+  xoshiro_256() = delete;
 
-  Xoshiro256(std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> seed) {
+  xoshiro_256(std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> seed) {
     state[0] = std::get<0>(seed);
     state[1] = std::get<1>(seed);
     state[2] = std::get<2>(seed);
@@ -69,7 +81,7 @@ class Xoshiro256 {
 
   // Generates a psuedo random number, uniformly distributed
   // over the 64-bit unsigned integers.
-  uint64_t step() {
+  uint64_t operator()() {
     uint64_t *s = state;
     uint64_t const result = rol64(state[1] * 5, 7) * 9;
     uint64_t const t = s[1] << 17;
@@ -92,8 +104,8 @@ class Xoshiro256 {
   // no malicious intent.
   std::string unique_name() {
     uint8_t data[16];
-    reinterpret_cast<uint64_t *>(data)[0] = step();
-    reinterpret_cast<uint64_t *>(data)[1] = step();
+    reinterpret_cast<uint64_t *>(data)[0] = (*this)();
+    reinterpret_cast<uint64_t *>(data)[1] = (*this)();
     return to_hex<uint8_t[16]>(&data);
   }
 };

--- a/tools/job-cache/job-cache.cpp
+++ b/tools/job-cache/job-cache.cpp
@@ -37,7 +37,7 @@
 #include "bloom.h"
 #include "logging.h"
 #include "unique_fd.h"
-#include "wcl/xoshiro256.h"
+#include "wcl/xoshiro_256.h"
 
 // moves the file or directory, crashes on error
 static void rename_no_fail(const char *old_path, const char *new_path) {
@@ -463,7 +463,7 @@ class Cache {
   OutputFiles output_files;
   Transaction transact;
   std::string dir;
-  wcl::Xoshiro256 rng;
+  wcl::xoshiro_256 rng;
 
  public:
   ~Cache() {}

--- a/tools/job-cache/job-cache.cpp
+++ b/tools/job-cache/job-cache.cpp
@@ -127,17 +127,6 @@ static void get_hex_data(const std::string &s, uint8_t (*data)[size]) {
   }
 }
 
-// Use /dev/urandom to get a good seed
-static std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> get_rng_seed() {
-  auto rng_fd = UniqueFd::open("/dev/urandom", O_RDONLY, 0644);
-  uint8_t seed_data[32] = {0};
-  if (read(rng_fd.get(), seed_data, sizeof(seed_data)) < 0) {
-    log_fatal("read(/dev/urandom): %s", strerror(errno));
-  }
-  uint64_t *data = reinterpret_cast<uint64_t *>(seed_data);
-  return std::make_tuple(data[0], data[1], data[2], data[3]);
-}
-
 class Database {
  private:
   sqlite3 *db = nullptr;
@@ -490,7 +479,7 @@ class Cache {
         output_files(db),
         transact(db),
         dir(std::move(_dir)),
-        rng(get_rng_seed()) {}
+        rng(wcl::get_rng_seed()) {}
 
   void add(const AddJobRequest &add_request) {
     // Create a unique name for the job dir (will rename later to correct name)

--- a/tools/job-cache/job-cache.cpp
+++ b/tools/job-cache/job-cache.cpp
@@ -37,7 +37,7 @@
 #include "bloom.h"
 #include "logging.h"
 #include "unique_fd.h"
-#include "xoshiro256.h"
+#include "wcl/xoshiro256.h"
 
 // moves the file or directory, crashes on error
 static void rename_no_fail(const char *old_path, const char *new_path) {
@@ -474,7 +474,7 @@ class Cache {
   OutputFiles output_files;
   Transaction transact;
   std::string dir;
-  Xoshiro256 rng;
+  wcl::Xoshiro256 rng;
 
  public:
   ~Cache() {}
@@ -536,7 +536,7 @@ class Cache {
     // atomically rename the temp job into place which completes
     // the insertion. At that point reads should suceed.
     uint8_t job_group = job_id & 0xFF;
-    std::string job_group_dir = dir + "/" + to_hex<uint8_t>(&job_group);
+    std::string job_group_dir = dir + "/" + wcl::to_hex<uint8_t>(&job_group);
     mkdir_no_fail(job_group_dir.c_str());
     std::string job_dir = job_group_dir + "/" + std::to_string(job_id);
     rename_no_fail(tmp_job_dir.c_str(), job_dir.c_str());


### PR DESCRIPTION
Moves `Xoshiro256` to wcl. `Xoshiro256` is currently used to generate unique file names for `job-cache`. We also need to generate unique filenames for `wake-format` so it is being moved to wcl to make it generally available