### PR TITLE
Newline top level pipes/dollars

### DIFF
--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -238,11 +238,17 @@ def t9 =
 
 
 def ff =
-    a | b | c | d
+    a
+    | b
+    | c
+    | d
 
 
 def ff =
-    a $ b $ c $ d
+    a
+    $ b
+    $ c
+    $ d
 
 
 def ff =
@@ -522,17 +528,24 @@ def toVariant =
 
 export def build: List String => Result String Error =
     match _
-        "tarball", Nil = tarball Unit | rmap (\_ "TARBALL")
+        "tarball", Nil =
+            tarball Unit
+            | rmap (\_ "TARBALL")
         kind, Nil =
             require Pass variant = toVariant kind
-            all variant | rmap (\_ "BUILD")
+            all variant
+            | rmap (\_ "BUILD")
         _ = Fail "no target specified (try: build default/debug/tarball)".makeError
 
 
 export def install: List String => Result String Error =
     match _
-        dest, kind, Nil = doInstall (in cwd dest) kind | rmap (\_ "INSTALL")
-        dest, Nil = doInstall (in cwd dest) "default" | rmap (\_ "INSTALL")
+        dest, kind, Nil =
+            doInstall (in cwd dest) kind
+            | rmap (\_ "INSTALL")
+        dest, Nil =
+            doInstall (in cwd dest) "default"
+            | rmap (\_ "INSTALL")
         _ = Fail "no directory specified (try: install /opt/local)".makeError
 
 
@@ -550,7 +563,9 @@ def targets =
 
 
 def all variant =
-    require Pass x = map (_ variant) targets | findFail
+    require Pass x =
+        map (_ variant) targets
+        | findFail
     Pass (flatten x)
 
 
@@ -578,7 +593,8 @@ def setVersion release file =
         sed "s/@VERSION@/%{release}/g" "%{in.getPathName}" > "%{file}.tmp"
         mv "%{file}.tmp" "%{file}"
         %"
-    shellJob script (in, Nil) | getJobOutput
+    shellJob script (in, Nil)
+    | getJobOutput
 
 
 # Create a release tarball
@@ -598,7 +614,11 @@ def tarball Unit =
         | filter (!matches `(\.circleci/|\.github/).*|\.dockerignore` _.getPathName) # omit CI files
         | filter (!matches `(.*/)*\.gitignore` _.getPathName) # omit git files
     def Pair testPaths wakePaths = splitBy (matches `tests/.*` _.getPathName) srcs
-    def wakeSourcesString = wakePaths | map (_.getPathName.format) | foldr (_, ",\n  ", _) Nil | cat
+    def wakeSourcesString =
+        wakePaths
+        | map (_.getPathName.format)
+        | foldr (_, ",\n  ", _) Nil
+        | cat
     def testSourcesString =
         testPaths
         | map (getPathName _ | format | replace `^"tests/` '"{here}/')
@@ -636,7 +656,9 @@ def tarball Unit =
                     which "tar"
                 else
                     gnutar
-            def files = map getPathName (manifest, testManifest, spec, srcs) | sortBy (_ <* _)
+            def files =
+                map getPathName (manifest, testManifest, spec, srcs)
+                | sortBy (_ <* _)
             tar,
             "--mtime={time}",
             "--transform=s@^@wake-{release}/@",
@@ -646,7 +668,8 @@ def tarball Unit =
             "-cJf",
             "wake_{release}.tar.xz",
             files
-        job cmd (manifest, testManifest, spec, srcs) | getJobOutput
+        job cmd (manifest, testManifest, spec, srcs)
+        | getJobOutput
     Pass (tarball, changelog, Nil)
 
 
@@ -667,7 +690,8 @@ export def static _: Result Path Error =
         "-cJf",
         "wake-static_{release}.tar.xz",
         map getPathName files | sortBy (_ <* _)
-    job cmd files | getJobOutput
+    job cmd files
+    | getJobOutput
 
 
 from test_wake import topic wakeTestBinary

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1131,22 +1131,30 @@ wcl::doc Emitter::walk_binary(ctx_t ctx, CSTElement node) {
     parts = collect_right_binary(op_token, node);
   }
 
-  std::vector<wcl::optional<wcl::doc>> choices = {
-      // 1
-      combine_flat(op_token, ctx, parts),
-      // 2
-      combine_explode_first(op_token, ctx, parts),
-      // 3
-      combine_explode_last(op_token, ctx, parts),
-      // 4
-      combine_explode_all(op_token, ctx, parts),
-      // 5
-      combine_explode_first_compress(op_token, ctx, parts),
-      // 6
-      combine_explode_last_compress(op_token, ctx, parts),
-  };
+  if (!ctx.nested_binop &&
+      (op_token.id() == TOKEN_OP_DOLLAR ||
+       (op_token.id() == TOKEN_OP_OR && op_token.fragment().segment().str() == "|"))) {
+    MEMO_RET(select_best_choice({
+        combine_explode_first(op_token, ctx.binop(), parts),
+        combine_explode_last(op_token, ctx.binop(), parts),
+        combine_explode_all(op_token, ctx.binop(), parts),
+    }));
+  }
 
-  MEMO_RET(select_best_choice(choices));
+  MEMO_RET(select_best_choice({
+      // 1
+      combine_flat(op_token, ctx.binop(), parts),
+      // 2
+      combine_explode_first(op_token, ctx.binop(), parts),
+      // 3
+      combine_explode_last(op_token, ctx.binop(), parts),
+      // 4
+      combine_explode_all(op_token, ctx.binop(), parts),
+      // 5
+      combine_explode_first_compress(op_token, ctx.binop(), parts),
+      // 6
+      combine_explode_last_compress(op_token, ctx.binop(), parts),
+  }));
 }
 
 wcl::doc Emitter::walk_block(ctx_t ctx, CSTElement node) {

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -168,6 +168,11 @@ static bool is_op_suffix(const CSTElement& op) {
   }
 }
 
+// determines if a given binop matches a given type and string literal
+static inline bool is_binop_matching_str(const CSTElement& op, cst_id_t type, std::string lit) {
+  return op.id() == type && op.fragment().segment().str() == lit;
+}
+
 static size_t count_leading_newlines(const token_traits_map_t& traits, const CSTElement& node) {
   CSTElement token = node;
   while (token.isNode()) {
@@ -1132,8 +1137,8 @@ wcl::doc Emitter::walk_binary(ctx_t ctx, CSTElement node) {
   }
 
   if (!ctx.nested_binop &&
-      (op_token.id() == TOKEN_OP_DOLLAR ||
-       (op_token.id() == TOKEN_OP_OR && op_token.fragment().segment().str() == "|"))) {
+      (is_binop_matching_str(op_token, TOKEN_OP_DOLLAR, "$") ||
+       is_binop_matching_str(op_token, TOKEN_OP_OR, "|"))) {
     MEMO_RET(select_best_choice({
         combine_explode_first(op_token, ctx.binop(), parts),
         combine_explode_last(op_token, ctx.binop(), parts),

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1136,9 +1136,8 @@ wcl::doc Emitter::walk_binary(ctx_t ctx, CSTElement node) {
     parts = collect_right_binary(op_token, node);
   }
 
-  if (!ctx.nested_binop &&
-      (is_binop_matching_str(op_token, TOKEN_OP_DOLLAR, "$") ||
-       is_binop_matching_str(op_token, TOKEN_OP_OR, "|"))) {
+  if (!ctx.nested_binop && (is_binop_matching_str(op_token, TOKEN_OP_DOLLAR, "$") ||
+                            is_binop_matching_str(op_token, TOKEN_OP_OR, "|"))) {
     MEMO_RET(select_best_choice({
         combine_explode_first(op_token, ctx.binop(), parts),
         combine_explode_last(op_token, ctx.binop(), parts),

--- a/tools/wake-format/types.h
+++ b/tools/wake-format/types.h
@@ -44,6 +44,7 @@ struct ctx_t {
   // 1: By default, don't explode unless you have to
   // 2: if prefer_explode, explode if you can
   bool prefer_explode = false;
+  bool nested_binop = false;
 
   ctx_t nest() const {
     ctx_t copy = *this;
@@ -54,6 +55,12 @@ struct ctx_t {
   ctx_t explode() {
     ctx_t copy = *this;
     copy.prefer_explode = true;
+    return copy;
+  }
+
+  ctx_t binop() {
+    ctx_t copy = *this;
+    copy.nested_binop = true;
     return copy;
   }
 
@@ -68,7 +75,7 @@ struct ctx_t {
 
   bool operator==(const ctx_t& other) const {
     return state == other.state && nest_level == other.nest_level &&
-           prefer_explode == other.prefer_explode;
+           prefer_explode == other.prefer_explode && nested_binop == other.nested_binop;
   }
 };
 


### PR DESCRIPTION
PTAL a look at the formatting @ag-eitilt but I wouldn't focus on the C++ implementation for the moment. I want to tweak how we add things to ctx_t so it'll probably change a bit.

This is the implementation of the rules
 -  always newline `|` and `$` when they are the "root" of a binary op chain
 - when `|` and `$` are not the root, apply the normal binop formatting rules (don't newline if you fit)