### PR TITLE
Implement `# wake-format off`

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -71,6 +71,16 @@ def t1 =match _
   # wake-format off
   n = 2+t(n-1)
 
+def t1 =match _
+  # many
+  # comments
+  # wake-format off
+  0=0
+  # many
+  # more
+  # comments
+  n = 2+t(n-1)
+
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake, Nil =
         require Pass (Pair path visible)=buildTestWake Unit

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -20,10 +20,18 @@ def name Unit =
   def other = here
   another
 
-def fexname Unit =
+def name Unit =
   def other = here
   # wake-format off
   def other = here
+  def other = here
+  another
+
+def name Unit =
+  def other = here
+  # wake-format off
+  def other = here
+
   def other = here
   another
 

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -8,8 +8,59 @@ def name Unit =
   def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   another
 
+# wake-format off
+def name Unit =
+  def other = here
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
+def name Unit =
+  # wake-format off
+  def other = here
+  def other = here
+  another
+
+def fexname Unit =
+  def other = here
+  # wake-format off
+  def other = here
+  def other = here
+  another
+
+def name Unit =
+  # ordinary comment
+  def other = here
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
+def name Unit = # wake-format off
+  def other = here
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
 def t1 =match _
   0=0
+  n = 2+t(n-1)
+
+# wake-format off
+def t1 =match _
+  0=0
+  n = 2+t(n-1)
+
+def t1 =match _
+  # wake-format off
+  0=0
+  n = 2+t(n-1)
+
+def t1 =match _
+  0=0
+  # wake-format off
+  n = 2+t(n-1)
+
+def t1 =match _
+  # wake-format off
+  0=0
+  # wake-format off
   n = 2+t(n-1)
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)

--- a/tests/wake-format/basic/pass.sh
+++ b/tests/wake-format/basic/pass.sh
@@ -1,3 +1,17 @@
 #! /bin/sh
 
-"${1}/wake-format" basic.wake
+tmp=$(mktemp ./basic.wake.XXXXXX)
+out=$(mktemp ./basic.wake.out.XXXXXX)
+
+# Running wake-format on itself shouldn't create any new changes
+"${1}/wake-format" basic.wake > "$tmp"
+"${1}/wake-format" "$tmp" > "$out"
+
+# nothing output if they are the same
+diff "$out" "$tmp"
+
+# re-emit to compare against stdout
+cat "$out"
+
+rm "$out"
+rm "$tmp"

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -17,11 +17,9 @@ def name Unit =
   another
 
 
-
 def name Unit =
     # wake-format off
     def other = here
-
     def other = @here
     another
 
@@ -30,7 +28,6 @@ def name Unit =
     def other = @here
     # wake-format off
     def other = here
-
     def other = @here
     another
 
@@ -39,7 +36,6 @@ def name Unit =
     def other = @here
     # wake-format off
     def other = here
-
     def other = @here
     another
 
@@ -54,7 +50,6 @@ def name Unit =
 def name Unit =
     # wake-format off
     def other = here
-
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
 
@@ -68,7 +63,6 @@ def t1 = match _
 def t1 =match _
   0=0
   n = 2+t(n-1)
-
 
 
 def t1 = match _

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -90,6 +90,17 @@ def t1 = match _
     n = 2+t(n-1)
 
 
+def t1 = match _
+    # many
+    # comments
+    # wake-format off
+    0=0
+    # many
+    # more
+    # comments
+    n = 2 + t (n - 1)
+
+
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake , Nil =
         require Pass (Pair path visible) = buildTestWake Unit

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -3,10 +3,12 @@ def name Unit =
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
 
+
 def name Unit =
     def other = @here
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
+
 
 # wake-format off
 def name Unit =
@@ -14,18 +16,33 @@ def name Unit =
   def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   another
 
+
+
 def name Unit =
     # wake-format off
     def other = here
-    def other = here
+
+    def other = @here
     another
 
-def fexname Unit =
+
+def name Unit =
     def other = @here
     # wake-format off
     def other = here
+
     def other = @here
     another
+
+
+def name Unit =
+    def other = @here
+    # wake-format off
+    def other = here
+
+    def other = @here
+    another
+
 
 def name Unit =
     # ordinary comment
@@ -33,36 +50,45 @@ def name Unit =
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
 
+
 def name Unit =
     # wake-format off
     def other = here
+
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
+
 
 def t1 = match _
     0 = 0
     n = 2 + t (n - 1)
+
 
 # wake-format off
 def t1 =match _
   0=0
   n = 2+t(n-1)
 
+
+
 def t1 = match _
     # wake-format off
     0=0
     n = 2 + t (n - 1)
+
 
 def t1 = match _
     0 = 0
     # wake-format off
     n = 2+t(n-1)
 
+
 def t1 = match _
     # wake-format off
     0=0
     # wake-format off
     n = 2+t(n-1)
+
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake , Nil =
@@ -70,6 +96,7 @@ def wakeToTestDir Unit = match (subscribe wakeTestBinary)
         Pass (Pair (simplify "{path}/..") visible)
     Nil = Pass (Pair "{wakePath}" Nil)
     _ = Fail (makeError "Two wake binaries declared for testing!")
+
 
 package test_wake
 

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -8,9 +8,61 @@ def name Unit =
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
 
+# wake-format off
+def name Unit =
+  def other = here
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
+def name Unit =
+    # wake-format off
+    def other = here
+    def other = here
+    another
+
+def fexname Unit =
+    def other = @here
+    # wake-format off
+    def other = here
+    def other = @here
+    another
+
+def name Unit =
+    # ordinary comment
+    def other = @here
+    def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    another
+
+def name Unit =
+    # wake-format off
+    def other = here
+    def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    another
+
 def t1 = match _
     0 = 0
     n = 2 + t (n - 1)
+
+# wake-format off
+def t1 =match _
+  0=0
+  n = 2+t(n-1)
+
+def t1 = match _
+    # wake-format off
+    0=0
+    n = 2 + t (n - 1)
+
+def t1 = match _
+    0 = 0
+    # wake-format off
+    n = 2+t(n-1)
+
+def t1 = match _
+    # wake-format off
+    0=0
+    # wake-format off
+    n = 2+t(n-1)
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake , Nil =

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -281,8 +281,9 @@ void Emitter::mark_no_format_nodes(CSTElement node) {
       // you can never format *just* the first block item
       if (child.id() == CST_BLOCK) {
         CSTElement block_item = child.firstChildElement();
-        for (; !(child.empty() || child.isNode()); child.nextSiblingElement())
-          ;
+        while (!(child.empty() || child.isNode())) {
+          child.nextSiblingElement();
+        }
 
         // This shouldn't be possible, but assert anyways just in case
         assert(!child.empty());
@@ -522,25 +523,26 @@ wcl::doc Emitter::walk_import(ctx_t ctx, CSTElement node) {
 
   auto id_list_fmt = fmt().walk(WALK_NODE).fmt_if(TOKEN_WS, fmt().ws());
 
-  MEMO_RET(fmt()
-               .token(TOKEN_KW_FROM)
-               .ws()
-               .walk(CST_ID, WALK_NODE)
-               .ws()
-               .token(TOKEN_KW_IMPORT)
-               .ws()
-               .fmt_if(CST_KIND, fmt().walk(WALK_NODE).ws())
-               .fmt_if(CST_ARITY, fmt().walk(WALK_NODE).ws())
-               // clang-format off
-               .fmt_if_else(
-                   TOKEN_P_HOLE,
-                   fmt().walk(WALK_TOKEN),
-                   fmt().fmt_while(
-                       CST_IDEQ,
-                       id_list_fmt))
-               // clang-format on
-               .consume_wsnl()
-               .format(ctx, node.firstChildElement()));
+  MEMO_RET(
+      fmt()
+          .token(TOKEN_KW_FROM)
+          .ws()
+          .walk(CST_ID, WALK_NODE)
+          .ws()
+          .token(TOKEN_KW_IMPORT)
+          .ws()
+          .fmt_if(CST_KIND, fmt().walk(WALK_NODE).ws())
+          .fmt_if(CST_ARITY, fmt().walk(WALK_NODE).ws())
+          // clang-format off
+          .fmt_if_else(
+              TOKEN_P_HOLE,
+              fmt().walk(WALK_TOKEN),
+              fmt().fmt_while(
+                  CST_IDEQ,
+                  id_list_fmt))
+          // clang-format on
+          .consume_wsnl()
+          .format(ctx, node.firstChildElement()));
 }
 
 wcl::doc Emitter::walk_interpolate(ctx_t ctx, CSTElement node) {

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -301,15 +301,12 @@ wcl::doc Emitter::walk_token(ctx_t ctx, CSTElement node) {
   assert(!node.isNode());
 
   switch (node.id()) {
-    case TOKEN_KW_MACRO_HERE: {
+    case TOKEN_KW_MACRO_HERE:
       MEMO_RET(wcl::doc::lit("@here"))
-    }
-    case TOKEN_NL: {
+    case TOKEN_NL:
       MEMO_RET(wcl::doc::lit("\n"));
-    }
-    case TOKEN_WS: {
+    case TOKEN_WS:
       MEMO_RET(wcl::doc::lit(" "));
-    }
     case TOKEN_COMMENT:
     case TOKEN_P_BOPEN:
     case TOKEN_P_BCLOSE:
@@ -570,14 +567,13 @@ wcl::doc Emitter::walk_match(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
   assert(node.id() == CST_MATCH);
 
-  MEMO_RET(fmt()
-               .token(TOKEN_KW_MATCH)
-               .ws()
-               .walk(WALK_NODE)
-               // clang-format off
+  MEMO_RET(
+      fmt()
+          .token(TOKEN_KW_MATCH)
+          .ws()
+          .walk(WALK_NODE)
+          // clang-format off
                .nest(fmt()
-                   .consume_wsnl()
-                   .fmt_if(TOKEN_COMMENT, fmt().newline().token(TOKEN_COMMENT))
                    .consume_wsnl()
                    .fmt_while(
                        {CST_CASE, TOKEN_COMMENT}, fmt()
@@ -587,8 +583,8 @@ wcl::doc Emitter::walk_match(ctx_t ctx, CSTElement node) {
                          fmt().token(TOKEN_COMMENT),
                          fmt().walk(WALK_NODE))
                        .consume_wsnl()))
-               // clang-format on
-               .format(ctx, node.firstChildElement()));
+          // clang-format on
+          .format(ctx, node.firstChildElement()));
 }
 
 wcl::doc Emitter::walk_op(ctx_t ctx, CSTElement node) {

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -23,7 +23,7 @@
 
 #include <cassert>
 #include <iostream>
-#include <unordered_set>
+#include <unordered_map>
 #include <vector>
 
 #include "formatter.h"
@@ -36,13 +36,23 @@ struct std::hash<std::pair<CSTElement, ctx_t>> {
   }
 };
 
+struct traits_t {
+  bool format_off = false;
+
+  traits_t turn_format_off() {
+    traits_t copy = *this;
+    copy.format_off = true;
+    return copy;
+  }
+};
+
 class Emitter {
  public:
   // Walks the CST, formats it, and returns the representative doc
   wcl::doc layout(CST cst);
 
  private:
-  std::unordered_set<CSTElement> no_format_nodes = {};
+  std::unordered_map<CSTElement, traits_t> traits = {};
 
   // Top level tree walk. Dispatches out the calls for various nodes
   wcl::doc walk(ctx_t ctx, CSTElement node);

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -23,7 +23,6 @@
 
 #include <cassert>
 #include <iostream>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -23,6 +23,8 @@
 
 #include <cassert>
 #include <iostream>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "formatter.h"
@@ -41,13 +43,19 @@ class Emitter {
   wcl::doc layout(CST cst);
 
  private:
-  std::unordered_map<CSTElement, wcl::doc> context_free_memo = {};
+  std::unordered_set<CSTElement> no_format_nodes = {};
 
   // Top level tree walk. Dispatches out the calls for various nodes
   wcl::doc walk(ctx_t ctx, CSTElement node);
 
   wcl::doc walk_node(ctx_t ctx, CSTElement node);
   wcl::doc walk_token(ctx_t ctx, CSTElement node);
+
+  // Walks a node and emits it without any formatting.
+  wcl::doc walk_no_edit(ctx_t ctx, CSTElement node);
+
+  // Marks all node elements that have had their formatting disabled
+  void mark_no_format_nodes(CSTElement node);
 
   // Returns a formatter that inserts the next node
   // on the current line if it fits, or on a new nested line

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -91,17 +91,12 @@ struct ConsumeWhitespaceAction {
 };
 
 struct CopyWhitespaceAction {
-  uint8_t space_per_indent;
-
-  CopyWhitespaceAction(uint8_t space_per_indent) : space_per_indent(space_per_indent) {}
-
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     while (!node.empty() && (node.id() == TOKEN_WS || node.id() == TOKEN_NL)) {
       if (node.id() == TOKEN_WS) {
         space(builder, node.fragment().segment().str().size());
       } else {
         builder.append(NL_STR);
-        space(builder, space_per_indent * ctx.nest_level);
       }
       node.nextSiblingElement();
     }
@@ -465,9 +460,7 @@ struct Formatter {
   Formatter(Action a) : action(a) {}
 
   Formatter<SeqAction<Action, ConsumeWhitespaceAction>> consume_wsnl() { return {{action, {}}}; }
-  Formatter<SeqAction<Action, CopyWhitespaceAction>> copy_wsnl() {
-    return {{action, {space_per_indent}}};
-  }
+  Formatter<SeqAction<Action, CopyWhitespaceAction>> copy_wsnl() { return {{action, {}}}; }
 
   Formatter<SeqAction<Action, WhitespaceTokenAction>> ws() { return {{action, {}}}; }
 

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -80,19 +80,6 @@ struct ConsumeWhitespaceAction {
   }
 };
 
-struct CopyWhitespaceAction {
-  ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
-    while (!node.empty() && (node.id() == TOKEN_WS || node.id() == TOKEN_NL)) {
-      if (node.id() == TOKEN_WS) {
-        space(builder, node.fragment().segment().str().size());
-      } else {
-        builder.append(NL_STR);
-      }
-      node.nextSiblingElement();
-    }
-  }
-};
-
 struct SpaceAction {
   uint8_t count;
   SpaceAction(uint8_t count) : count(count) {}
@@ -450,7 +437,6 @@ struct Formatter {
   Formatter(Action a) : action(a) {}
 
   Formatter<SeqAction<Action, ConsumeWhitespaceAction>> consume_wsnl() { return {{action, {}}}; }
-  Formatter<SeqAction<Action, CopyWhitespaceAction>> copy_wsnl() { return {{action, {}}}; }
 
   Formatter<SeqAction<Action, WhitespaceTokenAction>> ws() { return {{action, {}}}; }
 

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -37,17 +37,10 @@
 struct ctx_t {
   size_t width = 0;
   size_t nest_level = 0;
-  bool fmt_off = false;
 
   ctx_t nest() {
     ctx_t copy = *this;
     copy.nest_level++;
-    return copy;
-  }
-
-  ctx_t off() {
-    ctx_t copy = *this;
-    copy.fmt_off = true;
     return copy;
   }
 
@@ -62,17 +55,14 @@ struct ctx_t {
   }
 
   bool operator==(const ctx_t& other) const {
-    return width == other.width && nest_level == other.nest_level && fmt_off == other.fmt_off;
+    return width == other.width && nest_level == other.nest_level;
   }
 };
 
 template <>
 struct std::hash<ctx_t> {
   size_t operator()(ctx_t const& ctx) const noexcept {
-    size_t hash =
-        wcl::hash_combine(std::hash<size_t>{}(ctx.width), std::hash<size_t>{}(ctx.nest_level));
-    hash = wcl::hash_combine(hash, std::hash<bool>{}(ctx.fmt_off));
-    return hash;
+    return wcl::hash_combine(std::hash<size_t>{}(ctx.width), std::hash<size_t>{}(ctx.nest_level));
   }
 };
 

--- a/tools/wake-format/wake-format.cpp
+++ b/tools/wake-format/wake-format.cpp
@@ -102,6 +102,7 @@ void print_cst(CSTElement node, int depth) {
       case TOKEN_DOUBLE:
       case TOKEN_STR_SINGLE:
       case TOKEN_REG_SINGLE:
+      case TOKEN_COMMENT:
         std::cout << " -> " << child.fragment().segment().str() << std::endl;
         break;
       case TOKEN_WS: {


### PR DESCRIPTION
Implements `# wake-format off` with the following semantics.

1) For a `# wake-format off` comment at top level, the next sibling node and all its children will be re-emitted exactly as they are. Including whitespace, indents, and newlines
2) For all other `# wake-format off` comments, the next sibling node and all its children will be emitted exactly as they are except that indentation will be overwritten to match the indentation for the rest of the containing block. Since wake is whitespace sensitive, this is required to maintain a semantically valid program.