### PR TITLE
Extract doc_state into several monoids

### DIFF
--- a/src/wcl/doc.h
+++ b/src/wcl/doc.h
@@ -22,92 +22,10 @@
 #include <sstream>
 #include <vector>
 
+#include "doc_state.h"
 #include "utf8proc/utf8proc.h"
 
 namespace wcl {
-
-// Internal state for a doc object. It is intentionally not exposed in the
-// public API and should not be used directly.
-struct doc_state {
-  // Total number of bytes in the doc
-  size_t byte_count = 0;
-
-  // Total number of newlines in the doc
-  size_t newline_count = 0;
-
-  // Human visible "width" of the first line of the doc
-  size_t first_width = 0;
-
-  // Human visible "width" of the last line of the doc
-  size_t last_width = 0;
-
-  // Max human visible "width" of the doc
-  size_t max_width = 0;
-
-  // Returns the merged state of this and other.
-  doc_state merged(doc_state other) {
-    doc_state merged;
-
-    merged.byte_count = byte_count + other.byte_count;
-    merged.newline_count = newline_count + other.newline_count;
-
-    merged.last_width = other.last_width;
-    // If other doesn't have any newlines, then the left side needs to be accounted for
-    if (other.newline_count == 0) {
-      merged.last_width += last_width;
-    }
-
-    merged.first_width = first_width;
-    // If the left side doesn't have any newlines, then other side needs to be accounted for
-    if (newline_count == 0) {
-      merged.first_width += other.first_width;
-    }
-
-    merged.max_width = std::max(max_width, other.max_width);
-    // It is possible that the join point is a longer line than any other in either doc
-    merged.max_width = std::max(merged.max_width, last_width + other.first_width);
-
-    return merged;
-  }
-
-  static doc_state from_string(const std::string& str) {
-    doc_state state;
-
-    state.byte_count = str.size();
-
-    const utf8proc_uint8_t* iter = reinterpret_cast<const utf8proc_uint8_t*>(str.c_str());
-    const utf8proc_uint8_t* iter_end = iter + str.size();
-    while (iter < iter_end) {
-      utf8proc_int32_t codepoint;
-      iter += utf8proc_iterate(iter, -1, &codepoint);
-
-      assert(codepoint > 0);  // < 0 means error parsing utf8
-
-      int charwidth = utf8proc_charwidth(codepoint);
-
-      if (codepoint == '\n') {
-        // once we see a newline, check if the line was larger than any seen before
-        state.max_width = std::max(state.max_width, state.last_width);
-
-        state.last_width = 0;
-        state.newline_count++;
-        continue;
-      }
-
-      if (state.newline_count == 0) {
-        state.first_width += charwidth;
-      }
-
-      state.last_width += charwidth;
-    }
-
-    // Account for the case when the last line is the longest w/o a nl.
-    // ex: "a <newline> b <newline> cdef"
-    state.max_width = std::max(state.max_width, state.last_width);
-    return state;
-  }
-};
-
 class doc_impl_base {
  protected:
   doc_state state_;
@@ -120,14 +38,8 @@ class doc_impl_base {
   // methods that all RopeImpl share
   virtual void write(std::ostream&) const = 0;
 
-  size_t byte_count() const { return state_.byte_count; }
-  size_t newline_count() const { return state_.newline_count; }
-  size_t first_width() const { return state_.first_width; }
-  size_t last_width() const { return state_.last_width; }
-  size_t max_width() const { return state_.max_width; }
-
-  doc_state state() const { return state_; }
-  bool has_newline() const { return state_.newline_count > 0; }
+  const doc_state& operator->() const { return state_; }
+  const doc_state& operator*() const { return state_; }
 };
 
 class doc_impl_string : public doc_impl_base {
@@ -136,7 +48,7 @@ class doc_impl_string : public doc_impl_base {
 
  public:
   explicit doc_impl_string(std::string str)
-      : doc_impl_base(doc_state::from_string(str)), str(str) {}
+      : doc_impl_base(from_string<doc_state>(str)), str(str) {}
   void write(std::ostream& ostream) const override { ostream << str; }
 };
 
@@ -147,8 +59,7 @@ class doc_impl_pair : public doc_impl_base {
 
  public:
   doc_impl_pair(std::shared_ptr<doc_impl_base> left, std::shared_ptr<doc_impl_base> right)
-      : doc_impl_base(left->state().merged(right->state())),
-        pair(std::make_pair(std::move(left), std::move(right))) {}
+      : doc_impl_base(**left + **right), pair(std::make_pair(std::move(left), std::move(right))) {}
 
   void write(std::ostream& ostream) const override {
     pair.first->write(ostream);
@@ -178,8 +89,6 @@ class doc {
  private:
   std::shared_ptr<doc_impl_base> impl;
 
-  doc_state state() const { return impl->state(); }
-
   explicit doc(std::unique_ptr<doc_impl_base> impl) : impl(std::move(impl)) {}
 
  public:
@@ -201,26 +110,8 @@ class doc {
   // O(n)
   void write(std::ostream& ostream) const { impl->write(ostream); }
 
-  // O(1)
-  size_t first_width() const { return impl->first_width(); }
-
-  // O(1)
-  size_t last_width() const { return impl->last_width(); }
-
-  // O(1)
-  size_t max_width() const { return impl->max_width(); }
-
-  // O(1)
-  size_t byte_count() const { return impl->byte_count(); }
-
-  // O(1)
-  size_t newline_count() const { return impl->newline_count(); }
-
-  // O(1)
-  bool has_newline() const { return impl->has_newline(); }
-
-  // O(1)
-  size_t height() const { return newline_count() + 1; }
+  const doc_state& operator->() const { return **impl; }
+  const doc_state& operator*() const { return **impl; }
 
   friend doc_builder;
 };
@@ -245,7 +136,7 @@ class doc {
 class doc_builder {
  private:
   std::vector<doc> docs;
-  doc_state state;
+  doc_state state = doc_state::identity();
 
   doc merge(int start, int end) {
     if (start > end) {
@@ -268,7 +159,7 @@ class doc_builder {
   void append(std::string str) { append(doc::lit(std::move(str))); }
 
   void append(doc other) {
-    state = state.merged(other.state());
+    state = state + *other;
     docs.push_back(std::move(other));
   }
 
@@ -276,22 +167,17 @@ class doc_builder {
     docs.pop_back();
     state = {};
     for (const auto& r : docs) {
-      state = state.merged(r.state());
+      state = state + *r;
     }
   }
 
-  size_t first_width() const { return state.first_width; }
-  size_t last_width() const { return state.last_width; }
-  size_t max_width() const { return state.max_width; }
-  size_t byte_count() const { return state.byte_count; }
-  size_t newline_count() const { return state.newline_count; }
-  size_t height() const { return state.newline_count + 1; }
-  bool has_newline() const { return state.newline_count > 0; }
+  const doc_state& operator->() const { return state; }
+  const doc_state& operator*() const { return state; }
 
   doc build() && {
     doc copy = merge(0, docs.size() - 1);
     docs = {};
-    state = {};
+    state = doc_state::identity();
     return copy;
   }
 };

--- a/src/wcl/doc_state.h
+++ b/src/wcl/doc_state.h
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <wcl/hash.h>
+
+#include <cassert>
+#include <string>
+
+#include "utf8proc/utf8proc.h"
+
+namespace wcl {
+template <class State>
+State from_string(const std::string& str) {
+  State out = State::identity();
+
+  const utf8proc_uint8_t* iter = reinterpret_cast<const utf8proc_uint8_t*>(str.c_str());
+  const utf8proc_uint8_t* iter_end = iter + str.size();
+  while (iter < iter_end) {
+    utf8proc_int32_t codepoint;
+    size_t size = utf8proc_iterate(iter, -1, &codepoint);
+    iter += size;
+
+    assert(size > 0);
+    assert(codepoint > 0);  // < 0 means error parsing utf8
+
+    out = out + State::inject(size, codepoint);
+  }
+  return out;
+}
+
+struct empty_state {
+  empty_state operator+(empty_state other) const { return empty_state{}; }
+
+  bool operator==(const empty_state& other) const { return true; }
+
+  static empty_state identity() { return empty_state{}; }
+
+  static empty_state inject(size_t size, utf8proc_int32_t codepoint) { return empty_state{}; }
+};
+
+struct byte_count_state {
+  size_t count = 0;
+
+  byte_count_state() = default;
+  byte_count_state(size_t count) : count(count) {}
+
+  byte_count_state operator+(byte_count_state other) const {
+    return byte_count_state{count + other.count};
+  }
+
+  bool operator==(const byte_count_state& other) const { return count == other.count; }
+
+  static byte_count_state identity() { return byte_count_state{}; }
+
+  static byte_count_state inject(size_t size, utf8proc_int32_t codepoint) {
+    return byte_count_state{size};
+  }
+};
+
+struct newline_count_state {
+  size_t count = 0;
+
+  newline_count_state() = default;
+  newline_count_state(size_t count) : count(count) {}
+
+  newline_count_state operator+(newline_count_state other) const {
+    return newline_count_state{count + other.count};
+  }
+
+  bool operator==(const newline_count_state& other) const { return count == other.count; }
+
+  static newline_count_state identity() { return newline_count_state{}; }
+
+  static newline_count_state inject(size_t size, utf8proc_int32_t codepoint) {
+    return newline_count_state{codepoint == '\n'};
+  }
+};
+
+class first_width_state {
+ private:
+  first_width_state(bool wrapped, size_t width) : wrapped(wrapped), width(width) {}
+
+  bool wrapped = false;
+
+ public:
+  size_t width = 0;
+
+  first_width_state() = default;
+
+  first_width_state operator+(first_width_state other) const {
+    if (wrapped) {
+      return *this;
+    }
+    return first_width_state{other.wrapped, width + other.width};
+  }
+
+  bool operator==(const first_width_state& other) const {
+    return wrapped == other.wrapped && width == other.width;
+  }
+
+  static first_width_state identity() { return first_width_state{}; }
+
+  static first_width_state inject(size_t size, utf8proc_int32_t codepoint) {
+    if (codepoint == '\n') return first_width_state{true, 0};
+    return first_width_state{false, static_cast<size_t>(utf8proc_charwidth(codepoint))};
+  }
+
+  friend std::hash<first_width_state>;
+};
+
+class last_width_state {
+ private:
+  last_width_state(bool wrapped, size_t width) : wrapped(wrapped), width(width) {}
+
+  bool wrapped = false;
+
+ public:
+  size_t width = 0;
+
+  last_width_state() = default;
+
+  last_width_state operator+(last_width_state other) const {
+    if (other.wrapped) {
+      return other;
+    }
+    return last_width_state{wrapped, width + other.width};
+  }
+
+  bool operator==(const last_width_state& other) const {
+    return wrapped == other.wrapped && width == other.width;
+  }
+
+  static last_width_state identity() { return last_width_state{}; }
+
+  static last_width_state inject(size_t size, utf8proc_int32_t codepoint) {
+    if (codepoint == '\n') return last_width_state{true, 0};
+    return last_width_state{false, static_cast<size_t>(utf8proc_charwidth(codepoint))};
+  }
+
+  friend std::hash<last_width_state>;
+};
+
+class doc_state {
+ private:
+  doc_state(byte_count_state byte_count, newline_count_state newline_count,
+            first_width_state first_width, last_width_state last_width)
+      : byte_count_(byte_count),
+        newline_count_(newline_count),
+        first_width_(first_width),
+        last_width_(last_width) {}
+
+  // Total number of bytes in the doc
+  byte_count_state byte_count_;
+
+  // Total number of newlines in the doc
+  newline_count_state newline_count_;
+
+  // Human visible "width" of the first line of the doc
+  first_width_state first_width_;
+
+  // Human visible "width" of the last line of the doc
+  last_width_state last_width_;
+
+ public:
+  doc_state() = default;
+
+  doc_state operator+(doc_state other) const {
+    return doc_state{byte_count_ + other.byte_count_, newline_count_ + other.newline_count_,
+                     first_width_ + other.first_width_, last_width_ + other.last_width_};
+  }
+
+  bool operator==(const doc_state& other) const {
+    return byte_count_ == other.byte_count_ && newline_count_ == other.newline_count_ &&
+           first_width_ == other.first_width_ && last_width_ == other.last_width_;
+  }
+
+  const doc_state* operator->() const { return this; }
+
+  static doc_state identity() {
+    return doc_state{byte_count_state::identity(), newline_count_state::identity(),
+                     first_width_state::identity(), last_width_state::identity()};
+  }
+
+  static doc_state inject(size_t size, utf8proc_int32_t codepoint) {
+    return doc_state{
+        byte_count_state::inject(size, codepoint), newline_count_state::inject(size, codepoint),
+        first_width_state::inject(size, codepoint), last_width_state::inject(size, codepoint)};
+  }
+
+  size_t byte_count() const { return byte_count_.count; }
+  size_t newline_count() const { return newline_count_.count; }
+  size_t first_width() const { return first_width_.width; }
+  size_t last_width() const { return last_width_.width; }
+  bool has_newline() const { return newline_count() > 0; }
+  size_t height() const { return newline_count() + 1; }
+
+  friend std::hash<doc_state>;
+};
+
+}  // namespace wcl
+
+template <>
+struct std::hash<wcl::empty_state> {
+  size_t operator()(wcl::empty_state const& state) const noexcept { return 0; }
+};
+
+template <>
+struct std::hash<wcl::byte_count_state> {
+  size_t operator()(wcl::byte_count_state const& state) const noexcept {
+    return std::hash<size_t>{}(state.count);
+  }
+};
+
+template <>
+struct std::hash<wcl::newline_count_state> {
+  size_t operator()(wcl::newline_count_state const& state) const noexcept {
+    return std::hash<size_t>{}(state.count);
+  }
+};
+
+template <>
+struct std::hash<wcl::first_width_state> {
+  size_t operator()(wcl::first_width_state const& state) const noexcept {
+    return wcl::hash_combine(std::hash<bool>{}(state.wrapped), std::hash<size_t>{}(state.width));
+  }
+};
+
+template <>
+struct std::hash<wcl::last_width_state> {
+  size_t operator()(wcl::last_width_state const& state) const noexcept {
+    return wcl::hash_combine(std::hash<bool>{}(state.wrapped), std::hash<size_t>{}(state.width));
+  }
+};
+
+template <>
+struct std::hash<wcl::doc_state> {
+  size_t operator()(wcl::doc_state const& state) const noexcept {
+    size_t hash = wcl::hash_combine(std::hash<wcl::byte_count_state>{}(state.byte_count_),
+                                    std::hash<wcl::newline_count_state>{}(state.newline_count_));
+    hash = wcl::hash_combine(hash, std::hash<wcl::first_width_state>{}(state.first_width_));
+    hash = wcl::hash_combine(hash, std::hash<wcl::last_width_state>{}(state.last_width_));
+    return hash;
+  }
+};

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -729,7 +729,7 @@ wcl::doc Emitter::walk_paren(ctx_t ctx, CSTElement node) {
                    .token(TOKEN_P_PCLOSE)
                    .format(ctx, node.firstChildElement(), token_traits);
 
-  if (!no_nl.has_newline()) {
+  if (!no_nl->has_newline()) {
     MEMO_RET(no_nl);
   }
 

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -35,34 +35,34 @@
 // #define NL_STR "⏎\n"
 
 struct ctx_t {
-  size_t width = 0;
   size_t nest_level = 0;
+  wcl::doc_state state = wcl::doc_state::identity();
 
-  ctx_t nest() {
+  ctx_t nest() const {
     ctx_t copy = *this;
     copy.nest_level++;
     return copy;
   }
 
-  ctx_t sub(const wcl::doc_builder& builder) {
+  ctx_t operator+(const wcl::doc_builder& builder) const {
     ctx_t copy = *this;
-    if (builder.has_newline()) {
-      copy.width = builder.last_width();
-    } else {
-      copy.width += builder.last_width();
-    }
+    copy.state = state + *builder;
     return copy;
   }
 
+  const wcl::doc_state& operator*() const { return state; }
+  const wcl::doc_state& operator->() const { return state; }
+
   bool operator==(const ctx_t& other) const {
-    return width == other.width && nest_level == other.nest_level;
+    return state == other.state && nest_level == other.nest_level;
   }
 };
 
 template <>
 struct std::hash<ctx_t> {
   size_t operator()(ctx_t const& ctx) const noexcept {
-    return wcl::hash_combine(std::hash<size_t>{}(ctx.width), std::hash<size_t>{}(ctx.nest_level));
+    return wcl::hash_combine(std::hash<wcl::doc_state>{}(ctx.state),
+                             std::hash<size_t>{}(ctx.nest_level));
   }
 };
 
@@ -161,7 +161,7 @@ struct WalkPredicateAction {
       std::cerr << "Unexpected token: " << +node.id() << std::endl;
     }
     assert(result);
-    auto doc = walker(ctx.sub(builder), const_cast<const CSTElement&>(node));
+    auto doc = walker(ctx + builder, const_cast<const CSTElement&>(node));
     builder.append(doc);
     node.nextSiblingElement();
   }
@@ -174,7 +174,7 @@ struct NestAction {
   NestAction(FMT formatter) : formatter(formatter) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
-    builder.append(formatter.compose(ctx.sub(builder).nest(), node));
+    builder.append(formatter.compose(ctx.nest() + builder, node));
   }
 };
 
@@ -189,9 +189,9 @@ struct IfElseAction {
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     if (predicate(builder, ctx, node)) {
-      builder.append(if_formatter.compose(ctx.sub(builder), node));
+      builder.append(if_formatter.compose(ctx + builder, node));
     } else {
-      builder.append(else_formatter.compose(ctx.sub(builder), node));
+      builder.append(else_formatter.compose(ctx + builder, node));
     }
   }
 };
@@ -206,7 +206,7 @@ struct WhileAction {
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     while (predicate(builder, ctx, node)) {
-      builder.append(while_formatter.compose(ctx.sub(builder), node));
+      builder.append(while_formatter.compose(ctx + builder, node));
     }
   }
 };
@@ -219,7 +219,7 @@ struct WalkChildrenAction {
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     for (CSTElement child = node.firstChildElement(); !child.empty();) {
-      builder.append(formatter.compose(ctx.sub(builder), child));
+      builder.append(formatter.compose(ctx + builder, child));
     }
     node.nextSiblingElement();
   }
@@ -246,7 +246,7 @@ struct JoinAction {
   JoinAction(FMT formatter) : formatter(formatter) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
-    builder.append(formatter.compose(ctx.sub(builder), node));
+    builder.append(formatter.compose(ctx + builder, node));
   }
 };
 
@@ -280,11 +280,11 @@ class FitsPredicate {
 
   bool operator()(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     CSTElement copy = node;
-    wcl::doc doc = formatter.compose(ctx.sub(builder), copy);
-    if (builder.has_newline()) {
-      return builder.last_width() + doc.first_width() <= 100;
+    wcl::doc doc = formatter.compose(ctx + builder, copy);
+    if (builder->has_newline()) {
+      return builder->last_width() + doc->first_width() <= 100;
     } else {
-      return builder.last_width() + doc.first_width() + ctx.width <= 100;
+      return builder->last_width() + doc->first_width() + ctx->last_width() <= 100;
     }
   }
 };
@@ -371,7 +371,7 @@ struct PredicateCase {
     if (!predicate(builder, ctx, node)) {
       return false;
     }
-    builder.append(formatter.compose(ctx.sub(builder), node));
+    builder.append(formatter.compose(ctx + builder, node));
     return true;
   }
 };
@@ -383,7 +383,7 @@ struct OtherwiseCase {
   OtherwiseCase(FMT formatter) : formatter(formatter) {}
 
   ALWAYS_INLINE bool run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
-    builder.append(formatter.compose(ctx.sub(builder), node));
+    builder.append(formatter.compose(ctx + builder, node));
     return true;
   }
 };

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -44,7 +44,7 @@ struct ctx_t {
     return copy;
   }
 
-  ctx_t operator+(const wcl::doc_builder& builder) const {
+  ctx_t sub(const wcl::doc_builder& builder) const {
     ctx_t copy = *this;
     copy.state = state + *builder;
     return copy;
@@ -161,7 +161,7 @@ struct WalkPredicateAction {
       std::cerr << "Unexpected token: " << +node.id() << std::endl;
     }
     assert(result);
-    auto doc = walker(ctx + builder, const_cast<const CSTElement&>(node));
+    auto doc = walker(ctx.sub(builder), const_cast<const CSTElement&>(node));
     builder.append(doc);
     node.nextSiblingElement();
   }
@@ -174,7 +174,7 @@ struct NestAction {
   NestAction(FMT formatter) : formatter(formatter) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
-    builder.append(formatter.compose(ctx.nest() + builder, node));
+    builder.append(formatter.compose(ctx.nest().sub(builder), node));
   }
 };
 
@@ -189,9 +189,9 @@ struct IfElseAction {
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     if (predicate(builder, ctx, node)) {
-      builder.append(if_formatter.compose(ctx + builder, node));
+      builder.append(if_formatter.compose(ctx.sub(builder), node));
     } else {
-      builder.append(else_formatter.compose(ctx + builder, node));
+      builder.append(else_formatter.compose(ctx.sub(builder), node));
     }
   }
 };
@@ -206,7 +206,7 @@ struct WhileAction {
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     while (predicate(builder, ctx, node)) {
-      builder.append(while_formatter.compose(ctx + builder, node));
+      builder.append(while_formatter.compose(ctx.sub(builder), node));
     }
   }
 };
@@ -219,7 +219,7 @@ struct WalkChildrenAction {
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     for (CSTElement child = node.firstChildElement(); !child.empty();) {
-      builder.append(formatter.compose(ctx + builder, child));
+      builder.append(formatter.compose(ctx.sub(builder), child));
     }
     node.nextSiblingElement();
   }
@@ -246,7 +246,7 @@ struct JoinAction {
   JoinAction(FMT formatter) : formatter(formatter) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
-    builder.append(formatter.compose(ctx + builder, node));
+    builder.append(formatter.compose(ctx.sub(builder), node));
   }
 };
 
@@ -280,7 +280,7 @@ class FitsPredicate {
 
   bool operator()(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
     CSTElement copy = node;
-    wcl::doc doc = formatter.compose(ctx + builder, copy);
+    wcl::doc doc = formatter.compose(ctx.sub(builder), copy);
     if (builder->has_newline()) {
       return builder->last_width() + doc->first_width() <= 100;
     } else {
@@ -371,7 +371,7 @@ struct PredicateCase {
     if (!predicate(builder, ctx, node)) {
       return false;
     }
-    builder.append(formatter.compose(ctx + builder, node));
+    builder.append(formatter.compose(ctx.sub(builder), node));
     return true;
   }
 };
@@ -383,7 +383,7 @@ struct OtherwiseCase {
   OtherwiseCase(FMT formatter) : formatter(formatter) {}
 
   ALWAYS_INLINE bool run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node) {
-    builder.append(formatter.compose(ctx + builder, node));
+    builder.append(formatter.compose(ctx.sub(builder), node));
     return true;
   }
 };

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -117,13 +117,6 @@ inline void newline(wcl::doc_builder& builder, uint8_t space_count) {
   space(builder, space_count);
 }
 
-inline size_t curr_width(wcl::doc_builder& builder, ctx_t ctx) {
-  if (builder->has_newline()) {
-    return builder->last_width();
-  }
-  return builder->last_width() + ctx->last_width();
-}
-
 class IsWSNLCPredicate {
  public:
   bool operator()(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
@@ -396,7 +389,8 @@ class FitsPredicate {
                   const token_traits_map_t& traits) {
     CSTElement copy = node;
     wcl::doc doc = formatter.compose(ctx.sub(builder), copy, traits);
-    return curr_width(builder, ctx) + doc->first_width() <= MAX_COLUMN_WIDTH;
+
+    return ctx.sub(builder)->last_width() + doc->first_width() <= MAX_COLUMN_WIDTH;
   }
 };
 

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -389,7 +389,6 @@ class FitsPredicate {
                   const token_traits_map_t& traits) {
     CSTElement copy = node;
     wcl::doc doc = formatter.compose(ctx.sub(builder), copy, traits);
-
     return ctx.sub(builder)->last_width() + doc->first_width() <= MAX_COLUMN_WIDTH;
   }
 };

--- a/tools/wake-unit/doc.cpp
+++ b/tools/wake-unit/doc.cpp
@@ -38,7 +38,7 @@ TEST(doc_basic) {
   wcl::doc d = std::move(builder).build();
   std::string expected = "Hello World! My name is Ashley";
 
-  EXPECT_EQUAL(expected.size(), d.byte_count());
+  EXPECT_EQUAL(expected.size(), d->byte_count());
   EXPECT_EQUAL(expected, d.as_string());
 }
 
@@ -66,7 +66,7 @@ TEST(doc_large) {
   }
 
   wcl::doc d = std::move(builder).build();
-  ASSERT_EQUAL(3000000u, d.byte_count());
+  ASSERT_EQUAL(3000000u, d->byte_count());
 }
 
 TEST(doc_undo) {
@@ -82,7 +82,7 @@ TEST(doc_undo) {
   wcl::doc d = std::move(builder).build();
   std::string expected = "Hello ";
 
-  EXPECT_EQUAL(expected.size(), d.byte_count());
+  EXPECT_EQUAL(expected.size(), d->byte_count());
   EXPECT_EQUAL(expected, d.as_string());
 }
 
@@ -91,39 +91,39 @@ TEST(doc_unicode) {
     wcl::doc_builder builder;
     builder.append("····");
 
-    EXPECT_EQUAL(8u, builder.byte_count());
-    EXPECT_EQUAL(4u, builder.first_width());
-    EXPECT_EQUAL(4u, builder.last_width());
-    EXPECT_EQUAL(4u, builder.max_width());
-    EXPECT_EQUAL(0u, builder.newline_count());
-    EXPECT_EQUAL(1u, builder.height());
+    EXPECT_EQUAL(8u, builder->byte_count());
+    EXPECT_EQUAL(4u, builder->first_width());
+    EXPECT_EQUAL(4u, builder->last_width());
+    // EXPECT_EQUAL(4u, builder->max_width());
+    EXPECT_EQUAL(0u, builder->newline_count());
+    EXPECT_EQUAL(1u, builder->height());
 
     builder.append("⏎");
 
-    EXPECT_EQUAL(11u, builder.byte_count());
-    EXPECT_EQUAL(6u, builder.first_width());
-    EXPECT_EQUAL(6u, builder.last_width());
-    EXPECT_EQUAL(6u, builder.max_width());
-    EXPECT_EQUAL(0u, builder.newline_count());
-    EXPECT_EQUAL(1u, builder.height());
+    EXPECT_EQUAL(11u, builder->byte_count());
+    EXPECT_EQUAL(6u, builder->first_width());
+    EXPECT_EQUAL(6u, builder->last_width());
+    // EXPECT_EQUAL(6u, builder->max_width());
+    EXPECT_EQUAL(0u, builder->newline_count());
+    EXPECT_EQUAL(1u, builder->height());
 
     builder.append("\n·");
 
-    EXPECT_EQUAL(14u, builder.byte_count());
-    EXPECT_EQUAL(6u, builder.first_width());
-    EXPECT_EQUAL(1u, builder.last_width());
-    EXPECT_EQUAL(6u, builder.max_width());
-    EXPECT_EQUAL(1u, builder.newline_count());
-    EXPECT_EQUAL(2u, builder.height());
+    EXPECT_EQUAL(14u, builder->byte_count());
+    EXPECT_EQUAL(6u, builder->first_width());
+    EXPECT_EQUAL(1u, builder->last_width());
+    // EXPECT_EQUAL(6u, builder->max_width());
+    EXPECT_EQUAL(1u, builder->newline_count());
+    EXPECT_EQUAL(2u, builder->height());
 
     wcl::doc d = std::move(builder).build();
 
-    EXPECT_EQUAL(14u, d.byte_count());
-    EXPECT_EQUAL(6u, d.first_width());
-    EXPECT_EQUAL(1u, d.last_width());
-    EXPECT_EQUAL(6u, d.max_width());
-    EXPECT_EQUAL(1u, d.newline_count());
-    EXPECT_EQUAL(2u, d.height());
+    EXPECT_EQUAL(14u, d->byte_count());
+    EXPECT_EQUAL(6u, d->first_width());
+    EXPECT_EQUAL(1u, d->last_width());
+    // EXPECT_EQUAL(6u, d->max_width());
+    EXPECT_EQUAL(1u, d->newline_count());
+    EXPECT_EQUAL(2u, d->height());
   }
 }
 
@@ -132,38 +132,38 @@ TEST(doc_geometry) {
     wcl::doc_builder builder;
     builder.append("Hello");
 
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(5u, builder.last_width());
-    EXPECT_EQUAL(5u, builder.max_width());
-    EXPECT_EQUAL(0u, builder.newline_count());
-    EXPECT_EQUAL(1u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(5u, builder->last_width());
+    // EXPECT_EQUAL(5u, builder->max_width());
+    EXPECT_EQUAL(0u, builder->newline_count());
+    EXPECT_EQUAL(1u, builder->height());
 
     wcl::doc d = std::move(builder).build();
 
-    EXPECT_EQUAL(5u, d.first_width());
-    EXPECT_EQUAL(5u, d.last_width());
-    EXPECT_EQUAL(5u, d.max_width());
-    EXPECT_EQUAL(0u, d.newline_count());
-    EXPECT_EQUAL(1u, d.height());
+    EXPECT_EQUAL(5u, d->first_width());
+    EXPECT_EQUAL(5u, d->last_width());
+    // EXPECT_EQUAL(5u, d->max_width());
+    EXPECT_EQUAL(0u, d->newline_count());
+    EXPECT_EQUAL(1u, d->height());
   }
 
   {
     wcl::doc_builder builder;
     builder.append("Hello\n");
 
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(0u, builder.last_width());
-    EXPECT_EQUAL(5u, builder.max_width());
-    EXPECT_EQUAL(1u, builder.newline_count());
-    EXPECT_EQUAL(2u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(0u, builder->last_width());
+    // EXPECT_EQUAL(5u, builder->max_width());
+    EXPECT_EQUAL(1u, builder->newline_count());
+    EXPECT_EQUAL(2u, builder->height());
 
     wcl::doc d = std::move(builder).build();
 
-    EXPECT_EQUAL(5u, d.first_width());
-    EXPECT_EQUAL(0u, d.last_width());
-    EXPECT_EQUAL(5u, d.max_width());
-    EXPECT_EQUAL(1u, d.newline_count());
-    EXPECT_EQUAL(2u, d.height());
+    EXPECT_EQUAL(5u, d->first_width());
+    EXPECT_EQUAL(0u, d->last_width());
+    // EXPECT_EQUAL(5u, d->max_width());
+    EXPECT_EQUAL(1u, d->newline_count());
+    EXPECT_EQUAL(2u, d->height());
   }
 
   {
@@ -171,19 +171,19 @@ TEST(doc_geometry) {
     builder.append("Hello\n");
     builder.append("World!");
 
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(6u, builder.last_width());
-    EXPECT_EQUAL(6u, builder.max_width());
-    EXPECT_EQUAL(1u, builder.newline_count());
-    EXPECT_EQUAL(2u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(6u, builder->last_width());
+    // EXPECT_EQUAL(6u, builder->max_width());
+    EXPECT_EQUAL(1u, builder->newline_count());
+    EXPECT_EQUAL(2u, builder->height());
 
     wcl::doc d = std::move(builder).build();
 
-    EXPECT_EQUAL(5u, d.first_width());
-    EXPECT_EQUAL(6u, d.last_width());
-    EXPECT_EQUAL(6u, d.max_width());
-    EXPECT_EQUAL(1u, d.newline_count());
-    EXPECT_EQUAL(2u, d.height());
+    EXPECT_EQUAL(5u, d->first_width());
+    EXPECT_EQUAL(6u, d->last_width());
+    // EXPECT_EQUAL(6u, d->max_width());
+    EXPECT_EQUAL(1u, d->newline_count());
+    EXPECT_EQUAL(2u, d->height());
   }
 
   {
@@ -191,19 +191,19 @@ TEST(doc_geometry) {
     builder.append("Hello");
     builder.append("\nWorld!");
 
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(6u, builder.last_width());
-    EXPECT_EQUAL(6u, builder.max_width());
-    EXPECT_EQUAL(1u, builder.newline_count());
-    EXPECT_EQUAL(2u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(6u, builder->last_width());
+    // EXPECT_EQUAL(6u, builder->max_width());
+    EXPECT_EQUAL(1u, builder->newline_count());
+    EXPECT_EQUAL(2u, builder->height());
 
     wcl::doc d = std::move(builder).build();
 
-    EXPECT_EQUAL(5u, d.first_width());
-    EXPECT_EQUAL(6u, d.last_width());
-    EXPECT_EQUAL(6u, d.max_width());
-    EXPECT_EQUAL(1u, d.newline_count());
-    EXPECT_EQUAL(2u, d.height());
+    EXPECT_EQUAL(5u, d->first_width());
+    EXPECT_EQUAL(6u, d->last_width());
+    // EXPECT_EQUAL(6u, d->max_width());
+    EXPECT_EQUAL(1u, d->newline_count());
+    EXPECT_EQUAL(2u, d->height());
   }
 
   {
@@ -211,19 +211,19 @@ TEST(doc_geometry) {
     builder.append("He\nllo");
     builder.append("Worl\nd!");
 
-    EXPECT_EQUAL(2u, builder.first_width());
-    EXPECT_EQUAL(2u, builder.last_width());
-    EXPECT_EQUAL(7u, builder.max_width());
-    EXPECT_EQUAL(2u, builder.newline_count());
-    EXPECT_EQUAL(3u, builder.height());
+    EXPECT_EQUAL(2u, builder->first_width());
+    EXPECT_EQUAL(2u, builder->last_width());
+    // EXPECT_EQUAL(7u, builder->max_width());
+    EXPECT_EQUAL(2u, builder->newline_count());
+    EXPECT_EQUAL(3u, builder->height());
 
     wcl::doc d = std::move(builder).build();
 
-    EXPECT_EQUAL(2u, d.first_width());
-    EXPECT_EQUAL(2u, d.last_width());
-    EXPECT_EQUAL(7u, d.max_width());
-    EXPECT_EQUAL(2u, d.newline_count());
-    EXPECT_EQUAL(3u, d.height());
+    EXPECT_EQUAL(2u, d->first_width());
+    EXPECT_EQUAL(2u, d->last_width());
+    // EXPECT_EQUAL(7u, d->max_width());
+    EXPECT_EQUAL(2u, d->newline_count());
+    EXPECT_EQUAL(3u, d->height());
   }
 
   {
@@ -245,175 +245,175 @@ TEST(doc_geometry) {
     builder.append("\n");
     builder.append("123");
 
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(3u, builder.last_width());
-    EXPECT_EQUAL(30u, builder.max_width());
-    EXPECT_EQUAL(7u, builder.newline_count());
-    EXPECT_EQUAL(8u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(3u, builder->last_width());
+    // EXPECT_EQUAL(30u, builder->max_width());
+    EXPECT_EQUAL(7u, builder->newline_count());
+    EXPECT_EQUAL(8u, builder->height());
 
     wcl::doc d = std::move(builder).build();
 
-    EXPECT_EQUAL(5u, d.first_width());
-    EXPECT_EQUAL(3u, d.last_width());
-    EXPECT_EQUAL(30u, d.max_width());
-    EXPECT_EQUAL(7u, d.newline_count());
-    EXPECT_EQUAL(8u, d.height());
+    EXPECT_EQUAL(5u, d->first_width());
+    EXPECT_EQUAL(3u, d->last_width());
+    // EXPECT_EQUAL(30u, d->max_width());
+    EXPECT_EQUAL(7u, d->newline_count());
+    EXPECT_EQUAL(8u, d->height());
   }
 
   {
     wcl::doc_builder builder;
     builder.append("Hello");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(5u, builder.last_width());
-    EXPECT_EQUAL(5u, builder.max_width());
-    EXPECT_EQUAL(0u, builder.newline_count());
-    EXPECT_EQUAL(1u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(5u, builder->last_width());
+    // EXPECT_EQUAL(5u, builder->max_width());
+    EXPECT_EQUAL(0u, builder->newline_count());
+    EXPECT_EQUAL(1u, builder->height());
 
     builder.append("\nHello");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(5u, builder.last_width());
-    EXPECT_EQUAL(5u, builder.max_width());
-    EXPECT_EQUAL(1u, builder.newline_count());
-    EXPECT_EQUAL(2u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(5u, builder->last_width());
+    // EXPECT_EQUAL(5u, builder->max_width());
+    EXPECT_EQUAL(1u, builder->newline_count());
+    EXPECT_EQUAL(2u, builder->height());
 
     builder.append("Hello");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(10u, builder.last_width());
-    EXPECT_EQUAL(10u, builder.max_width());
-    EXPECT_EQUAL(1u, builder.newline_count());
-    EXPECT_EQUAL(2u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(10u, builder->last_width());
+    // EXPECT_EQUAL(10u, builder->max_width());
+    EXPECT_EQUAL(1u, builder->newline_count());
+    EXPECT_EQUAL(2u, builder->height());
 
     builder.append("Hello\n");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(0u, builder.last_width());
-    EXPECT_EQUAL(15u, builder.max_width());
-    EXPECT_EQUAL(2u, builder.newline_count());
-    EXPECT_EQUAL(3u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(0u, builder->last_width());
+    // EXPECT_EQUAL(15u, builder->max_width());
+    EXPECT_EQUAL(2u, builder->newline_count());
+    EXPECT_EQUAL(3u, builder->height());
 
     builder.append("Hello");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(5u, builder.last_width());
-    EXPECT_EQUAL(15u, builder.max_width());
-    EXPECT_EQUAL(2u, builder.newline_count());
-    EXPECT_EQUAL(3u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(5u, builder->last_width());
+    // EXPECT_EQUAL(15u, builder->max_width());
+    EXPECT_EQUAL(2u, builder->newline_count());
+    EXPECT_EQUAL(3u, builder->height());
 
     builder.append("\nWorld!");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(6u, builder.last_width());
-    EXPECT_EQUAL(15u, builder.max_width());
-    EXPECT_EQUAL(3u, builder.newline_count());
-    EXPECT_EQUAL(4u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(6u, builder->last_width());
+    // EXPECT_EQUAL(15u, builder->max_width());
+    EXPECT_EQUAL(3u, builder->newline_count());
+    EXPECT_EQUAL(4u, builder->height());
 
     builder.append("\nWorld!");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(6u, builder.last_width());
-    EXPECT_EQUAL(15u, builder.max_width());
-    EXPECT_EQUAL(4u, builder.newline_count());
-    EXPECT_EQUAL(5u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(6u, builder->last_width());
+    // EXPECT_EQUAL(15u, builder->max_width());
+    EXPECT_EQUAL(4u, builder->newline_count());
+    EXPECT_EQUAL(5u, builder->height());
 
     builder.append("\nWorld!");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(6u, builder.last_width());
-    EXPECT_EQUAL(15u, builder.max_width());
-    EXPECT_EQUAL(5u, builder.newline_count());
-    EXPECT_EQUAL(6u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(6u, builder->last_width());
+    // EXPECT_EQUAL(15u, builder->max_width());
+    EXPECT_EQUAL(5u, builder->newline_count());
+    EXPECT_EQUAL(6u, builder->height());
 
     builder.append("World!");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(12u, builder.last_width());
-    EXPECT_EQUAL(15u, builder.max_width());
-    EXPECT_EQUAL(5u, builder.newline_count());
-    EXPECT_EQUAL(6u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(12u, builder->last_width());
+    // EXPECT_EQUAL(15u, builder->max_width());
+    EXPECT_EQUAL(5u, builder->newline_count());
+    EXPECT_EQUAL(6u, builder->height());
 
     builder.append("World!");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(18u, builder.last_width());
-    EXPECT_EQUAL(18u, builder.max_width());
-    EXPECT_EQUAL(5u, builder.newline_count());
-    EXPECT_EQUAL(6u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(18u, builder->last_width());
+    // EXPECT_EQUAL(18u, builder->max_width());
+    EXPECT_EQUAL(5u, builder->newline_count());
+    EXPECT_EQUAL(6u, builder->height());
 
     builder.append("World!");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(24u, builder.last_width());
-    EXPECT_EQUAL(24u, builder.max_width());
-    EXPECT_EQUAL(5u, builder.newline_count());
-    EXPECT_EQUAL(6u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(24u, builder->last_width());
+    // EXPECT_EQUAL(24u, builder->max_width());
+    EXPECT_EQUAL(5u, builder->newline_count());
+    EXPECT_EQUAL(6u, builder->height());
 
     builder.append("World!");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(30u, builder.last_width());
-    EXPECT_EQUAL(30u, builder.max_width());
-    EXPECT_EQUAL(5u, builder.newline_count());
-    EXPECT_EQUAL(6u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(30u, builder->last_width());
+    // EXPECT_EQUAL(30u, builder->max_width());
+    EXPECT_EQUAL(5u, builder->newline_count());
+    EXPECT_EQUAL(6u, builder->height());
 
     builder.append("\n");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(0u, builder.last_width());
-    EXPECT_EQUAL(30u, builder.max_width());
-    EXPECT_EQUAL(6u, builder.newline_count());
-    EXPECT_EQUAL(7u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(0u, builder->last_width());
+    // EXPECT_EQUAL(30u, builder->max_width());
+    EXPECT_EQUAL(6u, builder->newline_count());
+    EXPECT_EQUAL(7u, builder->height());
 
     builder.append("Hello");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(5u, builder.last_width());
-    EXPECT_EQUAL(30u, builder.max_width());
-    EXPECT_EQUAL(6u, builder.newline_count());
-    EXPECT_EQUAL(7u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(5u, builder->last_width());
+    // EXPECT_EQUAL(30u, builder->max_width());
+    EXPECT_EQUAL(6u, builder->newline_count());
+    EXPECT_EQUAL(7u, builder->height());
 
     builder.append("\n");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(0u, builder.last_width());
-    EXPECT_EQUAL(30u, builder.max_width());
-    EXPECT_EQUAL(7u, builder.newline_count());
-    EXPECT_EQUAL(8u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(0u, builder->last_width());
+    // EXPECT_EQUAL(30u, builder->max_width());
+    EXPECT_EQUAL(7u, builder->newline_count());
+    EXPECT_EQUAL(8u, builder->height());
 
     builder.append("123");
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(3u, builder.last_width());
-    EXPECT_EQUAL(30u, builder.max_width());
-    EXPECT_EQUAL(7u, builder.newline_count());
-    EXPECT_EQUAL(8u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(3u, builder->last_width());
+    // EXPECT_EQUAL(30u, builder->max_width());
+    EXPECT_EQUAL(7u, builder->newline_count());
+    EXPECT_EQUAL(8u, builder->height());
 
     builder.undo();
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(0u, builder.last_width());
-    EXPECT_EQUAL(30u, builder.max_width());
-    EXPECT_EQUAL(7u, builder.newline_count());
-    EXPECT_EQUAL(8u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(0u, builder->last_width());
+    // EXPECT_EQUAL(30u, builder->max_width());
+    EXPECT_EQUAL(7u, builder->newline_count());
+    EXPECT_EQUAL(8u, builder->height());
 
     builder.undo();
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(5u, builder.last_width());
-    EXPECT_EQUAL(30u, builder.max_width());
-    EXPECT_EQUAL(6u, builder.newline_count());
-    EXPECT_EQUAL(7u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(5u, builder->last_width());
+    // EXPECT_EQUAL(30u, builder->max_width());
+    EXPECT_EQUAL(6u, builder->newline_count());
+    EXPECT_EQUAL(7u, builder->height());
 
     builder.undo();
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(0u, builder.last_width());
-    EXPECT_EQUAL(30u, builder.max_width());
-    EXPECT_EQUAL(6u, builder.newline_count());
-    EXPECT_EQUAL(7u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(0u, builder->last_width());
+    // EXPECT_EQUAL(30u, builder->max_width());
+    EXPECT_EQUAL(6u, builder->newline_count());
+    EXPECT_EQUAL(7u, builder->height());
 
     builder.undo();
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(30u, builder.last_width());
-    EXPECT_EQUAL(30u, builder.max_width());
-    EXPECT_EQUAL(5u, builder.newline_count());
-    EXPECT_EQUAL(6u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(30u, builder->last_width());
+    // EXPECT_EQUAL(30u, builder->max_width());
+    EXPECT_EQUAL(5u, builder->newline_count());
+    EXPECT_EQUAL(6u, builder->height());
 
     builder.undo();
-    EXPECT_EQUAL(5u, builder.first_width());
-    EXPECT_EQUAL(24u, builder.last_width());
-    EXPECT_EQUAL(24u, builder.max_width());
-    EXPECT_EQUAL(5u, builder.newline_count());
-    EXPECT_EQUAL(6u, builder.height());
+    EXPECT_EQUAL(5u, builder->first_width());
+    EXPECT_EQUAL(24u, builder->last_width());
+    // EXPECT_EQUAL(24u, builder->max_width());
+    EXPECT_EQUAL(5u, builder->newline_count());
+    EXPECT_EQUAL(6u, builder->height());
 
     wcl::doc d = std::move(builder).build();
-    EXPECT_EQUAL(5u, d.first_width());
-    EXPECT_EQUAL(24u, d.last_width());
-    EXPECT_EQUAL(24u, d.max_width());
-    EXPECT_EQUAL(5u, d.newline_count());
-    EXPECT_EQUAL(6u, d.height());
+    EXPECT_EQUAL(5u, d->first_width());
+    EXPECT_EQUAL(24u, d->last_width());
+    // EXPECT_EQUAL(24u, d->max_width());
+    EXPECT_EQUAL(5u, d->newline_count());
+    EXPECT_EQUAL(6u, d->height());
   }
 }

--- a/tools/wake-unit/doc.cpp
+++ b/tools/wake-unit/doc.cpp
@@ -228,6 +228,51 @@ TEST(doc_geometry) {
 
   {
     wcl::doc_builder builder;
+    builder.append("He\nllo");
+    builder.append("Worl\nd!");
+
+    EXPECT_EQUAL(0u, builder->last_ws_count());
+
+    wcl::doc d = std::move(builder).build();
+    EXPECT_EQUAL(0u, d->last_ws_count());
+  }
+  {
+    wcl::doc_builder builder;
+    builder.append("Hello");
+    builder.append("     ");
+
+    EXPECT_EQUAL(5u, builder->last_ws_count());
+
+    builder.append("     ");
+    EXPECT_EQUAL(10u, builder->last_ws_count());
+
+    builder.append("World");
+    EXPECT_EQUAL(10u, builder->last_ws_count());
+
+    builder.append("\n   Hello");
+    EXPECT_EQUAL(3u, builder->last_ws_count());
+
+    builder.append("   World");
+    EXPECT_EQUAL(6u, builder->last_ws_count());
+
+    builder.append("    ");
+    EXPECT_EQUAL(10u, builder->last_ws_count());
+
+    builder.append("\n");
+    EXPECT_EQUAL(0u, builder->last_ws_count());
+
+    builder.append("    ");
+    EXPECT_EQUAL(4u, builder->last_ws_count());
+
+    builder.append("    \n     ");
+    EXPECT_EQUAL(5u, builder->last_ws_count());
+
+    wcl::doc d = std::move(builder).build();
+    EXPECT_EQUAL(5u, d->last_ws_count());
+  }
+
+  {
+    wcl::doc_builder builder;
     builder.append("Hello");
     builder.append("\nHello");
     builder.append("Hello");


### PR DESCRIPTION
Splits doc_state into several monoids, enabling easier composition of other bits of data.
 
I started down the template path but it turned out to be quite combursome and prone so I'm hoping to put that off for now until it becomes more important.

max_width also isn't implemented, happy to throw it in but since we weren't using it I didn't put in the effort to pin it down