### PR TITLE
Wake format tuple

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -578,3 +578,21 @@ def loop aaaaa sssss eeeee =
         sssss
     else
         loop aaaaa (sssss+1) eeeee
+# A dictionary associating a key-value pair, providing fast lookup by key.
+# This is internally implemented by a balanced tree, so some total ordering must
+# be able to be produced for the key type.
+global export tuple Map k v =
+    # The ordering function in use, over the key type only.  The `Tree` also
+    # stores a version of this over the full `Pair` type, but some of the data
+    # manipulations require access to this minimal signature.
+    Comparison: k => k => Order
+    # The existing `Tree` type provides the storage and most of the manipulation
+    # features required, but is not always able to provide optimal retrieval
+    # when only the key is known, without access to non-exported details.
+    Data: Tree (Pair k v)
+
+export tuple a +++ b =
+  Bingo: Pair a b
+
+export tuple (z: Banger) =
+  export X: Integer

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -613,17 +613,17 @@ export data JValue =
     JNull
     JObject (List (Pair String JValue))
     JArray (List JValue)
-
+    
 
 export data List a =
     # The empty list. Nil represents a list with no elements.
     Nil
-
+    
 
 export data Option a =
     Some a
     None
-
+    
 
 data LogLevel = LogLevel (name: String)
 
@@ -631,7 +631,7 @@ data LogLevel = LogLevel (name: String)
 export data Result pass fail =
     Pass pass
     Fail fail
-
+    
 
 export data a; b = a; b
 
@@ -642,7 +642,7 @@ export data Boolean = True
 global export data Let =
     A
     B
-
+    
 
 def x + y = add x y
 
@@ -702,6 +702,7 @@ def loop aaaaa sssss eeeee =
     else
         loop aaaaa (sssss + 1) eeeee
 
+
 # A dictionary associating a key-value pair, providing fast lookup by key.
 # This is internally implemented by a balanced tree, so some total ordering must
 # be able to be produced for the key type.
@@ -720,3 +721,4 @@ export tuple a +++ b =
 
 export tuple (z: Banger) =
     export X: Integer
+

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -613,17 +613,17 @@ export data JValue =
     JNull
     JObject (List (Pair String JValue))
     JArray (List JValue)
-    
+
 
 export data List a =
     # The empty list. Nil represents a list with no elements.
     Nil
-    
+
 
 export data Option a =
     Some a
     None
-    
+
 
 data LogLevel = LogLevel (name: String)
 
@@ -631,7 +631,7 @@ data LogLevel = LogLevel (name: String)
 export data Result pass fail =
     Pass pass
     Fail fail
-    
+
 
 export data a; b = a; b
 
@@ -642,7 +642,7 @@ export data Boolean = True
 global export data Let =
     A
     B
-    
+
 
 def x + y = add x y
 
@@ -702,4 +702,21 @@ def loop aaaaa sssss eeeee =
     else
         loop aaaaa (sssss + 1) eeeee
 
+# A dictionary associating a key-value pair, providing fast lookup by key.
+# This is internally implemented by a balanced tree, so some total ordering must
+# be able to be produced for the key type.
+global export tuple Map k v =
+    # The ordering function in use, over the key type only.  The `Tree` also
+    # stores a version of this over the full `Pair` type, but some of the data
+    # manipulations require access to this minimal signature.
+    Comparison: k => k => Order
+    # The existing `Tree` type provides the storage and most of the manipulation
+    # features required, but is not always able to provide optimal retrieval
+    # when only the key is known, without access to non-exported details.
+    Data: Tree (Pair k v)
 
+export tuple a +++ b =
+    Bingo: Pair a b
+
+export tuple (z: Banger) =
+    export X: Integer

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1390,12 +1390,10 @@ wcl::doc Emitter::walk_tuple(ctx_t ctx, CSTElement node) {
           .token(TOKEN_P_EQUALS)
           .consume_wsnlc()
           // clang-format off
-               .nest(fmt()
-                   .fmt_while(
-                       {CST_TUPLE_ELT}, fmt()
-                       .freshline()
-                       .walk(WALK_NODE)
-                       .consume_wsnlc()))
+          .nest(fmt().fmt_while({CST_TUPLE_ELT}, fmt()
+                  .freshline()
+                  .walk(WALK_NODE)
+                  .consume_wsnlc()))
           // clang-format on
           .consume_wsnlc()
           .format(ctx, node.firstChildElement(), token_traits));

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1377,7 +1377,28 @@ wcl::doc Emitter::walk_topic(ctx_t ctx, CSTElement node) {
 
 wcl::doc Emitter::walk_tuple(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
-  MEMO_RET(walk_placeholder(ctx, node));
+  FMT_ASSERT(node.id() == CST_TUPLE, node, "Expected CST_TUPLE");
+
+  MEMO_RET(
+      fmt()
+          .fmt_if(CST_FLAG_GLOBAL, fmt().walk(WALK_NODE).ws())
+          .fmt_if(CST_FLAG_EXPORT, fmt().walk(WALK_NODE).ws())
+          .token(TOKEN_KW_TUPLE)
+          .ws()
+          .walk(is_expression, WALK_NODE)
+          .ws()
+          .token(TOKEN_P_EQUALS)
+          .consume_wsnlc()
+          // clang-format off
+               .nest(fmt()
+                   .fmt_while(
+                       {CST_TUPLE_ELT}, fmt()
+                       .freshline()
+                       .walk(WALK_NODE)
+                       .consume_wsnlc()))
+          // clang-format on
+          .consume_wsnlc()
+          .format(ctx, node.firstChildElement(), token_traits));
 }
 
 wcl::doc Emitter::walk_tuple_elt(ctx_t ctx, CSTElement node) {


### PR DESCRIPTION
Format the tuple subtree

Ex:

```
# A dictionary associating a key-value pair, providing fast lookup by key.
# This is internally implemented by a balanced tree, so some total ordering must
# be able to be produced for the key type.
global export tuple Map k v =
    # The ordering function in use, over the key type only.  The `Tree` also
    # stores a version of this over the full `Pair` type, but some of the data
    # manipulations require access to this minimal signature.
    Comparison: k => k => Order
    # The existing `Tree` type provides the storage and most of the manipulation
    # features required, but is not always able to provide optimal retrieval
    # when only the key is known, without access to non-exported details.
    Data: Tree (Pair k v)
```