### PR TITLE
Make the version tag safe to use in node

### DIFF
--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -62,20 +62,20 @@ def buildOn Unit = match (subscribe releaseOn)
 #       ^^^
 # which breaks node's version requiement and is considered invalid
 #
-# Capture the parts and insert '-post-' between the version and the commit. 
+# Capture the parts and insert '-plus-' between the version and the commit. 
 # Do nothing if the version is already safe.
 def mk_node_semver_safe v =
-    def unsafe_version_regex = `(v?[0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-(.*)`
-    #                           ^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^  ^^^^
-    #                           |                          |        |
-    #                           |                          |        | The "rest", everything after the '-' after the commit number
-    #                           |                          | The number of commits since the tagged version, surrounded by '-'
-    #                           | Matches the version tag, which should be 3 numbers separated by '.' with an optional leading 'v'
+    def unsafe_version_regex = `^(v?[0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-(.*)`
+    #                            ^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^  ^^^^
+    #                            |                          |        |
+    #                            |                          |        | The "rest", everything after the '-' after the commit number
+    #                            |                          | The number of commits since the tagged version, surrounded by '-'
+    #                            | Matches the version tag, which should be 3 numbers separated by '.' with an optional leading 'v'
     require True = matches unsafe_version_regex  v
     else v
 
     match (extract unsafe_version_regex v)
         version, commit, rest, Nil =
-            (version, "-post-", commit, "-", rest,)
+            (version, "-plus-", commit, "-", rest,)
             | cat
         _ = v

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -20,26 +20,6 @@ topic releaseAs: String
 def buildAs Unit = match (subscribe releaseAs)
     version, Nil = Pass version
     _ =
-        # Process the version when the version number and commit count are adjacent.
-        # v0.15.0-4-g6efe8e9
-        #       ^^^
-        # Without intervention this becomes
-        # v0.15.0.4-g6efe8e9
-        #       ^^^
-        # which breaks node's version requiement and is considered invalid
-        #
-        # Capture the two halves 'v0.15.0', '4-g6efe8e9' and insert '-safe-' in the middle
-        # Do nothing if the version is already safe.
-        def mk_node_semver_safe v =
-            require True = matches `.+[0-9]-[0-9].+` v
-            else v
-
-            match (extract `(.+[0-9])-([0-9].+)` v)
-                left, right, Nil =
-                    (left,"-safe-", right,)
-                    | cat
-                _ = v
-
         def cmdline = which "git", "describe", "--tags", "--dirty", Nil
 
         require Pass stdout =
@@ -73,3 +53,29 @@ def buildOn Unit = match (subscribe releaseOn)
             | runJob
             | getJobStdout
         Pass (replace `\n.*` '' stdout)
+
+# Process the version when the version number and commit count are adjacent.
+# v0.15.0-4-g6efe8e9
+#       ^^^
+# Without intervention this becomes
+# v0.15.0.4-g6efe8e9
+#       ^^^
+# which breaks node's version requiement and is considered invalid
+#
+# Capture the two halves 'v0.15.0', '4-g6efe8e9' and insert '-post-' in the middle
+# Do nothing if the version is already safe.
+def mk_node_semver_safe v =
+    def unsafe_version_regex = `(v?[0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-(.*)`
+    #                    ^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^  ^^^^
+    #                    |                          |        |
+    #                    |                          |        | The "rest", everything after the '-' after the commit number
+    #                    |                          | The number of commits since the tagged version, surrounded by '-'
+    #                    | Matches the version tag, which should be 3 numbers separated by '.' with an optional leading 'v'
+    require True = matches unsafe_version_regex  v
+    else v
+
+    match (extract unsafe_version_regex v)
+        version, commit, rest, Nil =
+            (version, "-post-", commit, "-", rest,)
+            | cat
+        _ = v

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -66,11 +66,11 @@ def buildOn Unit = match (subscribe releaseOn)
 # Do nothing if the version is already safe.
 def mk_node_semver_safe v =
     def unsafe_version_regex = `(v?[0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-(.*)`
-    #                    ^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^  ^^^^
-    #                    |                          |        |
-    #                    |                          |        | The "rest", everything after the '-' after the commit number
-    #                    |                          | The number of commits since the tagged version, surrounded by '-'
-    #                    | Matches the version tag, which should be 3 numbers separated by '.' with an optional leading 'v'
+    #                           ^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^  ^^^^
+    #                           |                          |        |
+    #                           |                          |        | The "rest", everything after the '-' after the commit number
+    #                           |                          | The number of commits since the tagged version, surrounded by '-'
+    #                           | Matches the version tag, which should be 3 numbers separated by '.' with an optional leading 'v'
     require True = matches unsafe_version_regex  v
     else v
 

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -20,7 +20,28 @@ topic releaseAs: String
 def buildAs Unit = match (subscribe releaseAs)
     version, Nil = Pass version
     _ =
+        # Process the version when the version number and commit count are adjacent.
+        # v0.15.0-4-g6efe8e9
+        #       ^^^
+        # Without intervention this becomes
+        # v0.15.0.4-g6efe8e9
+        #       ^^^
+        # which breaks node's version requiement and is considered invalid
+        #
+        # Capture the two halves 'v0.15.0', '4-g6efe8e9' and insert '-safe-' in the middle
+        # Do nothing if the version is already safe.
+        def mk_node_semver_safe v =
+            require True = matches `.+[0-9]-[0-9].+` v
+            else v
+
+            match (extract `(.+[0-9])-([0-9].+)` v)
+                left, right, Nil =
+                    (left,"-safe-", right,)
+                    | cat
+                _ = v
+
         def cmdline = which "git", "describe", "--tags", "--dirty", Nil
+
         require Pass stdout =
             makeExecPlan cmdline Nil
             | setPlanKeep False
@@ -29,6 +50,7 @@ def buildAs Unit = match (subscribe releaseAs)
             | runJob
             | getJobStdout
         stdout
+        | mk_node_semver_safe
         | replace `^v|\n.*` ''
         | replace `-([0-9]{1,3})-` '.\1+'
         | replace `-` '~'

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -62,7 +62,7 @@ def buildOn Unit = match (subscribe releaseOn)
 #       ^^^
 # which breaks node's version requiement and is considered invalid
 #
-# Capture the two halves 'v0.15.0', '4-g6efe8e9' and insert '-post-' in the middle
+# Capture the parts and insert '-post-' between the version and the commit. 
 # Do nothing if the version is already safe.
 def mk_node_semver_safe v =
     def unsafe_version_regex = `(v?[0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-(.*)`


### PR DESCRIPTION
Landing the non `alpha` tag on `master` broke how versions were generating for non-release CI builds. This fixes it so that node/npm doesn't fail to build in those cases by inserting `safe` where `alpha` normally goes if it is missing