### PR TITLE
parser: treat \x ... as a block

### DIFF
--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -1398,7 +1398,7 @@ static Expr *dst_expr(CSTElement expr) {
       CSTElement child = expr.firstChildNode();
       AST ast = dst_pattern(child, nullptr);
       child.nextSiblingNode();
-      Expr *body = dst_expr(child);
+      Expr *body = relabel_anon(dst_expr(child));
       Lambda *out;
       FileFragment l = expr.fragment();
       if (lex_kind(ast.name) != LOWER) {


### PR DESCRIPTION
Previously, wake treated lambda as a prefix operator. Since we switched to lemon, that hasn't been true anymore. Given that is the case, we might as well have `\x` introduce a block.

That makes these all the same:
```
(\x _ +. _): (x: a) => Double => Double => Double
\x (_ +. _): (x: a) => Double => Double => Double
(\(x: Integer) _ +. _): Integer => Double => Double => Double
(\(x: Integer) (_ +. _)): Integer => Double => Double => Double
```