### PR TITLE
job: fix pointer lifetime bug

### DIFF
--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -800,10 +800,10 @@ bool JobTable::wait(Runtime &runtime) {
     if (exit_now()) timeout = &nowait;
 
 #if !defined(__linux__)
+    struct timespec alarm;
     // In case SIGALRM with SA_RESTART doesn't stop pselect
     if (!timeout) {
       struct itimerval timer;
-      struct timespec alarm;
       getitimer(ITIMER_REAL, &timer);
       if (timer.it_value.tv_sec || timer.it_value.tv_usec) {
         alarm.tv_sec = timer.it_value.tv_sec;


### PR DESCRIPTION
This gets wake working again on macOS Monterey / M1:

```
terpstra@watermelon wake % uname -a
Darwin watermelon.local 21.5.0 Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:37 PDT 2022; root:xnu-8020.121.3~4/RELEASE_ARM64_T6000 arm64
terpstra@watermelon wake % ./bin/wake build default
Pass "BUILD"
```