### PR TITLE
Explicitly call into add_bool instead of relying on implict choice by compiler

### DIFF
--- a/src/json/json5.h
+++ b/src/json/json5.h
@@ -75,7 +75,7 @@ struct JAST {
 
   // Add a child to a JObject
   JAST &add(std::string key, SymbolJSON kind, std::string &&value);
-  JAST &add(std::string key, bool value) {
+  JAST &add_bool(std::string key, bool value) {
     if (value)
       return add(std::move(key), JSON_TRUE, "true");
     else

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -1684,7 +1684,7 @@ static PRIMFN(prim_job_cache_read) {
   // If nothing is found return a simple error message
   if (!result) {
     JAST out_json(JSON_OBJECT);
-    out_json.add("found", static_cast<bool>(false));
+    out_json.add_bool("found", static_cast<bool>(false));
     std::stringstream result_json_stream;
     result_json_stream << out_json;
     std::string s = result_json_stream.str();
@@ -1696,7 +1696,7 @@ static PRIMFN(prim_job_cache_read) {
   // If a job is found however we need to return some information about it
   JAST jast_result = result->to_json();
   JAST out_json(JSON_OBJECT);
-  out_json.add("found", static_cast<bool>(result));
+  out_json.add_bool("found", static_cast<bool>(result));
   out_json.add("match", result->to_json());
 
   // Because I'm very lazy however we also return a string and not a JValue.


### PR DESCRIPTION
Some of the json functions in the LSP code were incorrectly using the new bool json function do to implict operator overloading.

This broke the LSP; the change below makes bool `add`s explicit