### PR TITLE
shell: always escape empty strings

### DIFF
--- a/src/util/shell.cpp
+++ b/src/util/shell.cpp
@@ -111,6 +111,11 @@ static bool not_special(char c) {
 }
 
 std::string shell_escape(const char *x) {
+  // empty string should always be escaped
+  if (strnlen(x, 1) == 0) {
+    return "''";
+  }
+
   // check if we need escaping at all
   const char *ok;
   for (ok = x; not_special(*ok); ++ok) {

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -24,6 +24,10 @@ PASSED:
   option_some
   sanity_check1
   sanity_check2
+  shell_escape_empty_string
+  shell_escape_nominal
+  shell_escape_spaces
+  shell_escape_special
   trie_basic
   trie_basic_const
   trie_char

--- a/tools/wake-unit/shell.cpp
+++ b/tools/wake-unit/shell.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/shell.h"
+
+#include "unit.h"
+
+TEST(shell_escape_nominal) {
+  std::string esc = shell_escape("echo");
+  EXPECT_EQUAL(esc, "echo");
+  esc = shell_escape("test");
+  EXPECT_EQUAL(esc, "test");
+  esc = shell_escape("here");
+  EXPECT_EQUAL(esc, "here");
+}
+
+TEST(shell_escape_spaces) {
+  std::string esc = shell_escape("echo test here");
+  EXPECT_EQUAL(esc, "'echo test here'");
+  esc = shell_escape("a b c");
+  EXPECT_EQUAL(esc, "'a b c'");
+  esc = shell_escape("zz ss yy aa bb");
+  EXPECT_EQUAL(esc, "'zz ss yy aa bb'");
+}
+
+TEST(shell_escape_empty_string) {
+  std::string esc = shell_escape("");
+  EXPECT_EQUAL(esc, "''");
+}
+
+TEST(shell_escape_special) {
+  std::string esc = shell_escape("\n");
+  EXPECT_EQUAL(esc, "'\n'");
+
+  esc = shell_escape("'");
+  EXPECT_EQUAL(esc, "''\\'''");
+
+  esc = shell_escape("'test'");
+  EXPECT_EQUAL(esc, "''\\''test'\\'''");
+}

--- a/tools/wake-unit/shell.cpp
+++ b/tools/wake-unit/shell.cpp
@@ -35,6 +35,12 @@ TEST(shell_escape_spaces) {
   EXPECT_EQUAL(esc, "'a b c'");
   esc = shell_escape("zz ss yy aa bb");
   EXPECT_EQUAL(esc, "'zz ss yy aa bb'");
+
+  esc = shell_escape(" echo");
+  EXPECT_EQUAL(esc, "' echo'");
+
+  esc = shell_escape("echo ");
+  EXPECT_EQUAL(esc, "'echo '");
 }
 
 TEST(shell_escape_empty_string) {


### PR DESCRIPTION
Bug Fix: When calling `shell_escape()` over the components of a shell command and collecting it into a string [as done here](https://github.com/sifive/wake/blob/master/tools/wakebox/wakebox.cpp#L179-L186) an empty string gets re-emitted as an empty string effectively erasing it as an argument.
 
Ex: 
```
0: bash
1: -c
2: echo $#
3: test0
4: 
5: test1
6: test2
```
becomes `bash -c 'echo $#' test0 test1 test2` instead of the expected `bash -c 'echo $#' test0 '' test1 test2`

Fix this by always escaping empty string.