### PR TITLE
Add --single-fork option to wakebox to ensure fuse-waked exits before wakebox

### DIFF
--- a/src/wakefs/fuse.cpp
+++ b/src/wakefs/fuse.cpp
@@ -127,13 +127,13 @@ static bool collect_result_metadata(const std::string daemon_output, const struc
   return !result_ss.fail();
 }
 
-bool run_in_fuse(fuse_args &args, int &status, std::string &result_json) {
+bool run_in_fuse(fuse_args &args, bool single_fork, int &status, std::string &result_json) {
   if (0 != chdir(args.working_dir.c_str())) {
     std::cerr << "chdir " << args.working_dir << ": " << strerror(errno) << std::endl;
     return false;
   }
 
-  if (!args.daemon.connect(args.visible)) return false;
+  if (!args.daemon.connect(args.visible, single_fork)) return false;
 
   struct timeval start;
   gettimeofday(&start, 0);

--- a/src/wakefs/fuse.h
+++ b/src/wakefs/fuse.h
@@ -19,6 +19,8 @@
 #ifndef FUSE_H
 #define FUSE_H
 
+#include <wcl/optional.h>
+
 #include <string>
 #include <vector>
 
@@ -40,10 +42,12 @@ struct daemon_client {
   const std::string subdir_live_file;
   // JSON input file to the fuse daemon, listing which files should be visible.
   const std::string visibles_path;
+  // The child process if we single forked
+  wcl::optional<pid_t> child_pid;
 
   daemon_client(const std::string &base_dir);
 
-  bool connect(std::vector<std::string> &visible);
+  bool connect(std::vector<std::string> &visible, bool single_fork);
   bool disconnect(std::string &result);
 
  protected:
@@ -82,6 +86,6 @@ struct fuse_args : public json_args {
 
 bool json_as_struct(const std::string &json, json_args &result);
 
-bool run_in_fuse(fuse_args &args, int &retcode, std::string &result_json);
+bool run_in_fuse(fuse_args &args, bool single_fork, int &retcode, std::string &result_json);
 
 #endif

--- a/tools/fuse-waked/fuse-waked.cpp
+++ b/tools/fuse-waked/fuse-waked.cpp
@@ -1537,7 +1537,7 @@ int main(int argc, char *argv[]) {
    * This anti-feature was added in 2.4.0 and removed in 3.0.0.
    */
   if (fuse_opt_add_arg(&args, "wake") != 0 || fuse_opt_add_arg(&args, "-o") != 0 ||
-      fuse_opt_add_arg(&args, "nonempty") != 0) {
+      fuse_opt_add_arg(&args, "nonempty,auto_unmount") != 0) {
 #else
   if (fuse_opt_add_arg(&args, "wake") != 0) {
 #endif


### PR DESCRIPTION
We've observed some unusual cases where the fuse mounts stay around and fuse-waked seems to have been killed already (I think this is as yet unverified in our case). Rather than searching for the bug in our signal handling and exit logic or digging into how these processes are being killed, Richard suggested that we might try `auto_unmount` so that if fuse-waked dies without unmounting for some reason, it should unmount anyway.