### PR TITLE
Implement ctx width, basic def & block

### DIFF
--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1,9 +1,9 @@
-def name Unit = 
+def name Unit =
     def other = @here
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
 
-def name Unit = 
+def name Unit =
     def other = @here
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1,16 +1,14 @@
-def name Unit =
- def other = @here
- def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
- another
+def name Unit = 
+    def other = @here
+    def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    another
 
+def name Unit = 
+    def other = @here
+    def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    another
 
-def name Unit =
- def other = @here
- def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
- another
-
-
-def t1 =match _  0=0  n = 2+t(n-1) 
+def t1 = match _  0=0  n = 2+t(n-1)
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
  buildTestWake, Nil =
@@ -18,7 +16,6 @@ def wakeToTestDir Unit = match (subscribe wakeTestBinary)
  Pass (Pair (simplify "{path}/..") visible)
  Nil = Pass (Pair "{wakePath}" Nil)
  _ = Fail (makeError "Two wake binaries declared for testing!")
-
 
 package test_wake 
 

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -491,7 +491,6 @@ wcl::optional<wcl::doc> Emitter::walk_def(ctx_t ctx, CSTElement node) {
 
   assert(child.empty());
   return wcl::optional<wcl::doc>(wcl::in_place_t{}, std::move(builder).build());
-
 }
 
 wcl::optional<wcl::doc> Emitter::walk_export(ctx_t ctx, CSTElement node) {

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -29,7 +29,8 @@
 class Emitter {
  public:
   struct ctx_t {
-    int nest_level = 0;
+    size_t width = 0;
+    size_t nest_level = 0;
     bool is_flat = false;
 
     ctx_t flat() {
@@ -41,6 +42,16 @@ class Emitter {
     ctx_t nest() {
       ctx_t copy = *this;
       copy.nest_level++;
+      return copy;
+    }
+
+    ctx_t sub(const wcl::doc_builder& builder) {
+      ctx_t copy = *this;
+      if(builder.has_newline()) {
+        copy.width = builder.last_width();
+      } else {
+        copy.width += builder.last_width();
+      }
       return copy;
     }
   };

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -108,6 +108,12 @@ class Emitter {
 
   wcl::optional<wcl::doc> walk_placeholder(ctx_t ctx, CSTElement node);
 
+  // Detemines if a given doc fits in the current doc
+  bool fits(const wcl::doc_builder& bdr, ctx_t ctx, wcl::doc new_doc);
+
+  // Determines if a given node must be started on a newline
+  bool requires_nl(ctx_t ctx, CSTElement node);
+
   // Emits a newline and any indentation needed
   wcl::doc newline(ctx_t ctx);
 

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -47,7 +47,7 @@ class Emitter {
 
     ctx_t sub(const wcl::doc_builder& builder) {
       ctx_t copy = *this;
-      if(builder.has_newline()) {
+      if (builder.has_newline()) {
         copy.width = builder.last_width();
       } else {
         copy.width += builder.last_width();


### PR DESCRIPTION
This add support for `ctx.width` and implements `def` and `block` using it. Seems like this may actually be the final API. _knocks on wood_

I still need to go back and delete `flat` and make the walk functions not return `optional` but I wanted to get this up first before another major refactor.