### PR TITLE
wake-format: Add tree walk boilerplate code

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -7,3 +7,25 @@ def name Unit =
   def other = here
   def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   another
+
+def t1 =match _
+  0=0
+  n = 2+t(n-1)
+
+def wakeToTestDir Unit = match (subscribe wakeTestBinary)
+    buildTestWake, Nil =
+        require Pass (Pair path visible)=buildTestWake Unit
+        Pass (Pair (simplify "{path}/..") visible)
+    Nil = Pass (Pair "{wakePath}" Nil)
+    _ = Fail (makeError "Two wake binaries declared for testing!")
+
+package test_wake
+
+from wake import _
+from wake import source , Nil
+from test_wake import topic wakeTestBinary
+from gcc_wake import compileC linkO
+from wake import myMap=map foldl myFoldr=foldr
+from wake import def unary + -
+from wake import type Pair Result
+from wake import source,Nil

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1,10 +1,24 @@
-def name Unit =  def other = @here  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  another 
+def name Unit =
+ def other = @here
+ def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+ another
 
-def name Unit =  def other = @here  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  another 
+
+def name Unit =
+ def other = @here
+ def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+ another
+
 
 def t1 =match _  0=0  n = 2+t(n-1) 
 
-def wakeToTestDir Unit = match (subscribe wakeTestBinary)  buildTestWake, Nil =  require Pass (Pair path visible)=buildTestWake Unit  Pass (Pair (simplify "{path}/..") visible)  Nil = Pass (Pair "{wakePath}" Nil)  _ = Fail (makeError "Two wake binaries declared for testing!") 
+def wakeToTestDir Unit = match (subscribe wakeTestBinary)
+ buildTestWake, Nil =
+ require Pass (Pair path visible)=buildTestWake Unit
+ Pass (Pair (simplify "{path}/..") visible)
+ Nil = Pass (Pair "{wakePath}" Nil)
+ _ = Fail (makeError "Two wake binaries declared for testing!")
+
 
 package test_wake 
 

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1,7 +1,18 @@
-def·name·Unit·=·def·other·=·@here⏎
-····def·other·=·"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"⏎
-····another⏎
-⏎
-def·name·Unit·=·def·other·=·@here⏎
-····def·other·=·"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"⏎
-····another⏎
+def name Unit =  def other = @here  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  another 
+
+def name Unit =  def other = @here  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  another 
+
+def t1 =match _  0=0  n = 2+t(n-1) 
+
+def wakeToTestDir Unit = match (subscribe wakeTestBinary)  buildTestWake, Nil =  require Pass (Pair path visible)=buildTestWake Unit  Pass (Pair (simplify "{path}/..") visible)  Nil = Pass (Pair "{wakePath}" Nil)  _ = Fail (makeError "Two wake binaries declared for testing!") 
+
+package test_wake 
+
+from wake import _ 
+from wake import source , Nil 
+from test_wake import topic wakeTestBinary 
+from gcc_wake import compileC linkO 
+from wake import myMap=map foldl myFoldr=foldr 
+from wake import def unary + - 
+from wake import type Pair Result 
+from wake import source,Nil 

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -25,10 +25,30 @@
 
 #include "parser/parser.h"
 
+#define ASSERT_TOKEN(node, token) \
+  assert(!node.empty());          \
+  assert(node.id() == token);
+
+#define APPEND_OR_BUBBLE(func, ctx, node) \
+  {                                       \
+    auto subtree = func(ctx, node);       \
+    if (!subtree) {                       \
+      return {};                          \
+    }                                     \
+    builder.append(*subtree);             \
+  }
+
+#define CONSUME_WS_NL(node)                                                     \
+  {                                                                             \
+    while (!node.empty() && (node.id() == TOKEN_WS || node.id() == TOKEN_NL)) { \
+      node.nextSiblingElement();                                                \
+    }                                                                           \
+  }
+
 wcl::rope Emitter::newline(ctx_t ctx) {
   wcl::rope_builder builder;
 
-  builder.append("⏎\n");
+  builder.append("\n");
   for (int i = 0; i < ctx.nest_level; i++) {
     builder.append(space(space_per_indent));
   }
@@ -39,123 +59,75 @@ wcl::rope Emitter::newline(ctx_t ctx) {
 wcl::rope Emitter::space(uint8_t count) {
   wcl::rope_builder builder;
   for (uint8_t i = 0; i < count; i++) {
-    builder.append("·");
+    builder.append(" ");
   }
   return std::move(builder).build();
 }
 
 wcl::optional<wcl::rope> Emitter::flat(ctx_t ctx, CSTElement node) {
-  return walk_node(ctx.flat(), node);
-}
-
-wcl::rope Emitter::try_flat(ctx_t ctx, CSTElement node) {
-  auto flat_node = flat(ctx, node);
-  if (flat_node && flat_node->column() <= max_column_width) {
-    return *flat_node;
+  // Try to get the flat version of node
+  auto flat_node = walk_node(ctx.flat(), node);
+  if (!flat_node) {
+    return {};
   }
-  auto full_node = walk_node(ctx, node);
-  assert(full_node);
-  return *full_node;
+
+  if (flat_node->column() > max_column_width) {
+    return {};
+  }
+
+  return flat_node;
 }
 
-#define ASSERT_TOKEN(node, token) \
-  assert(!node.empty());          \
-  assert(node.id() == token);
+wcl::optional<wcl::rope> Emitter::flat_or(ctx_t ctx, CSTElement node) {
+  // Try to get the flat version of node
+  auto flat_node = flat(ctx, node);
+  if (flat_node) {
+    return flat_node;
+  }
+
+  // flat_or was called within a flat context, so the flat failure
+  // needs to be bubbled up.
+  if (ctx.is_flat) {
+    return {};
+  }
+
+  // fallback to full node
+  return walk_node(ctx, node);
+}
 
 wcl::rope Emitter::layout(CST cst) {
   ctx_t ctx;
-  return walk_top(ctx, cst.root()).concat(newline(ctx));
+  return walk(ctx, cst.root()).concat(newline(ctx));
 }
 
-wcl::rope Emitter::walk_top(ctx_t ctx, CSTElement node) {
+wcl::rope Emitter::walk(ctx_t ctx, CSTElement node) {
   wcl::rope_builder builder;
 
   for (CSTElement child = node.firstChildElement(); !child.empty(); child.nextSiblingElement()) {
-    if (child.isNode()) {
-      builder.append(try_flat(ctx, child));
-      builder.append(newline(ctx));
-    } else {
-      builder.append(walk_token(ctx, child));
+    // remove optional whitespace
+    if (child.id() == TOKEN_WS) {
+      continue;
     }
+
+    if (child.id() == TOKEN_NL) {
+      builder.append(newline(ctx));
+      continue;
+    }
+
+    if (child.id() == TOKEN_COMMENT) {
+      builder.append(walk_token(ctx, child));
+      continue;
+    }
+
+    assert(child.isNode());
+
+    auto r = flat_or(ctx, child);
+    assert(r);
+    builder.append(*r);
+    builder.append(newline(ctx));
   }
 
-  // probably shouldn't do this unconditionally
   builder.undo();
-
-  return std::move(builder).build();
-}
-
-wcl::rope Emitter::walk_block(ctx_t ctx, CSTElement node) {
-  ASSERT_TOKEN(node, CST_BLOCK);
-  return walk_top(ctx.nest(), node);
-}
-
-wcl::rope Emitter::walk_apply(ctx_t ctx, CSTElement node) {
-  ASSERT_TOKEN(node, CST_APP);
-
-  wcl::rope_builder builder;
-
-  CSTElement child = node.firstChildElement();
-  ASSERT_TOKEN(child, CST_ID);
-  {
-    auto node = walk_node(ctx, child);
-    assert(node);
-    builder.append(*node);
-  }
-
-  child.nextSiblingElement();
-  ASSERT_TOKEN(child, TOKEN_WS);
-  builder.append(space());
-
-  child.nextSiblingElement();
-  ASSERT_TOKEN(child, CST_ID);
-  {
-    auto node = walk_node(ctx, child);
-    assert(node);
-    builder.append(*node);
-  }
-
-  return std::move(builder).build();
-}
-
-wcl::rope Emitter::walk_def(ctx_t ctx, CSTElement node) {
-  ASSERT_TOKEN(node, CST_DEF);
-
-  wcl::rope_builder builder;
-
-  CSTElement child = node.firstChildElement();
-  ASSERT_TOKEN(child, TOKEN_KW_DEF);
-  builder.append("def");
-
-  child.nextSiblingElement();
-  ASSERT_TOKEN(child, TOKEN_WS);
-  builder.append(space());
-
-  // This is the id/function name + signature
-  child.nextSiblingElement();
-  assert(child.isNode());
-  builder.append(try_flat(ctx, child));
-
-  child.nextSiblingElement();
-  ASSERT_TOKEN(child, TOKEN_WS);
-  builder.append(space());
-
-  child.nextSiblingElement();
-  ASSERT_TOKEN(child, TOKEN_P_EQUALS);
-  builder.append("=");
-
-  child.nextSiblingElement();
-  while (!child.empty() && (child.id() == TOKEN_WS || child.id() == TOKEN_NL)) {
-    child.nextSiblingElement();
-  }
-
-  if (ctx.is_flat) {
-    builder.append(space());
-  } else {
-    builder.append(newline(ctx.nest()));
-  }
-
-  builder.append(try_flat(ctx, child));
 
   return std::move(builder).build();
 }
@@ -166,29 +138,142 @@ wcl::optional<wcl::rope> Emitter::walk_node(ctx_t ctx, CSTElement node) {
   wcl::rope_builder builder;
 
   switch (node.id()) {
-    case CST_DEF:
-      builder.append(walk_def(ctx, node));
-      break;
-    case CST_BLOCK:
-      builder.append(walk_block(ctx, node));
+    case CST_ARITY:
+      APPEND_OR_BUBBLE(walk_arity, ctx, node);
       break;
     case CST_APP:
-      builder.append(walk_apply(ctx, node));
+      APPEND_OR_BUBBLE(walk_apply, ctx, node);
       break;
-    default: {
-      for (CSTElement child = node.firstChildElement(); !child.empty();
-           child.nextSiblingElement()) {
-        if (child.isNode()) {
-          auto full_child = walk_node(ctx, child);
-          assert(full_child);
-          builder.append(*full_child);
-        } else {
-          builder.append(walk_token(ctx, child));
-        }
-      }
+    case CST_ASCRIBE:
+      APPEND_OR_BUBBLE(walk_ascribe, ctx, node);
       break;
+    case CST_BINARY:
+      APPEND_OR_BUBBLE(walk_binary, ctx, node);
+      break;
+    case CST_BLOCK:
+      APPEND_OR_BUBBLE(walk_block, ctx, node);
+      break;
+    case CST_CASE:
+      APPEND_OR_BUBBLE(walk_case, ctx, node);
+      break;
+    case CST_DATA:
+      APPEND_OR_BUBBLE(walk_data, ctx, node);
+      break;
+    case CST_DEF:
+      APPEND_OR_BUBBLE(walk_def, ctx, node);
+      break;
+    case CST_EXPORT:
+      APPEND_OR_BUBBLE(walk_export, ctx, node);
+      break;
+    case CST_FLAG_EXPORT:
+      APPEND_OR_BUBBLE(walk_flag_export, ctx, node);
+      break;
+    case CST_FLAG_GLOBAL:
+      APPEND_OR_BUBBLE(walk_flag_global, ctx, node);
+      break;
+    case CST_GUARD:
+      APPEND_OR_BUBBLE(walk_guard, ctx, node);
+      break;
+    case CST_HOLE:
+      APPEND_OR_BUBBLE(walk_hole, ctx, node);
+      break;
+    case CST_ID:
+      APPEND_OR_BUBBLE(walk_identifier, ctx, node);
+      break;
+    case CST_IDEQ:
+      APPEND_OR_BUBBLE(walk_ideq, ctx, node);
+      break;
+    case CST_IF:
+      APPEND_OR_BUBBLE(walk_if, ctx, node);
+      break;
+    case CST_IMPORT:
+      APPEND_OR_BUBBLE(walk_import, ctx, node);
+      break;
+    case CST_INTERPOLATE:
+      APPEND_OR_BUBBLE(walk_interpolate, ctx, node);
+      break;
+    case CST_KIND:
+      APPEND_OR_BUBBLE(walk_kind, ctx, node);
+      break;
+    case CST_LAMBDA:
+      APPEND_OR_BUBBLE(walk_lambda, ctx, node);
+      break;
+    case CST_LITERAL:
+      APPEND_OR_BUBBLE(walk_literal, ctx, node);
+      break;
+    case CST_MATCH:
+      APPEND_OR_BUBBLE(walk_match, ctx, node);
+      break;
+    case CST_OP:
+      APPEND_OR_BUBBLE(walk_op, ctx, node);
+      break;
+    case CST_PACKAGE:
+      APPEND_OR_BUBBLE(walk_package, ctx, node);
+      break;
+    case CST_PAREN:
+      APPEND_OR_BUBBLE(walk_paren, ctx, node);
+      break;
+    case CST_PRIM:
+      APPEND_OR_BUBBLE(walk_prim, ctx, node);
+      break;
+    case CST_PUBLISH:
+      APPEND_OR_BUBBLE(walk_publish, ctx, node);
+      break;
+    case CST_REQUIRE:
+      APPEND_OR_BUBBLE(walk_require, ctx, node);
+      break;
+    case CST_REQ_ELSE:
+      APPEND_OR_BUBBLE(walk_req_else, ctx, node);
+      break;
+    case CST_SUBSCRIBE:
+      APPEND_OR_BUBBLE(walk_subscribe, ctx, node);
+      break;
+    case CST_TARGET:
+      APPEND_OR_BUBBLE(walk_target, ctx, node);
+      break;
+    case CST_TARGET_ARGS:
+      APPEND_OR_BUBBLE(walk_target_args, ctx, node);
+      break;
+    case CST_TOP:
+      APPEND_OR_BUBBLE(walk_top, ctx, node);
+      break;
+    case CST_TOPIC:
+      APPEND_OR_BUBBLE(walk_topic, ctx, node);
+      break;
+    case CST_TUPLE:
+      APPEND_OR_BUBBLE(walk_tuple, ctx, node);
+      break;
+    case CST_TUPLE_ELT:
+      APPEND_OR_BUBBLE(walk_tuple_elt, ctx, node);
+      break;
+    case CST_UNARY:
+      APPEND_OR_BUBBLE(walk_unary, ctx, node);
+      break;
+    case CST_ERROR:
+      APPEND_OR_BUBBLE(walk_error, ctx, node);
+      break;
+    default:
+      assert(false);
+  }
+
+  return wcl::optional<wcl::rope>(wcl::in_place_t{}, std::move(builder).build());
+}
+
+wcl::optional<wcl::rope> Emitter::walk_placeholder(ctx_t ctx, CSTElement node) {
+  assert(node.isNode());
+
+  wcl::rope_builder builder;
+
+  for (CSTElement child = node.firstChildElement(); !child.empty(); child.nextSiblingElement()) {
+    if (child.isNode()) {
+      auto full_child = walk_node(ctx, child);
+      assert(full_child);
+      builder.append(*full_child);
+    } else {
+      builder.append(walk_token(ctx, child));
     }
   }
+
   return wcl::optional<wcl::rope>(wcl::in_place_t{}, std::move(builder).build());
 }
 
@@ -199,19 +284,248 @@ wcl::rope Emitter::walk_token(ctx_t ctx, CSTElement node) {
       return wcl::rope::lit("@here");
     case TOKEN_NL: {
       if (ctx.is_flat) {
-        return space();
+        return wcl::rope::lit(" ");
       }
-      return newline(ctx);
+      return wcl::rope::lit("\n");
     }
     case TOKEN_WS: {
-      return wcl::rope::lit("");
-      if (ctx.is_flat) {
-        return space();
-      }
-      return wcl::rope::lit(node.fragment().segment().str());
+      return wcl::rope::lit(" ");
     }
-    default: {
+    case TOKEN_COMMENT:
+    case TOKEN_P_BOPEN:
+    case TOKEN_P_BCLOSE:
+    case TOKEN_P_SOPEN:
+    case TOKEN_P_SCLOSE:
+    case TOKEN_ID:
+    case TOKEN_INDENT:
+    case TOKEN_DEDENT:
+    case TOKEN_KW_PACKAGE:
+    case TOKEN_KW_FROM:
+    case TOKEN_KW_IMPORT:
+    case TOKEN_P_HOLE:
+    case TOKEN_KW_EXPORT:
+    case TOKEN_KW_DEF:
+    case TOKEN_KW_TYPE:
+    case TOKEN_KW_TOPIC:
+    case TOKEN_KW_UNARY:
+    case TOKEN_KW_BINARY:
+    case TOKEN_P_EQUALS:
+    case TOKEN_OP_DOT:
+    case TOKEN_OP_QUANT:
+    case TOKEN_OP_EXP:
+    case TOKEN_OP_MULDIV:
+    case TOKEN_OP_ADDSUB:
+    case TOKEN_OP_COMPARE:
+    case TOKEN_OP_INEQUAL:
+    case TOKEN_OP_AND:
+    case TOKEN_OP_OR:
+    case TOKEN_OP_DOLLAR:
+    case TOKEN_OP_ASSIGN:
+    case TOKEN_OP_COMMA:
+    case TOKEN_KW_GLOBAL:
+    case TOKEN_P_ASCRIBE:
+    case TOKEN_KW_PUBLISH:
+    case TOKEN_KW_DATA:
+    case TOKEN_KW_TUPLE:
+    case TOKEN_KW_TARGET:
+    case TOKEN_P_BSLASH:
+    case TOKEN_P_POPEN:
+    case TOKEN_P_PCLOSE:
+    case TOKEN_STR_RAW:
+    case TOKEN_STR_SINGLE:
+    case TOKEN_STR_MID:
+    case TOKEN_STR_OPEN:
+    case TOKEN_STR_CLOSE:
+    case TOKEN_MSTR_CONTINUE:
+    case TOKEN_MSTR_BEGIN:
+    case TOKEN_MSTR_END:
+    case TOKEN_MSTR_PAUSE:
+    case TOKEN_MSTR_MID:
+    case TOKEN_MSTR_RESUME:
+    case TOKEN_LSTR_CONTINUE:
+    case TOKEN_LSTR_BEGIN:
+    case TOKEN_LSTR_END:
+    case TOKEN_LSTR_PAUSE:
+    case TOKEN_LSTR_MID:
+    case TOKEN_LSTR_RESUME:
+    case TOKEN_REG_SINGLE:
+    case TOKEN_REG_MID:
+    case TOKEN_REG_OPEN:
+    case TOKEN_REG_CLOSE:
+    case TOKEN_DOUBLE:
+    case TOKEN_INTEGER:
+    case TOKEN_KW_MACRO_LINE:
+    case TOKEN_KW_MACRO_FILE:
+    case TOKEN_KW_MACRO_BANG:
+    case TOKEN_KW_SUBSCRIBE:
+    case TOKEN_KW_PRIM:
+    case TOKEN_KW_MATCH:
+    case TOKEN_KW_IF:
+    case TOKEN_KW_THEN:
+    case TOKEN_KW_ELSE:
+    case TOKEN_KW_REQUIRE:
       return wcl::rope::lit(node.fragment().segment().str());
-    }
+    default:
+      assert(false);
   }
 }
+
+wcl::optional<wcl::rope> Emitter::walk_rhs(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_apply(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_arity(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_ascribe(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_binary(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_block(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_case(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_data(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_def(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_export(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_flag_export(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_flag_global(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_guard(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_hole(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_identifier(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_ideq(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_if(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_import(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_interpolate(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_kind(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_lambda(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_literal(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_match(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_op(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_package(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_paren(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_prim(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_publish(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_require(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_req_else(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_subscribe(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_target(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_target_args(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_top(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_topic(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_tuple(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_tuple_elt(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_unary(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+wcl::optional<wcl::rope> Emitter::walk_error(ctx_t ctx, CSTElement node) {
+  return walk_placeholder(ctx, node);
+}
+
+#undef CONSUME_WS_NL
+#undef APPEND_OR_BUBBLE
+#undef ASSERT_TOKEN

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -29,13 +29,13 @@
   assert(!node.empty());          \
   assert(node.id() == token);
 
-#define APPEND_OR_BUBBLE(func, ctx, node) \
-  {                                       \
-    auto subtree = func(ctx, node);       \
-    if (!subtree) {                       \
-      return {};                          \
-    }                                     \
-    builder.append(*subtree);             \
+#define APPEND_OR_BUBBLE(builder, func, ctx, node) \
+  {                                                \
+    auto subtree = func(ctx, node);                \
+    if (!subtree) {                                \
+      return {};                                   \
+    }                                              \
+    builder.append(*subtree);                      \
   }
 
 #define CONSUME_WS_NL(node)                                                     \
@@ -139,118 +139,118 @@ wcl::optional<wcl::rope> Emitter::walk_node(ctx_t ctx, CSTElement node) {
 
   switch (node.id()) {
     case CST_ARITY:
-      APPEND_OR_BUBBLE(walk_arity, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_arity, ctx, node);
       break;
     case CST_APP:
-      APPEND_OR_BUBBLE(walk_apply, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_apply, ctx, node);
       break;
     case CST_ASCRIBE:
-      APPEND_OR_BUBBLE(walk_ascribe, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_ascribe, ctx, node);
       break;
     case CST_BINARY:
-      APPEND_OR_BUBBLE(walk_binary, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_binary, ctx, node);
       break;
     case CST_BLOCK:
-      APPEND_OR_BUBBLE(walk_block, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_block, ctx, node);
       break;
     case CST_CASE:
-      APPEND_OR_BUBBLE(walk_case, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_case, ctx, node);
       break;
     case CST_DATA:
-      APPEND_OR_BUBBLE(walk_data, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_data, ctx, node);
       break;
     case CST_DEF:
-      APPEND_OR_BUBBLE(walk_def, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_def, ctx, node);
       break;
     case CST_EXPORT:
-      APPEND_OR_BUBBLE(walk_export, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_export, ctx, node);
       break;
     case CST_FLAG_EXPORT:
-      APPEND_OR_BUBBLE(walk_flag_export, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_flag_export, ctx, node);
       break;
     case CST_FLAG_GLOBAL:
-      APPEND_OR_BUBBLE(walk_flag_global, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_flag_global, ctx, node);
       break;
     case CST_GUARD:
-      APPEND_OR_BUBBLE(walk_guard, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_guard, ctx, node);
       break;
     case CST_HOLE:
-      APPEND_OR_BUBBLE(walk_hole, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_hole, ctx, node);
       break;
     case CST_ID:
-      APPEND_OR_BUBBLE(walk_identifier, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_identifier, ctx, node);
       break;
     case CST_IDEQ:
-      APPEND_OR_BUBBLE(walk_ideq, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_ideq, ctx, node);
       break;
     case CST_IF:
-      APPEND_OR_BUBBLE(walk_if, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_if, ctx, node);
       break;
     case CST_IMPORT:
-      APPEND_OR_BUBBLE(walk_import, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_import, ctx, node);
       break;
     case CST_INTERPOLATE:
-      APPEND_OR_BUBBLE(walk_interpolate, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_interpolate, ctx, node);
       break;
     case CST_KIND:
-      APPEND_OR_BUBBLE(walk_kind, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_kind, ctx, node);
       break;
     case CST_LAMBDA:
-      APPEND_OR_BUBBLE(walk_lambda, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_lambda, ctx, node);
       break;
     case CST_LITERAL:
-      APPEND_OR_BUBBLE(walk_literal, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_literal, ctx, node);
       break;
     case CST_MATCH:
-      APPEND_OR_BUBBLE(walk_match, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_match, ctx, node);
       break;
     case CST_OP:
-      APPEND_OR_BUBBLE(walk_op, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_op, ctx, node);
       break;
     case CST_PACKAGE:
-      APPEND_OR_BUBBLE(walk_package, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_package, ctx, node);
       break;
     case CST_PAREN:
-      APPEND_OR_BUBBLE(walk_paren, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_paren, ctx, node);
       break;
     case CST_PRIM:
-      APPEND_OR_BUBBLE(walk_prim, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_prim, ctx, node);
       break;
     case CST_PUBLISH:
-      APPEND_OR_BUBBLE(walk_publish, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_publish, ctx, node);
       break;
     case CST_REQUIRE:
-      APPEND_OR_BUBBLE(walk_require, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_require, ctx, node);
       break;
     case CST_REQ_ELSE:
-      APPEND_OR_BUBBLE(walk_req_else, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_req_else, ctx, node);
       break;
     case CST_SUBSCRIBE:
-      APPEND_OR_BUBBLE(walk_subscribe, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_subscribe, ctx, node);
       break;
     case CST_TARGET:
-      APPEND_OR_BUBBLE(walk_target, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_target, ctx, node);
       break;
     case CST_TARGET_ARGS:
-      APPEND_OR_BUBBLE(walk_target_args, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_target_args, ctx, node);
       break;
     case CST_TOP:
-      APPEND_OR_BUBBLE(walk_top, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_top, ctx, node);
       break;
     case CST_TOPIC:
-      APPEND_OR_BUBBLE(walk_topic, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_topic, ctx, node);
       break;
     case CST_TUPLE:
-      APPEND_OR_BUBBLE(walk_tuple, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_tuple, ctx, node);
       break;
     case CST_TUPLE_ELT:
-      APPEND_OR_BUBBLE(walk_tuple_elt, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_tuple_elt, ctx, node);
       break;
     case CST_UNARY:
-      APPEND_OR_BUBBLE(walk_unary, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_unary, ctx, node);
       break;
     case CST_ERROR:
-      APPEND_OR_BUBBLE(walk_error, ctx, node);
+      APPEND_OR_BUBBLE(builder, walk_error, ctx, node);
       break;
     default:
       assert(false);

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -50,14 +50,52 @@ class Emitter {
 
  private:
   // Top level tree walk. Dispatches out the calls for various nodes
-  wcl::rope walk_top(ctx_t ctx, CSTElement node);
+  wcl::rope walk(ctx_t ctx, CSTElement node);
 
   wcl::optional<wcl::rope> walk_node(ctx_t ctx, CSTElement node);
   wcl::rope walk_token(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_rhs(ctx_t ctx, CSTElement node);
 
-  wcl::rope walk_block(ctx_t ctx, CSTElement node);
-  wcl::rope walk_def(ctx_t ctx, CSTElement node);
-  wcl::rope walk_apply(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_apply(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_arity(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_ascribe(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_binary(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_block(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_case(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_data(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_def(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_export(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_flag_export(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_flag_global(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_guard(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_hole(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_identifier(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_ideq(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_if(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_import(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_interpolate(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_kind(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_lambda(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_literal(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_match(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_op(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_package(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_paren(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_prim(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_publish(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_require(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_req_else(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_subscribe(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_target(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_target_args(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_top(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_topic(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_tuple(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_tuple_elt(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_unary(ctx_t ctx, CSTElement node);
+  wcl::optional<wcl::rope> walk_error(ctx_t ctx, CSTElement node);
+
+  wcl::optional<wcl::rope> walk_placeholder(ctx_t ctx, CSTElement node);
 
   // Emits a newline and any indentation needed
   wcl::rope newline(ctx_t ctx);
@@ -65,13 +103,15 @@ class Emitter {
   // Emits a space character `count` times
   wcl::rope space(uint8_t count = 1);
 
-  // TODO: memoize this function
-  // returns the subtree with all newlines and indentation removed
-  // if possible, None otherwise
+  // tries to format the subree in a flat context,
+  // returns None if it fails
   wcl::optional<wcl::rope> flat(ctx_t ctx, CSTElement node);
 
-  // Attempts to flatten `node` with flat. On failure returns the full node
-  wcl::rope try_flat(ctx_t ctx, CSTElement node);
+  // TODO: memoize this function
+  // tries to format the subtree in a flat context, if it fails
+  // then None is returned when calling from a flat context and
+  // full is returned otherwise.
+  wcl::optional<wcl::rope> flat_or(ctx_t ctx, CSTElement node);
 
   const uint8_t space_per_indent = 4;
   const uint8_t max_column_width = 100;


### PR DESCRIPTION
Adds all the boilerplate code required to walk the CST. These changes are pulled out of of much larger set of changes for ease of review.

Formatting output is currently messed up but will be fixed in the follow up PR