### PR TITLE
Fix missing include on WSL build

### DIFF
--- a/src/wcl/trie.h
+++ b/src/wcl/trie.h
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 


### PR DESCRIPTION
WSL unittest builds fail due to a missing header import. This doesn't seem to effect other targets, likily due to slightly different imports and definition locations for `size_t`