### PR TITLE
CI: Update MacOS build image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
     build:
         name: "MacOS build"
-        runs-on: macos-10.15
+        runs-on: macos-12
 
         steps:
             - name: "Clone wake"


### PR DESCRIPTION
According to actions/virtual-environments#5583, the MacOS 10.15 image is deprecated; we're currently in the middle of a brownout which is keeping PRs from merging for another 24 hours.  Per Zoom discussion, this probably also needs changing the `osxfuse` to `macfuse`, but I'm trying first without it just to see if it works.