### PR TITLE
Support unicode with in wcl::doc

### DIFF
--- a/src/wcl/doc.h
+++ b/src/wcl/doc.h
@@ -75,16 +75,13 @@ struct doc_state {
 
     state.byte_count = str.size();
 
-    utf8proc_int32_t codepoint;
-    utf8proc_ssize_t pos = 0;
-    while (true) {
-      pos += utf8proc_iterate(reinterpret_cast<const unsigned char*>(str.c_str()) + pos, -1,
-                              &codepoint);
+    const utf8proc_uint8_t* iter = reinterpret_cast<const unsigned char*>(str.c_str());
+    const utf8proc_uint8_t* iter_end = iter + str.size();
+    while (iter < iter_end) {
+      utf8proc_int32_t codepoint;
+      iter += utf8proc_iterate(iter, -1, &codepoint);
 
-      assert(codepoint >= 0);  // < 0 means error parsing utf8
-      assert(pos >= 0);        // < 0 means pos was overflown
-
-      if (codepoint == 0) break;
+      assert(codepoint > 0);  // < 0 means error parsing utf8
 
       int charwidth = utf8proc_charwidth(codepoint);
 

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -3,6 +3,7 @@ PASSED:
   doc_geometry
   doc_large
   doc_undo
+  doc_unicode
   filepath_range_basic
   filepath_range_empty_node
   filepath_range_fuzz_garbage

--- a/tools/wake-unit/doc.cpp
+++ b/tools/wake-unit/doc.cpp
@@ -38,7 +38,7 @@ TEST(doc_basic) {
   wcl::doc d = std::move(builder).build();
   std::string expected = "Hello World! My name is Ashley";
 
-  EXPECT_EQUAL(expected.size(), d.character_count());
+  EXPECT_EQUAL(expected.size(), d.byte_count());
   EXPECT_EQUAL(expected, d.as_string());
 }
 
@@ -66,7 +66,7 @@ TEST(doc_large) {
   }
 
   wcl::doc d = std::move(builder).build();
-  ASSERT_EQUAL(3000000u, d.character_count());
+  ASSERT_EQUAL(3000000u, d.byte_count());
 }
 
 TEST(doc_undo) {
@@ -82,8 +82,49 @@ TEST(doc_undo) {
   wcl::doc d = std::move(builder).build();
   std::string expected = "Hello ";
 
-  EXPECT_EQUAL(expected.size(), d.character_count());
+  EXPECT_EQUAL(expected.size(), d.byte_count());
   EXPECT_EQUAL(expected, d.as_string());
+}
+
+TEST(doc_unicode) {
+  {
+    wcl::doc_builder builder;
+    builder.append("····");
+
+    EXPECT_EQUAL(8u, builder.byte_count());
+    EXPECT_EQUAL(4u, builder.first_width());
+    EXPECT_EQUAL(4u, builder.last_width());
+    EXPECT_EQUAL(4u, builder.max_width());
+    EXPECT_EQUAL(0u, builder.newline_count());
+    EXPECT_EQUAL(1u, builder.height());
+
+    builder.append("⏎");
+
+    EXPECT_EQUAL(11u, builder.byte_count());
+    EXPECT_EQUAL(6u, builder.first_width());
+    EXPECT_EQUAL(6u, builder.last_width());
+    EXPECT_EQUAL(6u, builder.max_width());
+    EXPECT_EQUAL(0u, builder.newline_count());
+    EXPECT_EQUAL(1u, builder.height());
+
+    builder.append("\n·");
+
+    EXPECT_EQUAL(14u, builder.byte_count());
+    EXPECT_EQUAL(6u, builder.first_width());
+    EXPECT_EQUAL(1u, builder.last_width());
+    EXPECT_EQUAL(6u, builder.max_width());
+    EXPECT_EQUAL(1u, builder.newline_count());
+    EXPECT_EQUAL(2u, builder.height());
+
+    wcl::doc d = std::move(builder).build();
+
+    EXPECT_EQUAL(14u, d.byte_count());
+    EXPECT_EQUAL(6u, d.first_width());
+    EXPECT_EQUAL(1u, d.last_width());
+    EXPECT_EQUAL(6u, d.max_width());
+    EXPECT_EQUAL(1u, d.newline_count());
+    EXPECT_EQUAL(2u, d.height());
+  }
 }
 
 TEST(doc_geometry) {


### PR DESCRIPTION
`wcl::doc` was incorrectly reporting width values when passed in unicode strings. As unicode is common place in wake code, we need to also support it here. This change does the thing.