### PR TITLE
Use npm ci to build in CI per the docs

### DIFF
--- a/extensions/vscode/vscode.wake
+++ b/extensions/vscode/vscode.wake
@@ -63,7 +63,7 @@ export def vscode _: Result Path Error =
         setVersion (replace `~` "-" release) "{here}/package.json"
 
     require Pass nodeModules =
-        makeExecPlan (which "npm", "install", Nil) (packageJSON, packageLockJSON, Nil)
+        makeExecPlan (which "npm", "ci", Nil) (packageJSON, packageLockJSON, Nil)
         | setPlanDirectory here
         | runJob
         | getJobOutputs

--- a/extensions/vscode/vscode.wake
+++ b/extensions/vscode/vscode.wake
@@ -99,7 +99,7 @@ export def vscode _: Result Path Error =
         nodeModules
 
     require Pass outputs =
-        makeExecPlan (which "npx", "@vscode/vsce", "package", Nil) vsceFiles
+        makeExecPlan (which "npx", "vsce@1.103.1", "package", Nil) vsceFiles
         | setPlanDirectory here
         | runJob
         | getJobOutputs

--- a/extensions/vscode/vscode.wake
+++ b/extensions/vscode/vscode.wake
@@ -99,7 +99,7 @@ export def vscode _: Result Path Error =
         nodeModules
 
     require Pass outputs =
-        makeExecPlan (which "npx", "@vscode/vsce@1.103.1", "package", Nil) vsceFiles
+        makeExecPlan (which "npx", "@vscode/vsce", "package", Nil) vsceFiles
         | setPlanDirectory here
         | runJob
         | getJobOutputs

--- a/extensions/vscode/vscode.wake
+++ b/extensions/vscode/vscode.wake
@@ -99,7 +99,7 @@ export def vscode _: Result Path Error =
         nodeModules
 
     require Pass outputs =
-        makeExecPlan (which "npx", "vsce@1.103.1", "package", Nil) vsceFiles
+        makeExecPlan (which "npx", "@vscode/vsce@1.103.1", "package", Nil) vsceFiles
         | setPlanDirectory here
         | runJob
         | getJobOutputs


### PR DESCRIPTION
Per https://docs.npmjs.com/cli/v9/commands/npm-ci, use `npm ci` instead of `npm install`.

In the long term we may want a `make vscode-ci` and `make vscode-dev` but this unblocks CI for now and enables landing other important changes.