### PR TITLE
Fix error message when running lsp in neovim

### DIFF
--- a/tools/lsp-wake/lsp.cpp
+++ b/tools/lsp-wake/lsp.cpp
@@ -302,7 +302,6 @@ class LSPServer {
     std::stringstream str;
     str << message;
 
-    str.seekg(0, std::ios::end);
     std::string msg = str.str();
 
     if (msg == "{}") {
@@ -312,11 +311,8 @@ class LSPServer {
       return;
     }
 
-    str.seekg(0, std::ios::end);
-    size_t length = str.tellg();
-    str.seekg(0, std::ios::beg);
-    std::cout << contentLength << (length + 2) << "\r\n\r\n";
-    std::cout << str.rdbuf() << "\r\n" << std::flush;
+    std::cout << contentLength << (msg.size() + 2) << "\r\n\r\n";
+    std::cout << msg << "\r\n" << std::flush;
   }
 
   MethodResult initialize(const JAST &receivedMessage) {

--- a/tools/lsp-wake/lsp.cpp
+++ b/tools/lsp-wake/lsp.cpp
@@ -301,6 +301,17 @@ class LSPServer {
   static void sendMessage(const JAST &message) {
     std::stringstream str;
     str << message;
+
+    str.seekg(0, std::ios::end);
+    std::string msg = str.str();
+
+    if (msg == "{}") {
+#ifdef CERR_DEBUG
+      std::cerr << "Throwing away empty response message" << std::endl;
+#endif
+      return;
+    }
+
     str.seekg(0, std::ios::end);
     size_t length = str.tellg();
     str.seekg(0, std::ios::beg);


### PR DESCRIPTION
The recent refactor to support the LSP in web based vscode transitioned to a 1:1 request-response model for LSP requests. This means that for some requests where there isn't a response `{}` is returned. Neovim emits an error and shutsdown the LSP when that happens.

In the short term, just skip `{}` messages, in the long term we need to rethink and rework the entry point into the LSP for the various platforms we support.