### PR TITLE
Check if file exists before parsing it

### DIFF
--- a/tools/wake-format/wake-format.cpp
+++ b/tools/wake-format/wake-format.cpp
@@ -192,6 +192,12 @@ int main(int argc, char **argv) {
     std::string tmp = name + ".tmp." + rng.unique_name();
 
     ExternalFile external_file = ExternalFile(*reporter, name.c_str());
+    if (terminalReporter.errors) {
+      std::cerr << argv[0] << ": failed to open file: '" << name << "'" << std::endl << std::endl;
+      terminalReporter.report_to_stderr();
+      exit(EXIT_FAILURE);
+    }
+
     CST cst = CST(external_file, *reporter);
     if (terminalReporter.errors) {
       std::cerr << argv[0] << ": failed to parse file: '" << name << "'" << std::endl << std::endl;


### PR DESCRIPTION
Check if we are able to open and read the file before attempting to parse it. This gives more informative errors when the input is bad