### PR TITLE
Warn on unused import

### DIFF
--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -1183,17 +1183,18 @@ static std::unique_ptr<Expr> fracture(std::unique_ptr<Top> top) {
 
       for (auto &import : file.content->imports.topics) {
         const std::string &qualified = import.second.qualified;
+        const std::string &topic_qualified = "topic " + import.second.qualified;
         const Location &location = import.second.fragment.location();
 
         filename = location.filename;
-        imports.insert({qualified, {0, location}});
+        imports.insert({topic_qualified, {0, location}});
 
         std::size_t at_pos = qualified.find("@");
         if (at_pos == std::string::npos) {
           continue;
         }
 
-        unqualified_to_qualified.insert({qualified.substr(0, at_pos), qualified});
+        unqualified_to_qualified.insert({qualified.substr(0, at_pos), topic_qualified});
       }
 
       // File doesn't have any import for us to verify
@@ -1220,7 +1221,7 @@ static std::unique_ptr<Expr> fracture(std::unique_ptr<Top> top) {
       }
 
       for (auto &publish : file.pubs) {
-        // If the publish was an imported publish, mark it as used
+        // Publishing to an imported topic should mark the topic as used
         auto qual_it = unqualified_to_qualified.find(publish.first);
         if (qual_it == unqualified_to_qualified.end()) {
           continue;

--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -1263,9 +1263,8 @@ static std::unique_ptr<Expr> fracture(std::unique_ptr<Top> top) {
           continue;
         }
 
-        WARNING(import.second.second, "unused import of '" << import.first
-                                                           << "'; consider removing. ("
-                                                           << import.second.first << ")");
+        WARNING(import.second.second,
+                "unused import of '" << import.first << "'; consider removing.");
       }
     }
   }

--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -1166,8 +1166,9 @@ static std::unique_ptr<Expr> fracture(std::unique_ptr<Top> top) {
 
         std::size_t at_pos = qualified.find("@");
         if (at_pos == std::string::npos) {
-          printf("unqualified ref: %s\n", qualified.c_str());
+          continue;
         }
+
         unqualified_to_qualified.insert({qualified.substr(0, at_pos), qualified});
       }
 
@@ -1180,8 +1181,9 @@ static std::unique_ptr<Expr> fracture(std::unique_ptr<Top> top) {
 
         std::size_t at_pos = qualified.find("@");
         if (at_pos == std::string::npos) {
-          printf("unqualified ref: %s\n", qualified.c_str());
+          continue;
         }
+
         unqualified_to_qualified.insert({qualified.substr(0, at_pos), qualified});
       }
 

--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -1162,6 +1162,15 @@ static std::unique_ptr<Expr> fracture(std::unique_ptr<Top> top) {
         const Location &location = import.second.fragment.location();
 
         filename = location.filename;
+
+        // TODO: Fix this. Its challenging to detect when a type has
+        // been used. Instead of solving that just ignore type imports for now
+        // This means some types will be imported when not used but some unused
+        // import warnings are better than none.
+        if (qualified[0] >= 'A' && qualified[0] <= 'Z') {
+          continue;
+        }
+
         imports.insert({qualified, {0, location}});
 
         std::size_t at_pos = qualified.find("@");

--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -976,9 +976,9 @@ static std::unique_ptr<Expr> fracture(Top &top, bool anon, const std::string &na
     asc->body = fracture(top, true, name, std::move(asc->body), binding);
     if (qualify_type(binding, asc->signature)) {
       return expr;
+    } else {
+      return std::move(asc->body);
     }
-
-    return std::move(asc->body);
   } else if (expr->type == &Prim::type) {
     // Use all the arguments
     for (ResolveBinding *iter = binding; iter && iter->defs.size() == 1 && !iter->defs[0].expr;

--- a/tests/dst/packages/stderr
+++ b/tests/dst/packages/stderr
@@ -24,7 +24,11 @@ test3.wake:7:[6-9]: package-local type 'Pkg1' also defined at test.wake:38:[13-1
 test.wake:38:[13-16]: package-local type 'Pkg1' also defined at test3.wake:7:[6-9]
 test3.wake:9:[7-10]: package-local topic 'pkg1' also defined at test.wake:40:[14-17]
 test.wake:40:[14-17]: package-local topic 'pkg1' also defined at test3.wake:9:[7-10]
-test.wake:51:[26-31]: (warning) unused import of 'unused@some_package'
+test.wake:9:[18-26]: (warning) unused import of 'Pair@wake'; consider removing.
+test.wake:11:[18-24]: (warning) unused import of 'binary +@wake'; consider removing.
+test.wake:15:[18-20]: (warning) unused import of 'map@wake'; consider removing.
+test.wake:11:[18-24]: (warning) unused import of 'unary +@wake'; consider removing.
+test.wake:51:[26-31]: (warning) unused import of 'unused@some_package'; consider removing.
 test.wake:27:[5-8]: (warning) unused top-level definition of 'bug2'; consider removing or renaming to _bug2
 test2.wake:7:[21-25]: (warning) unused top-level definition of 'Glob1'; consider removing or renaming to _Glob1
 test2.wake:4:[12-16]: (warning) unused top-level definition of 'glob1'; consider removing or renaming to _glob1

--- a/tests/dst/packages/stderr
+++ b/tests/dst/packages/stderr
@@ -26,6 +26,7 @@ test3.wake:9:[7-10]: package-local topic 'pkg1' also defined at test.wake:40:[14
 test.wake:40:[14-17]: package-local topic 'pkg1' also defined at test3.wake:9:[7-10]
 test.wake:11:[18-24]: (warning) unused import of 'binary +@wake'; consider removing.
 test.wake:15:[18-20]: (warning) unused import of 'map@wake'; consider removing.
+test.wake:53:[26-36]: (warning) unused import of 'topic unusedTopic@some_package'; consider removing.
 test.wake:11:[18-24]: (warning) unused import of 'unary +@wake'; consider removing.
 test.wake:51:[26-31]: (warning) unused import of 'unused@some_package'; consider removing.
 test.wake:27:[5-8]: (warning) unused top-level definition of 'bug2'; consider removing or renaming to _bug2

--- a/tests/dst/packages/stderr
+++ b/tests/dst/packages/stderr
@@ -24,7 +24,6 @@ test3.wake:7:[6-9]: package-local type 'Pkg1' also defined at test.wake:38:[13-1
 test.wake:38:[13-16]: package-local type 'Pkg1' also defined at test3.wake:7:[6-9]
 test3.wake:9:[7-10]: package-local topic 'pkg1' also defined at test.wake:40:[14-17]
 test.wake:40:[14-17]: package-local topic 'pkg1' also defined at test3.wake:9:[7-10]
-test.wake:9:[18-26]: (warning) unused import of 'Pair@wake'; consider removing.
 test.wake:11:[18-24]: (warning) unused import of 'binary +@wake'; consider removing.
 test.wake:15:[18-20]: (warning) unused import of 'map@wake'; consider removing.
 test.wake:11:[18-24]: (warning) unused import of 'unary +@wake'; consider removing.

--- a/tests/dst/packages/stderr
+++ b/tests/dst/packages/stderr
@@ -24,6 +24,7 @@ test3.wake:7:[6-9]: package-local type 'Pkg1' also defined at test.wake:38:[13-1
 test.wake:38:[13-16]: package-local type 'Pkg1' also defined at test3.wake:7:[6-9]
 test3.wake:9:[7-10]: package-local topic 'pkg1' also defined at test.wake:40:[14-17]
 test.wake:40:[14-17]: package-local topic 'pkg1' also defined at test3.wake:9:[7-10]
+test.wake:51:[26-31]: (warning) unused import of 'unused@some_package'
 test.wake:27:[5-8]: (warning) unused top-level definition of 'bug2'; consider removing or renaming to _bug2
 test2.wake:7:[21-25]: (warning) unused top-level definition of 'Glob1'; consider removing or renaming to _Glob1
 test2.wake:4:[12-16]: (warning) unused top-level definition of 'glob1'; consider removing or renaming to _glob1

--- a/tests/dst/packages/test.wake
+++ b/tests/dst/packages/test.wake
@@ -47,8 +47,16 @@ global data Glob1 = Glob1
 #test.wake:32:[14-18]: global topic 'glob1' also defined at test2.wake:5:[14-18]
 global topic glob1: String
 
-#test.wake:50:[26-31]: (warning) unused import of 'unused@some_package'
+#test.wake:53:[26-36]: (warning) unused import of 'topic unusedTopic@some_package'; consider removing.
 from some_package import unused
+#test.wake:53:[26-36]: (warning) unused import of 'topic unusedTopic@some_package'; consider removing.
+from some_package import unusedTopic
+# No warning because its used
+from some_package import usedTopic
+
+export def usedTopicSubscribe =
+  def x = subscribe usedTopic
+  x
 
 export def test _ =
   Pass "Fail"

--- a/tests/dst/packages/test.wake
+++ b/tests/dst/packages/test.wake
@@ -47,5 +47,8 @@ global data Glob1 = Glob1
 #test.wake:32:[14-18]: global topic 'glob1' also defined at test2.wake:5:[14-18]
 global topic glob1: String
 
+#test.wake:50:[26-31]: (warning) unused import of 'unused@some_package'
+from some_package import unused
+
 export def test _ =
   Pass "Fail"

--- a/tests/dst/packages/test4.wake
+++ b/tests/dst/packages/test4.wake
@@ -1,0 +1,3 @@
+package some_package
+
+export def unused = "hello"

--- a/tests/dst/packages/test4.wake
+++ b/tests/dst/packages/test4.wake
@@ -1,3 +1,6 @@
 package some_package
 
 export def unused = "hello"
+
+export topic unusedTopic: Integer
+export topic usedTopic: Integer


### PR DESCRIPTION
Emit an LSP warning on unused import. Right now it only works for qualified imports but should be possible to support import all imports.

One thing I'm not sure about is how we roll out to existing users without causing a bunch of warnings? Maybe we are okay with doing that? Not sure if many folks use "warn as fail" or not.