### PR TITLE
colorless --failed

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -90,7 +90,6 @@ struct Database::detail {
   sqlite3_stmt *remove_all_jobs;
   sqlite3_stmt *get_unhashed_file_paths;
   sqlite3_stmt *insert_unhashed_file;
-  sqlite3_stmt *find_failed_outputs;
   sqlite3_stmt *get_interleaved_output;
 
   long run_id;
@@ -136,7 +135,6 @@ struct Database::detail {
         get_edges(0),
         get_job_visualization(0),
         get_file_access(0),
-        find_failed_outputs(0),
         get_interleaved_output(0) {}
 };
 
@@ -467,12 +465,6 @@ std::string Database::open(bool wait, bool memory, bool tty) {
   const char *sql_remove_all_jobs = "delete from jobs";
   const char *sql_get_unhashed_file_paths = "select path from unhashed_files";
   const char *sql_insert_unhashed_file = "insert into unhashed_files(job_id, path) values(?, ?)";
-  const char *sql_find_failed_outputs =
-      "select j.job_id, j.label, j.directory, j.commandline, j.environment, l.output, l.descriptor"
-      " from jobs j left join stats s on j.stat_id=s.stat_id join log l on j.job_id=l.job_id"
-      " where s.status <> 0"
-      " order by j.job_id, l.seconds";
-
   const char *sql_get_interleaved_output =
       "select l.output, l.descriptor"
       " from log l"
@@ -531,7 +523,6 @@ std::string Database::open(bool wait, bool memory, bool tty) {
   PREPARE(sql_remove_all_jobs, remove_all_jobs);
   PREPARE(sql_get_unhashed_file_paths, get_unhashed_file_paths);
   PREPARE(sql_insert_unhashed_file, insert_unhashed_file);
-  PREPARE(sql_find_failed_outputs, find_failed_outputs);
   PREPARE(sql_get_interleaved_output, get_interleaved_output);
 
   return "";
@@ -595,7 +586,6 @@ void Database::close() {
   FINALIZE(remove_all_jobs);
   FINALIZE(get_unhashed_file_paths);
   FINALIZE(insert_unhashed_file);
-  FINALIZE(find_failed_outputs);
   FINALIZE(get_interleaved_output);
 
   close_db(imp.get());

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -71,22 +71,13 @@ struct JobReflection {
   Time endtime;
   Time wake_start;
   std::string wake_cmdline;
-  std::string stdout_payload;
-  std::string stderr_payload;
+  // List of interleaved writes to stdout and stderr
+  std::vector<std::pair<std::string, int>> std_writes;
   Usage usage;
   std::vector<FileReflection> visible;
   std::vector<FileReflection> inputs;
   std::vector<FileReflection> outputs;
   std::vector<JobTag> tags;
-};
-
-struct JobOutput {
-  long job;
-  std::string label;
-  std::string directory;
-  std::vector<std::string> commandline;
-  std::vector<std::string> environment;
-  std::vector<std::pair<std::string, int>> outputs;
 };
 
 struct JobEdge {
@@ -160,13 +151,13 @@ struct Database {
 
   std::string get_hash(const std::string &file, long modified);
 
-  std::vector<JobReflection> explain(long job, bool verbose);
+  std::vector<JobReflection> explain(long job);
 
-  std::vector<JobReflection> explain(const std::string &file, int use, bool verbose);
+  std::vector<JobReflection> explain(const std::string &file, int use);
 
-  std::vector<JobReflection> failed(bool verbose);
+  std::vector<JobReflection> failed();
 
-  std::vector<JobReflection> last(bool verbose);
+  std::vector<JobReflection> last();
 
   std::vector<JobEdge> get_edges();
   std::vector<JobTag> get_tags();
@@ -174,7 +165,7 @@ struct Database {
   std::vector<JobReflection> get_job_visualization() const;
   std::vector<FileAccess> get_file_accesses() const;
 
-  std::vector<JobOutput> failed_output() const;
+  std::vector<std::pair<std::string, int>> get_interleaved_output(long job_id) const;
 };
 
 #endif

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -80,6 +80,15 @@ struct JobReflection {
   std::vector<JobTag> tags;
 };
 
+struct JobOutput {
+  long job;
+  std::string label;
+  std::string directory;
+  std::vector<std::string> commandline;
+  std::vector<std::string> environment;
+  std::vector<std::pair<std::string, int>> outputs;
+};
+
 struct JobEdge {
   long user;
   long used;
@@ -164,6 +173,8 @@ struct Database {
 
   std::vector<JobReflection> get_job_visualization() const;
   std::vector<FileAccess> get_file_accesses() const;
+
+  std::vector<JobOutput> failed_output() const;
 };
 
 #endif

--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -215,14 +215,10 @@ void describe_human(const std::vector<JobReflection> &jobs) {
     }
     std::cout << "\n\n";
 
-    std::cout << "================================================\n" << std::endl;
-
     // We have to use our speical stream for the output of the program
     for (auto &log_line : job.std_writes) {
       std::cout << log_line.first;
     }
-
-    std::cout << "------------------------------------------------\n" << std::endl;
   }
 }
 

--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -51,7 +51,7 @@ static std::string describe_hash(const std::string &hash, bool verbose, bool sta
   return hash.substr(0, SHORT_HASH);
 }
 
-static void describe_human(const std::vector<JobReflection> &jobs, bool debug, bool verbose) {
+static void describe_metadata(const std::vector<JobReflection> &jobs, bool debug, bool verbose) {
   for (auto &job : jobs) {
     std::cout << "Job " << job.job;
     if (!job.label.empty()) std::cout << " (" << job.label << ")";
@@ -87,14 +87,32 @@ static void describe_human(const std::vector<JobReflection> &jobs, bool debug, b
       std::cout << "Stack:";
       indent("  ", job.stack);
     }
-    if (!job.stdout_payload.empty()) {
+
+    std::vector<std::string> stdout_writes;
+    std::vector<std::string> stderr_writes;
+    for (auto &write : job.std_writes) {
+      if (write.second == 1) {
+        stdout_writes.push_back(write.first);
+      }
+      if (write.second == 2) {
+        stderr_writes.push_back(write.first);
+      }
+    }
+
+    if (!stdout_writes.empty()) {
       std::cout << "Stdout:";
-      indent("  ", job.stdout_payload);
+      for (std::string write : stdout_writes) {
+        indent("  ", write);
+      }
     }
-    if (!job.stderr_payload.empty()) {
+
+    if (!stderr_writes.empty()) {
       std::cout << "Stderr:";
-      indent("  ", job.stderr_payload);
+      for (std::string write : stderr_writes) {
+        indent("  ", write);
+      }
     }
+
     if (!job.tags.empty()) {
       std::cout << "Tags:" << std::endl;
       for (auto &x : job.tags) {
@@ -151,14 +169,32 @@ static void describe_shell(const std::vector<JobReflection> &jobs, bool debug, b
       std::cout << "# Stack:";
       indent("#   ", job.stack);
     }
-    if (!job.stdout_payload.empty()) {
+
+    std::vector<std::string> stdout_writes;
+    std::vector<std::string> stderr_writes;
+    for (auto &write : job.std_writes) {
+      if (write.second == 1) {
+        stdout_writes.push_back(write.first);
+      }
+      if (write.second == 2) {
+        stderr_writes.push_back(write.first);
+      }
+    }
+
+    if (!stdout_writes.empty()) {
       std::cout << "# Stdout:";
-      indent("#   ", job.stdout_payload);
+      for (std::string write : stdout_writes) {
+        indent("#   ", write);
+      }
     }
-    if (!job.stderr_payload.empty()) {
+
+    if (!stderr_writes.empty()) {
       std::cout << "# Stderr:";
-      indent("#   ", job.stderr_payload);
+      for (std::string write : stderr_writes) {
+        indent("#   ", write);
+      }
     }
+
     if (!job.tags.empty()) {
       std::cout << "# Tags:" << std::endl;
       for (auto &x : job.tags) {
@@ -169,33 +205,53 @@ static void describe_shell(const std::vector<JobReflection> &jobs, bool debug, b
   }
 }
 
-void describe(const std::vector<JobReflection> &jobs, bool script, bool debug, bool verbose,
-              const char *taguri) {
-  if (taguri) {
-    for (auto &job : jobs)
-      for (auto &tag : job.tags)
-        if (tag.uri == taguri) std::cout << tag.content << std::endl;
-  } else if (script) {
-    describe_shell(jobs, debug, verbose);
-  } else {
-    describe_human(jobs, debug, verbose);
-  }
-}
-
-void describe_failed(const std::vector<JobOutput> &jobs) {
+void describe_human(const std::vector<JobReflection> &jobs) {
   for (auto &job : jobs) {
-    std::cout << "\n# " << job.label << "(" << job.job << ")\n";
+    std::cout << "\n# " << job.label << "(" << job.job << ")\n$ ";
     for (auto &cmd_part : job.commandline) {
       std::cout << cmd_part << " ";  // # TODO: don't output trailing space
     }
-    std::cout << ":\n\n";
+    std::cout << "\n\n";
+
+    std::cout << "================================================\n" << std::endl;
 
     // We have to use our speical stream for the output of the program
-    for (auto &log_line : job.outputs) {
+    for (auto &log_line : job.std_writes) {
       std::cout << log_line.first;
     }
 
-    std::cout << "\n" << std::endl;
+    std::cout << "------------------------------------------------\n" << std::endl;
+  }
+}
+
+void describe(const std::vector<JobReflection> &jobs, DescribePolicy policy) {
+  switch (policy.type) {
+    case policy.SCRIPT: {
+      describe_shell(jobs, true, true);
+      break;
+    }
+    case policy.HUMAN: {
+      describe_human(jobs);
+      break;
+    }
+    case policy.TAG_URI: {
+      for (auto &job : jobs)
+        for (auto &tag : job.tags)
+          if (tag.uri == policy.tag_uri) std::cout << tag.content << std::endl;
+      break;
+    }
+    case policy.METADATA: {
+      describe_metadata(jobs, false, false);
+      break;
+    }
+    case policy.DEBUG: {
+      describe_metadata(jobs, true, false);
+      break;
+    }
+    case policy.VERBOSE: {
+      describe_metadata(jobs, false, true);
+      break;
+    }
   }
 }
 

--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -182,6 +182,23 @@ void describe(const std::vector<JobReflection> &jobs, bool script, bool debug, b
   }
 }
 
+void describe_failed(const std::vector<JobOutput> &jobs) {
+  for (auto &job : jobs) {
+    std::cout << "\n# " << job.label << "(" << job.job << ")\n";
+    for (auto &cmd_part : job.commandline) {
+      std::cout << cmd_part << " ";  // # TODO: don't output trailing space
+    }
+    std::cout << ":\n\n";
+
+    // We have to use our speical stream for the output of the program
+    for (auto &log_line : job.outputs) {
+      std::cout << log_line.first;
+    }
+
+    std::cout << "\n" << std::endl;
+  }
+}
+
 class BitVector {
  public:
   BitVector() : imp() {}

--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -99,17 +99,19 @@ static void describe_metadata(const std::vector<JobReflection> &jobs, bool debug
       }
     }
 
-    if (!stdout_writes.empty()) {
-      std::cout << "Stdout:";
-      for (std::string write : stdout_writes) {
-        indent("  ", write);
+    if (verbose) {
+      if (!stdout_writes.empty()) {
+        std::cout << "Stdout:";
+        for (std::string write : stdout_writes) {
+          indent("  ", write);
+        }
       }
-    }
 
-    if (!stderr_writes.empty()) {
-      std::cout << "Stderr:";
-      for (std::string write : stderr_writes) {
-        indent("  ", write);
+      if (!stderr_writes.empty()) {
+        std::cout << "Stderr:";
+        for (std::string write : stderr_writes) {
+          indent("  ", write);
+        }
       }
     }
 
@@ -226,29 +228,29 @@ void describe_human(const std::vector<JobReflection> &jobs) {
 
 void describe(const std::vector<JobReflection> &jobs, DescribePolicy policy) {
   switch (policy.type) {
-    case policy.SCRIPT: {
+    case DescribePolicy::SCRIPT: {
       describe_shell(jobs, true, true);
       break;
     }
-    case policy.HUMAN: {
+    case DescribePolicy::HUMAN: {
       describe_human(jobs);
       break;
     }
-    case policy.TAG_URI: {
+    case DescribePolicy::TAG_URI: {
       for (auto &job : jobs)
         for (auto &tag : job.tags)
           if (tag.uri == policy.tag_uri) std::cout << tag.content << std::endl;
       break;
     }
-    case policy.METADATA: {
+    case DescribePolicy::METADATA: {
       describe_metadata(jobs, false, false);
       break;
     }
-    case policy.DEBUG: {
+    case DescribePolicy::DEBUG: {
       describe_metadata(jobs, true, false);
       break;
     }
-    case policy.VERBOSE: {
+    case DescribePolicy::VERBOSE: {
       describe_metadata(jobs, false, true);
       break;
     }

--- a/tools/wake/describe.h
+++ b/tools/wake/describe.h
@@ -30,18 +30,41 @@ struct DescribePolicy {
   };
 
   static DescribePolicy tag_url(const char *tag_uri) {
-    return DescribePolicy{.type = TAG_URI, .tag_uri = tag_uri};
+    DescribePolicy policy;
+    policy.type = TAG_URI;
+    policy.tag_uri = tag_uri;
+    return policy;
   }
 
-  static DescribePolicy script() { return DescribePolicy{.type = SCRIPT}; }
+  static DescribePolicy script() {
+    DescribePolicy policy;
+    policy.type = SCRIPT;
+    return policy;
+  }
 
-  static DescribePolicy human() { return DescribePolicy{.type = HUMAN}; }
+  static DescribePolicy human() {
+    DescribePolicy policy;
+    policy.type = HUMAN;
+    return policy;
+  }
 
-  static DescribePolicy metadata() { return DescribePolicy{.type = METADATA}; }
+  static DescribePolicy metadata() {
+    DescribePolicy policy;
+    policy.type = METADATA;
+    return policy;
+  }
 
-  static DescribePolicy debug() { return DescribePolicy{.type = DEBUG}; }
+  static DescribePolicy debug() {
+    DescribePolicy policy;
+    policy.type = DEBUG;
+    return policy;
+  }
 
-  static DescribePolicy verbose() { return DescribePolicy{.type = VERBOSE}; }
+  static DescribePolicy verbose() {
+    DescribePolicy policy;
+    policy.type = VERBOSE;
+    return policy;
+  }
 };
 
 void describe(const std::vector<JobReflection> &jobs, DescribePolicy policy);

--- a/tools/wake/describe.h
+++ b/tools/wake/describe.h
@@ -23,9 +23,27 @@
 #include "json/json5.h"
 #include "runtime/database.h"
 
-void describe_failed(const std::vector<JobOutput> &jobs);
-void describe(const std::vector<JobReflection> &jobs, bool script, bool debug, bool verbose,
-              const char *tag);
+struct DescribePolicy {
+  enum type { TAG_URI, SCRIPT, HUMAN, METADATA, DEBUG, VERBOSE } type;
+  union {
+    const char *tag_uri;
+  };
+
+  static DescribePolicy tag_url(const char *tag_uri) {
+    return {.type = TAG_URI, .tag_uri = tag_uri};
+  }
+  static DescribePolicy script() { return {.type = SCRIPT}; }
+
+  static DescribePolicy human() { return {.type = HUMAN}; }
+
+  static DescribePolicy metadata() { return {.type = METADATA}; }
+
+  static DescribePolicy debug() { return {.type = DEBUG}; }
+
+  static DescribePolicy verbose() { return {.type = VERBOSE}; }
+};
+
+void describe(const std::vector<JobReflection> &jobs, DescribePolicy policy);
 JAST create_tagdag(Database &db, const std::string &tag);
 
 #endif

--- a/tools/wake/describe.h
+++ b/tools/wake/describe.h
@@ -30,17 +30,18 @@ struct DescribePolicy {
   };
 
   static DescribePolicy tag_url(const char *tag_uri) {
-    return {.type = TAG_URI, .tag_uri = tag_uri};
+    return DescribePolicy{.type = TAG_URI, .tag_uri = tag_uri};
   }
-  static DescribePolicy script() { return {.type = SCRIPT}; }
 
-  static DescribePolicy human() { return {.type = HUMAN}; }
+  static DescribePolicy script() { return DescribePolicy{.type = SCRIPT}; }
 
-  static DescribePolicy metadata() { return {.type = METADATA}; }
+  static DescribePolicy human() { return DescribePolicy{.type = HUMAN}; }
 
-  static DescribePolicy debug() { return {.type = DEBUG}; }
+  static DescribePolicy metadata() { return DescribePolicy{.type = METADATA}; }
 
-  static DescribePolicy verbose() { return {.type = VERBOSE}; }
+  static DescribePolicy debug() { return DescribePolicy{.type = DEBUG}; }
+
+  static DescribePolicy verbose() { return DescribePolicy{.type = VERBOSE}; }
 };
 
 void describe(const std::vector<JobReflection> &jobs, DescribePolicy policy);

--- a/tools/wake/describe.h
+++ b/tools/wake/describe.h
@@ -23,6 +23,7 @@
 #include "json/json5.h"
 #include "runtime/database.h"
 
+void describe_failed(const std::vector<JobOutput> &jobs);
 void describe(const std::vector<JobReflection> &jobs, bool script, bool debug, bool verbose,
               const char *tag);
 JAST create_tagdag(Database &db, const std::string &tag);

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -553,7 +553,11 @@ int main(int argc, char **argv) {
   }
 
   if (failed) {
-    describe(db.failed(verbose || tag), script, debug, verbose, tag);
+    if (verbose) {
+      describe(db.failed(verbose || tag), script, debug, verbose, tag);
+    } else {
+      describe_failed(db.failed_output());
+    }
   }
 
   if (tagdag) {

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -104,6 +104,7 @@ void print_help(const char *argv0) {
     << "    --last     -l    Report recorded meta-data for all jobs run by last build"   << std::endl
     << "    --failed   -f    Report recorded meta-data for jobs which failed last build" << std::endl
     << "    --verbose  -v    Report recorded standard output and error of matching jobs" << std::endl
+    << "    --metadata       Report recorded metadata without output of matching jobs"   << std::endl
     << "    --debug    -d    Report recorded stack frame of matching jobs"               << std::endl
     << "    --script   -s    Format reported jobs as an executable shell script"         << std::endl
     << "    --timeline       Print the timeline of wake jobs as HTML"                    << std::endl
@@ -176,6 +177,7 @@ int main(int argc, char **argv) {
     {0, "lsp", GOPT_ARGUMENT_FORBIDDEN},
     {'f', "failed", GOPT_ARGUMENT_FORBIDDEN},
     {'s', "script", GOPT_ARGUMENT_FORBIDDEN},
+    {0, "metadata", GOPT_ARGUMENT_FORBIDDEN},
     {0, "init", GOPT_ARGUMENT_REQUIRED},
     {0, "version", GOPT_ARGUMENT_FORBIDDEN},
     {'g', "globals", GOPT_ARGUMENT_FORBIDDEN},
@@ -224,6 +226,7 @@ int main(int argc, char **argv) {
   bool lsp = arg(options, "lsp")->count;
   bool failed = arg(options, "failed")->count;
   bool script = arg(options, "script")->count;
+  bool metadata = arg(options, "metadata")->count;
   bool version = arg(options, "version")->count;
   bool html = arg(options, "html")->count;
   bool global = arg(options, "globals")->count;
@@ -527,37 +530,53 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  DescribePolicy policy = DescribePolicy::human();
+
+  if (tag) {
+    policy = DescribePolicy::tag_url(tag);
+  }
+
+  if (script) {
+    policy = DescribePolicy::script();
+  }
+
+  if (metadata) {
+    policy = DescribePolicy::metadata();
+  }
+
+  if (debug) {
+    policy = DescribePolicy::debug();
+  }
+
+  if (verbose) {
+    policy = DescribePolicy::verbose();
+  }
+
   if (job) {
-    auto hits = db.explain(std::atol(job), verbose || tag);
-    describe(hits, script, debug, verbose, tag);
+    auto hits = db.explain(std::atol(job));
+    describe(hits, policy);
     if (hits.empty())
       std::cerr << "Job '" << job << "' was not found in the database!" << std::endl;
   }
 
   if (input) {
     for (int i = 1; i < argc; ++i) {
-      describe(db.explain(make_canonical(wake_cwd + argv[i]), 1, verbose || tag), script, debug,
-               verbose, tag);
+      describe(db.explain(make_canonical(wake_cwd + argv[i]), 1), policy);
     }
   }
 
   if (output) {
     for (int i = 1; i < argc; ++i) {
-      describe(db.explain(make_canonical(wake_cwd + argv[i]), 2, verbose || tag), script, debug,
-               verbose, tag);
+      describe(db.explain(make_canonical(wake_cwd + argv[i]), 2), policy);
     }
   }
 
   if (last) {
-    describe(db.last(verbose || tag), script, debug, verbose, tag);
+    describe(db.last(), policy);
   }
 
   if (failed) {
-    if (verbose) {
-      describe(db.failed(verbose || tag), script, debug, verbose, tag);
-    } else {
-      describe_failed(db.failed_output());
-    }
+    describe(db.failed(), policy);
   }
 
   if (tagdag) {

--- a/tools/wake/timeline.cpp
+++ b/tools/wake/timeline.cpp
@@ -54,8 +54,10 @@ void write_job_reflections(std::ostream &os, const std::vector<JobReflection> &j
     job_json.add("wake_start", jobReflection.wake_start.as_int64());
 
     job_json.add("wake_cmdline", jobReflection.wake_cmdline.c_str());
-    job_json.add("stdout_payload", jobReflection.stdout_payload.c_str());
-    job_json.add("stderr_payload", jobReflection.stderr_payload.c_str());
+
+    // TODO: figure out what this is supposed to be
+    // job_json.add("stdout_payload", jobReflection.stdout_payload.c_str());
+    // job_json.add("stderr_payload", jobReflection.stderr_payload.c_str());
 
     std::stringstream usage;
     usage << "status: " << jobReflection.usage.status << "<br>"

--- a/tools/wake/timeline.cpp
+++ b/tools/wake/timeline.cpp
@@ -55,19 +55,19 @@ void write_job_reflections(std::ostream &os, const std::vector<JobReflection> &j
 
     job_json.add("wake_cmdline", jobReflection.wake_cmdline.c_str());
 
-    std::stringstream out_stream;
-    std::stringstream err_stream;
+    std::string out_stream;
+    std::string err_stream;
     for (auto &write : jobReflection.std_writes) {
       if (write.second == 1) {
-        out_stream << write.first;
+        out_stream += write.first;
       }
       if (write.second == 2) {
-        err_stream << write.first;
+        err_stream += write.first;
       }
     }
 
-    job_json.add("stdout_payload", out_stream.str().c_str());
-    job_json.add("stderr_payload", err_stream.str().c_str());
+    job_json.add("stdout_payload", out_stream.c_str());
+    job_json.add("stderr_payload", err_stream.c_str());
 
     std::stringstream usage;
     usage << "status: " << jobReflection.usage.status << "<br>"

--- a/tools/wake/timeline.cpp
+++ b/tools/wake/timeline.cpp
@@ -55,9 +55,19 @@ void write_job_reflections(std::ostream &os, const std::vector<JobReflection> &j
 
     job_json.add("wake_cmdline", jobReflection.wake_cmdline.c_str());
 
-    // TODO: figure out what this is supposed to be
-    // job_json.add("stdout_payload", jobReflection.stdout_payload.c_str());
-    // job_json.add("stderr_payload", jobReflection.stderr_payload.c_str());
+    std::stringstream out_stream;
+    std::stringstream err_stream;
+    for (auto& write : jobReflection.std_writes) {
+      if (write.second == 1) {
+        out_stream << write.first;
+      }
+      if (write.second == 2) {
+        out_stream << write.first;
+      }
+    }
+
+    job_json.add("stdout_payload", out_stream.str().c_str());
+    job_json.add("stderr_payload", err_stream.str().c_str());
 
     std::stringstream usage;
     usage << "status: " << jobReflection.usage.status << "<br>"

--- a/tools/wake/timeline.cpp
+++ b/tools/wake/timeline.cpp
@@ -57,7 +57,7 @@ void write_job_reflections(std::ostream &os, const std::vector<JobReflection> &j
 
     std::stringstream out_stream;
     std::stringstream err_stream;
-    for (auto& write : jobReflection.std_writes) {
+    for (auto &write : jobReflection.std_writes) {
       if (write.second == 1) {
         out_stream << write.first;
       }

--- a/tools/wake/timeline.cpp
+++ b/tools/wake/timeline.cpp
@@ -62,7 +62,7 @@ void write_job_reflections(std::ostream &os, const std::vector<JobReflection> &j
         out_stream << write.first;
       }
       if (write.second == 2) {
-        out_stream << write.first;
+        err_stream << write.first;
       }
     }
 


### PR DESCRIPTION
Previous `wake --failed` output

```
Job 6942:
  Command-line: /usr/bin/pkg-config --short-errors --modversion utf8proc
  Environment:
    PATH=/usr/bin:/bin
  Directory: .
  Built:     2023-01-31 13:18:42.072612856
  Runtime:   0.00104657
  CPUtime:   0.000832
  Mem bytes: 0
  In  bytes: 0
  Out bytes: 0
  Status:    1
  Stdin:     /dev/null
Inputs:
Outputs:
Job 6962 (compile c++ src/runtime/job.native-cpp14-release.o):
  Command-line: /usr/bin/c++ -std=c++14 -Wall -Wno-format-security -O2 -Isrc -Ivendor -pthread -Isrc -Ivendor -c src/runtime/job.cpp -frandom-seed=src/runtime/job.native-cpp14-release.o -o src/runtime/job.native-cpp14-release.o
  Environment:
    PATH=/usr/bin:/bin
  Directory: .
  Built:     2023-01-31 13:18:42.957944086
  Runtime:   0.785592
  CPUtime:   0.778175
  Mem bytes: 191926272
  In  bytes: 291708
  Out bytes: 0
  Status:    1
  Stdin:     /dev/null
Inputs:
  7aa5aaee src/compat/mtime.h
  a6a49605 src/compat/physmem.h
  33578fe2 src/compat/rusage.h
  d14a7399 src/compat/sigwinch.h
  5a9394d0 src/compat/spawn.h
  cf3e3f34 src/job-cache/bloom.h
  fad83f58 src/job-cache/hash.h
  a712fe81 src/job-cache/job-cache.h
  342d3b92 src/job-cache/logging.h
  79eff2d4 src/json/json5.h
  b0c18a2b src/runtime/database.h
  b11d733b src/runtime/gc.h
  f5c10b5d src/runtime/job.cpp
  624a3bfe src/runtime/job.h
  825f087f src/runtime/poll.h
  bde4e1f2 src/runtime/prim.h
  9b49f356 src/runtime/runtime.h
  aedd0f4f src/runtime/status.h
  f1833a59 src/runtime/tuple.h
  d7d103c5 src/runtime/value.h
  8ebf67e4 src/types/data.h
  6cd5ee6a src/types/dsu.h
  a1a44d25 src/types/primfn.h
  e13433dd src/types/type.h
  59d1d705 src/util/execpath.h
  eb6f0531 src/util/file.h
  b1f44787 src/util/fragment.h
  f8b041a4 src/util/hash.h
  58b8d934 src/util/location.h
  58d80f36 src/util/mkdir_parents.h
  b350efae src/util/segment.h
  54da471e src/util/shell.h
  36ec5420 src/wcl/filepath.h
  d36b415e src/wcl/optional.h
  a37b2f5d src/wcl/trie.h
  fe67a6bf src/wcl/xoshiro_256.h
  0b2a75e4 vendor/blake2/blake2.h
Outputs:
Job 6963 (compile c++ src/runtime/runtime.native-cpp14-release.o):
  Command-line: /usr/bin/c++ -std=c++14 -Wall -Wno-format-security -O2 -Isrc -Ivendor -pthread -Isrc -Ivendor -c src/runtime/runtime.cpp -frandom-seed=src/runtime/runtime.native-cpp14-release.o -o src/runtime/runtime.native-cpp14-release.o
  Environment:
    PATH=/usr/bin:/bin
  Directory: .
  Built:     2023-01-31 13:18:42.787258425
  Runtime:   0.615317
  CPUtime:   0.608214
  Mem bytes: 165736448
  In  bytes: 204280
  Out bytes: 0
  Status:    1
  Stdin:     /dev/null
Inputs:
  cf3e3f34 src/job-cache/bloom.h
  fad83f58 src/job-cache/hash.h
  a712fe81 src/job-cache/job-cache.h
  342d3b92 src/job-cache/logging.h
  79eff2d4 src/json/json5.h
  2dcedee6 src/optimizer/ssa.h
  b11d733b src/runtime/gc.h
  624a3bfe src/runtime/job.h
  5b81062e src/runtime/profile.h
  29fc0bff src/runtime/runtime.cpp
  9b49f356 src/runtime/runtime.h
  aedd0f4f src/runtime/status.h
  f1833a59 src/runtime/tuple.h
  d7d103c5 src/runtime/value.h
  1d159f02 src/types/datatype.h
  a1a44d25 src/types/primfn.h
  59d1d705 src/util/execpath.h
  eb6f0531 src/util/file.h
  b1f44787 src/util/fragment.h
  f8b041a4 src/util/hash.h
  58b8d934 src/util/location.h
  58d80f36 src/util/mkdir_parents.h
  9523fa43 src/util/optional.h
  b350efae src/util/segment.h
  36ec5420 src/wcl/filepath.h
  d36b415e src/wcl/optional.h
  a37b2f5d src/wcl/trie.h
  fe67a6bf src/wcl/xoshiro_256.h
  0b2a75e4 vendor/blake2/blake2.h
Outputs:
Job 6964 (compile c++ src/runtime/status.native-cpp14-release.o):
  Command-line: /usr/bin/c++ -std=c++14 -Wall -Wno-format-security -O2 -Isrc -Ivendor -pthread -Isrc -Ivendor -c src/runtime/status.cpp -frandom-seed=src/runtime/status.native-cpp14-release.o -o src/runtime/status.native-cpp14-release.o
  Environment:
    PATH=/usr/bin:/bin
  Directory: .
  Built:     2023-01-31 13:18:42.768308207
  Runtime:   0.595752
  CPUtime:   0.556819
  Mem bytes: 155000832
  In  bytes: 93927
  Out bytes: 0
  Status:    1
  Stdin:     /dev/null
Inputs:
  d14a7399 src/compat/sigwinch.h
  cf3e3f34 src/job-cache/bloom.h
  fad83f58 src/job-cache/hash.h
  a712fe81 src/job-cache/job-cache.h
  342d3b92 src/job-cache/logging.h
  79eff2d4 src/json/json5.h
  624a3bfe src/runtime/job.h
  95c9f38c src/runtime/status.cpp
  aedd0f4f src/runtime/status.h
  59d1d705 src/util/execpath.h
  58b8d934 src/util/location.h
  58d80f36 src/util/mkdir_parents.h
  1d2e0afe src/util/term.h
  36ec5420 src/wcl/filepath.h
  d36b415e src/wcl/optional.h
  a37b2f5d src/wcl/trie.h
  fe67a6bf src/wcl/xoshiro_256.h
  0b2a75e4 vendor/blake2/blake2.h
Outputs:
```

New `wake --failed` output

```
# compile c++ src/runtime/status.native-cpp14-release.o(0)
/usr/bin/c++ -std=c++14 -Wall -Wno-format-security -O2 -Isrc -Ivendor -pthread -Isrc -Ivendor -c src/runtime/status.cpp -frandom-seed=src/runtime/status.native-cpp14-release.o -o src/runtime/status.native-cpp14-release.o :

In file included from src/runtime/status.cpp:45:
src/runtime/job.h:29:1: error: 'as' does not name a type
   29 | as int into static_cast
      | ^~
src/runtime/job.h:61:26: error: 'ResourceBudget' has not been declared
   61 |   JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool debug, bool verbose,
      |                          ^~~~~~~~~~~~~~
src/runtime/job.h:61:49: error: 'ResourceBudget' has not been declared
   61 |   JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool debug, bool verbose,
      |                                                 ^~~~~~~~~~~~~~



# compile c++ src/runtime/runtime.native-cpp14-release.o(0)
/usr/bin/c++ -std=c++14 -Wall -Wno-format-security -O2 -Isrc -Ivendor -pthread -Isrc -Ivendor -c src/runtime/runtime.cpp -frandom-seed=src/runtime/runtime.native-cpp14-release.o -o src/runtime/runtime.native-cpp14-release.o :

In file included from src/runtime/runtime.cpp:28:
src/runtime/job.h:29:1: error: 'as' does not name a type
   29 | as int into static_cast
      | ^~
src/runtime/job.h:61:26: error: 'ResourceBudget' has not been declared
   61 |   JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool debug, bool verbose,
      |                          ^~~~~~~~~~~~~~
src/runtime/job.h:61:49: error: 'ResourceBudget' has not been declared
   61 |   JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool debug, bool verbose,
      |                                                 ^~~~~~~~~~~~~~



# compile c++ src/runtime/job.native-cpp14-release.o(0)
/usr/bin/c++ -std=c++14 -Wall -Wno-format-security -O2 -Isrc -Ivendor -pthread -Isrc -Ivendor -c src/runtime/job.cpp -frandom-seed=src/runtime/job.native-cpp14-release.o -o src/runtime/job.native-cpp14-release.o :

In file included from src/runtime/job.cpp:22:
src/runtime/job.h:29:1: error: 'as' does not name a type
   29 | as int into static_cast
      | ^~
src/runtime/job.h:61:26: error: 'ResourceBudget' has not been declared
   61 |   JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool debug, bool verbose,
      |                          ^~~~~~~~~~~~~~
src/runtime/job.h:61:49: error: 'ResourceBudget' has not been declared
   61 |   JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool debug, bool verbose,
      |                                                 ^~~~~~~~~~~~~~
src/runtime/job.cpp:340:13: error: 'ResourceBudget' has not been declared
  340 | const char *ResourceBudget::parse(const char *str, ResourceBudget &output) {
      |             ^~~~~~~~~~~~~~
src/runtime/job.cpp:340:52: error: 'ResourceBudget' has not been declared
  340 | const char *ResourceBudget::parse(const char *str, ResourceBudget &output) {
      |                                                    ^~~~~~~~~~~~~~
src/runtime/job.cpp: In function 'const char* parse(const char*, int&)':
src/runtime/job.cpp:348:14: error: request for member 'percentage' in 'output', which is of non-class type 'int'
  348 |       output.percentage = percentage / 100.0;
      |              ^~~~~~~~~~
src/runtime/job.cpp:349:14: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  349 |       output.fixed = 0;
      |              ^~~~~
src/runtime/job.cpp:363:10: error: request for member 'percentage' in 'output', which is of non-class type 'int'
  363 |   output.percentage = 0;
      |          ^~~~~~~~~~
src/runtime/job.cpp:364:10: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  364 |   output.fixed = val;
      |          ^~~~~
src/runtime/job.cpp:369:22: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  369 |   overflow |= output.fixed > limit;
      |                      ^~~~~
src/runtime/job.cpp:370:10: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  370 |   output.fixed *= 1024;
      |          ^~~~~
src/runtime/job.cpp:373:22: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  373 |   overflow |= output.fixed > limit;
      |                      ^~~~~
src/runtime/job.cpp:374:10: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  374 |   output.fixed *= 1024;
      |          ^~~~~
src/runtime/job.cpp:377:22: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  377 |   overflow |= output.fixed > limit;
      |                      ^~~~~
src/runtime/job.cpp:378:10: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  378 |   output.fixed *= 1024;
      |          ^~~~~
src/runtime/job.cpp:381:22: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  381 |   overflow |= output.fixed > limit;
      |                      ^~~~~
src/runtime/job.cpp:382:10: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  382 |   output.fixed *= 1024;
      |          ^~~~~
src/runtime/job.cpp:385:22: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  385 |   overflow |= output.fixed > limit;
      |                      ^~~~~
src/runtime/job.cpp:386:10: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  386 |   output.fixed *= 1024;
      |          ^~~~~
src/runtime/job.cpp:389:22: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  389 |   overflow |= output.fixed > limit;
      |                      ^~~~~
src/runtime/job.cpp:390:10: error: request for member 'fixed' in 'output', which is of non-class type 'int'
  390 |   output.fixed *= 1024;
      |          ^~~~~
src/runtime/job.cpp: At global scope:
src/runtime/job.cpp:401:13: error: 'ResourceBudget' has not been declared
  401 | std::string ResourceBudget::format(uint64_t x) {
      |             ^~~~~~~~~~~~~~
src/runtime/job.cpp:449:34: error: 'ResourceBudget' has not been declared
  449 | JobTable::JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool debug,
      |                                  ^~~~~~~~~~~~~~
src/runtime/job.cpp:449:57: error: 'ResourceBudget' has not been declared
  449 | JobTable::JobTable(Database *db, ResourceBudget memory, ResourceBudget cpu, bool debug,
      |                                                         ^~~~~~~~~~~~~~
src/runtime/job.cpp: In constructor 'JobTable::JobTable(Database*, int, int, bool, bool, bool, bool, bool)':
src/runtime/job.cpp:460:20: error: request for member 'get' in 'cpu', which is of non-class type 'int'
  460 |   imp->limit = cpu.get(get_concurrency());
      |                    ^~~
src/runtime/job.cpp:462:28: error: request for member 'get' in 'memory', which is of non-class type 'int'
  462 |   imp->phys_limit = memory.get(get_physical_memory());
      |                            ^~~
src/runtime/job.cpp:470:8: error: 'ResourceBudget' has not been declared
  470 |     << ResourceBudget::format(imp->phys_limit) << " of memory." << std::endl;
      |        ^~~~~~~~~~~~~~



# (0)
/usr/bin/pkg-config --short-errors --modversion utf8proc :

No package 'utf8proc' found
```