### PR TITLE
Re-emit top level newlines to maintain author separation

### DIFF
--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -267,6 +267,7 @@ from wake import myMap=map foldl myFoldr=foldr
 from wake import def unary + -
 from wake import type Pair Result
 from wake import source,Nil
+
 # comment
 def linkKind =
     # comment
@@ -302,6 +303,7 @@ export topic path: String
 export topic wakeUnitTestBinary: (variant: Pair String String) => Result (List Path) Error
 global export topic glob1: String
 global topic glob1: String
+
 def app1 =
     Pair # comment
     "a"
@@ -365,31 +367,22 @@ def t1 = match _
 
 
 publish wakeTestBinary = defaultWake, Nil
-
 publish animal = "Cat", Nil
-
 publish animal = replace `u` "o" "Mouse", Nil
-
 publish compileC = makeCompileC "native-c11-debug" (which "cc") (c11Flags ++ debugCFlags)
-
 publish path = match (getenv "WAKE_PATH")
     Some x = tokenize `:` x
     None = Nil
-
 publish path = match sysname
     "Darwin" = "/opt/local/bin", "/usr/local/bin", Nil
     "FreeBSD" = "/usr/local/bin", Nil
     _ = Nil
-
 publish compileC = emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags))
-
 publish compileC =
     emccFn
     (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags) (another) ("thing" "here"))
-
 publish compileC = # comment
     emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags))
-
 publish compileC =
     # comment
     emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags))
@@ -618,7 +611,6 @@ export def static _: Result Path Error =
 from test_wake import topic wakeTestBinary
 from test_wake import topic wakeUnitTestBinary
 publish wakeTestBinary = defaultWake, Nil
-
 publish wakeUnitTestBinary = buildWakeUnit, Nil
 
 def defaultWake Unit =

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -318,10 +318,8 @@ def app =
     Pair "a" "b" # comment
 
 
-
 def app =
     Pair "a" "b" # comment
-
 
 
 def app =
@@ -334,7 +332,6 @@ def app =
     Pair # comment
     "a" # comment
     "b" # comment
-
 
 
 def app =
@@ -389,7 +386,6 @@ publish compileC =
 
 publish compileC =
     emccFn (makeCompileC "a" "b") # comment
-
 
 publish compileC =
     emccFn
@@ -747,11 +743,9 @@ export data List a =
 export data List a =
     (head: a), (tail: List a) # comment
 
-
 export data List a =
     # comment
     (head: a), (tail: List a) # comment
-
 
 def buildRE2WASM Unit =
     require Pass outputs = job.getJobOutputs

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -291,7 +291,7 @@ wcl::doc Emitter::dispatch(ctx_t ctx, CSTElement node, Func func) {
 wcl::doc Emitter::walk(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
 
-  auto node_fmt = fmt().walk(WALK_NODE).newline();
+  auto node_fmt = fmt().walk(WALK_NODE).freshline();
 
   // clang-format off
   auto body_fmt = fmt().match(

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -295,12 +295,11 @@ wcl::doc Emitter::walk(ctx_t ctx, CSTElement node) {
 
   // clang-format off
   auto body_fmt = fmt().match(
-    // TODO: starting 'pred()' function doesn't allow init lists
-    pred(ConstPredicate(false), fmt())
-   .pred({TOKEN_WS, TOKEN_NL, TOKEN_COMMENT}, fmt().next())
-   .pred({CST_IMPORT, CST_TOPIC}, node_fmt)
-   .pred(CST_DEF, node_fmt.join(fmt().newline().newline()))
-   .otherwise(node_fmt.join(fmt().newline())));
+    pred(TOKEN_WS, fmt().next())
+   .pred(TOKEN_COMMENT, fmt().consume_wsnlc())
+   .pred(TOKEN_NL, fmt().next().newline())
+   .pred(CST_DEF, node_fmt.join(fmt().newline().newline()).consume_wsnlc())
+   .otherwise(node_fmt));
   // clang-format on
 
   MEMO_RET(fmt().walk_all(body_fmt).format(ctx, node.firstChildElement(), token_traits));


### PR DESCRIPTION
Re-emits author provided newlines for everything except defs which should be followed by 2 newlines. When a comment is encountered it and all wsnl is skipped as that is managed by the comment subsystem.