### PR TITLE
format simple constructor applies on the same line

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -816,3 +816,65 @@ export def !(x: Boolean): Boolean =
         False
     else
         True
+
+export def mapPartial (f: a => Option b): (list: List a) => List b =
+    def loop = match _
+        Nil  = Nil
+        h, t =
+            # don't wait on f to process tail:
+            def sub = loop t
+            match (f h)
+                Some x = x, sub
+                None   = sub
+    loop
+
+target writeImp inputs mode path content =
+    def writeRunner =
+        def imp m p c = prim "write"
+        def pre input = Pair input Unit
+        def post = match _
+            Pair (Fail f) _ = Fail f
+            Pair (Pass output) Unit =
+                if mode < 0 || mode > 0x1ff then
+                    Fail (makeError "write {path}: Invalid mode ({strOctal mode})")
+                else match (imp mode path content)
+                    Fail f = Fail (makeError f)
+                    Pass path = Pass (editRunnerOutputOutputs (path, _) output)
+        makeRunner "write" (\_ Pass 0.0) pre post virtualRunner
+    makeExecPlan ("<write>", str mode, path, Nil) inputs
+    | setPlanOnce        False
+    | setPlanEnvironment Nil
+    | runJobWith writeRunner
+    | getJobOutput
+
+export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
+  def json = JObject (
+    "label"       :-> JString label,
+    "command"     :-> command     | map JString | JArray,
+    "environment" :-> environment | map JString | JArray,
+    "visible"     :-> visible | map (_.getPathName.JString) | JArray,
+    "directory"   :-> JString directory,
+    "stdin"       :-> JString stdin,
+    "resources"   :-> res | map JString | JArray,
+    "version"     :-> JString version,
+    "mount-ops"      :-> JArray (
+      JObject (
+        "type"        :-> JString "workspace",
+        "destination" :-> JString ".",
+        Nil
+      ),
+      Nil
+    ),
+    "usage"       :-> JObject (
+      "status"    :-> JInteger status,
+      "runtime"   :-> JDouble  runtime,
+      "cputime"   :-> JDouble  cputime,
+      "membytes"  :-> JInteger membytes,
+      "inbytes"   :-> JInteger inbytes,
+      "outbytes"  :-> JInteger outbytes,
+      Nil
+    ),
+    Nil
+  )
+
+  json

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -447,8 +447,7 @@ publish compileC =
     emccFn (makeCompileC "a" "b") # comment
 
 publish compileC =
-    emccFn
-    (
+    emccFn (
         makeCompileC # comment
         "wasm-c11-release"
         _
@@ -980,5 +979,64 @@ def longFunc param: Result (List Path) Error =
 
 export def !(x: Boolean): Boolean =
     if x then False else True
+
+
+export def mapPartial (f: a => Option b): (list: List a) => List b =
+    def loop = match _
+        Nil = Nil
+        h, t =
+            # don't wait on f to process tail:
+            def sub = loop t
+            match (f h)
+                Some x = x, sub
+                None = sub
+    loop
+
+
+target writeImp inputs mode path content =
+    def writeRunner =
+        def imp m p c = prim "write"
+        def pre input = Pair input Unit
+        def post = match _
+            Pair (Fail f) _ = Fail f
+            Pair (Pass output) Unit =
+                if mode < 0 || mode > 0x1ff then
+                    Fail (makeError "write {path}: Invalid mode ({strOctal mode})")
+                else
+                    match (imp mode path content)
+                        Fail f = Fail (makeError f)
+                        Pass path = Pass (editRunnerOutputOutputs (path, _) output)
+        makeRunner "write" (\_ Pass 0.0) pre post virtualRunner
+    makeExecPlan ("<write>", str mode, path, Nil) inputs
+    | setPlanOnce False
+    | setPlanEnvironment Nil
+    | runJobWith writeRunner
+    | getJobOutput
+
+export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
+    def json =
+        JObject (
+            "label" :-> JString label,
+            "command" :-> command | map JString | JArray,
+            "environment" :-> environment | map JString | JArray,
+            "visible" :-> visible | map (_.getPathName.JString) | JArray,
+            "directory" :-> JString directory,
+            "stdin" :-> JString stdin,
+            "resources" :-> res | map JString | JArray,
+            "version" :-> JString version,
+            "mount-ops" :-> JArray (JObject ("type" :-> JString "workspace", "destination" :-> JString ".", Nil), Nil),
+            "usage" :-> JObject (
+                "status" :-> JInteger status,
+                "runtime" :-> JDouble runtime,
+                "cputime" :-> JDouble cputime,
+                "membytes" :-> JInteger membytes,
+                "inbytes" :-> JInteger inbytes,
+                "outbytes" :-> JInteger outbytes,
+                Nil
+            ),
+            Nil
+        )
+
+    json
 
 

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1002,10 +1002,9 @@ target writeImp inputs mode path content =
             Pair (Pass output) Unit =
                 if mode < 0 || mode > 0x1ff then
                     Fail (makeError "write {path}: Invalid mode ({strOctal mode})")
-                else
-                    match (imp mode path content)
-                        Fail f = Fail (makeError f)
-                        Pass path = Pass (editRunnerOutputOutputs (path, _) output)
+                else match (imp mode path content)
+                    Fail f = Fail (makeError f)
+                    Pass path = Pass (editRunnerOutputOutputs (path, _) output)
         makeRunner "write" (\_ Pass 0.0) pre post virtualRunner
     makeExecPlan ("<write>", str mode, path, Nil) inputs
     | setPlanOnce False

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1336,8 +1336,9 @@ wcl::doc Emitter::walk_if(ctx_t ctx, CSTElement node) {
                // clang-format off
                // False body
                .match(
+                 pred(ConstPredicate(false), fmt())
                  // For an 'else if' block, we explode in the explode case to prevent partial flat emission
-                 pred(CST_IF, fmt().space().explode(fmt().walk(DISPATCH(walk_if))))
+                .pred({CST_IF, CST_MATCH}, fmt().space().explode(fmt().walk(WALK_NODE)))
                 .pred(is_expression, fmt().nest(fmt().freshline().walk(WALK_NODE)))
                 // fallthrough is fail
                )

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -139,6 +139,8 @@ class Emitter {
   // Functions to combine apply using various 'full choice' options
   //
   wcl::optional<wcl::doc> combine_apply_flat(ctx_t ctx, const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_apply_constructor(ctx_t ctx,
+                                                    const std::vector<CSTElement>& parts);
   wcl::optional<wcl::doc> combine_apply_explode_all(ctx_t ctx,
                                                     const std::vector<CSTElement>& parts);
 


### PR DESCRIPTION
An apply that "looks" like a constructor, something like 

```
Identifier (
  some,
  expression
)
```

is now formatted without a newline between the lhs and rhs

Bonus: the assign operator (`:->` )  is always emitted "flat" as adding newlines makes the code confusing.

Bonus #2: if-else-match has else and match on the same line