### PR TITLE
Format if subtree

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -201,6 +201,15 @@ from wake import def unary + -
 from wake import type Pair Result
 from wake import source,Nil
 
+# comment
+def linkKind =
+    # comment
+    if empty cppSources then
+        cVariant # comment
+    else
+        # comment
+        cppVariant
+
 export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
 export topic compileC: Pair String ((extraFlags: List String) => (headers: List Path) => (cfile: Path) => Result (List Path) Error)
 topic linkO: (

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -210,6 +210,12 @@ def linkKind =
         # comment
         cppVariant
 
+def linkKind =
+    if verrrrrrrry loooooooooooog naaaaaaaaaaaame then
+        verrrrrrrrrrrrrrrrrrrrrrry
+    else
+        looooooooooooooooong
+
 export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
 export topic compileC: Pair String ((extraFlags: List String) => (headers: List Path) => (cfile: Path) => Result (List Path) Error)
 topic linkO: (

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -216,6 +216,11 @@ def linkKind =
     else
         looooooooooooooooong
 
+def linkKind =
+  if true
+  then short
+  else short
+
 export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
 export topic compileC: Pair String ((extraFlags: List String) => (headers: List Path) => (cfile: Path) => Result (List Path) Error)
 topic linkO: (

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -268,6 +268,16 @@ from wake import myMap=map foldl myFoldr=foldr
 from wake import def unary + -
 from wake import type Pair Result
 from wake import source,Nil
+# comment
+def linkKind =
+    # comment
+    if empty cppSources then
+        cVariant # comment
+    else
+        # comment
+        cppVariant
+
+
 export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
 export topic compileC: (
     Pair
@@ -539,7 +549,11 @@ def tarball Unit =
     require Pass tarball =
         def cmd =
             def gnutar = which "gnutar"
-            def tar = if gnutar ==* "gnutar" then which "tar" else gnutar
+            def tar =
+                if gnutar ==* "gnutar" then
+                    which "tar"
+                else
+                    gnutar
             def files = map getPathName (manifest, testManifest, spec, srcs) | sortBy (_ <* _)
             tar,
             "--mtime={time}",

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -278,6 +278,13 @@ def linkKind =
         cppVariant
 
 
+def linkKind =
+    if verrrrrrrry loooooooooooog naaaaaaaaaaaame then
+        verrrrrrrrrrrrrrrrrrrrrrry
+    else
+        looooooooooooooooong
+
+
 export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
 export topic compileC: (
     Pair
@@ -549,11 +556,7 @@ def tarball Unit =
     require Pass tarball =
         def cmd =
             def gnutar = which "gnutar"
-            def tar =
-                if gnutar ==* "gnutar" then
-                    which "tar"
-                else
-                    gnutar
+            def tar = if gnutar ==* "gnutar" then which "tar" else gnutar
             def files = map getPathName (manifest, testManifest, spec, srcs) | sortBy (_ <* _)
             tar,
             "--mtime={time}",

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -285,6 +285,9 @@ def linkKind =
         looooooooooooooooong
 
 
+def linkKind = if true then short else short
+
+
 export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
 export topic compileC: (
     Pair

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1013,8 +1013,30 @@ wcl::doc Emitter::walk_if(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
   assert(node.id() == CST_IF);
 
-  // TODO: support flat case?
-  // Ex: def x = if true then 5 else 6
+  auto fits_no_nl =
+      fmt()
+          .fmt_if_fits_all(
+              fmt()
+                  .token(TOKEN_KW_IF)
+                  .ws()
+                  .walk(is_expression, WALK_NODE)  // if cond
+                  .ws()
+                  .token(TOKEN_KW_THEN)
+                  .consume_wsnlc()
+                  .space()
+                  .walk(is_expression, WALK_NODE)  // true body
+                  .consume_wsnlc()
+                  .space()
+                  .token(TOKEN_KW_ELSE)
+                  .consume_wsnlc()
+                  .space()
+                  .walk(is_expression, WALK_NODE),     // false body
+              fmt().walk_all(fmt().next()).newline())  // garbage format to fail NL check
+          .format(ctx, node.firstChildElement(), token_traits);
+
+  if (!fits_no_nl->has_newline()) {
+    MEMO_RET(fits_no_nl);
+  }
 
   MEMO_RET(fmt()
                .token(TOKEN_KW_IF)

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1018,9 +1018,11 @@ wcl::doc Emitter::walk_if(ctx_t ctx, CSTElement node) {
           .fmt_if_fits_all(
               fmt()
                   .token(TOKEN_KW_IF)
-                  .ws()
+                  .consume_wsnlc()
+                  .space()
                   .walk(is_expression, WALK_NODE)  // if cond
-                  .ws()
+                  .consume_wsnlc()
+                  .space()
                   .token(TOKEN_KW_THEN)
                   .consume_wsnlc()
                   .space()
@@ -1040,9 +1042,11 @@ wcl::doc Emitter::walk_if(ctx_t ctx, CSTElement node) {
 
   MEMO_RET(fmt()
                .token(TOKEN_KW_IF)
-               .ws()
+               .consume_wsnlc()
+               .space()
                .walk(is_expression, WALK_NODE)  // if cond
-               .ws()
+               .consume_wsnlc()
+               .space()
                .token(TOKEN_KW_THEN)
                .consume_wsnlc()
                .nest(fmt().freshline().walk(is_expression, WALK_NODE))  // true body


### PR DESCRIPTION
Formats the `if` subtree. Short expressions are on a single line

```
def x = if true then 5 else 3
```

while expressions with NLs or expressions that don't fit are split across several 

```
def linkKind =
    if verrrrrrrry loooooooooooog naaaaaaaaaaaame then
        verrrrrrrrrrrrrrrrrrrrrrry
    else
        looooooooooooooooong
```