### PR TITLE
[WIP] Implement wake-format off

### DIFF
--- a/src/parser/cst.cpp
+++ b/src/parser/cst.cpp
@@ -257,6 +257,11 @@ CSTElement CSTElement::firstChildNode() const {
   return out;
 }
 
+bool CSTElement::operator==(const CSTElement &other) const {
+  return cst == other.cst && node == other.node && limit == other.limit && token == other.token &&
+         end == other.end;
+}
+
 #define MAX_SNIPPET 30
 #define MAX_SNIPPET_HALF ((MAX_SNIPPET / 2) - 1)
 

--- a/src/parser/cst.h
+++ b/src/parser/cst.h
@@ -19,6 +19,7 @@
 #define CST_H
 
 #include <stdint.h>
+#include <wcl/hash_combine.h>
 
 #include <ostream>
 #include <string>
@@ -140,12 +141,26 @@ class CSTElement {
   CSTElement firstChildElement() const;
   CSTElement firstChildNode() const;
 
+  bool operator==(const CSTElement &other) const;
+
  private:
   const CST *cst;
   uint32_t node, limit;
   uint32_t token, end;  // in bytes
 
   friend class CST;
+  friend std::hash<CSTElement>;
+};
+
+template <>
+struct std::hash<CSTElement> {
+  size_t operator()(CSTElement const &element) const noexcept {
+    size_t hash =
+        hash_combine(std::hash<size_t>{}(element.node), std::hash<size_t>{}(element.limit));
+    hash = hash_combine(hash, std::hash<size_t>{}(element.token));
+    hash = hash_combine(hash, std::hash<size_t>{}(element.end));
+    return hash;
+  }
 };
 
 #endif

--- a/src/parser/cst.h
+++ b/src/parser/cst.h
@@ -19,7 +19,7 @@
 #define CST_H
 
 #include <stdint.h>
-#include <wcl/hash_combine.h>
+#include <wcl/hash.h>
 
 #include <ostream>
 #include <string>
@@ -156,9 +156,9 @@ template <>
 struct std::hash<CSTElement> {
   size_t operator()(CSTElement const &element) const noexcept {
     size_t hash =
-        hash_combine(std::hash<size_t>{}(element.node), std::hash<size_t>{}(element.limit));
-    hash = hash_combine(hash, std::hash<size_t>{}(element.token));
-    hash = hash_combine(hash, std::hash<size_t>{}(element.end));
+        wcl::hash_combine(std::hash<size_t>{}(element.node), std::hash<size_t>{}(element.limit));
+    hash = wcl::hash_combine(hash, std::hash<size_t>{}(element.token));
+    hash = wcl::hash_combine(hash, std::hash<size_t>{}(element.end));
     return hash;
   }
 };

--- a/src/parser/cst.h
+++ b/src/parser/cst.h
@@ -159,6 +159,7 @@ struct std::hash<CSTElement> {
         wcl::hash_combine(std::hash<size_t>{}(element.node), std::hash<size_t>{}(element.limit));
     hash = wcl::hash_combine(hash, std::hash<size_t>{}(element.token));
     hash = wcl::hash_combine(hash, std::hash<size_t>{}(element.end));
+    hash = wcl::hash_combine(hash, std::hash<const CST *>{}(element.cst));
     return hash;
   }
 };

--- a/src/wcl/doc.h
+++ b/src/wcl/doc.h
@@ -163,6 +163,9 @@ class doc {
   explicit doc(std::unique_ptr<doc_impl_base> impl) : impl(std::move(impl)) {}
 
  public:
+  // Copy constructed doc just points to the same underlying document, increasing its ref count
+  doc(const doc& other) { impl = other.impl; }
+
   // O(n) (n = character count)
   static doc lit(std::string str) { return doc(std::make_unique<doc_impl_string>(std::move(str))); }
 

--- a/src/wcl/doc.h
+++ b/src/wcl/doc.h
@@ -163,8 +163,7 @@ class doc {
   explicit doc(std::unique_ptr<doc_impl_base> impl) : impl(std::move(impl)) {}
 
  public:
-  // Copy constructed doc just points to the same underlying document, increasing its ref count
-  doc(const doc& other) { impl = other.impl; }
+  doc(const doc& other) = default;
 
   // O(n) (n = character count)
   static doc lit(std::string str) { return doc(std::make_unique<doc_impl_string>(std::move(str))); }

--- a/src/wcl/hash.h
+++ b/src/wcl/hash.h
@@ -21,6 +21,8 @@
 #include <functional>
 #include <utility>
 
+namespace wcl {
 inline uint64_t hash_combine(uint64_t a, uint64_t b) {
   return a ^ (b + 0x9e3779b9 + (a << 6) + (a >> 2));
 }
+}  // namespace wcl

--- a/src/wcl/hash_combine.h
+++ b/src/wcl/hash_combine.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <utility>
+
+inline uint64_t hash_combine(uint64_t a, uint64_t b) {
+  return a ^ (b + 0x9e3779b9 + (a << 6) + (a >> 2));
+}
+
+// struct pair_hash
+// {
+//     template <class T1, class T2>
+//     std::size_t operator() (const std::pair<T1, T2> &pair) const {
+//         return hash_combine(std::hash<T1>{}(pair.first), std::hash<T2>{}(pair.second));
+//     }
+// };

--- a/src/wcl/hash_combine.h
+++ b/src/wcl/hash_combine.h
@@ -24,11 +24,3 @@
 inline uint64_t hash_combine(uint64_t a, uint64_t b) {
   return a ^ (b + 0x9e3779b9 + (a << 6) + (a >> 2));
 }
-
-// struct pair_hash
-// {
-//     template <class T1, class T2>
-//     std::size_t operator() (const std::pair<T1, T2> &pair) const {
-//         return hash_combine(std::hash<T1>{}(pair.first), std::hash<T2>{}(pair.second));
-//     }
-// };

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -8,8 +8,46 @@ def name Unit =
   def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   another
 
+# wake-format off
+def name Unit =
+  def other = here
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
+def name Unit =
+  # wake-format off
+  def other = here
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
+def name Unit = # wake-format off
+  def other = here
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
 def t1 =match _
   0=0
+  n = 2+t(n-1)
+
+# wake-format off
+def t1 =match _
+  0=0
+  n = 2+t(n-1)
+
+def t1 =match _
+  # wake-format off
+  0=0
+  n = 2+t(n-1)
+
+def t1 =match _
+  0=0
+  # wake-format off
+  n = 2+t(n-1)
+
+def t1 =match _
+  # wake-format off
+  0=0
+  # wake-format off
   n = 2+t(n-1)
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -8,9 +8,50 @@ def name Unit =
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
 
+# wake-format off
+def name Unit =
+  def other = here
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
+
+def name Unit =
+    # wake-format off
+    def other = here
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
+def name Unit =
+    # wake-format off
+    def other = here
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
 def t1 = match _
     0 = 0
     n = 2 + t (n - 1)
+
+# wake-format off
+def t1 =match _
+  0=0
+  n = 2+t(n-1)
+
+
+def t1 = match _
+    # wake-format off
+    0=0
+    n = 2 + t (n - 1)
+
+def t1 = match _
+    0 = 0
+    # wake-format off
+    n = 2+t(n-1)
+
+def t1 = match _
+    # wake-format off
+    0=0
+    # wake-format off
+    n = 2+t(n-1)
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake , Nil =

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -28,23 +28,24 @@
 #define WALK(func) [this](ctx_t ctx, CSTElement node) { return func(ctx, node); }
 
 #define MEMO(ctx, node)                                                                       \
+  static std::unordered_map<std::pair<CSTElement, ctx_t>, wcl::doc> __memo_map__ = {};        \
   auto __memoize_input__ = [node, ctx]() { return std::pair<CSTElement, ctx_t>(node, ctx); }; \
   {                                                                                           \
     auto ctx_free = context_free_memo.find(node);                                             \
     if (ctx_free != context_free_memo.end()) {                                                \
       return wcl::doc(ctx_free->second);                                                      \
     }                                                                                         \
-    auto value = memo.find(__memoize_input__());                                              \
-    if (value != memo.end()) {                                                                \
+    auto value = __memo_map__.find(__memoize_input__());                                      \
+    if (value != __memo_map__.end()) {                                                        \
       return wcl::doc(value->second);                                                         \
     }                                                                                         \
   }
 
-#define MEMO_RET(value)                    \
-  {                                        \
-    wcl::doc v = (value);                  \
-    memo.insert({__memoize_input__(), v}); \
-    return v;                              \
+#define MEMO_RET(value)                            \
+  {                                                \
+    wcl::doc v = (value);                          \
+    __memo_map__.insert({__memoize_input__(), v}); \
+    return v;                                      \
   }
 
 #define CTX_FREE_RET(value)                      \

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -651,6 +651,7 @@ wcl::doc Emitter::walk_error(ctx_t ctx, CSTElement node) {
   MEMO_RET(ctx, node, walk_placeholder(ctx, node));
 }
 
+#undef CTX_FREE_RET
 #undef MEMO_RET
 #undef MEMO
 #undef WALK

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <wcl/doc.h>
+#include <wcl/hash_combine.h>
 #include <wcl/optional.h>
 
 #include <cassert>
@@ -27,12 +28,21 @@
 #include "formatter.h"
 #include "parser/cst.h"
 
+template <>
+struct std::hash<std::pair<CSTElement, ctx_t>> {
+  size_t operator()(std::pair<CSTElement, ctx_t> const &pair) const noexcept {
+    return hash_combine(std::hash<CSTElement>{}(pair.first), std::hash<ctx_t>{}(pair.second));
+  }
+};
+
 class Emitter {
  public:
   // Walks the CST, formats it, and returns the representative doc
   wcl::doc layout(CST cst);
 
  private:
+  std::unordered_map<std::pair<CSTElement, ctx_t>, wcl::doc> memo = {};
+
   // Top level tree walk. Dispatches out the calls for various nodes
   wcl::doc walk(ctx_t ctx, CSTElement node);
 

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <wcl/doc.h>
-#include <wcl/hash_combine.h>
+#include <wcl/hash.h>
 #include <wcl/optional.h>
 
 #include <cassert>
@@ -31,7 +31,7 @@
 template <>
 struct std::hash<std::pair<CSTElement, ctx_t>> {
   size_t operator()(std::pair<CSTElement, ctx_t> const &pair) const noexcept {
-    return hash_combine(std::hash<CSTElement>{}(pair.first), std::hash<ctx_t>{}(pair.second));
+    return wcl::hash_combine(std::hash<CSTElement>{}(pair.first), std::hash<ctx_t>{}(pair.second));
   }
 };
 

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -42,7 +42,6 @@ class Emitter {
 
  private:
   std::unordered_map<CSTElement, wcl::doc> context_free_memo = {};
-  std::unordered_map<std::pair<CSTElement, ctx_t>, wcl::doc> memo = {};
 
   // Top level tree walk. Dispatches out the calls for various nodes
   wcl::doc walk(ctx_t ctx, CSTElement node);

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -41,6 +41,7 @@ class Emitter {
   wcl::doc layout(CST cst);
 
  private:
+  std::unordered_map<CSTElement, wcl::doc> context_free_memo = {};
   std::unordered_map<std::pair<CSTElement, ctx_t>, wcl::doc> memo = {};
 
   // Top level tree walk. Dispatches out the calls for various nodes

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -49,6 +49,13 @@ class Emitter {
   wcl::doc walk_node(ctx_t ctx, CSTElement node);
   wcl::doc walk_token(ctx_t ctx, CSTElement node);
 
+  // Walks a node and emits it without any formatting.
+  wcl::doc walk_no_edit(ctx_t ctx, CSTElement node);
+
+  // Prefills the context free memo table with the subtrees
+  // that shouldn't be formatted
+  void prefill_format_skip(CSTElement node);
+
   // Returns a formatter that inserts the next node
   // on the current line if it fits, or on a new nested line
   auto rhs_fmt();

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <wcl/doc.h>
+#include <wcl/hash_combine.h>
 
 #include <bitset>
 #include <cassert>
@@ -51,6 +52,17 @@ struct ctx_t {
       copy.width += builder.last_width();
     }
     return copy;
+  }
+
+  bool operator==(const ctx_t& other) const {
+    return width == other.width && nest_level == other.nest_level;
+  }
+};
+
+template <>
+struct std::hash<ctx_t> {
+  size_t operator()(ctx_t const& ctx) const noexcept {
+    return hash_combine(std::hash<size_t>{}(ctx.width), std::hash<size_t>{}(ctx.nest_level));
   }
 };
 

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <wcl/doc.h>
-#include <wcl/hash_combine.h>
+#include <wcl/hash.h>
 
 #include <bitset>
 #include <cassert>
@@ -62,7 +62,7 @@ struct ctx_t {
 template <>
 struct std::hash<ctx_t> {
   size_t operator()(ctx_t const& ctx) const noexcept {
-    return hash_combine(std::hash<size_t>{}(ctx.width), std::hash<size_t>{}(ctx.nest_level));
+    return wcl::hash_combine(std::hash<size_t>{}(ctx.width), std::hash<size_t>{}(ctx.nest_level));
   }
 };
 

--- a/tools/wake-format/wake-format.cpp
+++ b/tools/wake-format/wake-format.cpp
@@ -102,6 +102,7 @@ void print_cst(CSTElement node, int depth) {
       case TOKEN_DOUBLE:
       case TOKEN_STR_SINGLE:
       case TOKEN_REG_SINGLE:
+      case TOKEN_COMMENT:
         std::cout << " -> " << child.fragment().segment().str() << std::endl;
         break;
       case TOKEN_WS: {


### PR DESCRIPTION
Adding `# wake-format off` as a comment will skip formatting for the next `subtree` what this means in practice is the next `def` block but can be used inside of a `match` block to skip formatting on a specific case.

Automatically re-enables formatting after the end of the subtree