### PR TITLE
Remove v and add '-bootstrap' to bootstrap build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Bootstrap build file
 
-VERSION	:= $(shell if test -f manifest.wake; then sed -n "/publish releaseAs/ s/^[^']*'\([^']*\)'.*/\1/p" manifest.wake; else git describe --tags --dirty; fi)
+VERSION	:= $(shell if test -f manifest.wake; then sed -n "/publish releaseAs/ s/^[^']*'\([^']*\)'.*/\1/p" manifest.wake; else git describe --tags --dirty | cut -c 2- | tr -d '\n' | sed 's/$$/-bootstrap/'; fi)
 
 CC	:= cc -std=c11
 CXX	:= c++


### PR DESCRIPTION
1) `wake --version` prepended `v` for the bootstrap build while the main build didn't. This brings them in alignment with no `v`

2) Adds `-bootstrap` to the bootstrap build so that it explicitly calls out that its the bootstrap build and not the main one