### PR TITLE
Add ability to emit compile commands for wake code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ manifest.wake
 .build
 .fuse*
 compile_commands.json
-/compile_commands
+/.compile_commands
 /.vscode/*.log
 /**/wake.db*
 /wake.db*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ manifest.wake
 *.o
 .build
 .fuse*
+compile_commands.json
+/compile_commands
 /.vscode/*.log
 /**/wake.db*
 /wake.db*

--- a/scripts/compile_commands
+++ b/scripts/compile_commands
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+rm -rf compile_commands
+EMIT_COMPILE_COMMANDS=1 make
+python3 ./scripts/compile_commands.py

--- a/scripts/compile_commands
+++ b/scripts/compile_commands
@@ -1,5 +1,5 @@
 #! /bin/bash
 
-rm compile_commands/*.json
+rm .compile_commands/*.json
 EMIT_COMPILE_COMMANDS=1 make
 python3 ./scripts/compile_commands.py

--- a/scripts/compile_commands
+++ b/scripts/compile_commands
@@ -1,5 +1,5 @@
 #! /bin/bash
 
-rm -rf compile_commands
+rm compile_commands/*.json
 EMIT_COMPILE_COMMANDS=1 make
 python3 ./scripts/compile_commands.py

--- a/scripts/compile_commands.py
+++ b/scripts/compile_commands.py
@@ -18,7 +18,7 @@ from os.path import isfile, join
 import json
 
 out = []
-cmd_dir = "compile_commands"
+cmd_dir = ".compile_commands"
 for compile_command_path in [f for f in listdir(cmd_dir) if isfile(join(cmd_dir, f))]:
     with open(join(cmd_dir, compile_command_path)) as compile_command_file:
         cmd_json = json.load(compile_command_file)

--- a/scripts/compile_commands.py
+++ b/scripts/compile_commands.py
@@ -1,0 +1,28 @@
+# Copyright 2022 SiFive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You should have received a copy of LICENSE.Apache2 along with
+# this software. If not, you may obtain a copy at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from os import listdir
+from os.path import isfile, join
+import json
+
+out = []
+cmd_dir = "compile_commands"
+for compile_command_path in [f for f in listdir(cmd_dir) if isfile(join(cmd_dir, f))]:
+    with open(join(cmd_dir, compile_command_path)) as compile_command_file:
+        cmd_json = json.load(compile_command_file)
+        out.append(cmd_json)
+
+with open("compile_commands.json", "w") as compile_cmd_json:
+    json.dump(out, compile_cmd_json, indent=2)

--- a/share/wake/lib/gcc_wake/gcc.wake
+++ b/share/wake/lib/gcc_wake/gcc.wake
@@ -63,7 +63,6 @@ def doCompileC variant gcc flags headers cfile =
 
     def get f = prim "get_hash"
     def path_hash = get (cfile.getPathName)
-    #require Pass _ = mkdir "compile_commands"
     def cmd_file_path = "compile_commands/{path_hash}.json"
 
     require Pass _ = write cmd_file_path (prettyJSON outJson)

--- a/share/wake/lib/gcc_wake/gcc.wake
+++ b/share/wake/lib/gcc_wake/gcc.wake
@@ -25,15 +25,50 @@ export def releaseLFlags = (Nil)
 export def staticCFlags =  ("-Wall", "-Wno-format-security", "-O2", "-flto", Nil)
 export def staticLFlags  = ("-flto", "-static", "-s", Nil)
 
+target pwd _ =
+    makeExecPlan ("pwd",) Nil
+    | setPlanLocalOnly True
+    | runJob
+    | getJobStdout
+
 def doCompileC variant gcc flags headers cfile =
     def obj = replace `\.c(pp)?$` ".{variant}.o" cfile.getPathName
     def cmdline =
         gcc, flags ++
         ("-c", cfile.getPathName, "-frandom-seed={obj}", "-o", obj, Nil)
-    makeExecPlan cmdline (cfile, headers)
-    | setPlanLabel "compile {replace `^.*/` '' gcc} {obj}"
-    | runJob
-    | getJobOutputs
+
+    def emitCompileCmd =
+        require Some var = getenv "EMIT_COMPILE_COMMANDS"
+        else False
+
+        var ==~ "1"
+
+    def out =
+      makeExecPlan cmdline (cfile, headers)
+      | setPlanLabel "compile {replace `^.*/` '' gcc} {obj}"
+      | runJob
+      | getJobOutputs
+
+    require True = emitCompileCmd
+    else out
+
+    require Pass pwd_out = pwd Unit
+    def dir = replace `[\n]` "" pwd_out
+
+    def outJson = JObject (
+        "directory" :-> JString dir,
+        "arguments" :-> JArray $ map JString cmdline,
+        "file" :-> JString "cfile.getPathName",
+    )
+
+    def get f = prim "get_hash"
+    def path_hash = get (cfile.getPathName)
+    #require Pass _ = mkdir "compile_commands"
+    def cmd_file_path = "compile_commands/{path_hash}.json"
+
+    require Pass _ = write cmd_file_path (prettyJSON outJson)
+
+    out
 
 def doLinkO variant linker flags objects targ extraFiles =
     def cmdline =
@@ -84,7 +119,7 @@ def pickVariant variant variants =
 
 export def compileC (variant: String) (extraFlags: List String) (headers: List Path) (cfile: Path) : Result (List Path) Error =
     require Pass compileFn = pickVariant variant (subscribe compileC)
-    compileFn extraFlags headers cfile 
+    compileFn extraFlags headers cfile
 
 export def linkO    (variant: String) (extraFlags: List String) (objects: List Path) (targ: String) (extraFiles: List Path) : Result (List Path) Error =
     require Pass linkFn = pickVariant variant (subscribe linkO)

--- a/share/wake/lib/gcc_wake/gcc.wake
+++ b/share/wake/lib/gcc_wake/gcc.wake
@@ -63,7 +63,7 @@ def doCompileC variant gcc flags headers cfile =
 
     def get f = prim "get_hash"
     def path_hash = get (cfile.getPathName)
-    def cmd_file_path = "compile_commands/{path_hash}.json"
+    def cmd_file_path = ".compile_commands/{path_hash}.json"
 
     require Pass _ = write cmd_file_path (prettyJSON outJson)
 


### PR DESCRIPTION
This change adds a "simple-enough" means to create a compile_commands.json file for the wake repo. The process is as follows

```
rm -rf compile_commands # Make sure we remove old compile commands
EMIT_COMPILE_COMMANDS=1 make # It shouldn't matter if the build is clean, this also works with `wake build <variant>`
python3 ./scripts/compile_commands.py
```

...wait I just realized that that always works so I think I'm going to add a bash script too