### PR TITLE
wake: check the hash of a symlink itself, not of the target

### DIFF
--- a/.circleci/dockerfiles/alpine
+++ b/.circleci/dockerfiles/alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.11.5
+FROM alpine:3.14.0
 
 RUN apk add m4 g++ make pkgconf git tar xz gmp-dev re2-dev sqlite-dev fuse-dev ncurses-dev dash sqlite-static ncurses-static linux-headers
 

--- a/scripts/fetch
+++ b/scripts/fetch
@@ -9,7 +9,6 @@ version="$2"
 
 curl -L -o wake_${version}.tar.xz                      ${url}/wake_${version}.tar.xz
 curl -L -o wake-${version}.vsix                        ${url}/vscode/wake-${version}.vsix
-curl -L -o wake-static_${version}.tar.xz               ${url}/alpine/wake-static_${version}.tar.xz
 curl -L -o centos-7-6-wake-${version}-1.x86_64.rpm     ${url}/centos_7_6/wake-${version}-1.x86_64.rpm
 curl -L -o rocky_8-wake-${version}-1.x86_64.rpm        ${url}/rocky_8/wake-${version}-1.x86_64.rpm
 curl -L -o debian-bullseye-wake_${version}-1_amd64.deb ${url}/debian_bullseye/wake_${version}-1_amd64.deb

--- a/tests/runtime/symlinks/pass.sh
+++ b/tests/runtime/symlinks/pass.sh
@@ -12,17 +12,15 @@ rm -f datFile badLink goodLink wake.db
 rm wake.db
 "${WAKE}" -v test
 
-rm -f datFile badLink goodLink
-ln -s whatever datFile
-ln -s whatever badLink
-ln -s whatever goodLink
+rm -f badLink goodLink
+ln -s badFile badLink
+ln -s datFile goodLink
 "${WAKE}" -v test
 "${WAKE}" -v test
 
 rm -f datFile badLink goodLink wake.db
-ln -s whatever datFile
-ln -s whatever badLink
-ln -s whatever goodLink
+ln -s badFile badLink
+ln -s datFile goodLink
 "${WAKE}" -v test
 "${WAKE}" -v test
 

--- a/tools/fuse-waked/fuse-waked.cpp
+++ b/tools/fuse-waked/fuse-waked.cpp
@@ -334,7 +334,7 @@ static int wakefuse_access(const char *path, int mask) {
 
   if (!it->second.is_readable(key.second)) return -ENOENT;
 
-  int res = faccessat(context.rootfd, key.second.c_str(), mask, 0);
+  int res = faccessat(context.rootfd, key.second.c_str(), mask, AT_SYMLINK_NOFOLLOW);
   if (res == -1) return -errno;
 
   return 0;

--- a/tools/fuse-waked/fuse-waked.cpp
+++ b/tools/fuse-waked/fuse-waked.cpp
@@ -334,7 +334,7 @@ static int wakefuse_access(const char *path, int mask) {
 
   if (!it->second.is_readable(key.second)) return -ENOENT;
 
-  int res = faccessat(context.rootfd, key.second.c_str(), mask, AT_SYMLINK_NOFOLLOW);
+  int res = faccessat(context.rootfd, key.second.c_str(), mask, 0);
   if (res == -1) return -errno;
 
   return 0;


### PR DESCRIPTION
When a symlink was included as part of a job's input or output files, wake had previously been hashing the *target* rather than the link itself; when the symlink was broken on-disc (e.g. referring to an absolute `/workspace` sandboxed path), this could cause the job to rerun unnecessarily as it saw the symlink as having been "deleted".  By using the flag-aware `faccessat` rather than the simpler `access`, we can instruct wake to just look at but not follow the link for the proper behaviour.  This is a similar but distinct bug to that solved by #1008.

This does break compatibility with some older versions of MacOS; current/recent versions do implement the required features.