### PR TITLE
Update `minsertWith` examples and label arguments in type signature

### DIFF
--- a/share/wake/lib/core/map.wake
+++ b/share/wake/lib/core/map.wake
@@ -138,10 +138,10 @@ export def minsertReplace (key: k) (value: v) (map: Map k v): Map k v =
 #
 # *Examples:*
 #   ```
-#   mnew scmp | minsertWith (_+_) "a" 2 | mlookup "a" = Some 2
-#   listToMap scmp ("a" → 1, Nil) | minsertWith (_+_) "a" 2 | mlookup "a" = Some 3
+#   mnew scmp | minsertWith (\_key \old \new old + new) "a" 2 | mlookup "a" = Some 2
+#   listToMap scmp ("a" → 1, Nil) | minsertWith (\_key \old \new old + new) "a" 2 | mlookup "a" = Some 3
 #   ```
-export def minsertWith (fn: k => v => v => v) (key: k) (value: v) (map: Map k v): Map k v =
+export def minsertWith (fn: k => (old: v) => (new: v) => v) (key: k) (value: v) (map: Map k v): Map k v =
     def pairFn (Pair k l) (Pair _ r) = Pair k (fn k l r)
     editMapData (tinsertWith pairFn (Pair key value)) map
 

--- a/share/wake/lib/core/map.wake
+++ b/share/wake/lib/core/map.wake
@@ -138,10 +138,10 @@ export def minsertReplace (key: k) (value: v) (map: Map k v): Map k v =
 #
 # *Examples:*
 #   ```
-#   mnew scmp | minsertWith (\_key \old \new old + new) "a" 2 | mlookup "a" = Some 2
-#   listToMap scmp ("a" → 1, Nil) | minsertWith (\_key \old \new old + new) "a" 2 | mlookup "a" = Some 3
+#   mnew scmp | minsertWith (\_k (_+_)) "a" 2 | mlookup "a" = Some 2
+#   listToMap scmp ("a" → 1, Nil) | minsertWith (\_k (_+_)) "a" 2 | mlookup "a" = Some 3
 #   ```
-export def minsertWith (fn: k => (old: v) => (new: v) => v) (key: k) (value: v) (map: Map k v): Map k v =
+export def minsertWith (fn: k => (incoming: v) => (existing: v) => v) (key: k) (value: v) (map: Map k v): Map k v =
     def pairFn (Pair k l) (Pair _ r) = Pair k (fn k l r)
     editMapData (tinsertWith pairFn (Pair key value)) map
 

--- a/share/wake/lib/core/tree.wake
+++ b/share/wake/lib/core/tree.wake
@@ -97,7 +97,7 @@ export def tinsertMulti (y: a) (Tree cmp root: Tree a): Tree a =
 
 # Insert y into the tree, or the value resulting from fn on a collision
 # `y` is passed as the left-hand value of `fn`.
-export def tinsertWith (fn: a => a => a) (y: a) (tree: Tree a): Tree a =
+export def tinsertWith (fn: (incoming: a) => (existing: a) => a) (y: a) (tree: Tree a): Tree a =
     def Tree cmp root = tree
     def helper = match _
         Tip         = Bin 1 Tip y Tip


### PR DESCRIPTION
It looks like `minsertWith` was updated at some point to include the key in the update `fn` function, but the examples were out of date. So I updated the examples. I went with `\_key \old \new old + new` as I couldn't figure out how to make it more concise with Wake's syntax. I did try `(\_key _+_)` but this didn't work as expected. For example:

```bash
$ wakex '(\_key _+_)'
(\_key _+_): Integer => Integer => (_key: a) => Integer
```

But as you can see, this is the wrong type signature. I do find this a bit non-intuitive, as I might have expected (or maybe I should say hoped for to make the examples cleaner) `(_key: a) => Integer => Integer => Integer`.

Also, when using this function, it wasn't clear to me which value in the update function `(fn: k => v => v => v)` was the old or existing value and what the new incoming value to compute the result were. So I labeled the arguments to (hopefully) make this more clear with `(fn: k => (old: v) => (new: v) => v)`. Maybe this is even more clear, but potentially overkill, with `(fn: (key: k) => (old: v) => (new: v) => (result: v))`? I couldn't think of a better word for `new` other than maybe `incoming`.

Thoughts are welcome of course!