### PR TITLE
re-emit author provided newlines inside of BLOCKs

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -622,3 +622,27 @@ export data List a =
 export data List a =
     # comment
     (head: a), (tail: List a) # comment
+
+def buildRE2WASM Unit =
+    require Pass outputs =
+        job.getJobOutputs
+
+    Pass (SysLib "1.0" headers objects cflags lflags)
+
+def buildRE2WASM Unit =
+    require Pass outputs =
+        job.getJobOutputs
+
+
+    else
+        blah
+
+    Pass (SysLib "1.0" headers objects cflags lflags)
+
+def buildRE2WASM Unit =
+    require Pass outputs =
+        job.getJobOutputs
+    else
+        blah
+
+    Pass (SysLib "1.0" headers objects cflags lflags)

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -646,3 +646,16 @@ def buildRE2WASM Unit =
         blah
 
     Pass (SysLib "1.0" headers objects cflags lflags)
+
+def a =
+  # comment
+  def b = 5
+
+  # comment
+
+  def c = 5
+
+  def d = 5
+  # comment
+
+  result

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -53,6 +53,7 @@ def name Unit =
     def other = @here
     # wake-format off
     def other = here
+
     def other = @here
     another
 
@@ -403,13 +404,18 @@ global export target fib n = match n
 
 def buildRE2WASM Unit =
     def version = "2021-08-01"
+
     require Some emmake = emmake
     else
         # comment
         failWithError "emmake is not available"
+
     def emsdk = replace `/[^/]*$` "" emmake
+
     require Pass patch = source "{@here}/re2.patch"
+
     require Pass buildDir = vendorBuildDir Unit
+
     def job =
         """
             cd .build
@@ -423,11 +429,17 @@ def buildRE2WASM Unit =
         | editPlanEnvironment (addEnvironmentPath emsdk)
         | setPlanDirectory @here
         | runJob
+
     require Pass outputs = job.getJobOutputs
+
     def headers = filter (matches `.*\.h` _.getPathName) outputs
+
     def objects = filter (matches `.*\.o` _.getPathName) outputs
+
     def cflags = "-I{@here}/.build/re2-{version}", Nil
+
     def lflags = Nil
+
     Pass (SysLib "1.0" headers objects cflags lflags)
 
 
@@ -594,6 +606,7 @@ publish wakeUnitTestBinary = buildWakeUnit, Nil
 
 def defaultWake Unit =
     require Pass wakeVisible = doInstall "tmp" "default"
+
     Pass (Pair "tmp/bin/wake" wakeVisible)
 
 
@@ -729,5 +742,21 @@ export data List a =
 export data List a =
     # comment
     (head: a), (tail: List a) # comment
+def buildRE2WASM Unit =
+    require Pass outputs = job.getJobOutputs
+
+    Pass (SysLib "1.0" headers objects cflags lflags)
 
 
+def buildRE2WASM Unit =
+    require Pass outputs = job.getJobOutputs
+    else blah
+
+    Pass (SysLib "1.0" headers objects cflags lflags)
+
+
+def buildRE2WASM Unit =
+    require Pass outputs = job.getJobOutputs
+    else blah
+
+    Pass (SysLib "1.0" headers objects cflags lflags)

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -742,6 +742,8 @@ export data List a =
 export data List a =
     # comment
     (head: a), (tail: List a) # comment
+
+
 def buildRE2WASM Unit =
     require Pass outputs = job.getJobOutputs
 
@@ -760,3 +762,17 @@ def buildRE2WASM Unit =
     else blah
 
     Pass (SysLib "1.0" headers objects cflags lflags)
+
+
+def a =
+    # comment
+    def b = 5
+
+    # comment
+    def c = 5
+
+    def d = 5
+    # comment
+    result
+
+

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -940,8 +940,9 @@ wcl::doc Emitter::walk_block(ctx_t ctx, CSTElement node) {
     // user creating 'pseudo-blocks'
     pred(TOKEN_NL, fmt().newline().newline().next())
    .pred(TOKEN_WS, fmt().next())
-   // Comments are following by a block level newline that shouldn't be emitted
-   .pred(TOKEN_COMMENT, fmt().next().next())
+   // Comments are following by ws/nl/c that have already been tagged and will be
+   // handled later. Skip them for now.
+   .pred(TOKEN_COMMENT, fmt().consume_wsnlc())
    .otherwise(fmt().freshline().walk(WALK_NODE)));
   // clang-format on
 

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -940,7 +940,7 @@ wcl::doc Emitter::walk_block(ctx_t ctx, CSTElement node) {
     // user creating 'pseudo-blocks'
     pred(TOKEN_NL, fmt().newline().newline().next())
    .pred(TOKEN_WS, fmt().next())
-   // Comments are following by ws/nl/c that have already been tagged and will be
+   // Comments are followed by ws/nl/c that have already been tagged and will be
    // handled later. Skip them for now.
    .pred(TOKEN_COMMENT, fmt().consume_wsnlc())
    .otherwise(fmt().freshline().walk(WALK_NODE)));


### PR DESCRIPTION
non-comment "top level" newlines inside of a CST_BLOCK or CST_REQUIRE should be re-emitted as they represent spacing requested by the author. This implements that change.