### PR TITLE
Add `match` syntax to the formatter API

### DIFF
--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -69,10 +69,10 @@ auto Emitter::rhs_fmt() {
   auto full_fmt = fmt().nest(fmt().newline().walk(WALK(walk_node)));
 
   // clang-format off
-  return fmt().match(match()
-      .pred(requires_nl, nl_required_fmt)
-      .fits(flat_fmt)
-      .otherwise(full_fmt));
+  return fmt().match(
+    pred(requires_nl, nl_required_fmt)
+   .fits(flat_fmt)
+   .otherwise(full_fmt));
   // clang-format on
 }
 
@@ -84,11 +84,13 @@ wcl::doc Emitter::layout(CST cst) {
 wcl::doc Emitter::walk(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
 
-  auto body_fmt = fmt().match(match()
-                                  .pred(TOKEN_WS, fmt().next())
-                                  .pred(TOKEN_NL, fmt().next().newline())
-                                  .pred(TOKEN_COMMENT, fmt().walk(WALK(walk_token)))
-                                  .otherwise(fmt().walk(WALK(walk_node)).newline()));
+  // clang-format off
+  auto body_fmt = fmt().match(
+    pred(TOKEN_WS, fmt().next())
+   .pred(TOKEN_NL, fmt().next().newline())
+   .pred(TOKEN_COMMENT, fmt().walk(WALK(walk_token)))
+   .otherwise(fmt().walk(WALK(walk_node)).newline()));
+  // clang-format on
 
   MEMO_RET(fmt().walk_children(body_fmt).format(ctx, node));
 }
@@ -371,10 +373,12 @@ wcl::doc Emitter::walk_block(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
   assert(node.id() == CST_BLOCK);
 
-  auto body_fmt = fmt().match(match()
-                                  .pred(TOKEN_WS, fmt().next())
-                                  .pred(TOKEN_NL, fmt().next())
-                                  .otherwise(fmt().newline().walk(WALK(walk_node))));
+  // clang-format off
+  auto body_fmt = fmt().match(
+    pred(TOKEN_WS, fmt().next())
+   .pred(TOKEN_NL, fmt().next())
+   .otherwise(fmt().newline().walk(WALK(walk_node))));
+  // clang-format on
 
   MEMO_RET(fmt().walk_children(body_fmt).consume_wsnl().format(ctx, node));
 }

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -71,7 +71,7 @@ auto Emitter::rhs_fmt() {
   // clang-format off
   return fmt().match(
     pred(requires_nl, nl_required_fmt)
-   .fits(flat_fmt)
+   .pred_fits(flat_fmt)
    .otherwise(full_fmt));
   // clang-format on
 }

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -395,8 +395,9 @@ struct MatchAction {
 
   MatchAction(Case c) : c(c) {}
 
+  // Predicate case that is accepted if FMT passes the FitsPredicate
   template <class FMT>
-  MatchAction<MatchSeq<Case, PredicateCase<FitsPredicate<FMT>, FMT>>> fits(FMT formatter) {
+  MatchAction<MatchSeq<Case, PredicateCase<FitsPredicate<FMT>, FMT>>> pred_fits(FMT formatter) {
     return {{c, {FitsPredicate<FMT>(formatter), formatter}}};
   }
 

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -347,10 +347,6 @@ struct FmtPredicate<std::initializer_list<T>> {
   bool operator()(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) { return set[node.id()]; }
 };
 
-struct EpsilonCase {
-  ALWAYS_INLINE bool run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) { return false; }
-};
-
 template <class Predicate, class FMT>
 struct PredicateCase {
   Predicate predicate;
@@ -558,6 +554,10 @@ struct Formatter {
 
 inline Formatter<EpsilonAction> fmt() { return {{}}; }
 
-inline MatchAction<EpsilonCase> match() { return {{}}; }
+template <class Predicate, class FMT>
+inline MatchAction<PredicateCase<FmtPredicate<Predicate>, FMT>> pred(Predicate predicate,
+                                                                     FMT formatter) {
+  return {{predicate, formatter}};
+}
 
 #undef ALWAYS_INLINE

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -347,6 +347,85 @@ struct FmtPredicate<std::initializer_list<T>> {
   bool operator()(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) { return set[node.id()]; }
 };
 
+struct EpsilonCase {
+  ALWAYS_INLINE bool run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) { return false; }
+};
+
+template <class Predicate, class FMT>
+struct PredicateCase {
+  Predicate predicate;
+  FMT formatter;
+
+  PredicateCase(Predicate predicate, FMT formatter) : predicate(predicate), formatter(formatter) {}
+
+  ALWAYS_INLINE bool run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
+    if (!predicate(builder, ctx, node)) {
+      return false;
+    }
+    builder.append(formatter.compose(ctx.sub(builder), node));
+    return true;
+  }
+};
+
+template <class FMT>
+struct OtherwiseCase {
+  FMT formatter;
+
+  OtherwiseCase(FMT formatter) : formatter(formatter) {}
+
+  ALWAYS_INLINE bool run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
+    builder.append(formatter.compose(ctx.sub(builder), node));
+    return true;
+  }
+};
+
+template <class Case1, class Case2>
+struct MatchSeq {
+  Case1 case1;
+  Case2 case2;
+  MatchSeq(Case1 c1, Case2 c2) : case1(c1), case2(c2) {}
+
+  ALWAYS_INLINE bool run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
+    if (case1.run(builder, ctx, node)) {
+      return true;
+    }
+    return case2.run(builder, ctx, node);
+  }
+};
+
+template <class Case>
+struct MatchAction {
+  Case c;
+
+  MatchAction(Case c) : c(c) {}
+
+  template <class FMT>
+  MatchAction<MatchSeq<Case, PredicateCase<FitsPredicate<FMT>, FMT>>> fits(FMT formatter) {
+    return {{c, {FitsPredicate<FMT>(formatter), formatter}}};
+  }
+
+  template <class FMT>
+  MatchAction<MatchSeq<Case, PredicateCase<FmtPredicate<std::initializer_list<uint8_t>>, FMT>>>
+  pred(std::initializer_list<uint8_t> ids, FMT formatter) {
+    return {{c, {ids, formatter}}};
+  }
+
+  template <class Predicate, class FMT>
+  MatchAction<MatchSeq<Case, PredicateCase<FmtPredicate<Predicate>, FMT>>> pred(Predicate predicate,
+                                                                                FMT formatter) {
+    return {{c, {predicate, formatter}}};
+  }
+
+  template <class FMT>
+  MatchAction<MatchSeq<Case, OtherwiseCase<FMT>>> otherwise(FMT formatter) {
+    return {{c, {formatter}}};
+  }
+
+  ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
+    assert(c.run(builder, ctx, node));
+  }
+};
+
 template <class Action>
 struct Formatter {
   Action action;
@@ -420,6 +499,11 @@ struct Formatter {
     return {{action, {predicate, formatter}}};
   }
 
+  template <class Case>
+  Formatter<SeqAction<Action, MatchAction<Case>>> match(MatchAction<Case> match_action) {
+    return {{action, match_action}};
+  }
+
   template <class Walker>
   Formatter<SeqAction<Action, WalkPredicateAction<FmtPredicate<ConstPredicate>, Walker>>> walk(
       Walker texas_ranger) {
@@ -472,6 +556,8 @@ struct Formatter {
   }
 };
 
-inline Formatter<EpsilonAction> fmt() { return Formatter<EpsilonAction>({}); }
+inline Formatter<EpsilonAction> fmt() { return {{}}; }
+
+inline MatchAction<EpsilonCase> match() { return {{}}; }
 
 #undef ALWAYS_INLINE


### PR DESCRIPTION
Adds `match` to the formatting API. Used as shown below

```
fmt().match(match()
  .pred(TOKEN_ID, fmt())
  .pred({TOKEN_ID, TOKEN_ID}, fmt())
  .pred(some_predicate, fmt())
  .fits(fmt())
  .otherwise(fmt())
.format(..., ...)
```

- `pred` -> the `case` statement. if predicate returns true then fmt is used, if false the the next entry is considered
- `fits` -> fmt is used if it fits the size limit, otherwise the next entry is considered
- `otherwise` -> the `default` statement. fmt is always used and no other case is considered. Should be the last item in a match

if no statement is accepted then an assertion is thrown; therefore a `match` should always end in an `otherwise` unless it is known that a `pred` will always pass 

Cases are evaluated top down, the first to be accepted is the one that is used.