### PR TITLE
add wcl::defer

### DIFF
--- a/src/wcl/defer.h
+++ b/src/wcl/defer.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace wcl {
+template <class F>
+class defer {
+private:
+  F f;
+  bool moved = false;
+
+public:
+  defer(const defer&) = delete;
+  defer(defer&& d) : f(std::move(d.f)) {
+    d.moved = true;
+  }
+  defer(F&& f) : f(std::move(f)) {}
+  defer(const F& f) : f(f) {}
+  ~defer() {
+    if(!moved) f();
+  }
+};
+
+template <class F>
+auto make_defer(F&& f) -> defer<F> {
+  return defer<F>(f);
+}
+
+}

--- a/src/wcl/defer.h
+++ b/src/wcl/defer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 SiFive, Inc.
+ * Copyright 2023 SiFive, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/wcl/defer.h
+++ b/src/wcl/defer.h
@@ -20,19 +20,17 @@
 namespace wcl {
 template <class F>
 class defer {
-private:
+ private:
   F f;
   bool moved = false;
 
-public:
+ public:
   defer(const defer&) = delete;
-  defer(defer&& d) : f(std::move(d.f)) {
-    d.moved = true;
-  }
+  defer(defer&& d) : f(std::move(d.f)) { d.moved = true; }
   defer(F&& f) : f(std::move(f)) {}
   defer(const F& f) : f(f) {}
   ~defer() {
-    if(!moved) f();
+    if (!moved) f();
   }
 };
 
@@ -41,4 +39,4 @@ auto make_defer(F&& f) -> defer<F> {
   return defer<F>(f);
 }
 
-}
+}  // namespace wcl


### PR DESCRIPTION
I think I'm going to modify this so that the function inside is a wcl::optional. This will give us the desired move semantics by default AND will allow default construction....still I'm trying think of how to modify this so that you don't have to use std::function<void()> and yet you can still declare it. Ideally I want to capture this pattern

```
wcl::defer opt_resource_defer;
ResourceType optional_resource;
if (my_condition_here) {
  optional_resource = make_the_resource;
  opt_resource_defer = wcl::make_defer([&]() {
    clean_up_resource(optional_resource);
  });
}
```