### PR TITLE
Replace walk_children with walk_all

### DIFF
--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -245,7 +245,7 @@ wcl::doc Emitter::walk(ctx_t ctx, CSTElement node) {
    .otherwise(node_fmt.join(fmt().newline())));
   // clang-format on
 
-  MEMO_RET(fmt().walk_children(body_fmt).format(ctx, node, token_traits));
+  MEMO_RET(fmt().walk_all(body_fmt).format(ctx, node.firstChildElement(), token_traits));
 }
 
 wcl::doc Emitter::walk_node(ctx_t ctx, CSTElement node) {
@@ -891,7 +891,7 @@ wcl::doc Emitter::walk_block(ctx_t ctx, CSTElement node) {
    .otherwise(fmt().freshline().walk(WALK_NODE)));
   // clang-format on
 
-  MEMO_RET(fmt().walk_children(body_fmt).consume_wsnlc().format(ctx, node, token_traits));
+  MEMO_RET(fmt().walk_all(body_fmt).format(ctx, node.firstChildElement(), token_traits));
 }
 
 wcl::doc Emitter::walk_case(ctx_t ctx, CSTElement node) {

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -364,17 +364,16 @@ struct WhileAction {
 };
 
 template <class FMT>
-struct WalkChildrenAction {
+struct WalkAllAction {
   FMT formatter;
 
-  WalkChildrenAction(FMT formatter) : formatter(formatter) {}
+  WalkAllAction(FMT formatter) : formatter(formatter) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
                          const token_traits_map_t& traits) {
-    for (CSTElement child = node.firstChildElement(); !child.empty();) {
-      builder.append(formatter.compose(ctx.sub(builder), child, traits));
+    while (!node.empty()) {
+      builder.append(formatter.compose(ctx.sub(builder), node, traits));
     }
-    node.nextSiblingElement();
   }
 };
 
@@ -736,7 +735,7 @@ struct Formatter {
   }
 
   template <class FMT>
-  Formatter<SeqAction<Action, WalkChildrenAction<FMT>>> walk_children(FMT formatter) {
+  Formatter<SeqAction<Action, WalkAllAction<FMT>>> walk_all(FMT formatter) {
     return {{action, {formatter}}};
   }
 


### PR DESCRIPTION
walk_children doesn't compose well with `format()` since fully consuming the parent node only moves the pointer to the parent's sibling. Instead this changes the aspect to that of the children thus "walking all" from a starting (child) node. In this aspect, fully consuming the children results in the expected `node.empty() == true` and has the bonus effect of making the function more generic.