### PR TITLE
Introduce wcl::rope and wcl::rope_builder

### DIFF
--- a/src/wcl/rope.h
+++ b/src/wcl/rope.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <memory>
+
+namespace wcl {
+
+class rope_impl_base {
+protected:
+  // On construction this has to be set
+  size_t length;
+
+  rope_impl_base(size_t len) : length(len) {}
+public:
+  // methods that all RopeImpl share
+  virtual void write(std::ostream&) const = 0;
+  virtual std::string as_string() const = 0;
+  size_t size() const {
+    return length;
+  }
+};
+
+class rope_impl_string : public rope_impl_base {
+  private:
+   std::string str;
+  public:
+  explicit rope_impl_string(std::string str): rope_impl_base(str.size()), str(str){}
+  void write(std::ostream& ostream) const override {
+    ostream << str;
+  }
+
+  std::string as_string() const override {
+    return str;
+  }
+};
+
+class rope_impl_pair: public rope_impl_base {
+ // this concats two ropes togethor
+  private:
+   std::pair<std::shared_ptr<rope_impl_base>,std::shared_ptr<rope_impl_base>> pair;
+  public:
+  rope_impl_pair(std::shared_ptr<rope_impl_base> left, std::shared_ptr<rope_impl_base> right):
+  rope_impl_base(left->size() + right->size()), pair(std::make_pair(std::move(left), std::move(right))) {}
+  void write(std::ostream& ostream) const override {
+    pair.first->write(ostream);
+    pair.second->write(ostream);
+  }
+  std::string as_string() const override {
+    return pair.first->as_string() + pair.second->as_string();
+  }
+};
+
+class rope {
+private:
+  std::shared_ptr<rope_impl_base> impl;
+
+  explicit rope(std::unique_ptr<rope_impl_base> impl) : impl(std::move(impl)) {}
+
+public:
+  // O(1) but constructing the string takes O(n)
+  static rope lit(std::string&& str) {
+    return rope(std::make_unique<rope_impl_string>(std::move(str)));
+  }
+  // O(1)
+  rope concat(rope r) {
+    return rope(std::make_unique<rope_impl_pair>(impl, r.impl));
+  }
+
+  // O(n)
+  std::string as_string() {
+    return impl->as_string();
+  }
+
+  // O(n)
+  void write(std::ostream& ostream) const {
+    impl ->write(ostream);
+  }
+
+  // O(1)
+  size_t size() { return impl->size(); }
+
+};
+
+class rope_builder {
+private:
+  rope r = rope::lit("");
+
+public:
+  void append(const char* str) {
+    r = r.concat(rope::lit(str));
+  }
+  void append(rope other) {
+    r = r.concat(other);
+  }
+
+  rope build() {
+    rope copy = r;
+    r = rope::lit("");
+    return copy;
+  }
+};
+
+}  // namespace wcl

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -9,6 +9,9 @@ PASSED:
   option_no_construct
   option_none_is_none
   option_some
+  rope_basic
+  rope_builder_build_once
+  rope_large
   sanity_check1
   sanity_check2
   trie_basic

--- a/tools/wake-unit/rope.cpp
+++ b/tools/wake-unit/rope.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <wcl/rope.h>
+
+#include "unit.h"
+
+TEST(rope_basic) {
+    wcl::rope_builder builder;
+    builder.append("Hello");
+    builder.append(" ");
+    builder.append("World");
+    builder.append("!");
+
+    {
+        wcl::rope_builder other;
+        other.append("My name is");
+        other.append(" John");
+        wcl::rope r = other.build();
+        builder.append(" ");
+        builder.append(r);
+    }
+
+    wcl::rope r = builder.build();
+    std::string expected = "Hello World! My name is John";
+    ASSERT_EQUAL(expected.size(), r.size());
+    ASSERT_EQUAL(expected, r.as_string());
+}
+
+TEST(rope_builder_build_once) {
+    wcl::rope_builder builder;
+    builder.append("Hello");
+    builder.append(" ");
+    builder.append("World");
+    builder.append("!");
+    wcl::rope r = builder.build();
+
+    std::string expected = "Hello World!";
+    ASSERT_EQUAL(expected.size(), r.size());
+    ASSERT_EQUAL(expected, r.as_string());
+
+    r = builder.build();
+
+    expected = "";
+    ASSERT_EQUAL(expected.size(), r.size());
+    ASSERT_EQUAL(expected, r.as_string());
+}
+
+TEST(rope_large) {
+    wcl::rope_builder builder;
+   for (int i = 0; i < 1000; i++) {
+    wcl::rope_builder a;
+    for (int j = 0; j < 1000; j++) {
+        a.append("a");
+    }
+
+    wcl::rope_builder b;
+    for (int j = 0; j < 1000; j++) {
+        b.append("b");
+    }
+
+    wcl::rope_builder c;
+    for (int j = 0; j < 1000; j++) {
+        c.append("c");
+    }
+
+    a.append(b.build());
+    a.append(c.build());
+    builder.append(a.build());
+   }
+
+    wcl::rope r = builder.build();
+    ASSERT_EQUAL(3000000u, r.size());
+}


### PR DESCRIPTION
Creates a very simple rope class for efficiently building up a very long string. Will be used by `wake-format` when walking the CST.

The rope has the following properties
- O(1) append for `rope`
- O(n) append for `string` (most strings will be n < 10)
- O(1) for `size`
- O(n) string conversion where n = number of nodes (this will also ilicit a bunch of string constructions so its pretty expensive)
- O(n) emit to ostream where n = number of nodes