### PR TITLE
Update "Sources and `Path` objects" section in the quick reference

### DIFF
--- a/share/doc/wake/quickref.md
+++ b/share/doc/wake/quickref.md
@@ -251,9 +251,7 @@ Environment packages can be added to a workspace to provide tools (using runners
 
 #### Sources and `Path` objects
 
-Sources are the set of files in a Git repository. A `Path` in Wake is either a) a file in Git or b) a file produced from a build step.
-
-To get a path, use the
+Sources are the set of files in a Git repository. A `Path` in Wake is either a) a file in Git or b) a file produced from a build step. The `Path` type has no public constructor to help enforce this. To get a `Path` value, use the
 
 * `source: (file: String) => Result Path Error`
 * `sources: (dir: String) => (filterRegexp: RegExp) => Result (List Path) Error`

--- a/share/doc/wake/quickref.md
+++ b/share/doc/wake/quickref.md
@@ -264,10 +264,10 @@ The `Path` type has no public constructor function to help enforce this. To get 
 functions. For example, to get all the header files under the current Wake root:
 
 ```wake
-sources "." `.*?\.h`
+sources "." `.*\.h`
 ```
 
-Note that the directory given to `sources` is always relative to the Wake root and not the current directory of a source file. So the above expression, when evaluated, has the same effect whether it is run in a `.wake` file in any directory under the root or as `` wake -x 'sources "." `.*?\.h`' ``.
+Note that the directory given to `sources` is always relative to the Wake root and not the current directory of a source file. So the above expression, when evaluated, has the same effect whether it is run in a `.wake` file in any directory under the root or as `` wake -x 'sources "." `.*\.h`' ``.
 
 When working inside a file, `@here: String` is a built-in macro that expands to the relative path from the workspace root to the directory containing the source file that contains `@here`. This can be useful when only wanting to source files in the current directory that your source file is in and in any subdirectory.
 
@@ -283,7 +283,7 @@ As a further example, suppose we had a source file `share/wake/lib/gcc_wake/test
 
 ```wake
 package sourcesExample
-export def sourcesExample = sources @here `.*?\.wake`
+export def sourcesExample = sources @here `.*\.wake`
 ```
 
 Then `sourcesExample` would have a value of

--- a/share/doc/wake/quickref.md
+++ b/share/doc/wake/quickref.md
@@ -256,13 +256,20 @@ Sources are the set of files in a Git repository. A `Path` in Wake is either a) 
 * `source: (file: String) => Result Path Error`
 * `sources: (dir: String) => (filterRegexp: RegExp) => Result (List Path) Error`
 
-functions. For example, to get all the header files in the current repository:
+functions. For example, to get all the header files in the current repository inside a Wake source file located at the workspace root:
 
 ```wake
-sources here `.*\.h`
+sources @here `.*\.h`
 ```
 
-Note that the directory given to `sources` is always relative to the root directory of the current Git repository and not the current directory. `here: String = "."` is just a helper value.
+
+Note that the directory given to `sources` is always relative to the root directory of the current Git repository and not the current directory. The expression `@here: String` is a built-in macro that expands to the relative path from the workspace root to the folder containing the Wake source file that contains `@here`. For example:
+
+```
+./build.wake @here -> "."
+./src/other.wake @here -> "src"
+./src/test/another.wake @here -> "src/test"
+```
 
 ### Wakisms
 

--- a/share/doc/wake/quickref.md
+++ b/share/doc/wake/quickref.md
@@ -249,17 +249,22 @@ Runners are created using `makeRunner`. `makeRunner` is defined as follows:
 
 Environment packages can be added to a workspace to provide tools (using runners) for running the workflow. They are composed of Wake files that define and publish runners. Environment packages should be defined for each unique running environment to decouple Wake rules from how tools are installed in each environment. You can check out [environment-example-sifive](https://github.com/sifive/environment-example-sifive) as an example of an environment package that contains runners for Wake-based workflows. 
 
-#### sources and Path objects
+#### Sources and `Path` objects
 
-Sources are the set of files in git.
+Sources are the set of files in a Git repository. A `Path` in Wake is either a) a file in Git or b) a file produced from a build step.
 
-A Path is either a) a file in git or b) a file produced from a build step
+To get a path, use the
 
-To get a path, use the source function. For example, all the header files in this directory:
+* `source: (file: String) => Result Path Error`
+* `sources: (dir: String) => (filterRegexp: RegExp) => Result (List Path) Error`
 
+functions. For example, to get all the header files in the current repository:
+
+```wake
+sources here `.*\.h`
 ```
-source `.*\.h` here
-```
+
+Note that the directory given to `sources` is always relative to the root directory of the current Git repository and not the current directory. `here: String = "."` is just a helper value.
 
 ### Wakisms
 

--- a/share/doc/wake/tutorial.md
+++ b/share/doc/wake/tutorial.md
@@ -555,7 +555,7 @@ export def infoH _args =
         getWhenFail "" os.getJobStdout
     def body =
         "#define OS {str}\n#define WAKE {version}\n"
-    write "{here}/info.h" body    # created with mode: rw-r--r--
+    write "{@here}/info.h" body    # created with mode: rw-r--r--
 ```
 
 This example creates a header file suitable for inclusion in some C/C++ project.
@@ -586,8 +586,8 @@ in case the job failed. There is other information we can get from a `Job`
 object: `getJobStatus` is an `Integer` equal to the job's exit status,
 `getJobOutputs` returns a `List` of `Paths` created by the job, among others.
 
-`version` is just a `String` with the current wake version, and `here` a
-`String` with the location of the wake file.  We also have an example of a
+`version` is just a `String` with the current wake version, and `@here` is a
+`String` with the directory of the Wake file.  We also have an example of a
 comment, `# ...`, reminding us of the default permissions used by `write`.
 
 ```console
@@ -937,7 +937,7 @@ export def buildAll _ =
         compileC variant ("-I.", Nil) Nil
     def objectsResult =
         require Pass srcFiles =
-            sources here `.*\.cpp`
+            sources @here `.*\.cpp`
         map compile srcFiles
         | findFail
     def allResult =
@@ -1003,12 +1003,12 @@ will fail.
 ```wake
 export def buildHeaders _ =
     require Pass headers =
-        sources here `.*\.h`
+        sources @here `.*\.h`
     def compile =
         compileC variant ("-I.", Nil) headers
     def objectsResult =
         require Pass srcFiles =
-            sources here `.*\.cpp`
+            sources @here `.*\.cpp`
         map compile srcFiles
         | findFail
     def headersResult =
@@ -1053,7 +1053,7 @@ Stderr:
 
 In `buildHeaders`, we've used the `sources` command to find all the header
 files in the same directory and pass them as legal inputs to gcc -- the
-keyword `here` expands to the directory of the `.wake` file.  The second
+keyword `@here` expands to the directory of the `.wake` file.  The second
 argument to `sources` is a regular expression to select which files to
 return. We've used ``` `` ```s here which define regular expression literals
 with the [standard syntax](https://github.com/google/re2/wiki/Syntax).
@@ -1155,7 +1155,7 @@ def curl url extension =
         # This construction is somewhat specific to GitHub's url scheme, which
         # names release tarballs according to the tag version, but doesn't
         # include the `.tar.gz` (or `.json`) extension.
-        "{here}/{basename url}.{extension}"
+        "{@here}/{basename url}.{extension}"
     def cmdline =
         which "curl",
         "-o", outputFile,

--- a/share/doc/wake/tutorial.md
+++ b/share/doc/wake/tutorial.md
@@ -587,7 +587,7 @@ object: `getJobStatus` is an `Integer` equal to the job's exit status,
 `getJobOutputs` returns a `List` of `Paths` created by the job, among others.
 
 `version` is just a `String` with the current wake version, and `@here` is a
-`String` with the directory of the Wake file.  We also have an example of a
+`String` with the directory of the wake file.  We also have an example of a
 comment, `# ...`, reminding us of the default permissions used by `write`.
 
 ```console


### PR DESCRIPTION
The Wake quick reference had a couple of typos for the example given in the "Sources and `Path` objects" section. I updated the section with a little bit of elaboration and updated the example.

I tried being accurate for the details of `source` and `sources`, but please review for accuracy.