### PR TITLE
Create explicit type for CSTElement ids

### DIFF
--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -136,7 +136,7 @@ static void dst_import(CSTElement topdef, DefMap &map) {
   for (; !child.empty(); child.nextSiblingNode()) {
     CSTElement ideq = child.firstChildNode();
 
-    uint8_t idop1 = ideq.id(), idop2;
+    cst_id_t idop1 = ideq.id(), idop2;
     std::string name = getIdentifier(ideq);
     ideq.nextSiblingNode();
 
@@ -213,7 +213,7 @@ static void dst_export(CSTElement topdef, Package &package) {
   for (; !child.empty(); child.nextSiblingNode()) {
     CSTElement ideq = child.firstChildNode();
 
-    uint8_t idop1 = ideq.id(), idop2;
+    cst_id_t idop1 = ideq.id(), idop2;
     std::string name = getIdentifier(ideq);
     ideq.nextSiblingNode();
 
@@ -816,7 +816,7 @@ static void dst_def(CSTElement def, DefMap &map, Package *package, Symbols *glob
   std::string name = std::move(ast.name);
   ast.name.clear();
 
-  uint8_t kind = lex_kind(name);
+  IdKind kind = lex_kind(name);
   bool extract = kind == UPPER || (child.id() == CST_PAREN && kind == OPERATOR);
   if (extract && (target || publish)) {
     ERROR(ast.token.location(),
@@ -954,11 +954,11 @@ static void dst_def(CSTElement def, DefMap &map, Package *package, Symbols *glob
 }
 
 static void mstr_add(std::ostream &os, CSTElement token, std::string::size_type wsCut) {
-  uint8_t nid = token.id();
+  cst_id_t nid = token.id();
   while (!token.empty()) {
     StringSegment ti = token.segment();
     token.nextSiblingElement();
-    uint8_t id = nid;
+    cst_id_t id = nid;
     nid = token.id();
 
     switch (id) {
@@ -1052,7 +1052,7 @@ void MultiLineStringIndentationFSM::accept(CSTElement lit) {
 
 static Literal *dst_literal(CSTElement lit, std::string::size_type wsCut) {
   CSTElement child = lit.firstChildElement();
-  uint8_t id = child.id();
+  cst_id_t id = child.id();
   switch (id) {
     case TOKEN_STR_RAW: {
       StringSegment ti = child.segment();

--- a/src/parser/cst.cpp
+++ b/src/parser/cst.cpp
@@ -29,21 +29,21 @@
 
 CSTBuilder::CSTBuilder(const FileContent &fcontent) { file = &fcontent; }
 
-CSTNode::CSTNode(uint8_t id_, uint32_t size_, uint32_t begin_, uint32_t end_)
+CSTNode::CSTNode(cst_id_t id_, uint32_t size_, uint32_t begin_, uint32_t end_)
     : id(id_), size(size_), begin(begin_), end(end_) {}
 
-void CSTBuilder::addToken(uint8_t id, StringSegment token) {
+void CSTBuilder::addToken(cst_id_t id, StringSegment token) {
   token_ids.push_back(id);
   token_starts.set(token.start - file->segment().start);
 }
 
-void CSTBuilder::addNode(uint8_t id, StringSegment begin) {
+void CSTBuilder::addNode(cst_id_t id, StringSegment begin) {
   uint32_t b = begin.start - file->segment().start;
   uint32_t e = begin.end - file->segment().start;
   nodes.emplace_back(id, 1, b, e);
 }
 
-void CSTBuilder::addNode(uint8_t id, uint32_t children) {
+void CSTBuilder::addNode(cst_id_t id, uint32_t children) {
   uint32_t b = 0;
   uint32_t e = nodes.empty() ? 0 : nodes.back().end;
 
@@ -56,7 +56,7 @@ void CSTBuilder::addNode(uint8_t id, uint32_t children) {
   nodes.emplace_back(id, size, b, e);
 }
 
-void CSTBuilder::addNode(uint8_t id, StringSegment begin, uint32_t children) {
+void CSTBuilder::addNode(cst_id_t id, StringSegment begin, uint32_t children) {
   uint32_t b = 0;
   uint32_t e = nodes.empty() ? 0 : nodes.back().end;
 
@@ -72,7 +72,7 @@ void CSTBuilder::addNode(uint8_t id, StringSegment begin, uint32_t children) {
   nodes.emplace_back(id, size, b, e);
 }
 
-void CSTBuilder::addNode(uint8_t id, uint32_t children, StringSegment end) {
+void CSTBuilder::addNode(cst_id_t id, uint32_t children, StringSegment end) {
   uint32_t b = 0;
   uint32_t e = nodes.empty() ? 0 : nodes.back().end;
 
@@ -88,7 +88,7 @@ void CSTBuilder::addNode(uint8_t id, uint32_t children, StringSegment end) {
   nodes.emplace_back(id, size, b, e);
 }
 
-void CSTBuilder::addNode(uint8_t id, StringSegment begin, uint32_t children, StringSegment end) {
+void CSTBuilder::addNode(cst_id_t id, StringSegment begin, uint32_t children, StringSegment end) {
   uint32_t b2 = 0;
 
   int size = 1;
@@ -170,7 +170,7 @@ bool CSTElement::empty() const { return node == limit && token >= end; }
 
 bool CSTElement::isNode() const { return node != limit && token >= cst->nodes[node].begin; }
 
-uint8_t CSTElement::id() const {
+cst_id_t CSTElement::id() const {
   if (isNode()) {
     return cst->nodes[node].id;
   } else {

--- a/src/parser/cst.h
+++ b/src/parser/cst.h
@@ -69,6 +69,8 @@
 #define CST_UNARY 164
 #define CST_ERROR 255
 
+typedef uint8_t cst_id_t;
+
 class FileContent;
 class CSTElement;
 class DiagnosticReporter;
@@ -81,26 +83,26 @@ struct CSTNode {
   // Byte range covered by this node
   uint32_t begin, end;
 
-  CSTNode(uint8_t id_, uint32_t size_, uint32_t begin_, uint32_t end_);
+  CSTNode(cst_id_t id_, uint32_t size_, uint32_t begin_, uint32_t end_);
 };
 
 class CSTBuilder {
  public:
   CSTBuilder(const FileContent &fcontent);
 
-  void addToken(uint8_t id, StringSegment token);
+  void addToken(cst_id_t id, StringSegment token);
 
-  void addNode(uint8_t id, StringSegment begin);
-  void addNode(uint8_t id, uint32_t children);
-  void addNode(uint8_t id, StringSegment begin, uint32_t children);
-  void addNode(uint8_t id, uint32_t children, StringSegment end);
-  void addNode(uint8_t id, StringSegment begin, uint32_t children, StringSegment end);
+  void addNode(cst_id_t id, StringSegment begin);
+  void addNode(cst_id_t id, uint32_t children);
+  void addNode(cst_id_t id, StringSegment begin, uint32_t children);
+  void addNode(cst_id_t id, uint32_t children, StringSegment end);
+  void addNode(cst_id_t id, StringSegment begin, uint32_t children, StringSegment end);
 
   void delNodes(size_t num);
 
  private:
   const FileContent *file;
-  std::vector<uint8_t> token_ids;
+  std::vector<cst_id_t> token_ids;
   std::vector<CSTNode> nodes;
   RankBuilder token_starts;
 
@@ -119,7 +121,7 @@ class CST {
 
   RankSelect1Map token_starts;
   const FileContent *file;
-  std::vector<uint8_t> token_ids;
+  std::vector<cst_id_t> token_ids;
   std::vector<CSTNode> nodes;
 
   friend class CSTElement;
@@ -130,7 +132,7 @@ class CSTElement {
   bool empty() const;
   bool isNode() const;
 
-  uint8_t id() const;
+  cst_id_t id() const;
   FileFragment fragment() const;
   StringSegment segment() const { return fragment().segment(); }
   Location location() const { return fragment().location(); }

--- a/src/parser/cst.h
+++ b/src/parser/cst.h
@@ -69,7 +69,7 @@
 #define CST_UNARY 164
 #define CST_ERROR 255
 
-typedef uint8_t cst_id_t;
+using cst_id_t = uint8_t;
 
 class FileContent;
 class CSTElement;

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -56,9 +56,9 @@
     return v;                                    \
   }
 
-static bool requires_nl(uint8_t type) { return type == CST_BLOCK || type == CST_REQUIRE; }
+static bool requires_nl(cst_id_t type) { return type == CST_BLOCK || type == CST_REQUIRE; }
 
-static bool is_expression(uint8_t type) {
+static bool is_expression(cst_id_t type) {
   return type == CST_ID || type == CST_APP || type == CST_LITERAL || type == CST_HOLE ||
          type == CST_BINARY;
 }

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -100,8 +100,8 @@ struct NewlineAction {
 };
 
 struct TokenAction {
-  uint8_t token_id;
-  TokenAction(uint8_t token_id) : token_id(token_id) {}
+  cst_id_t token_id;
+  TokenAction(cst_id_t token_id) : token_id(token_id) {}
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     assert(node.id() == token_id);
     builder.append(node.fragment().segment().str());
@@ -110,10 +110,10 @@ struct TokenAction {
 };
 
 struct TokenReplaceAction {
-  uint8_t token_id;
+  cst_id_t token_id;
   const char* str;
 
-  TokenReplaceAction(uint8_t token_id, const char* str) : token_id(token_id), str(str) {}
+  TokenReplaceAction(cst_id_t token_id, const char* str) : token_id(token_id), str(str) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     assert(node.id() == token_id);
@@ -298,9 +298,10 @@ struct FmtPredicate {
 
   template <
       class CTX,
-      std::enable_if_t<std::is_same<bool, decltype(std::declval<typename DepDeclType<
-                                                       CTX, Predicate>::type>()(uint8_t()))>::value,
-                       bool> = true>
+      std::enable_if_t<
+          std::is_same<bool, decltype(std::declval<typename DepDeclType<CTX, Predicate>::type>()(
+                                 cst_id_t()))>::value,
+          bool> = true>
   bool operator()(wcl::doc_builder& builder, CTX ctx, CSTElement& node) {
     return predicate(node.id());
   }
@@ -318,9 +319,9 @@ struct FmtPredicate {
 };
 
 template <>
-struct FmtPredicate<uint8_t> {
-  uint8_t id;
-  FmtPredicate(uint8_t id) : id(id) {}
+struct FmtPredicate<cst_id_t> {
+  cst_id_t id;
+  FmtPredicate(cst_id_t id) : id(id) {}
   bool operator()(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     return node.id() == id;
   }
@@ -363,9 +364,9 @@ struct Formatter {
 
   Formatter<SeqAction<Action, NewlineAction>> newline() { return {{action, {space_per_indent}}}; }
 
-  Formatter<SeqAction<Action, TokenAction>> token(uint8_t id) { return {{action, {id}}}; }
+  Formatter<SeqAction<Action, TokenAction>> token(cst_id_t id) { return {{action, {id}}}; }
 
-  Formatter<SeqAction<Action, TokenReplaceAction>> token(uint8_t id, const char* str) {
+  Formatter<SeqAction<Action, TokenReplaceAction>> token(cst_id_t id, const char* str) {
     return {{action, {id, str}}};
   }
 
@@ -383,9 +384,9 @@ struct Formatter {
   }
 
   template <class FMT>
-  Formatter<SeqAction<Action, IfElseAction<FmtPredicate<std::initializer_list<uint8_t>>, FMT,
+  Formatter<SeqAction<Action, IfElseAction<FmtPredicate<std::initializer_list<cst_id_t>>, FMT,
                                            Formatter<EpsilonAction>>>>
-  fmt_if(std::initializer_list<uint8_t> ids, FMT formatter) {
+  fmt_if(std::initializer_list<cst_id_t> ids, FMT formatter) {
     return fmt_if_else(ids, formatter, Formatter<EpsilonAction>({}));
   }
 
@@ -397,8 +398,8 @@ struct Formatter {
 
   template <class IFMT, class EFMT>
   Formatter<
-      SeqAction<Action, IfElseAction<FmtPredicate<std::initializer_list<uint8_t>>, IFMT, EFMT>>>
-  fmt_if_else(std::initializer_list<uint8_t> ids, IFMT if_formatter, EFMT else_formatter) {
+      SeqAction<Action, IfElseAction<FmtPredicate<std::initializer_list<cst_id_t>>, IFMT, EFMT>>>
+  fmt_if_else(std::initializer_list<cst_id_t> ids, IFMT if_formatter, EFMT else_formatter) {
     return {{action, {ids, if_formatter, else_formatter}}};
   }
 
@@ -409,8 +410,8 @@ struct Formatter {
   }
 
   template <class FMT>
-  Formatter<SeqAction<Action, WhileAction<FmtPredicate<std::initializer_list<uint8_t>>, FMT>>>
-  fmt_while(std::initializer_list<uint8_t> ids, FMT formatter) {
+  Formatter<SeqAction<Action, WhileAction<FmtPredicate<std::initializer_list<cst_id_t>>, FMT>>>
+  fmt_while(std::initializer_list<cst_id_t> ids, FMT formatter) {
     return {{action, {ids, formatter}}};
   }
 
@@ -428,8 +429,8 @@ struct Formatter {
 
   template <class Walker>
   Formatter<
-      SeqAction<Action, WalkPredicateAction<FmtPredicate<std::initializer_list<uint8_t>>, Walker>>>
-  walk(std::initializer_list<uint8_t> ids, Walker texas_ranger) {
+      SeqAction<Action, WalkPredicateAction<FmtPredicate<std::initializer_list<cst_id_t>>, Walker>>>
+  walk(std::initializer_list<cst_id_t> ids, Walker texas_ranger) {
     return {{action, {ids, texas_ranger}}};
   }
 

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -336,6 +336,10 @@ struct FmtPredicate<int> {
   }
 };
 
+// if sizeof(cst_id_t) is increased then
+// std::bitset<256> set from FmtPredicate needs to be increased
+static_assert(sizeof(cst_id_t) == 1);
+
 template <class T>
 struct FmtPredicate<std::initializer_list<T>> {
   std::bitset<256> set;


### PR DESCRIPTION
Creates an explicit type for CSTElement Ids. This makes the documentation in `wake-format` more clear and serves as a safety net if we ever expand past 256 CST ids

I know I missed some. `lexer.h` and `lexer.re` has a lot of suspicious `uint8_t`s, but this is a start down the correct path.