### PR TITLE
emit flat paren node when NL from a comment

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -599,3 +599,15 @@ export tuple a +++ b =
 
 export tuple (z: Banger) =
   export X: Integer
+
+export data List a =
+    # The empty list. Nil represents a list with no elements.
+    Nil
+    # The prepend constructor. This is often called "cons".
+    #
+    # Examples:
+    # ```
+    #   10, list       # Add a number to `list`
+    #   1, 2, 3, Nil   # Create a list of 3 elements
+    # ```
+    (head: a), (tail: List a) # comment

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -610,4 +610,15 @@ export data List a =
     #   10, list       # Add a number to `list`
     #   1, 2, 3, Nil   # Create a list of 3 elements
     # ```
+    (head: a), (tail: List a)
+
+export data List a =
+    # comment
+    (head: a), (tail: List a)
+
+export data List a =
+    (head: a), (tail: List a) # comment
+
+export data List a =
+    # comment
     (head: a), (tail: List a) # comment

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -249,9 +249,7 @@ def wakeToTestDir Unit = match (subscribe wakeTestBinary)
         require (
             Pass
             # comment
-            (
-                Pair path visible
-            )
+            (Pair path visible)
         ) = buildTestWake Unit
         Pass (Pair (simplify "{path}/..") visible)
     Nil = Pass (Pair "{wakePath}" Nil)
@@ -516,18 +514,9 @@ def tarball Unit =
     require Pass allSources = sources "." `.*`
     def srcs =
         allSources
-        | filter
-        (
-            ! matches `(debian/|wake.spec).*` _.getPathName
-        ) # omit packaging files
-        | filter
-        (
-            ! matches `(\.circleci/|\.github/).*|\.dockerignore` _.getPathName
-        ) # omit CI files
-        | filter
-        (
-            ! matches `(.*/)*\.gitignore` _.getPathName
-        ) # omit git files
+        | filter (! matches `(debian/|wake.spec).*` _.getPathName) # omit packaging files
+        | filter (! matches `(\.circleci/|\.github/).*|\.dockerignore` _.getPathName) # omit CI files
+        | filter (! matches `(.*/)*\.gitignore` _.getPathName) # omit git files
     def Pair testPaths wakePaths = splitBy (matches `tests/.*` _.getPathName) srcs
     def wakeSourcesString = wakePaths | map (_.getPathName.format) | foldr (_, ",\n  ", _) Nil | cat
     def testSourcesString =
@@ -716,4 +705,17 @@ export tuple a +++ b =
 
 export tuple (z: Banger) =
     export X: Integer
+
+export data List a =
+    # The empty list. Nil represents a list with no elements.
+    Nil
+    # The prepend constructor. This is often called "cons".
+    #
+    # Examples:
+    # ```
+    #   10, list       # Add a number to `list`
+    #   1, 2, 3, Nil   # Create a list of 3 elements
+    # ```
+    (head: a), (tail: List a) # comment
+
 

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -716,6 +716,18 @@ export data List a =
     #   10, list       # Add a number to `list`
     #   1, 2, 3, Nil   # Create a list of 3 elements
     # ```
+    (head: a), (tail: List a)
+
+export data List a =
+    # comment
+    (head: a), (tail: List a)
+
+export data List a =
+    (head: a), (tail: List a) # comment
+
+
+export data List a =
+    # comment
     (head: a), (tail: List a) # comment
 
 

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -142,6 +142,12 @@ static size_t count_trailing_newlines(const token_traits_map_t& traits, const CS
   return it->second.after_bound.size();
 }
 
+static size_t count_allowed_newlines(const token_traits_map_t& traits, const CSTElement& node) {
+  FMT_ASSERT(node.isNode(), node,
+             "Expected node, Saw <" + std::string(symbolName(node.id())) + ">");
+  return count_leading_newlines(traits, node) + count_trailing_newlines(traits, node);
+}
+
 static size_t count_allowed_newlines(const token_traits_map_t& traits,
                                      const std::vector<CSTElement>& parts) {
   assert(parts.size() >= 2);
@@ -1251,7 +1257,7 @@ wcl::doc Emitter::walk_paren(ctx_t ctx, CSTElement node) {
                    .token(TOKEN_P_PCLOSE)
                    .format(ctx, node.firstChildElement(), token_traits);
 
-  if (!no_nl->has_newline()) {
+  if (no_nl->newline_count() == count_allowed_newlines(token_traits, node)) {
     MEMO_RET(no_nl);
   }
 


### PR DESCRIPTION
Comments were forcing paren nodes to be multi-lined. This was changing the semantics of the `data` subtree and was also just wrong formatting. This PR fixes it so they are only multi-lined when appropriate.