### PR TITLE
Decrease nesting in DST, and clear warning of unused release() value

### DIFF
--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -516,7 +516,7 @@ static std::unique_ptr<Expr> expand_patterns(const std::string &fnname,
           p->index = -2;
         }
       }
-      std::unique_ptr<DefMap> rmap(new DefMap(fragment));
+      DefMap *rmap = new DefMap(fragment);
       rmap->body = expand_patterns(fnname, bucket);
       if (!rmap->body) return nullptr;
       for (size_t i = args; i > 0; --i) {
@@ -524,8 +524,7 @@ static std::unique_ptr<Expr> expand_patterns(const std::string &fnname,
             "_ a" + std::to_string(--var), DefValue(FRAGMENT_CPP_LINE, std::move(gets[i - 1]))));
         assert(out.second);
       }
-      DefMap *unowned_rmap = rmap.release();
-      Lambda *lam = new Lambda(unowned_rmap->body->fragment, "_ tuple_case", unowned_rmap);
+      Lambda *lam = new Lambda(rmap->body->fragment, "_ tuple_case", rmap);
       lam->fnname = fnname;
       des->cases.emplace_back(lam);
       for (auto p = patterns.rbegin(); p != patterns.rend(); ++p) {
@@ -573,8 +572,8 @@ static std::unique_ptr<Expr> expand_patterns(const std::string &fnname,
           DefValue(p.fragment, std::unique_ptr<Expr>(
                                    new App(p.fragment, new VarRef(p.fragment, "getPairSecond@wake"),
                                            new VarRef(p.fragment, "_ guardpair"))))));
-      Expr *guard_true(new App(p.fragment, new VarRef(p.fragment, "_ rhs"),
-                               new VarRef(p.fragment, "Unit@wake")));
+      Expr *guard_true =
+          new App(p.fragment, new VarRef(p.fragment, "_ rhs"), new VarRef(p.fragment, "Unit@wake"));
       std::unique_ptr<Destruct> des(
           new Destruct(fragment, Boolean,
                        new App(p.fragment, new VarRef(p.fragment, "_ guard"),

--- a/src/dst/bind.cpp
+++ b/src/dst/bind.cpp
@@ -707,8 +707,7 @@ static std::unique_ptr<Expr> rebind_match(const std::string &fnname, ResolveBind
       std::string cname =
           match->patterns.size() == 1 ? fnname : fnname + ".case" + std::to_string(f);
       auto frag = p.expr->fragment;
-      expr = std::unique_ptr<Expr>(
-          new Lambda(frag, "_", p.expr.release(), cname.c_str()));
+      expr = std::unique_ptr<Expr>(new Lambda(frag, "_", p.expr.release(), cname.c_str()));
     }
     if (p.guard) {
       patterns.back().guard_fragment = p.guard->fragment;


### PR DESCRIPTION
The following refactors were done
 - if { return} else if { return} else { blah } -> if { return} if {return} blah
 - there was a previous change to fix UB where we replaced `release()` with `get()` then `release()` discarding the `release()` value which is a (very valid & important) warning. I re-wrote this so it captures the unowned var to pass around