### PR TITLE
Format data subtree

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -486,3 +486,35 @@ def defaultWake Unit =
         doInstall "tmp" "default"
 
     Pass (Pair "tmp/bin/wake" wakeVisible)
+
+export data JValue =
+  JString  String
+  JInteger Integer
+  JDouble  Double
+  JBoolean Boolean
+  JNull
+  JObject  (List (Pair String JValue))
+  JArray   (List JValue)
+
+export data List a =
+# The empty list. Nil represents a list with no elements.
+    Nil
+
+export data Option a =
+    Some a
+    None
+
+data LogLevel = LogLevel (name: String)
+
+export data Result pass fail =
+    Pass pass
+    Fail fail
+
+export data a; b = a; b
+
+export data Boolean =
+    True
+
+global export data Let =
+    A
+    B

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -585,3 +585,42 @@ def defaultWake Unit =
     Pass (Pair "tmp/bin/wake" wakeVisible)
 
 
+export data JValue =
+    JString String
+    JInteger Integer
+    JDouble Double
+    JBoolean Boolean
+    JNull
+    JObject (List (Pair String JValue))
+    JArray (List JValue)
+    
+
+export data List a =
+    # The empty list. Nil represents a list with no elements.
+    Nil
+    
+
+export data Option a =
+    Some a
+    None
+    
+
+data LogLevel = LogLevel (name: String)
+
+
+export data Result pass fail =
+    Pass pass
+    Fail fail
+    
+
+export data a; b = a; b
+
+
+export data Boolean = True
+
+
+global export data Let =
+    A
+    B
+    
+

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -918,7 +918,39 @@ wcl::doc Emitter::walk_case(ctx_t ctx, CSTElement node) {
 
 wcl::doc Emitter::walk_data(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
-  MEMO_RET(walk_placeholder(ctx, node));
+  assert(node.id() == CST_DATA);
+
+  auto fmt_members = fmt().walk_all(fmt().walk(WALK_NODE).freshline().consume_wsnlc());
+
+  auto no_nl = fmt()
+                   .fmt_if(CST_FLAG_GLOBAL, fmt().walk(WALK_NODE).ws())
+                   .fmt_if(CST_FLAG_EXPORT, fmt().walk(WALK_NODE).ws())
+                   .token(TOKEN_KW_DATA)
+                   .ws()
+                   .walk(is_expression, WALK_NODE)
+                   .ws()
+                   .token(TOKEN_P_EQUALS)
+                   .consume_wsnlc()
+                   .space()
+                   .join(fmt_members)
+                   .format(ctx, node.firstChildElement(), token_traits);
+
+  // We always add one NL in fmt_members
+  if (no_nl->newline_count() == count_leading_newlines(token_traits, node) + 1) {
+    MEMO_RET(no_nl);
+  }
+
+  MEMO_RET(fmt()
+               .fmt_if(CST_FLAG_GLOBAL, fmt().walk(WALK_NODE).ws())  // maybe not needed
+               .fmt_if(CST_FLAG_EXPORT, fmt().walk(WALK_NODE).ws())
+               .token(TOKEN_KW_DATA)
+               .ws()
+               .walk(is_expression, WALK_NODE)
+               .ws()
+               .token(TOKEN_P_EQUALS)
+               .consume_wsnlc()
+               .nest(fmt().freshline().join(fmt_members))
+               .format(ctx, node.firstChildElement(), token_traits));
 }
 
 wcl::doc Emitter::walk_def(ctx_t ctx, CSTElement node) {


### PR DESCRIPTION
Formats the `data` subtree

Ex:

```
export data JValue =
  JString  String
  JInteger Integer
  JDouble  Double
  JBoolean Boolean
  JNull
  JObject  (List (Pair String JValue))
  JArray   (List JValue)
```