### PR TITLE
only allow flat if for trivial ternaries

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -611,6 +611,14 @@ def loop a s e =
     else
         loop a (s+1) e
 
+def loop a s e =
+    if s == e then
+        e
+    else if shouldStop then
+        s
+    else
+        t
+
 def loop aaaaa sssss eeeee =
     if sssss == eeeee then
         eeeee

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -632,7 +632,11 @@ def tarball Unit =
     require Pass tarball =
         def cmd =
             def gnutar = which "gnutar"
-            def tar = if gnutar ==* "gnutar" then which "tar" else gnutar
+            def tar =
+                if gnutar ==* "gnutar" then
+                    which "tar"
+                else
+                    gnutar
             def files = map getPathName (manifest, testManifest, spec, srcs) | sortBy (_ <* _)
             tar,
             "--mtime={time}",
@@ -747,7 +751,12 @@ export def vfoldl (combiningFn: accum => element => accum): accum => Vector elem
 
 
 def loop a s e =
-    if s == e then e else if stopFn (vget a s) then s else loop a (s + 1) e
+    if s == e then
+        e
+    else if stopFn (vget a s) then
+        s
+    else
+        loop a (s + 1) e
 
 
 def loop aaaaa sssss eeeee =

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -759,6 +759,15 @@ def loop a s e =
         loop a (s + 1) e
 
 
+def loop a s e =
+    if s == e then
+        e
+    else if shouldStop then
+        s
+    else
+        t
+
+
 def loop aaaaa sssss eeeee =
     if sssss == eeeee then
         eeeee


### PR DESCRIPTION
Only allow flat `if - then - else -` when  `-` is a "simple" thing. Right now that is defined as a literal or identifier but that can be refined over time.