### PR TITLE
Wake format binop full choice

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -115,12 +115,12 @@ def t5 = (
   + 5
 )
 
-# TODO: These cases are actually binop not paren
-# def t7 = (
-#   x # comment
-#   + 5
-# )
+def t7 = (
+  x # comment
+  + 5
+)
 
+# TODO: These cases are actually binop not paren
 # def t8 = (
 #   x + # comment
 #   5
@@ -165,7 +165,7 @@ def ff = a | b | c | d
 
 def ff = a $ b $ c $ d
 
-# def ff = a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a
+def ff = a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake, Nil =

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -148,6 +148,24 @@ def t6 = ( # comment
   + 5
 )
 
+# def t8 = (
+#   # comment
+#   x # comment
+#   + # comment
+#   5 # comment
+#   - # comment
+#   2 # comment
+# )
+
+
+# TODO: operating is getting changed here which is hecking bad
+def t9 = x + 5 - 2
+
+def ff = a | b | c | d
+
+def ff = a $ b $ c $ d
+
+# def ff = a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake, Nil =

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -120,11 +120,10 @@ def t7 = (
   + 5
 )
 
-# TODO: These cases are actually binop not paren
-# def t8 = (
-#   x + # comment
-#   5
-# )
+def t8 = (
+  x + # comment
+  5
+)
 
 def t9 = (
   x
@@ -148,17 +147,16 @@ def t6 = ( # comment
   + 5
 )
 
-# def t8 = (
-#   # comment
-#   x # comment
-#   + # comment
-#   5 # comment
-#   - # comment
-#   2 # comment
-# )
+def t8 = (
+  # comment
+  x # comment
+  + # comment
+  5 # comment
+  - # comment
+  2 # comment
+)
 
 
-# TODO: operating is getting changed here which is hecking bad
 def t9 = x + 5 - 2
 
 def ff = a | b | c | d

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -110,8 +110,7 @@ def t2 = ((x + 7) * 3)
 
 def t4 = (
     # comment
-    x
-    + 5
+    x + 5
 )
 
 
@@ -119,8 +118,7 @@ def t4 = (
     # comment
     (
         # comment
-        x
-        + 5
+        x + 5
     )
 )
 
@@ -129,8 +127,7 @@ def t5 = (
     # comment
     # comment
     # comment
-    x
-    + 5
+    x + 5
 )
 
 
@@ -144,8 +141,7 @@ def t5 = (
 #   5
 # )
 def t9 = (
-    x
-    + 5 # comment
+    x + 5 # comment
 )
 
 
@@ -163,8 +159,7 @@ def t3 = ( # comment
 def t6 = ( # comment
     # comment
     # comment
-    x
-    + 5
+    x + 5
 )
 
 

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -137,11 +137,13 @@ def t7 = (
 )
 
 
-# TODO: These cases are actually binop not paren
-# def t8 = (
-#   x + # comment
-#   5
-# )
+def t8 = (
+    x
+    + # comment
+    5
+)
+
+
 def t9 = (
     x + 5 # comment
 )
@@ -165,16 +167,17 @@ def t6 = ( # comment
 )
 
 
-# def t8 = (
-#   # comment
-#   x # comment
-#   + # comment
-#   5 # comment
-#   - # comment
-#   2 # comment
-# )
-# TODO: operating is getting changed here which is hecking bad
-def t9 = x - 5 - 2
+def t8 = (
+    # comment
+    x # comment
+    + # comment
+    5 # comment
+    - # comment
+    2 # comment
+)
+
+
+def t9 = x + 5 - 2
 
 
 def ff = a | b | c | d

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -131,11 +131,13 @@ def t5 = (
 )
 
 
+def t7 = (
+    x # comment
+    + 5
+)
+
+
 # TODO: These cases are actually binop not paren
-# def t7 = (
-#   x # comment
-#   + 5
-# )
 # def t8 = (
 #   x + # comment
 #   5
@@ -181,7 +183,57 @@ def ff = a | b | c | d
 def ff = a $ b $ c $ d
 
 
-# def ff = a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a
+def ff =
+    a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+    | a
+
+
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake , Nil =
         require Pass (Pair path visible) = buildTestWake Unit

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -110,7 +110,8 @@ def t2 = ((x + 7) * 3)
 
 def t4 = (
     # comment
-    x + 5
+    x
+    + 5
 )
 
 
@@ -118,7 +119,8 @@ def t4 = (
     # comment
     (
         # comment
-        x + 5
+        x
+        + 5
     )
 )
 
@@ -127,7 +129,8 @@ def t5 = (
     # comment
     # comment
     # comment
-    x + 5
+    x
+    + 5
 )
 
 
@@ -141,7 +144,8 @@ def t5 = (
 #   5
 # )
 def t9 = (
-    x + 5 # comment
+    x
+    + 5 # comment
 )
 
 
@@ -159,10 +163,30 @@ def t3 = ( # comment
 def t6 = ( # comment
     # comment
     # comment
-    x + 5
+    x
+    + 5
 )
 
 
+# def t8 = (
+#   # comment
+#   x # comment
+#   + # comment
+#   5 # comment
+#   - # comment
+#   2 # comment
+# )
+# TODO: operating is getting changed here which is hecking bad
+def t9 = x - 5 - 2
+
+
+def ff = a | b | c | d
+
+
+def ff = a $ b $ c $ d
+
+
+# def ff = a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a|a
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake , Nil =
         require Pass (Pair path visible) = buildTestWake Unit

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -930,25 +930,26 @@ wcl::doc Emitter::walk_import(ctx_t ctx, CSTElement node) {
 
   auto id_list_fmt = fmt().walk(WALK_NODE).fmt_if(TOKEN_WS, fmt().ws());
 
-  MEMO_RET(fmt()
-               .token(TOKEN_KW_FROM)
-               .ws()
-               .walk(CST_ID, WALK_NODE)
-               .ws()
-               .token(TOKEN_KW_IMPORT)
-               .ws()
-               .fmt_if(CST_KIND, fmt().walk(WALK_NODE).ws())
-               .fmt_if(CST_ARITY, fmt().walk(WALK_NODE).ws())
-               // clang-format off
+  MEMO_RET(
+      fmt()
+          .token(TOKEN_KW_FROM)
+          .ws()
+          .walk(CST_ID, WALK_NODE)
+          .ws()
+          .token(TOKEN_KW_IMPORT)
+          .ws()
+          .fmt_if(CST_KIND, fmt().walk(WALK_NODE).ws())
+          .fmt_if(CST_ARITY, fmt().walk(WALK_NODE).ws())
+          // clang-format off
           .fmt_if_else(
               TOKEN_P_HOLE,
               fmt().walk(WALK_TOKEN),
               fmt().fmt_while(
                   CST_IDEQ,
                   id_list_fmt))
-               // clang-format on
-               .consume_wsnlc()
-               .format(ctx, node.firstChildElement(), token_traits));
+          // clang-format on
+          .consume_wsnlc()
+          .format(ctx, node.firstChildElement(), token_traits));
 }
 
 wcl::doc Emitter::walk_interpolate(ctx_t ctx, CSTElement node) {

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -48,7 +48,9 @@
   }
 
 static inline bool requires_nl(cst_id_t type) { return type == CST_BLOCK || type == CST_REQUIRE; }
-static inline bool requires_fits_all(cst_id_t type) { return type == CST_APP; }
+static inline bool requires_fits_all(cst_id_t type) {
+  return type == CST_APP || type == CST_BINARY;
+}
 
 static inline bool is_expression(cst_id_t type) {
   return type == CST_ID || type == CST_APP || type == CST_LITERAL || type == CST_HOLE ||

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -786,8 +786,6 @@ wcl::doc Emitter::walk_binary(ctx_t ctx, CSTElement node) {
     }
   }
 
-  ;
-
   if (lte_fmt.size() > 0) {
     auto min_height = std::min_element(lte_fmt.begin(), lte_fmt.end(), min_doc_height);
     MEMO_RET(*min_height);

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -527,7 +527,7 @@ wcl::doc Emitter::walk_ascribe(ctx_t ctx, CSTElement node) {
   MEMO_RET(walk_placeholder(ctx, node));
 }
 
-std::vector<CSTElement> collect_binary_parts(CSTElement collect_over, CSTElement node) {
+std::vector<CSTElement> collect_left_binary(CSTElement collect_over, CSTElement node) {
   if (node.id() != CST_BINARY) {
     return {node};
   }
@@ -546,12 +546,37 @@ std::vector<CSTElement> collect_binary_parts(CSTElement collect_over, CSTElement
     return {node};
   }
 
-  auto left_collect = collect_binary_parts(collect_over, left);
-  auto right_collect = collect_binary_parts(collect_over, right);
+  auto collect = collect_left_binary(collect_over, left);
+  collect.push_back(right);
 
-  left_collect.insert(left_collect.end(), right_collect.begin(), right_collect.end());
+  return collect;
+}
 
-  return left_collect;
+std::vector<CSTElement> collect_right_binary(CSTElement collect_over, CSTElement node) {
+  if (node.id() != CST_BINARY) {
+    return {node};
+  }
+
+  // NOTE: The 'node' variant functions are being used here which is differnt than everywhere else
+  // This is fine since COMMENTS are bound to the nodes and this func only needs to process nodes
+  CSTElement left = node.firstChildNode();
+  CSTElement op = left;
+  op.nextSiblingNode();
+  CSTElement right = op;
+  right.nextSiblingNode();
+
+  if (!(op.id() == CST_OP && op.firstChildElement().id() == collect_over.id() &&
+        op.firstChildElement().fragment().segment().str() ==
+            collect_over.fragment().segment().str())) {
+    return {node};
+  }
+
+  std::vector<CSTElement> collect = {left};
+  auto right_collect = collect_right_binary(collect_over, right);
+
+  collect.insert(collect.end(), right_collect.begin(), right_collect.end());
+
+  return collect;
 }
 
 size_t count_allowed_newlines(const token_traits_map_t& traits,
@@ -603,6 +628,9 @@ bool min_doc_height(const wcl::doc& lhs, const wcl::doc& rhs) {
 bool min_doc_max_width(const wcl::doc& lhs, const wcl::doc& rhs) {
   return lhs->max_width() < rhs->max_width();
 }
+
+// TODO: this is far from fully correct
+bool is_op_left_assoc(const CSTElement& op) { return op.id() == TOKEN_OP_OR; }
 
 wcl::doc select_best_choice(std::vector<wcl::optional<wcl::doc>> choices) {
   std::vector<wcl::doc> lte_fmt = {};
@@ -777,7 +805,12 @@ wcl::doc Emitter::walk_binary(ctx_t ctx, CSTElement node) {
   assert(op.id() == CST_OP);
   CSTElement op_token = op.firstChildElement();
 
-  auto parts = collect_binary_parts(op_token, node);
+  std::vector<CSTElement> parts = {};
+  if (is_op_left_assoc(op_token)) {
+    parts = collect_left_binary(op_token, node);
+  } else {
+    parts = collect_right_binary(op_token, node);
+  }
 
   std::vector<wcl::optional<wcl::doc>> choices = {
       // 1
@@ -897,26 +930,25 @@ wcl::doc Emitter::walk_import(ctx_t ctx, CSTElement node) {
 
   auto id_list_fmt = fmt().walk(WALK_NODE).fmt_if(TOKEN_WS, fmt().ws());
 
-  MEMO_RET(
-      fmt()
-          .token(TOKEN_KW_FROM)
-          .ws()
-          .walk(CST_ID, WALK_NODE)
-          .ws()
-          .token(TOKEN_KW_IMPORT)
-          .ws()
-          .fmt_if(CST_KIND, fmt().walk(WALK_NODE).ws())
-          .fmt_if(CST_ARITY, fmt().walk(WALK_NODE).ws())
-          // clang-format off
+  MEMO_RET(fmt()
+               .token(TOKEN_KW_FROM)
+               .ws()
+               .walk(CST_ID, WALK_NODE)
+               .ws()
+               .token(TOKEN_KW_IMPORT)
+               .ws()
+               .fmt_if(CST_KIND, fmt().walk(WALK_NODE).ws())
+               .fmt_if(CST_ARITY, fmt().walk(WALK_NODE).ws())
+               // clang-format off
           .fmt_if_else(
               TOKEN_P_HOLE,
               fmt().walk(WALK_TOKEN),
               fmt().fmt_while(
                   CST_IDEQ,
                   id_list_fmt))
-          // clang-format on
-          .consume_wsnlc()
-          .format(ctx, node.firstChildElement(), token_traits));
+               // clang-format on
+               .consume_wsnlc()
+               .format(ctx, node.firstChildElement(), token_traits));
 }
 
 wcl::doc Emitter::walk_interpolate(ctx_t ctx, CSTElement node) {

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -83,6 +83,42 @@ class Emitter {
   //   will bind '# comment1' and '# comment2' to the second 'def'
   void bind_comments(CSTElement node);
 
+  // Functions to combine binops using various 'full choice' options
+  //
+  // defs:
+  //   combine flat: combine the LHS and RHS without NLs. Spaces may be added as appropiate per OP
+  //   combine explode: combine the LHS and RHS with at least one NL
+  //   with prefer_explode: ctx.prefer_explode = true
+  //   with !prefer_explode: ctx.prefer_explode = false
+  //
+  // (1) combine_flat: format all elements with !prefer_explode, combine flat
+  // (2) combine_explode_first: first element prefer_explode, rest !prefer_explode, combine explode
+  // (3) combine_explode_last: last element prefer_explode, rest !prefer_explode, combine explode
+  // (4) combine_explode_all: all elements prefer_explode, combine explode
+  // (5) combine_explode_first_compress: first element prefer_explode, rest !prefer_explode, combine
+  //     flat
+  // (6) combine_explode_last_compress: last element prefer_explode, rest !prefer_explode, combine
+  //     flat
+  //
+  // Making the 'full choice'
+  //
+  // - format all 6 options and apply the following rules
+  //   - if 1, 5, or 6 have a NL, remove them from consideration
+  //   - divide the remain options into two groups.
+  //     - GT = options where max_width > MAX_COL_WIDTH
+  //     - LTE = options where max_width <= MAX_COL_WIDTH
+  //     if LTE has any elements choose the element with the smallest height
+  //     otherwise choose the element with the smallest width from GT
+  //
+  wcl::doc combine_flat(CSTElement over, ctx_t ctx, const std::vector<CSTElement>& parts);
+  wcl::doc combine_explode_first(CSTElement over, ctx_t ctx, const std::vector<CSTElement>& parts);
+  wcl::doc combine_explode_last(CSTElement over, ctx_t ctx, const std::vector<CSTElement>& parts);
+  wcl::doc combine_explode_all(CSTElement over, ctx_t ctx, const std::vector<CSTElement>& parts);
+  wcl::doc combine_explode_first_compress(CSTElement over, ctx_t ctx,
+                                          const std::vector<CSTElement>& parts);
+  wcl::doc combine_explode_last_compress(CSTElement over, ctx_t ctx,
+                                         const std::vector<CSTElement>& parts);
+
   // Returns a formatter that inserts the next node
   // on the current line if it fits, or on a new nested line
   auto rhs_fmt();

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -110,14 +110,18 @@ class Emitter {
   //     if LTE has any elements choose the element with the smallest height
   //     otherwise choose the element with the smallest width from GT
   //
-  wcl::doc combine_flat(CSTElement over, ctx_t ctx, const std::vector<CSTElement>& parts);
-  wcl::doc combine_explode_first(CSTElement over, ctx_t ctx, const std::vector<CSTElement>& parts);
-  wcl::doc combine_explode_last(CSTElement over, ctx_t ctx, const std::vector<CSTElement>& parts);
-  wcl::doc combine_explode_all(CSTElement over, ctx_t ctx, const std::vector<CSTElement>& parts);
-  wcl::doc combine_explode_first_compress(CSTElement over, ctx_t ctx,
-                                          const std::vector<CSTElement>& parts);
-  wcl::doc combine_explode_last_compress(CSTElement over, ctx_t ctx,
-                                         const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_flat(CSTElement over, ctx_t ctx,
+                                       const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_explode_first(CSTElement over, ctx_t ctx,
+                                                const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_explode_last(CSTElement over, ctx_t ctx,
+                                               const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_explode_all(CSTElement over, ctx_t ctx,
+                                              const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_explode_first_compress(CSTElement over, ctx_t ctx,
+                                                         const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_explode_last_compress(CSTElement over, ctx_t ctx,
+                                                        const std::vector<CSTElement>& parts);
 
   // Returns a formatter that inserts the next node
   // on the current line if it fits, or on a new nested line


### PR DESCRIPTION
Implements 'full choice' for binary op formatting. Explores six different formatting options and then chooses the one that best optimizes for formatting, character width, and height.