### PR TITLE
enact def + = newline rules

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -784,3 +784,27 @@ def x =
 def x = (\_\_ prim "p") x y
 def x = (\a\b\x prim "p") x y
 def x = (\a \b \x prim "p") x y
+
+def a = 5
+def b = 6
+def c = "asdf"
+def d = identifier
+
+def longFunc param: Result (List Path) Error =
+    match _
+        Nil = Nil,
+        a, b =
+            def f = funcB b
+            match f
+                Some x = x
+                None = x
+        c, e =
+          match f0
+            Some x = x
+            None = x
+
+export def !(x: Boolean): Boolean =
+    if x then
+        False
+    else
+        True

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -98,9 +98,10 @@ def name Unit =
     another
 
 
-def t1 = match _
-    0 = 0
-    n = 2 + t (n - 1)
+def t1 =
+    match _
+        0 = 0
+        n = 2 + t (n - 1)
 
 
 # wake-format off
@@ -109,84 +110,96 @@ def t1 =match _
   n = 2+t(n-1)
 
 
-def t1 = match _
-    # wake-format off
-    0=0
-    n = 2 + t (n - 1)
+def t1 =
+    match _
+        # wake-format off
+        0=0
+        n = 2 + t (n - 1)
 
 
-def t1 = match _
-    0 = 0
-    # wake-format off
-    n = 2+t(n-1)
+def t1 =
+    match _
+        0 = 0
+        # wake-format off
+        n = 2+t(n-1)
 
 
-def t1 = match _
-    # wake-format off
-    0=0
-    # wake-format off
-    n = 2+t(n-1)
+def t1 =
+    match _
+        # wake-format off
+        0=0
+        # wake-format off
+        n = 2+t(n-1)
 
 
-def t1 = match _
-    # many
-    # comments
-    # wake-format off
-    0=0
-    # many
-    # more
-    # comments
-    n = 2 + t (n - 1)
+def t1 =
+    match _
+        # many
+        # comments
+        # wake-format off
+        0=0
+        # many
+        # more
+        # comments
+        n = 2 + t (n - 1)
 
 
-def t2 = ((x + 7) * 3)
+def t2 =
+    ((x + 7) * 3)
 
 
-def t4 = (
-    # comment
-    x + 5
-)
-
-
-def t4 = (
-    # comment
+def t4 =
     (
         # comment
         x + 5
     )
-)
 
 
-def t5 = (
-    # comment
-    # comment
-    # comment
-    x + 5
-)
+def t4 =
+    (
+        # comment
+        (
+            # comment
+            x + 5
+        )
+    )
 
 
-def t7 = (
-    x # comment
-    + 5
-)
+def t5 =
+    (
+        # comment
+        # comment
+        # comment
+        x + 5
+    )
 
 
-def t8 = (
-    x
-    + # comment
-    5
-)
+def t7 =
+    (
+        x # comment
+        + 5
+    )
 
 
-def t9 = (
-    x + 5 # comment
-)
+def t8 =
+    (
+        x
+        + # comment
+        5
+    )
 
 
-def t10 = (
-    x, # comment
-    5
-)
+def t9 =
+    (
+        x + 5 # comment
+    )
+
+
+def t10 =
+    (
+        x, # comment
+        5
+    )
 
 
 def name Unit = # wake-format off
@@ -195,35 +208,41 @@ def name Unit = # wake-format off
     another
 
 
-def t3 = ( # comment
-    x + 5
-)
+def t3 =
+    ( # comment
+        x + 5
+    )
 
 
-def t6 = ( # comment
-    # comment
-    # comment
-    x + 5
-)
+def t6 =
+    ( # comment
+        # comment
+        # comment
+        x + 5
+    )
 
 
-def t8 = (
-    # comment
-    x # comment
-    + # comment
-    5 # comment
-    - # comment
-    2 # comment
-)
+def t8 =
+    (
+        # comment
+        x # comment
+        + # comment
+        5 # comment
+        - # comment
+        2 # comment
+    )
 
 
-def t9 = x + 5 - 2
+def t9 =
+    x + 5 - 2
 
 
-def ff = a | b | c | d
+def ff =
+    a | b | c | d
 
 
-def ff = a $ b $ c $ d
+def ff =
+    a $ b $ c $ d
 
 
 def ff =
@@ -270,24 +289,26 @@ def ff =
     .hhhhhhhhhhh
 
 
-def wakeToTestDir Unit = match (subscribe wakeTestBinary)
-    buildTestWake, Nil =
-        require Pass (Pair path visible) = buildTestWake Unit
-        Pass (Pair (simplify "{path}/..") visible)
-    Nil = Pass (Pair "{wakePath}" Nil)
-    _ = Fail (makeError "Two wake binaries declared for testing!")
+def wakeToTestDir Unit =
+    match (subscribe wakeTestBinary)
+        buildTestWake, Nil =
+            require Pass (Pair path visible) = buildTestWake Unit
+            Pass (Pair (simplify "{path}/..") visible)
+        Nil = Pass (Pair "{wakePath}" Nil)
+        _ = Fail (makeError "Two wake binaries declared for testing!")
 
 
-def wakeToTestDir Unit = match (subscribe wakeTestBinary)
-    buildTestWake, Nil =
-        require (
-            Pass
-            # comment
-            (Pair path visible)
-        ) = buildTestWake Unit
-        Pass (Pair (simplify "{path}/..") visible)
-    Nil = Pass (Pair "{wakePath}" Nil)
-    _ = Fail (makeError "Two wake binaries declared for testing!")
+def wakeToTestDir Unit =
+    match (subscribe wakeTestBinary)
+        buildTestWake, Nil =
+            require (
+                Pass
+                # comment
+                (Pair path visible)
+            ) = buildTestWake Unit
+            Pass (Pair (simplify "{path}/..") visible)
+        Nil = Pass (Pair "{wakePath}" Nil)
+        _ = Fail (makeError "Two wake binaries declared for testing!")
 
 
 package test_wake
@@ -318,7 +339,8 @@ def linkKind =
         looooooooooooooooong
 
 
-def linkKind = if true then short else short
+def linkKind =
+    if true then short else short
 
 
 export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
@@ -343,7 +365,8 @@ def app1 =
     "b"
 
 
-def app = Pair "a" "b"
+def app =
+    Pair "a" "b"
 
 
 # TODO: The trailing NL here causes a failure for 'fits all' which is why this is NL'd
@@ -378,22 +401,25 @@ def app =
     hhhhhhhhhhhhhh
 
 
-def t1 = match _
-    0 = 0
-    n # comment
-    = 2 + t (n - 1)
+def t1 =
+    match _
+        0 = 0
+        n # comment
+        = 2 + t (n - 1)
 
 
-def t1 = match _
-    # comment
-    0 = 0
-    n = 2 + t (n - 1)
+def t1 =
+    match _
+        # comment
+        0 = 0
+        n = 2 + t (n - 1)
 
 
-def t1 = match _
-    0 = 0
-    # comment
-    n = 2 + t (n - 1)
+def t1 =
+    match _
+        0 = 0
+        # comment
+        n = 2 + t (n - 1)
 
 
 publish wakeTestBinary = defaultWake, Nil
@@ -482,29 +508,33 @@ def buildRE2WASM Unit =
     Pass (SysLib "1.0" headers objects cflags lflags)
 
 
-def t5 = a.b.c
+def t5 =
+    a.b.c
 
 
-def toVariant = match _
-    "default" = Pass (Pair "native-cpp14-release" "native-c11-release")
-    "static" = Pass (Pair "native-cpp14-static" "native-c11-static")
-    "debug" = Pass (Pair "native-cpp14-debug" "native-c11-debug")
-    "wasm" = Pass (Pair "wasm-cpp14-release" "wasm-c11-release")
-    s = Fail "Unknown build target ({s})".makeError
+def toVariant =
+    match _
+        "default" = Pass (Pair "native-cpp14-release" "native-c11-release")
+        "static" = Pass (Pair "native-cpp14-static" "native-c11-static")
+        "debug" = Pass (Pair "native-cpp14-debug" "native-c11-debug")
+        "wasm" = Pass (Pair "wasm-cpp14-release" "wasm-c11-release")
+        s = Fail "Unknown build target ({s})".makeError
 
 
-export def build: List String => Result String Error = match _
-    "tarball", Nil = tarball Unit | rmap (\_ "TARBALL")
-    kind, Nil =
-        require Pass variant = toVariant kind
-        all variant | rmap (\_ "BUILD")
-    _ = Fail "no target specified (try: build default/debug/tarball)".makeError
+export def build: List String => Result String Error =
+    match _
+        "tarball", Nil = tarball Unit | rmap (\_ "TARBALL")
+        kind, Nil =
+            require Pass variant = toVariant kind
+            all variant | rmap (\_ "BUILD")
+        _ = Fail "no target specified (try: build default/debug/tarball)".makeError
 
 
-export def install: List String => Result String Error = match _
-    dest, kind, Nil = doInstall (in cwd dest) kind | rmap (\_ "INSTALL")
-    dest, Nil = doInstall (in cwd dest) "default" | rmap (\_ "INSTALL")
-    _ = Fail "no directory specified (try: install /opt/local)".makeError
+export def install: List String => Result String Error =
+    match _
+        dest, kind, Nil = doInstall (in cwd dest) kind | rmap (\_ "INSTALL")
+        dest, Nil = doInstall (in cwd dest) "default" | rmap (\_ "INSTALL")
+        _ = Fail "no directory specified (try: install /opt/local)".makeError
 
 
 # Build all wake targets
@@ -679,28 +709,30 @@ global export data Let =
     A
     B
 
-def x + y = add x y
+def x + y =
+    add x y
 
 
-def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) =
-    ""
+def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) = ""
 
 
-def f0 = match _ _
-    (x: Integer) (True: Boolean) = x + 1
-    (x: Integer) (False: Boolean) = x + 0
+def f0 =
+    match _ _
+        (x: Integer) (True: Boolean) = x + 1
+        (x: Integer) (False: Boolean) = x + 0
 
 
-def f0 = match (
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-)
-    (
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+def f0 =
+    match (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     )
-    = x + 1
-    x b = x + 0
+        (
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        )
+        = x + 1
+        x b = x + 0
 
 
 export def vfoldl (combiningFn: accum => element => accum): accum => Vector element => accum =
@@ -714,7 +746,8 @@ export def vfoldl (combiningFn: accum => element => accum): accum => Vector elem
     top
 
 
-def loop a s e = if s == e then e else if stopFn (vget a s) then s else loop a (s + 1) e
+def loop a s e =
+    if s == e then e else if stopFn (vget a s) then s else loop a (s + 1) e
 
 
 def loop aaaaa sssss eeeee =
@@ -793,7 +826,8 @@ def buildRE2WASM Unit =
     Pass (SysLib "1.0" headers objects cflags lflags)
 
 
-def x = (x,) ++ xs
+def x =
+    (x,) ++ xs
 
 
 def a =
@@ -885,15 +919,48 @@ def a name =
         Nil = Nil
 
 
-def x = map (\(Pair a b) c a b)
+def x =
+    map (\(Pair a b) c a b)
 
 
-def x = (\_ \_ prim "p") x y
+def x =
+    (\_ \_ prim "p") x y
 
 
-def x = (\a \b \x prim "p") x y
+def x =
+    (\a \b \x prim "p") x y
 
 
-def x = (\a \b \x prim "p") x y
+def x =
+    (\a \b \x prim "p") x y
+
+
+def a = 5
+
+
+def b = 6
+
+
+def c = "asdf"
+
+
+def d = identifier
+
+
+def longFunc param: Result (List Path) Error =
+    match _
+        Nil = Nil,
+        a, b =
+            def f = funcB b
+            match f
+                Some x = x
+                None = x
+        c, e = match f0
+            Some x = x
+            None = x
+
+
+export def !(x: Boolean): Boolean =
+    if x then False else True
 
 

--- a/tests/wake-format/disallowed-input/stdout
+++ b/tests/wake-format/disallowed-input/stdout
@@ -1,25 +1,28 @@
 # Input that wake-format doesn't attempt to format correctly
 
 
-def t10 = (
-    x + 5
-# comment
-)
+def t10 =
+    (
+        x + 5
+    # comment
+    )
 
 
-def t11 = (
-    x + 5 # comment
-# comment
-# comment
-)
+def t11 =
+    (
+        x + 5 # comment
+    # comment
+    # comment
+    )
 
 
-def t12 = (
-    x + 5
-# comment
-# comment
-# comment
-)
+def t12 =
+    (
+        x + 5
+    # comment
+    # comment
+    # comment
+    )
 
 
 # trailing comment

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -293,7 +293,7 @@ auto Emitter::rhs_fmt(bool always_newline) {
       return count_leading_newlines(token_traits, node) > 0;
    }, full_fmt)
     // Always newline when requested unless the thing to be formatted is a "single literal".
-    // Used for top-level defs and top-level "constatn" defs
+    // Used for top-level defs and top-level "constant" defs
    .pred(ConstPredicate(always_newline), fmt().fmt_if_else(is_single_literal, flat_fmt, full_fmt))
 
     // if our hand hand hasn't yet been forced then decide based on how well RHS fits
@@ -336,7 +336,7 @@ wcl::doc Emitter::layout(CST cst) {
   ctx_t ctx;
   bind_comments(cst.root());
   mark_no_format_nodes(cst.root());
-  mark_top_level_notes(cst.root());
+  mark_top_level_nodes(cst.root());
   return walk(ctx, cst.root());
 }
 
@@ -695,7 +695,7 @@ void Emitter::bind_comments(CSTElement node) {
   bind_nested_comments(node);
 }
 
-void Emitter::mark_top_level_notes(CSTElement node) {
+void Emitter::mark_top_level_nodes(CSTElement node) {
   FMT_ASSERT(node.isNode(), node, "Expected node");
 
   // Note: we are iterating over nodes here rather than the more common element

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -73,7 +73,7 @@ class Emitter {
   void mark_no_format_nodes(CSTElement node);
 
   // Marks top level nodes. Any node on 'top level' will have top level = true
-  void mark_top_level_notes(CSTElement node);
+  void mark_top_level_nodes(CSTElement node);
 
   // Binds all comments in the tree to their associated token as a human would consider it.
   //

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -38,8 +38,10 @@ struct std::hash<std::pair<CSTElement, ctx_t>> {
 
 struct node_traits_t {
   bool format_off = false;
+  bool top_level = false;
 
   void turn_format_off() { format_off = true; }
+  void set_top_level() { top_level = true; }
 };
 
 class Emitter {
@@ -69,6 +71,9 @@ class Emitter {
 
   // Marks all node elements that have had their formatting disabled
   void mark_no_format_nodes(CSTElement node);
+
+  // Marks top level nodes. Any node on 'top level' will have top level = true
+  void mark_top_level_notes(CSTElement node);
 
   // Binds all comments in the tree to their associated token as a human would consider it.
   //
@@ -139,7 +144,7 @@ class Emitter {
 
   // Returns a formatter that inserts the next node
   // on the current line if it fits, or on a new nested line
-  auto rhs_fmt();
+  auto rhs_fmt(bool always_newline = false);
 
   // Returns a formatter that consumes a pattern continuing until *stop_at* is seen. Pattern is
   // separated by spaces if possible, freshlines otherwise


### PR DESCRIPTION
Enacts the rules for newlining defs as discussed in chat.

Specially
- Same rules as current formatter (the first bikeshed PR) plus
- Top level = always newlines
- except no newlines for single top level literals/identifiers