### PR TITLE
Suppress slow disk warning when --quiet is set

### DIFF
--- a/src/parser/wakefiles.cpp
+++ b/src/parser/wakefiles.cpp
@@ -157,7 +157,7 @@ bool push_files(int ok, char *files, std::vector<std::string> &out, const re2::R
 }
 
 bool push_files(std::vector<std::string> &out, const std::string &path, const re2::RE2 &re,
-                size_t skip) {
+                size_t skip, FILE * /* warn_dest*/) {
   int ok;
   char *files = vscode_getfiles(path.c_str(), &ok);
   return push_files(ok, files, out, re, skip);
@@ -528,7 +528,7 @@ std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbo
     });
     // clang-format on
     if (isNode) {
-      if (push_files(libfiles, libdir, exp, 0)) ok = false;
+      if (push_files(libfiles, libdir, exp, 0, user_warning_dest)) ok = false;
     } else {
       if (push_packaged_stdlib_files(libfiles, exp, 0)) ok = false;
     }

--- a/src/parser/wakefiles.h
+++ b/src/parser/wakefiles.h
@@ -26,10 +26,11 @@ class RE2;
 };
 
 bool push_files(std::vector<std::string> &out, const std::string &path, const re2::RE2 &re,
-                size_t skip);
+                size_t skip, FILE *user_warning_dest);
 std::string make_canonical(const std::string &x);
 std::string glob2regexp(const std::string &glob);
 std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbose,
-                                            const std::string &libdir, const std::string &workdir);
+                                            const std::string &libdir, const std::string &workdir,
+                                            FILE *user_warning_dest);
 
 #endif

--- a/src/runtime/sources.cpp
+++ b/src/runtime/sources.cpp
@@ -440,7 +440,7 @@ static PRIMFN(prim_files) {
   size_t skip = (root == ".") ? 0 : (root.size() + 1);
 
   std::vector<std::string> match;
-  bool fail = push_files(match, root, *arg1->exp, skip);
+  bool fail = push_files(match, root, *arg1->exp, skip, stdout);
   (void)fail;  // !!! There's a hole in the API
 
   size_t need = reserve_list(match.size());

--- a/src/wcl/defer.h
+++ b/src/wcl/defer.h
@@ -39,8 +39,8 @@ class defer {
   defer() = delete;
   defer(const defer&) = delete;
   defer(defer&&) = default;
-  defer(F&& f) : f(wcl::inplace_t{}, std::move(f)) {}
-  defer(const F& f) : f(wcl::inplace_t{}, f) {}
+  defer(F&& f) : f(wcl::in_place_t{}, std::move(f)) {}
+  defer(const F& f) : f(wcl::in_place_t{}, f) {}
 
   void nullify() { f = {}; }
 
@@ -51,7 +51,7 @@ class defer {
 
 template <class F>
 defer<F> make_defer(F&& f) {
-  return defer(std::forward<F>(f));
+  return defer<F>(std::forward<F>(f));
 }
 
 // NOTE: opt_defer requires a dynamic memory allocation,
@@ -63,10 +63,12 @@ class opt_defer {
   wcl::optional<std::function<void()>> f;
 
  public:
+  opt_defer() = default;
   opt_defer(const opt_defer&) = delete;
   opt_defer(opt_defer&& d) = default;
+  opt_defer& operator=(opt_defer&&) = default;
   template <class F>
-  opt_defer(F&& f) : f(wcl::inplace_t{}, std::forward<F>(f)) {}
+  opt_defer(F&& f) : f(wcl::in_place_t{}, std::forward<F>(f)) {}
   ~opt_defer() {
     if (f) (*f)();
   }

--- a/tools/lsp-wake/astree.cpp
+++ b/tools/lsp-wake/astree.cpp
@@ -62,7 +62,7 @@ void ASTree::diagnoseProject(const std::function<void(FileDiagnostics &)> &proce
   comments.clear();
 
   bool enumok = true;
-  auto allFiles = find_all_wakefiles(enumok, true, false, absLibDir, absWorkDir);
+  auto allFiles = find_all_wakefiles(enumok, true, false, absLibDir, absWorkDir, stdout);
 
   std::map<std::string, std::vector<Diagnostic>> diagnostics;
   LSPReporter lspReporter(diagnostics, allFiles);

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -570,7 +570,7 @@ int main(int argc, char **argv) {
   bool enumok = true;
   std::string libdir = make_canonical(find_execpath() + "/../share/wake/lib");
   auto wakefilenames =
-      find_all_wakefiles(enumok, workspace, verbose, libdir, ".", quiet ? stdout : stderr);
+      find_all_wakefiles(enumok, workspace, verbose, libdir, ".", user_warn);
   if (!enumok) {
     if (verbose) std::cerr << "Workspace wake file enumeration failed" << std::endl;
     // Try to run the build anyway; if wake files are missing, it will fail later

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <wcl/defer.h>
 
 #include <algorithm>
 #include <chrono>
@@ -563,8 +564,10 @@ int main(int argc, char **argv) {
   if (noparse) return 0;
 
   FILE *user_warn = stdout;
+  wcl::opt_defer user_warn_defer;
   if (quiet) {
     user_warn = fopen("/dev/null", "w");
+    user_warn_defer = wcl::make_opt_defer([&]() { fclose(user_warn); });
   }
 
   bool enumok = true;
@@ -574,10 +577,6 @@ int main(int argc, char **argv) {
     if (verbose) std::cerr << "Workspace wake file enumeration failed" << std::endl;
     // Try to run the build anyway; if wake files are missing, it will fail later
     // The unreadable location might be irrelevant to the build
-  }
-
-  if (quiet) {
-    fclose(user_warn);
   }
 
   Profile tree;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -569,8 +569,7 @@ int main(int argc, char **argv) {
 
   bool enumok = true;
   std::string libdir = make_canonical(find_execpath() + "/../share/wake/lib");
-  auto wakefilenames =
-      find_all_wakefiles(enumok, workspace, verbose, libdir, ".", user_warn);
+  auto wakefilenames = find_all_wakefiles(enumok, workspace, verbose, libdir, ".", user_warn);
   if (!enumok) {
     if (verbose) std::cerr << "Workspace wake file enumeration failed" << std::endl;
     // Try to run the build anyway; if wake files are missing, it will fail later

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -562,7 +562,7 @@ int main(int argc, char **argv) {
 
   if (noparse) return 0;
 
-  FILE* user_warn = stdout;
+  FILE *user_warn = stdout;
   if (quiet) {
     user_warn = fopen("/dev/null", "w");
   }


### PR DESCRIPTION
I'm not sure that I'm happy with this implementation, but I don't know how else to do it.

The MacOS builder is running slow enough that the warning is emitted to stdout and causing the tests to fail (however only on release build for some reason). I wanted to nip this in the bud before it became a larger issue.

Since the tests all set the -q flag, this will suppress the warning from triggering during the tests.