### PR TITLE
path: ignore trailing slashes in basename

### DIFF
--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -72,12 +72,14 @@ export def cwd: String =
 #
 # ```
 # basename "abc/def"  = "def"
+# basename "abc/def/" = "def"
 # basename "/foo/bar" = "bar"
 # basename "/foo"     = "foo"
 # basename "foo-bar"  = "foo-bar"
 # ```
 export def basename (file: String): String =
-    replace `^.*/` '' file
+    replace `/*$` '' file
+    | replace `^.*/` ''
 
 # Extract the directory name from `file`.
 #


### PR DESCRIPTION
Unix/C/Python/... basename implementations return the final directory when given a path ending in a slash; ours returned the empty string (`basename "foo/bar/"` -> `""`).  This seems like something we'd want to align with the common understanding of the command.

I've not added a backwards-compatibility wrapper since to me this feels more like a bug rather than like something people would have been relying on, but if y'all think it would be better to keep the empty-string behaviour for previous versioned packages, I can certainly add it back.

I also tried to come up with some single-call version based on `extract`, but the regex greedy-matching behaviour made that rather difficult.