### PR TITLE
Add walk children, remove extra functions

### DIFF
--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -25,13 +25,6 @@
 
 #include "parser/parser.h"
 
-#define CONSUME_WS_NL(node)                                                     \
-  {                                                                             \
-    while (!node.empty() && (node.id() == TOKEN_WS || node.id() == TOKEN_NL)) { \
-      node.nextSiblingElement();                                                \
-    }                                                                           \
-  }
-
 #define WALK(func) [this](ctx_t ctx, CSTElement node) { return func(ctx, node); }
 
 bool Emitter::fits(const wcl::doc_builder& bdr, ctx_t ctx, wcl::doc doc) {
@@ -51,69 +44,48 @@ static bool is_expression(uint8_t type) {
 }
 
 void Emitter::walk_rhs(wcl::doc_builder& bdr, ctx_t ctx, CSTElement& node) {
-  wcl::doc doc = space().concat(walk_node(ctx.sub(bdr), node));
-  if (fits(bdr, ctx, doc) && !requires_nl(ctx, node)) {
+  auto nested_fmt = formatter().nest(formatter().walk(WALK(walk_node)));
+  if (requires_nl(ctx, node)) {
+    bdr.append(nested_fmt.format(ctx, node, false));
+    node.nextSiblingElement();
+    return;
+  }
+
+  wcl::doc doc = formatter().space().walk(WALK(walk_node)).format(ctx, node, false);
+  if (fits(bdr, ctx, doc)) {
     bdr.append(doc);
-  } else {
-    ctx_t n_ctx = ctx.nest();
-    bdr.append(newline(n_ctx));
-    bdr.append(walk_node(n_ctx.sub(bdr), node));
+    node.nextSiblingElement();
+    return;
   }
+
+  bdr.append(nested_fmt.format(ctx, node, false));
   node.nextSiblingElement();
-}
-
-wcl::doc Emitter::newline(ctx_t ctx) {
-  wcl::doc_builder bdr;
-
-  bdr.append("\n");
-  for (size_t i = 0; i < ctx.nest_level; i++) {
-    bdr.append(space(space_per_indent));
-  }
-
-  return std::move(bdr).build();
-}
-
-wcl::doc Emitter::space(uint8_t count) {
-  wcl::doc_builder bdr;
-  for (uint8_t i = 0; i < count; i++) {
-    bdr.append(" ");
-  }
-  return std::move(bdr).build();
 }
 
 wcl::doc Emitter::layout(CST cst) {
   ctx_t ctx;
-  return walk(ctx, cst.root()).concat(newline(ctx));
+  return formatter().walk(WALK(walk)).format(ctx, cst.root());
 }
 
 wcl::doc Emitter::walk(ctx_t ctx, CSTElement node) {
   wcl::doc_builder bdr;
 
-  for (CSTElement child = node.firstChildElement(); !child.empty(); child.nextSiblingElement()) {
-    // remove optional whitespace
-    if (child.id() == TOKEN_WS) {
-      continue;
-    }
+  // clang-format off
+  auto body_fmt = formatter()
+              .fmt_if_else(
+                TOKEN_WS,
+                formatter(),
+                formatter()
+                  .fmt_if_else(
+                    TOKEN_NL,
+                    formatter().newline(space_per_indent),
+                    formatter().fmt_if_else(
+                      TOKEN_COMMENT,
+                      formatter().walk(WALK(walk_token)),
+                      formatter().walk(WALK(walk_node)).newline(space_per_indent))));
+  // clang-format on
 
-    if (child.id() == TOKEN_NL) {
-      bdr.append(newline(ctx));
-      continue;
-    }
-
-    if (child.id() == TOKEN_COMMENT) {
-      bdr.append(walk_token(ctx, child));
-      continue;
-    }
-
-    assert(child.isNode());
-
-    bdr.append(walk_node(ctx, child));
-    bdr.append(newline(ctx));
-  }
-
-  bdr.undo();
-
-  return std::move(bdr).build();
+  return formatter().walk_children(body_fmt).format(ctx, node);
 }
 
 wcl::doc Emitter::walk_node(ctx_t ctx, CSTElement node) {
@@ -382,21 +354,19 @@ wcl::doc Emitter::walk_block(ctx_t ctx, CSTElement node) {
   assert(node.id() == CST_BLOCK);
   wcl::doc_builder bdr;
 
-  for (CSTElement child = node.firstChildElement(); !child.empty(); child.nextSiblingElement()) {
-    // remove optional whitespace
-    if (child.id() == TOKEN_WS || child.id() == TOKEN_NL) {
-      continue;
-    }
+  // clang-format off
+  auto body_fmt = formatter()
+              .fmt_if_else(
+                TOKEN_WS,
+                formatter(),
+                formatter()
+                  .fmt_if_else(
+                    TOKEN_NL,
+                    formatter(),
+                    formatter().newline(space_per_indent).walk(WALK(walk_node))));
+  // clang-format on
 
-    // No non-whitespace tokens should be in a block
-    assert(child.isNode());
-    bdr.append(walk_node(ctx.sub(bdr), child));
-    bdr.append(newline(ctx));
-  }
-
-  bdr.undo();
-
-  return std::move(bdr).build();
+  return formatter().walk_children(body_fmt).consume_wsnl().format(ctx, node);
 }
 
 wcl::doc Emitter::walk_case(ctx_t ctx, CSTElement node) {
@@ -532,6 +502,7 @@ wcl::doc Emitter::walk_require(ctx_t ctx, CSTElement node) {
   assert(node.id() == CST_REQUIRE);
 
   return formatter()
+      .newline(space_per_indent)
       .token(TOKEN_KW_REQUIRE)
       .ws()
       .walk(WALK(walk_node))
@@ -578,4 +549,3 @@ wcl::doc Emitter::walk_unary(ctx_t ctx, CSTElement node) { return walk_placehold
 wcl::doc Emitter::walk_error(ctx_t ctx, CSTElement node) { return walk_placeholder(ctx, node); }
 
 #undef WALK
-#undef CONSUME_WS_NL

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -32,13 +32,15 @@ class Emitter {
   // Walks the CST, formats it, and returns the representative doc
   wcl::doc layout(CST cst);
 
+  static const uint8_t space_per_indent = 4;
+  static const uint8_t max_column_width = 100;
+
  private:
   // Top level tree walk. Dispatches out the calls for various nodes
   wcl::doc walk(ctx_t ctx, CSTElement node);
 
   wcl::doc walk_node(ctx_t ctx, CSTElement node);
   wcl::doc walk_token(ctx_t ctx, CSTElement node);
-  void walk_rhs(wcl::doc_builder& bdr, ctx_t ctx, CSTElement& node);
 
   wcl::doc walk_apply(ctx_t ctx, CSTElement node);
   wcl::doc walk_arity(ctx_t ctx, CSTElement node);
@@ -80,19 +82,4 @@ class Emitter {
   wcl::doc walk_error(ctx_t ctx, CSTElement node);
 
   wcl::doc walk_placeholder(ctx_t ctx, CSTElement node);
-
-  // Detemines if a given doc fits in the current doc
-  bool fits(const wcl::doc_builder& bdr, ctx_t ctx, wcl::doc new_doc);
-
-  // Determines if a given node must be started on a newline
-  bool requires_nl(ctx_t ctx, CSTElement node);
-
-  // Emits a newline and any indentation needed
-  wcl::doc newline(ctx_t ctx);
-
-  // Emits a space character `count` times
-  wcl::doc space(uint8_t count = 1);
-
-  const uint8_t space_per_indent = 4;
-  const uint8_t max_column_width = 100;
 };

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -42,6 +42,8 @@ class Emitter {
   wcl::doc walk_node(ctx_t ctx, CSTElement node);
   wcl::doc walk_token(ctx_t ctx, CSTElement node);
 
+  void walk_rhs(wcl::doc_builder& bdr, ctx_t ctx, CSTElement& node);
+
   wcl::doc walk_apply(ctx_t ctx, CSTElement node);
   wcl::doc walk_arity(ctx_t ctx, CSTElement node);
   wcl::doc walk_ascribe(ctx_t ctx, CSTElement node);

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -151,17 +151,17 @@ struct NestAction {
   }
 };
 
-template <class IFMT, class EFMT>
+template <class Predicate, class IFMT, class EFMT>
 struct IfElseAction {
+  Predicate predicate;
   IFMT if_formatter;
   EFMT else_formatter;
-  uint8_t node_type;
 
-  IfElseAction(IFMT if_formatter, EFMT else_formatter, uint8_t node_type)
-      : if_formatter(if_formatter), else_formatter(else_formatter), node_type(node_type) {}
+  IfElseAction(Predicate predicate, IFMT if_formatter, EFMT else_formatter)
+      : predicate(predicate), if_formatter(if_formatter), else_formatter(else_formatter) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
-    if (node.id() == node_type) {
+    if (predicate(node.id())) {
       builder.append(if_formatter.compose(ctx, node));
     } else {
       builder.append(else_formatter.compose(ctx, node));
@@ -169,16 +169,16 @@ struct IfElseAction {
   }
 };
 
-template <class FMT>
+template <class Predicate, class FMT>
 struct WhileAction {
+  Predicate predicate;
   FMT while_formatter;
-  uint8_t node_type;
 
-  WhileAction(FMT while_formatter, uint8_t node_type)
-      : while_formatter(while_formatter), node_type(node_type) {}
+  WhileAction(Predicate predicate, FMT while_formatter)
+      : predicate(predicate), while_formatter(while_formatter) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
-    while (node.id() == node_type) {
+    while (predicate(node.id())) {
       builder.append(while_formatter.compose(ctx.sub(builder), node));
     }
   }
@@ -191,10 +191,8 @@ struct WalkChildrenAction {
   WalkChildrenAction(FMT formatter) : formatter(formatter) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
-    for (CSTElement child = node.firstChildElement(); !child.empty(); child.nextSiblingElement()) {
-      // Here we can't assert that child is empty since we are processing
-      // each child element in parts.
-      builder.append(formatter.format(ctx.sub(builder), child, false));
+    for (CSTElement child = node.firstChildElement(); !child.empty();) {
+      builder.append(formatter.compose(ctx.sub(builder), child));
     }
     node.nextSiblingElement();
   }
@@ -225,9 +223,35 @@ struct JoinAction {
   }
 };
 
+struct NextAction {
+  ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
+    node.nextSiblingElement();
+  }
+};
+
 // This does nothing, good for kicking off a chain of formatters
 struct EpsilonAction {
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {}
+};
+
+class TruePredicate {
+ public:
+  bool operator()(uint8_t t) { return true; }
+};
+
+class InitListMembershipPredicate {
+ private:
+  std::bitset<256> type_bits;
+
+ public:
+  InitListMembershipPredicate(std::initializer_list<uint8_t> types) {
+    // TODO: static assert(sizeof(token type) == 1)
+    for (uint8_t t : types) {
+      type_bits[t] = true;
+    }
+  }
+
+  bool operator()(uint8_t type) { return type_bits[type]; }
 };
 
 template <class Action>
@@ -264,52 +288,83 @@ struct Formatter {
     return {SeqAction<Action, NestAction<FMT>>(action, NestAction<FMT>{formatter})};
   }
 
+  Formatter<SeqAction<Action, NextAction>> next() {
+    return {SeqAction<Action, NextAction>(action, NextAction{})};
+  }
+
   template <class FMT>
-  Formatter<SeqAction<Action, IfElseAction<FMT, Formatter<EpsilonAction>>>> fmt_if(
-      uint8_t node_type, FMT formatter) {
-    return {SeqAction<Action, IfElseAction<FMT, Formatter<EpsilonAction>>>(
-        action, IfElseAction<FMT, Formatter<EpsilonAction>>{formatter, Formatter<EpsilonAction>({}),
-                                                            node_type})};
+  Formatter<
+      SeqAction<Action, IfElseAction<InitListMembershipPredicate, FMT, Formatter<EpsilonAction>>>>
+  fmt_if(uint8_t type, FMT formatter) {
+    return fmt_if_else(InitListMembershipPredicate({type}), formatter,
+                       Formatter<EpsilonAction>({}));
+  }
+
+  template <class FMT>
+  Formatter<
+      SeqAction<Action, IfElseAction<InitListMembershipPredicate, FMT, Formatter<EpsilonAction>>>>
+  fmt_if(std::initializer_list<uint8_t> types, FMT formatter) {
+    return fmt_if_else(InitListMembershipPredicate(types), formatter, Formatter<EpsilonAction>({}));
+  }
+
+  template <
+      class Predicate, class FMT,
+      std::enable_if_t<std::is_same<bool, decltype(std::declval<Predicate>()(uint8_t()))>::value,
+                       bool> = true>
+  Formatter<SeqAction<Action, IfElseAction<Predicate, FMT, Formatter<EpsilonAction>>>> fmt_if(
+      Predicate predicate, FMT formatter) {
+    return fmt_if_else(predicate, formatter, Formatter<EpsilonAction>({}));
   }
 
   template <class IFMT, class EFMT>
-  Formatter<SeqAction<Action, IfElseAction<IFMT, EFMT>>> fmt_if_else(uint8_t node_type,
-                                                                     IFMT if_formatter,
-                                                                     EFMT else_formatter) {
-    return {SeqAction<Action, IfElseAction<IFMT, EFMT>>(
-        action, IfElseAction<IFMT, EFMT>{if_formatter, else_formatter, node_type})};
+  Formatter<SeqAction<Action, IfElseAction<InitListMembershipPredicate, IFMT, EFMT>>> fmt_if_else(
+      uint8_t type, IFMT if_formatter, EFMT else_formatter) {
+    return fmt_if_else(InitListMembershipPredicate({type}), if_formatter, else_formatter);
+  }
+
+  template <class IFMT, class EFMT>
+  Formatter<SeqAction<Action, IfElseAction<InitListMembershipPredicate, IFMT, EFMT>>> fmt_if_else(
+      std::initializer_list<uint8_t> types, IFMT if_formatter, EFMT else_formatter) {
+    return fmt_if_else(InitListMembershipPredicate(types), if_formatter, else_formatter);
+  }
+
+  template <
+      class Predicate, class IFMT, class EFMT,
+      std::enable_if_t<std::is_same<bool, decltype(std::declval<Predicate>()(uint8_t()))>::value,
+                       bool> = true>
+  Formatter<SeqAction<Action, IfElseAction<Predicate, IFMT, EFMT>>> fmt_if_else(
+      Predicate predicate, IFMT if_formatter, EFMT else_formatter) {
+    return {SeqAction<Action, IfElseAction<Predicate, IFMT, EFMT>>(
+        action, IfElseAction<Predicate, IFMT, EFMT>(predicate, if_formatter, else_formatter))};
   }
 
   template <class FMT>
-  Formatter<SeqAction<Action, WhileAction<FMT>>> fmt_while(uint8_t node_type, FMT formatter) {
-    return {SeqAction<Action, WhileAction<FMT>>(action, WhileAction<FMT>{formatter, node_type})};
+  Formatter<SeqAction<Action, WhileAction<InitListMembershipPredicate, FMT>>> fmt_while(
+      uint8_t type, FMT formatter) {
+    return fmt_while(InitListMembershipPredicate({type}), formatter);
   }
 
-  class TruePredicate {
-   public:
-    bool operator()(uint8_t t) { return true; }
-  };
+  template <class FMT>
+  Formatter<SeqAction<Action, WhileAction<InitListMembershipPredicate, FMT>>> fmt_while(
+      std::initializer_list<uint8_t> types, FMT formatter) {
+    return fmt_while(InitListMembershipPredicate(types), formatter);
+  }
+
+  template <
+      class Predicate, class FMT,
+      std::enable_if_t<std::is_same<bool, decltype(std::declval<Predicate>()(uint8_t()))>::value,
+                       bool> = true>
+  Formatter<SeqAction<Action, WhileAction<Predicate, FMT>>> fmt_while(Predicate predicate,
+                                                                      FMT formatter) {
+    return {SeqAction<Action, WhileAction<Predicate, FMT>>(
+        action, WhileAction<Predicate, FMT>(predicate, formatter))};
+  }
 
   template <class Walker>
   Formatter<SeqAction<Action, WalkPredicateAction<Walker, TruePredicate>>> walk(
       Walker texas_ranger) {
     return walk(TruePredicate(), texas_ranger);
   }
-
-  class InitListMembershipPredicate {
-   private:
-    std::bitset<256> type_bits;
-
-   public:
-    InitListMembershipPredicate(std::initializer_list<uint8_t> types) {
-      // TODO: static assert(sizeof(token type) == 1)
-      for (uint8_t t : types) {
-        type_bits[t] = true;
-      }
-    }
-
-    bool operator()(uint8_t type) { return type_bits[type]; }
-  };
 
   template <class Walker>
   Formatter<SeqAction<Action, WalkPredicateAction<Walker, InitListMembershipPredicate>>> walk(
@@ -348,16 +403,14 @@ struct Formatter {
     return {SeqAction<Action, EscapeAction<F>>(action, EscapeAction<F>{f})};
   }
 
-  wcl::doc format(ctx_t ctx, CSTElement node, bool assert_empty = true) {
+  wcl::doc format(ctx_t ctx, CSTElement node) {
     wcl::doc_builder builder;
     action.run(builder, ctx, node);
-    if (assert_empty) {
-      if (!node.empty()) {
-        std::cerr << "Not empty: " << +node.id() << std::endl;
-        std::cerr << "Failed at: " << std::move(builder).build().as_string() << std::endl;
-      }
-      assert(node.empty());
+    if (!node.empty()) {
+      std::cerr << "Not empty: " << +node.id() << std::endl;
+      std::cerr << "Failed at: " << std::move(builder).build().as_string() << std::endl;
     }
+    assert(node.empty());
     return std::move(builder).build();
   }
 


### PR DESCRIPTION
This PR does two primary (dependent) things
- It deletes the functions `space` and `newline` and unused MACROs from emitter.cpp since they are now redundant
- replaces previous calls to `space` and `newline` with calls into the format DSL which required adding `walk_children`
- bonus: it slightly rewrites `walk_rhs` to make less calls when possible
- bonus 2: it slightly moves around where newlines are added so that `undo` is no longer used