### PR TITLE
test: Provide dir to bin/ instead of wake as $1

### DIFF
--- a/tests/command-line/qv/fail.sh
+++ b/tests/command-line/qv/fail.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
-
-"${1:-wake}" -qv -x Unit
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -qv -x Unit

--- a/tests/dst/colon/fail.sh
+++ b/tests/dst/colon/fail.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -q test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -q test

--- a/tests/dst/packages/fail.sh
+++ b/tests/dst/packages/fail.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" --in foo -q test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" --in foo -q test

--- a/tests/dst/typedef/fail.sh
+++ b/tests/dst/typedef/fail.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -q test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -q test

--- a/tests/parser/unicode/pass.sh
+++ b/tests/parser/unicode/pass.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" test

--- a/tests/runtime/symlinks/pass.sh
+++ b/tests/runtime/symlinks/pass.sh
@@ -2,26 +2,29 @@
 
 set -ex
 
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
 rm -f datFile badLink goodLink wake.db
-"${1:-wake}" -v test
-"${1:-wake}" -v test
+"${WAKE}" -v test
+"${WAKE}" -v test
 
 rm wake.db
-"${1:-wake}" -v test
+"${WAKE}" -v test
 
 rm -f datFile badLink goodLink
 ln -s whatever datFile
 ln -s whatever badLink
 ln -s whatever goodLink
-"${1:-wake}" -v test
-"${1:-wake}" -v test
+"${WAKE}" -v test
+"${WAKE}" -v test
 
 rm -f datFile badLink goodLink wake.db
 ln -s whatever datFile
 ln -s whatever badLink
 ln -s whatever goodLink
-"${1:-wake}" -v test
-"${1:-wake}" -v test
+"${WAKE}" -v test
+"${WAKE}" -v test
 
 rm -f datFile badLink goodLink .fuse.log
 echo "Symlinks work!"

--- a/tests/standard-library/groupBy/pass.sh
+++ b/tests/standard-library/groupBy/pass.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" --stdout=warning,report test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" --stdout=warning,report test

--- a/tests/standard-library/json-normalize-merge/compat-identity/pass.sh
+++ b/tests/standard-library/json-normalize-merge/compat-identity/pass.sh
@@ -1,7 +1,8 @@
 #! /bin/sh
 
 ln ../json-test.wake .
-"${1:-wake}" --quiet --stdout=warning,report 'jsonTest normalizeJSONIdentity' \
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" --quiet --stdout=warning,report 'jsonTest normalizeJSONIdentity' \
     infinity.json \
     nan.json \
     unicode.json

--- a/tests/standard-library/json-normalize-merge/compat-valid/pass.sh
+++ b/tests/standard-library/json-normalize-merge/compat-valid/pass.sh
@@ -1,6 +1,7 @@
 #! /bin/sh
 
 ln ../json-test.wake .
-"${1:-wake}" --quiet --stdout=warning,report 'jsonTest normalizeJSONCompat' input.json
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" --quiet --stdout=warning,report 'jsonTest normalizeJSONCompat' input.json
 rm json-test.wake
 rm -r build

--- a/tests/standard-library/json-normalize-merge/compat/pass.sh
+++ b/tests/standard-library/json-normalize-merge/compat/pass.sh
@@ -1,7 +1,8 @@
 #! /bin/sh
 
 ln ../json-test.wake .
-"${1:-wake}" --quiet --stdout=warning,report 'jsonTest normalizeJSONCompat' \
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" --quiet --stdout=warning,report 'jsonTest normalizeJSONCompat' \
     infinity.json \
     nan.json \
     unicode.json \

--- a/tests/standard-library/json-normalize-merge/deduplicate/pass.sh
+++ b/tests/standard-library/json-normalize-merge/deduplicate/pass.sh
@@ -1,7 +1,8 @@
 #! /bin/sh
 
 ln ../json-test.wake .
-"${1:-wake}" --quiet --stdout=warning,report 'jsonTest normalizeJSONCompat' \
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" --quiet --stdout=warning,report 'jsonTest normalizeJSONCompat' \
     valid.json \
     valid-nesting.json \
     invalid-boolean.json \

--- a/tests/standard-library/json-normalize-merge/mergeJSON/pass.sh
+++ b/tests/standard-library/json-normalize-merge/mergeJSON/pass.sh
@@ -1,7 +1,8 @@
 #! /bin/sh
 
 ln ../json-test.wake .
-"${1:-wake}" --quiet --stdout=warning,report 'jsonArrayTest mergeJSON' \
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" --quiet --stdout=warning,report 'jsonArrayTest mergeJSON' \
     recurse.json \
     override.json
 rm json-test.wake

--- a/tests/standard-library/json-normalize-merge/overrideJSON/pass.sh
+++ b/tests/standard-library/json-normalize-merge/overrideJSON/pass.sh
@@ -1,7 +1,8 @@
 #! /bin/sh
 
 ln ../json-test.wake .
-"${1:-wake}" --quiet --stdout=warning,report 'jsonArrayTest (_.overrideJSON | Pass)' \
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" --quiet --stdout=warning,report 'jsonArrayTest (_.overrideJSON | Pass)' \
     recurse.json \
     override.json
 rm json-test.wake

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -35,11 +35,12 @@ export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
 # the way we test currently.
 export topic wakeUnitTestBinary: (variant: Pair String String) => Result (List Path) Error
 
-def wakeToTestDir Unit =
-    require buildTestWake, Nil = subscribe wakeTestBinary
-    else failWithError "wake binary to test not found"
-    require Pass (Pair path visible) = buildTestWake Unit
-    Pass (Pair (simplify "{path}/..") visible)
+def wakeToTestDir Unit = match (subscribe wakeTestBinary)
+    buildTestWake, Nil =
+        require Pass (Pair path visible) = buildTestWake Unit
+        Pass (Pair (simplify "{path}/..") visible)
+    Nil = Pass (Pair "{wakePath}" Nil)
+    _ = Fail (makeError "Two wake binaries declared for testing!")
 
 def wakeUnitToTest Unit =
     require buildWakeUnit, Nil = subscribe wakeUnitTestBinary

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -35,10 +35,11 @@ export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
 # the way we test currently.
 export topic wakeUnitTestBinary: (variant: Pair String String) => Result (List Path) Error
 
-def wakeToTest Unit = match (subscribe wakeTestBinary)
-    fn, Nil = fn Unit
-    Nil = Pass (Pair "{wakePath}/wake" Nil)
-    _ = Fail (makeError "Two wake binaries declared for testing!")
+def wakeToTestDir Unit =
+    require buildTestWake, Nil = subscribe wakeTestBinary
+    else failWithError "wake binary to test not found"
+    require Pass (Pair path visible) = buildTestWake Unit
+    Pass (Pair (simplify "{path}/..") visible)
 
 def wakeUnitToTest Unit =
     require buildWakeUnit, Nil = subscribe wakeUnitTestBinary
@@ -54,8 +55,8 @@ export def runTests (cmdline: List String): Result String Error =
         arg, Nil = stringToRegExp arg
         _        = Fail (makeError "Too many arguments to runTests")
 
-    require Pass (Pair wakeBin _) =
-        wakeToTest Unit
+    require Pass (Pair wakeDir _) =
+        wakeToTestDir Unit
 
     require Pass tests =
         sources here `${filter}/(pass|fail)\.sh`
@@ -90,7 +91,7 @@ export def runTests (cmdline: List String): Result String Error =
         | map formatCategory
         | catWith "\n"
 
-    def _ = printlnLevel logWarning "{wakeBin} unit testing results:\n{report}\n---"
+    def _ = printlnLevel logWarning "{wakeDir}/wake unit testing results:\n{report}\n---"
 
     require Pass _ = findFailFn getTripleThird results
 
@@ -202,11 +203,11 @@ def runTest (testScript: Path): Result Unit Error =
     def inTestDir path =
         relative testDirectory path
 
-    require Pass (Pair wakeBin wakeVisible) =
-        wakeToTest Unit
+    require Pass (Pair wakeDir wakeVisible) =
+        wakeToTestDir Unit
 
     def testJob =
-        makeExecPlan ("./{testScript.getPathName.inTestDir}", wakeBin.inTestDir, Nil) (visibleFiles ++ wakeVisible)
+        makeExecPlan ("./{testScript.getPathName.inTestDir}", wakeDir.inTestDir, Nil) (visibleFiles ++ wakeVisible)
         | setPlanDirectory testDirectory
         | setPlanLabel "testing: {testName}"
         | setPlanLocalOnly True # On OS/X you cannot mount fuse within fuse

--- a/tests/type-system/extract-fail/fail.sh
+++ b/tests/type-system/extract-fail/fail.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -q test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -q test

--- a/tests/type-system/extract-pass/pass.sh
+++ b/tests/type-system/extract-pass/pass.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -v test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -v test

--- a/tests/type-system/lambda-fail/fail.sh
+++ b/tests/type-system/lambda-fail/fail.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -q test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -q test

--- a/tests/type-system/lambda-pass/pass.sh
+++ b/tests/type-system/lambda-pass/pass.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -v test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -v test

--- a/tests/type-system/match-fail/fail.sh
+++ b/tests/type-system/match-fail/fail.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -q test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -q test

--- a/tests/type-system/match-pass/pass.sh
+++ b/tests/type-system/match-pass/pass.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -v test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -v test

--- a/tests/type-system/multi-match-fail/fail.sh
+++ b/tests/type-system/multi-match-fail/fail.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -q test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -q test

--- a/tests/type-system/multi-match-pass/pass.sh
+++ b/tests/type-system/multi-match-pass/pass.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -v test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -v test

--- a/tests/type-system/require-fail/fail.sh
+++ b/tests/type-system/require-fail/fail.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -q test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -q test

--- a/tests/type-system/require-pass/pass.sh
+++ b/tests/type-system/require-pass/pass.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -v test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -v test

--- a/tests/type-system/value-restriction/pass.sh
+++ b/tests/type-system/value-restriction/pass.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
-"${1:-wake}" -v test
+WAKE="${1:+$1/wake}"
+"${WAKE:-wake}" -v test


### PR DESCRIPTION
Instead of setting `$1` to `<something>/bin/wake` set it to `<something>/bin`.
This allows tests to execute any of the tools installed by wake.

Also updates all wake tests to point to bin/wake.

It is mainly needed to support wake-format tests but may be used for
other tools in the future.