### PR TITLE
quickref: Add some more useful tips about getting job info.

### DIFF
--- a/share/doc/wake/quickref.md
+++ b/share/doc/wake/quickref.md
@@ -17,9 +17,14 @@ the wake.db directory and below.
 
 1. Other useful flags
     1. `wake -v <varible>` to get type information
-    1. `wake -o <file>` to get dependency information for job which write file
-    1. `wake -i <file>` to get dependency information for job which read file
-    1. `wake -g` To get a list of all global symbols
+    1. Getting information about jobs. For all these commands, adding `-v` will
+       include the jobs' stdout/stderr, and adding `-d` will include the Wake
+       stack trace of when the job was run.
+        1. `wake -o <file>` to get dependency information for job which write file
+        1. `wake -i <file>` to get dependency information for job which read file
+        1. `wake -g` to get a list of all global symbols
+        1. `wake --failed` to get a list of failed jobs
+        1. `wake --last` to get a list of the most recent jobs, regardless of status
 
 
 ### Syntax

--- a/share/doc/wake/quickref.md
+++ b/share/doc/wake/quickref.md
@@ -10,13 +10,20 @@
 the wake library (share/wake/lib) and all files *.wake in
 the wake.db directory and below.
 
-1. wake is invoked normally, although arguments are generally quoted.
+1. wake is invoked normally with a command-line target and its arguments.
+   Targets are any wake function in scope with a single `args: List String` parameter.
+    ```wake
+    wake runThing "a string"
     ```
-    wake 'runThing "a string"'
+
+1. Arbitrary wake expressions can be invoked with `-x`,
+   although the entire expression is generally quoted with single quotes to avoid interactions with the shell.
+    ```wake
+    wake -x 'runThing "a string"'
     ```
 
 1. Other useful flags
-    1. `wake -v <varible>` to get type information
+    1. `wake -xv <varible>` to get type information for a variable or function that is in scope
     1. Getting information about jobs. For all these commands, adding `-v` will
        include the jobs' stdout/stderr, and adding `-d` will include the Wake
        stack trace of when the job was run.

--- a/share/doc/wake/quickref.md
+++ b/share/doc/wake/quickref.md
@@ -27,8 +27,8 @@ the wake.db directory and below.
     1. Getting information about jobs. For all these commands, adding `-v` will
        include the jobs' stdout/stderr, and adding `-d` will include the Wake
        stack trace of when the job was run.
-        1. `wake -o <file>` to get dependency information for job which write file
-        1. `wake -i <file>` to get dependency information for job which read file
+        1. `wake -o <file>` to get dependency information for job which write `file`
+        1. `wake -i <file>` to get dependency information for job which read `file`
         1. `wake -g` to get a list of all global symbols
         1. `wake --failed` to get a list of failed jobs
         1. `wake --last` to get a list of the most recent jobs, regardless of status


### PR DESCRIPTION
I didn't want to do a total overhaul, since a lot of this is out of date, but I wanted to update a few examples that need the `-x` to work today and I wanted to add a few more notes on getting info about jobs.