### PR TITLE
job: include lookup id in job error messages

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -355,7 +355,7 @@ def guardPath job = match _
     Pass l if job.isJobOk =
         findFailFn treeOk l
     _ =
-        failWithError "Non-zero exit status ({format job.getJobStatus}) for '{job.getJobDescription}'"
+        failWithError "Non-zero exit status ({format job.getJobStatus}) for job {str job.getJobId}: '{job.getJobDescription}'"
 def mapPath = match _
     Fail e = Fail e
     Pass l = findFailFn treeOk l
@@ -385,11 +385,11 @@ export def getJobOutput (job: Job): Result Path Error =
         getJobOutputs job
     match outputs
         Nil =
-            failWithError "No outputs available from '{job.getJobDescription}'"
+            failWithError "No outputs available from job {str job.getJobId}: '{job.getJobDescription}'"
         (singleOutput, Nil) =
             Pass singleOutput
         _ =
-            failWithError "More than one output found from '{job.getJobDescription}'"
+            failWithError "More than one output found from job {str job.getJobId}: '{job.getJobDescription}'"
 
 export def isJobOk (job: Job): Boolean = match (getJobReport job)
   Fail _ = False

--- a/vendor/lemon/lemon.wake
+++ b/vendor/lemon/lemon.wake
@@ -43,7 +43,7 @@ def m4 (file: Path): Result Path Error =
     match run.getJobStatus
         Exited 0 = write output stdout
         Aborted e = Fail e
-        z = failWithError "Non-zero exit status ({format z}) for '{run.getJobDescription}'"
+        z = failWithError "Non-zero exit status ({format z}) for job {str run.getJobId}: '{run.getJobDescription}'"
 
 def lemon variant (file: Path): Result (Pair Path Path) Error =
     require Pass lemon =
@@ -93,4 +93,4 @@ def lemon variant (file: Path): Result (Pair Path Path) Error =
     match zip.getJobStatus
         Exited 0 = Pass (Pair cppfile hfile)
         Aborted e = Fail e
-        z = failWithError "Non-zero exit status ({format z}) for '{zip.getJobDescription}'"
+        z = failWithError "Non-zero exit status ({format z}) for job {str zip.getJobId}: '{zip.getJobDescription}'"


### PR DESCRIPTION
Debugging what went wrong with a Job sometimes/often requires looking it up in the database, and if another `wake` invocation has been run since the failed job, or if we're looking into a reported issue rather than one we've triggered ourselves, `wake --last`/`wake --failed` can sometimes be less than helpful.  Printing the job ID directly in the error message doesn't introduce much extra noise but makes any `wake --job` calls to zero in on the info much simpler to construct.