### PR TITLE
Make fmt_fits generic via try_else

### DIFF
--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -326,16 +326,16 @@ struct MatchAction {
 
   // Predicate case that is accepted if FMT passes the FitsFirstPredicate
   template <class FMT>
-  MatchAction<MatchSeq<Case, PredicateCase<FitsFirstPredicate<FMT>, FMT>>> pred_fits_first(
-      FMT formatter) {
-    return {{c, {FitsFirstPredicate<FMT>(formatter), formatter}}};
+  MatchAction<MatchSeq<Case, PredicateCase<TryPredicate<DocFitsFirstPred, FMT>, FMT>>>
+  pred_fits_first(FMT formatter) {
+    return {{c, {TryPredicate<DocFitsFirstPred, FMT>(DocFitsFirstPred(), formatter), formatter}}};
   }
 
   // Predicate case that is accepted if FMT passes the FitsAllPredicate
   template <class FMT>
-  MatchAction<MatchSeq<Case, PredicateCase<FitsAllPredicate<FMT>, FMT>>> pred_fits_all(
+  MatchAction<MatchSeq<Case, PredicateCase<TryPredicate<DocFitsAllPred, FMT>, FMT>>> pred_fits_all(
       FMT formatter) {
-    return {{c, {FitsAllPredicate<FMT>(formatter), formatter}}};
+    return {{c, {TryPredicate<DocFitsFirstPred, FMT>(DocFitsAllPred(), formatter), formatter}}};
   }
 
   template <class FMT>

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -101,18 +101,6 @@ struct Formatter {
 
   Formatter<SeqAction<Action, NextAction>> next() { return {{action, {}}}; }
 
-  template <class IFMT, class EFMT>
-  Formatter<SeqAction<Action, IfElseAction<FmtPredicate<FitsFirstPredicate<IFMT>>, IFMT, EFMT>>>
-  fmt_if_fits_first(IFMT fits_formatter, EFMT else_formatter) {
-    return fmt_if_else(FitsFirstPredicate<IFMT>(fits_formatter), fits_formatter, else_formatter);
-  }
-
-  template <class IFMT, class EFMT>
-  Formatter<SeqAction<Action, IfElseAction<FmtPredicate<FitsAllPredicate<IFMT>>, IFMT, EFMT>>>
-  fmt_if_fits_all(IFMT fits_formatter, EFMT else_formatter) {
-    return fmt_if_else(FitsAllPredicate<IFMT>(fits_formatter), fits_formatter, else_formatter);
-  }
-
   template <class FMT>
   Formatter<SeqAction<Action, IfElseAction<FmtPredicate<std::initializer_list<cst_id_t>>, FMT,
                                            Formatter<EpsilonAction>>>>
@@ -137,6 +125,28 @@ struct Formatter {
   Formatter<SeqAction<Action, IfElseAction<FmtPredicate<Predicate>, IFMT, EFMT>>> fmt_if_else(
       Predicate predicate, IFMT if_formatter, EFMT else_formatter) {
     return {{action, {predicate, if_formatter, else_formatter}}};
+  }
+
+  template <class IFMT, class EFMT, class Predicate>
+  Formatter<
+      SeqAction<Action, IfElseAction<FmtPredicate<TryPredicate<Predicate, IFMT>>, IFMT, EFMT>>>
+  fmt_try_else(Predicate predicate, IFMT try_formatter, EFMT else_formatter) {
+    return fmt_if_else(TryPredicate<Predicate, IFMT>(predicate, try_formatter), try_formatter,
+                       else_formatter);
+  }
+
+  template <class IFMT, class EFMT>
+  Formatter<SeqAction<Action,
+                      IfElseAction<FmtPredicate<TryPredicate<DocFitsFirstPred, IFMT>>, IFMT, EFMT>>>
+  fmt_if_fits_first(IFMT fits_formatter, EFMT else_formatter) {
+    return fmt_try_else(DocFitsFirstPred(), fits_formatter, else_formatter);
+  }
+
+  template <class IFMT, class EFMT>
+  Formatter<
+      SeqAction<Action, IfElseAction<FmtPredicate<TryPredicate<DocFitsAllPred, IFMT>>, IFMT, EFMT>>>
+  fmt_if_fits_all(IFMT fits_formatter, EFMT else_formatter) {
+    return fmt_try_else(DocFitsAllPred(), fits_formatter, else_formatter);
   }
 
   template <class FMT>


### PR DESCRIPTION
In the formatting API there is this use case to say "use this formatter if it fits" otherwise use this other formatter. Since fitting can only be checked after actually running the formatter we previously ran the formatter on a copy, checked if it fit, then threw out the copy. 

This idea of asking a question about an already formatted bit of code before continuing to format actually comes up in other formatting cases and is a precursor to any kind of "full choice" formatting. 

This change makes the idea of "try to format something and make a decision on how to proceed based on the format" generic so that it can be used in any formatter. This genercism also simplifies our previous implementations of `fits_first` and `fits_all`

A common case is to format condidtionally on if something previously emitted a newline. Ex:

```
  return fmt().fmt_try_else(
      [](const wcl::doc_builder& builder, ctx_t ctx, wcl::doc doc) { return doc->has_newline(); },
      fmt().freshline(), fmt().space());
```

This gives the formatting API two types of conditional questions. `fmt_if_else(pred, if_fmt, else_fmt)` which calls `pred` _before_ calling `if_fmt` and `fmt_try_else(pred, try_fmt, else_fmt)` which calls `pred` _after_ calling `try_fmt` (on a fake copy)
