### PR TITLE
Refactor: remove flat() and wcl::optional from format API

### DIFF
--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -8,7 +8,9 @@ def name Unit =
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
 
-def t1 = match _  0=0  n = 2+t(n-1)
+def t1 = match _
+ 0=0
+ n = 2+t(n-1)
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
  buildTestWake, Nil =
@@ -17,13 +19,22 @@ def wakeToTestDir Unit = match (subscribe wakeTestBinary)
  Nil = Pass (Pair "{wakePath}" Nil)
  _ = Fail (makeError "Two wake binaries declared for testing!")
 
-package test_wake 
+package test_wake
 
-from wake import _ 
-from wake import source , Nil 
-from test_wake import topic wakeTestBinary 
-from gcc_wake import compileC linkO 
-from wake import myMap=map foldl myFoldr=foldr 
-from wake import def unary + - 
-from wake import type Pair Result 
-from wake import source,Nil 
+
+from wake import _
+
+from wake import source , Nil
+
+from test_wake import topic wakeTestBinary
+
+from gcc_wake import compileC linkO
+
+from wake import myMap=map foldl myFoldr=foldr
+
+from wake import def unary + -
+
+from wake import type Pair Result
+
+from wake import source,Nil
+

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -31,13 +31,6 @@ class Emitter {
   struct ctx_t {
     size_t width = 0;
     size_t nest_level = 0;
-    bool is_flat = false;
-
-    ctx_t flat() {
-      ctx_t copy = *this;
-      copy.is_flat = true;
-      return copy;
-    }
 
     ctx_t nest() {
       ctx_t copy = *this;
@@ -63,50 +56,50 @@ class Emitter {
   // Top level tree walk. Dispatches out the calls for various nodes
   wcl::doc walk(ctx_t ctx, CSTElement node);
 
-  wcl::optional<wcl::doc> walk_node(ctx_t ctx, CSTElement node);
+  wcl::doc walk_node(ctx_t ctx, CSTElement node);
   wcl::doc walk_token(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_rhs(ctx_t ctx, CSTElement node);
+  wcl::doc walk_rhs(ctx_t ctx, CSTElement node);
 
-  wcl::optional<wcl::doc> walk_apply(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_arity(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_ascribe(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_binary(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_block(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_case(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_data(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_def(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_export(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_flag_export(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_flag_global(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_guard(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_hole(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_identifier(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_ideq(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_if(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_import(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_interpolate(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_kind(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_lambda(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_literal(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_match(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_op(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_package(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_paren(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_prim(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_publish(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_require(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_req_else(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_subscribe(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_target(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_target_args(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_top(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_topic(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_tuple(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_tuple_elt(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_unary(ctx_t ctx, CSTElement node);
-  wcl::optional<wcl::doc> walk_error(ctx_t ctx, CSTElement node);
+  wcl::doc walk_apply(ctx_t ctx, CSTElement node);
+  wcl::doc walk_arity(ctx_t ctx, CSTElement node);
+  wcl::doc walk_ascribe(ctx_t ctx, CSTElement node);
+  wcl::doc walk_binary(ctx_t ctx, CSTElement node);
+  wcl::doc walk_block(ctx_t ctx, CSTElement node);
+  wcl::doc walk_case(ctx_t ctx, CSTElement node);
+  wcl::doc walk_data(ctx_t ctx, CSTElement node);
+  wcl::doc walk_def(ctx_t ctx, CSTElement node);
+  wcl::doc walk_export(ctx_t ctx, CSTElement node);
+  wcl::doc walk_flag_export(ctx_t ctx, CSTElement node);
+  wcl::doc walk_flag_global(ctx_t ctx, CSTElement node);
+  wcl::doc walk_guard(ctx_t ctx, CSTElement node);
+  wcl::doc walk_hole(ctx_t ctx, CSTElement node);
+  wcl::doc walk_identifier(ctx_t ctx, CSTElement node);
+  wcl::doc walk_ideq(ctx_t ctx, CSTElement node);
+  wcl::doc walk_if(ctx_t ctx, CSTElement node);
+  wcl::doc walk_import(ctx_t ctx, CSTElement node);
+  wcl::doc walk_interpolate(ctx_t ctx, CSTElement node);
+  wcl::doc walk_kind(ctx_t ctx, CSTElement node);
+  wcl::doc walk_lambda(ctx_t ctx, CSTElement node);
+  wcl::doc walk_literal(ctx_t ctx, CSTElement node);
+  wcl::doc walk_match(ctx_t ctx, CSTElement node);
+  wcl::doc walk_op(ctx_t ctx, CSTElement node);
+  wcl::doc walk_package(ctx_t ctx, CSTElement node);
+  wcl::doc walk_paren(ctx_t ctx, CSTElement node);
+  wcl::doc walk_prim(ctx_t ctx, CSTElement node);
+  wcl::doc walk_publish(ctx_t ctx, CSTElement node);
+  wcl::doc walk_require(ctx_t ctx, CSTElement node);
+  wcl::doc walk_req_else(ctx_t ctx, CSTElement node);
+  wcl::doc walk_subscribe(ctx_t ctx, CSTElement node);
+  wcl::doc walk_target(ctx_t ctx, CSTElement node);
+  wcl::doc walk_target_args(ctx_t ctx, CSTElement node);
+  wcl::doc walk_top(ctx_t ctx, CSTElement node);
+  wcl::doc walk_topic(ctx_t ctx, CSTElement node);
+  wcl::doc walk_tuple(ctx_t ctx, CSTElement node);
+  wcl::doc walk_tuple_elt(ctx_t ctx, CSTElement node);
+  wcl::doc walk_unary(ctx_t ctx, CSTElement node);
+  wcl::doc walk_error(ctx_t ctx, CSTElement node);
 
-  wcl::optional<wcl::doc> walk_placeholder(ctx_t ctx, CSTElement node);
+  wcl::doc walk_placeholder(ctx_t ctx, CSTElement node);
 
   // Detemines if a given doc fits in the current doc
   bool fits(const wcl::doc_builder& bdr, ctx_t ctx, wcl::doc new_doc);
@@ -119,16 +112,6 @@ class Emitter {
 
   // Emits a space character `count` times
   wcl::doc space(uint8_t count = 1);
-
-  // tries to format the subree in a flat context,
-  // returns None if it fails
-  wcl::optional<wcl::doc> flat(ctx_t ctx, CSTElement node);
-
-  // TODO: memoize this function
-  // tries to format the subtree in a flat context, if it fails
-  // then None is returned when calling from a flat context and
-  // full is returned otherwise.
-  wcl::optional<wcl::doc> flat_or(ctx_t ctx, CSTElement node);
 
   const uint8_t space_per_indent = 4;
   const uint8_t max_column_width = 100;


### PR DESCRIPTION
Now that `flat()` and `wcl::optional` are no longer part of the wake-format internal API, remove them