### PR TITLE
Improve binop separation

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -130,6 +130,11 @@ def t9 = (
   + 5 # comment
 )
 
+def t10 = (
+  x, # comment
+  5
+)
+
 def name Unit = # wake-format off
   def other = here
   def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -163,6 +168,9 @@ def ff = a | b | c | d
 def ff = a $ b $ c $ d
 
 def ff = aaaaaaaaaaaaa | bbbbbbbbbbbbbbbb | cccccccccccccccccc | ddddddddddddddddddd | eeeeeeeeeeeeeee | ffffffffff | ggggggggggg | hhhhhhhhhhh
+def ff = aaaaaaaaaaaaa $ bbbbbbbbbbbbbbbb $ cccccccccccccccccc $ ddddddddddddddddddd $ eeeeeeeeeeeeeee $ ffffffffff $ ggggggggggg $ hhhhhhhhhhh
+def ff = aaaaaaaaaaaaa , bbbbbbbbbbbbbbbb , cccccccccccccccccc , ddddddddddddddddddd , eeeeeeeeeeeeeee , ffffffffff , ggggggggggg , hhhhhhhhhhh
+def ff = aaaaaaaaaaaaa . bbbbbbbbbbbbbbbb . cccccccccccccccccc . ddddddddddddddddddd . eeeeeeeeeeeeeee . ffffffffff . ggggggggggg . hhhhhhhhhhh
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake, Nil =
@@ -326,3 +334,5 @@ def buildRE2WASM Unit =
         Nil
 
     Pass (SysLib "1.0" headers objects cflags lflags)
+
+def t5 = a.b.c

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -149,6 +149,12 @@ def t9 = (
 )
 
 
+def t10 = (
+    x, # comment
+    5
+)
+
+
 def name Unit = # wake-format off
     def other = here
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -197,8 +203,41 @@ def ff =
     | hhhhhhhhhhh
 
 
+def ff =
+    aaaaaaaaaaaaa
+    $ bbbbbbbbbbbbbbbb
+    $ cccccccccccccccccc
+    $ ddddddddddddddddddd
+    $ eeeeeeeeeeeeeee
+    $ ffffffffff
+    $ ggggggggggg
+    $ hhhhhhhhhhh
+
+
+def ff =
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbb,
+    cccccccccccccccccc,
+    ddddddddddddddddddd,
+    eeeeeeeeeeeeeee,
+    ffffffffff,
+    ggggggggggg,
+    hhhhhhhhhhh
+
+
+def ff =
+    aaaaaaaaaaaaa
+    .bbbbbbbbbbbbbbbb
+    .cccccccccccccccccc
+    .ddddddddddddddddddd
+    .eeeeeeeeeeeeeee
+    .ffffffffff
+    .ggggggggggg
+    .hhhhhhhhhhh
+
+
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
-    buildTestWake , Nil =
+    buildTestWake, Nil =
         require Pass (Pair path visible) = buildTestWake Unit
         Pass (Pair (simplify "{path}/..") visible)
     Nil = Pass (Pair "{wakePath}" Nil)
@@ -206,7 +245,7 @@ def wakeToTestDir Unit = match (subscribe wakeTestBinary)
 
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
-    buildTestWake , Nil =
+    buildTestWake, Nil =
         require (
             Pass
             # comment
@@ -306,11 +345,11 @@ def t1 = match _
     n = 2 + t (n - 1)
 
 
-publish wakeTestBinary = defaultWake , Nil
+publish wakeTestBinary = defaultWake, Nil
 
-publish animal = "Cat" , Nil
+publish animal = "Cat", Nil
 
-publish animal = replace `u` "o" "Mouse" , Nil
+publish animal = replace `u` "o" "Mouse", Nil
 
 publish compileC = makeCompileC "native-c11-debug" (which "cc") (c11Flags ++ debugCFlags)
 
@@ -319,22 +358,22 @@ publish path = match (getenv "WAKE_PATH")
     None = Nil
 
 publish path = match sysname
-    "Darwin" = "/opt/local/bin" , "/usr/local/bin" , Nil
-    "FreeBSD" = "/usr/local/bin" , Nil
+    "Darwin" = "/opt/local/bin", "/usr/local/bin", Nil
+    "FreeBSD" = "/usr/local/bin", Nil
     _ = Nil
 
-publish compileC = emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11" , emscriptenCFlags))
+publish compileC = emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags))
 
 publish compileC =
     emccFn
-    (makeCompileC "wasm-c11-release" _ ("-std=gnu11" , emscriptenCFlags) (another) ("thing" "here"))
+    (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags) (another) ("thing" "here"))
 
 publish compileC = # comment
- emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11" , emscriptenCFlags))
+ emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags))
 
 publish compileC =
     # comment
-    emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11" , emscriptenCFlags))
+    emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags))
 
 global export target fib n = match n
     0 = 1
@@ -356,18 +395,21 @@ def buildRE2WASM Unit =
             wget https://github.com/google/re2/archive/refs/tags/%{version}.tar.gz
             tar xvzf %{version}.tar.gz
             cd re2-%{version}
-            patch -p0 < ../../%{relative @here patch . getPathName}
+            patch -p0 < ../../%{relative @here patch.getPathName}
             emmake make -j4 RE2_CXXFLAGS="-std=c++14 -I. -Wall -DNO_THREADS" CXXFLAGS="-O2" obj/libre2.a
         """
-        | makePlan "compiling re2" (buildDir , patch , Nil)
+        | makePlan "compiling re2" (buildDir, patch, Nil)
         | editPlanEnvironment (addEnvironmentPath emsdk)
         | setPlanDirectory @here
         | runJob
-    require Pass outputs = job . getJobOutputs
-    def headers = filter (matches `.*\.h` _ . getPathName) outputs
-    def objects = filter (matches `.*\.o` _ . getPathName) outputs
-    def cflags = "-I{@here}/.build/re2-{version}" , Nil
+    require Pass outputs = job.getJobOutputs
+    def headers = filter (matches `.*\.h` _.getPathName) outputs
+    def objects = filter (matches `.*\.o` _.getPathName) outputs
+    def cflags = "-I{@here}/.build/re2-{version}", Nil
     def lflags = Nil
     Pass (SysLib "1.0" headers objects cflags lflags)
+
+
+def t5 = a.b.c
 
 

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -137,6 +137,25 @@ class Emitter {
   // on the current line if it fits, or on a new nested line
   auto rhs_fmt();
 
+  // Returns a doc with a binop surrounded by the appropiate separation. This depends heavily on
+  // the context and which operator is being used.
+  //
+  // Ex:
+  // "flat comma": ', '
+  // "flat or": ' | '
+  // "flat dot": '.'
+  // "explode or": '\n| '
+  // "explode comma": ',\n'
+  //
+  // When an operator grows a NL, the rules are slightly different as the spacing is forced.
+  //
+  // Ex:
+  //  '''x
+  //     + # comment
+  // <FR>5
+  //  '''
+  wcl::doc place_binop(CSTElement op, bool is_flat, ctx_t ctx);
+
   wcl::doc walk_apply(ctx_t ctx, CSTElement node);
   wcl::doc walk_arity(ctx_t ctx, CSTElement node);
   wcl::doc walk_ascribe(ctx_t ctx, CSTElement node);

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -198,6 +198,16 @@ struct FreshlineAction {
   }
 };
 
+struct LiteralAction {
+  wcl::doc lit;
+  LiteralAction(wcl::doc lit) : lit(lit) {}
+
+  ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
+                         const token_traits_map_t& traits) {
+    builder.append(std::move(lit));
+  }
+};
+
 struct TokenAction {
   cst_id_t token_id;
   TokenAction(cst_id_t token_id) : token_id(token_id) {}
@@ -635,6 +645,8 @@ struct Formatter {
   Formatter<SeqAction<Action, NewlineAction>> newline() { return {{action, {}}}; }
 
   Formatter<SeqAction<Action, FreshlineAction>> freshline() { return {{action, {}}}; }
+
+  Formatter<SeqAction<Action, LiteralAction>> lit(wcl::doc lit) { return {{action, {lit}}}; }
 
   Formatter<SeqAction<Action, TokenAction>> token(cst_id_t id) { return {{action, {id}}}; }
 


### PR DESCRIPTION
Binop separation was moved to a single function/source of truth. This enabled things like moving the `,` to be a suffix instead of a prefix and had the bonus benefit of cleaning up the combine_* functions significantly 