### PR TITLE
Format multi-match subtree

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -543,3 +543,11 @@ def x + y = add x y
 
 def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) =
     ""
+
+def f0 = match _ _
+  (x: Integer) (True:  Boolean) = x+1
+  (x: Integer) (False: Boolean) = x+0
+
+def f0 = match aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = x+1
+  x b = x+0

--- a/tests/wake-format/basic/small.wake
+++ b/tests/wake-format/basic/small.wake
@@ -1,0 +1,7 @@
+def f0 = match aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  (x: Integer) (True:  Boolean) = x+1
+  (x: Integer) (False: Boolean) = x+0
+
+#target runOnce cmd env dir stdin \ res usage finputs foutputs vis keep run echo stdout stderr label =
+#  runAlways cmd env dir stdin res usage finputs foutputs vis keep run echo stdout stderr label
+def a = 1

--- a/tests/wake-format/basic/small.wake
+++ b/tests/wake-format/basic/small.wake
@@ -1,7 +1,0 @@
-def f0 = match aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  (x: Integer) (True:  Boolean) = x+1
-  (x: Integer) (False: Boolean) = x+0
-
-#target runOnce cmd env dir stdin \ res usage finputs foutputs vis keep run echo stdout stderr label =
-#  runAlways cmd env dir stdin res usage finputs foutputs vis keep run echo stdout stderr label
-def a = 1

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -663,3 +663,20 @@ def (
 ) = ""
 
 
+def f0 = match _ _
+    (x: Integer) (True: Boolean) = x + 1
+    (x: Integer) (False: Boolean) = x + 0
+
+
+def f0 = match (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+)
+    (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    )
+    = x + 1
+    x b = x + 0
+
+

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -214,17 +214,16 @@ auto Emitter::rhs_fmt() {
 }
 
 auto Emitter::pattern_fmt(cst_id_t stop_at) {
-  auto first = fmt().walk(is_expression, WALK_NODE).consume_wsnlc();
-  auto rest_flat = fmt().space().walk(is_expression, WALK_NODE).consume_wsnlc();
-  auto all_flat =
-      fmt().join(first).fmt_while([stop_at](cst_id_t id) { return id != stop_at; }, rest_flat);
-  auto rest_explode = fmt().freshline().walk(is_expression, WALK_NODE).consume_wsnlc();
-  auto all_explode = fmt()
-                         .lit(wcl::doc::lit("("))
-                         .nest(fmt().freshline().join(first).fmt_while(
-                             [stop_at](cst_id_t id) { return id != stop_at; }, rest_explode))
-                         .freshline()
-                         .lit(wcl::doc::lit(")"));
+  auto part_fmt = fmt().walk(is_expression, WALK_NODE).consume_wsnlc();
+  auto all_flat = fmt().join(part_fmt).fmt_while([stop_at](cst_id_t id) { return id != stop_at; },
+                                                 fmt().space().join(part_fmt));
+  auto all_explode =
+      fmt()
+          .lit(wcl::doc::lit("("))
+          .nest(fmt().freshline().join(part_fmt).fmt_while(
+              [stop_at](cst_id_t id) { return id != stop_at; }, fmt().freshline().join(part_fmt)))
+          .freshline()
+          .lit(wcl::doc::lit(")"));
   // 4 Cases
   // 1) The "flat format" doesn't have a newline and fits()
   // 2) The "flat format" doesn't have a newline and doesn't fits()

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -137,6 +137,10 @@ class Emitter {
   // on the current line if it fits, or on a new nested line
   auto rhs_fmt();
 
+  // Returns a formatter that consumes a pattern continuing until *stop_at* is seen. Pattern is
+  // separated by spaces if possible, freshlines otherwise
+  auto pattern_fmt(cst_id_t stop_at);
+
   // Returns a doc with a binop surrounded by the appropiate separation. This depends heavily on
   // the context and which operator is being used.
   //


### PR DESCRIPTION
Formats a subtree that has multiple variables in the match pattern

Ex
```
def f0 = match _ _
  (x: Integer) (True:  Boolean) = x+1
  (x: Integer) (False: Boolean) = x+0
```