### PR TITLE
Massively improved filtering and testing for TermInfoBuf

### DIFF
--- a/src/util/term.h
+++ b/src/util/term.h
@@ -61,7 +61,18 @@ class FdBuf : public std::streambuf {
 // to it as we go.
 class TermInfoBuf : public std::streambuf {
  private:
-  enum class State { default_state, esc_state, ignore_state, num_state };
+  enum class State {
+    default_state,
+    esc_state,
+    ignore_state,
+    control_seq_state,
+    unicode2_state,
+    unicode3_state,
+    unicode4_state,
+    control_seq_ignore_state,
+    os_command_ignore_state,
+    os_command_ignore_st_state
+  };
 
   State state = State::default_state;
   int cur_code = -1;

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -54,12 +54,17 @@ PASSED:
   term_basic_intense_foreground_colors
   term_basic_resets
   term_basic_resets_dumb
+  term_dumb_fuzz
   term_dumb_gcc_smoke_test
+  term_dumb_git_smoke_test
+  term_dumb_unicode_smoke_test
   term_gcc_smoke_test
+  term_git_smoke_test
   term_rich_background_colors
   term_rich_background_colors_dumb
   term_rich_foreground_colors
   term_rich_foreground_colors_dumb
+  term_unicode_smoke_test
   trie_basic
   trie_basic_const
   trie_char

--- a/tools/wake-unit/unit.h
+++ b/tools/wake-unit/unit.h
@@ -197,9 +197,32 @@ struct TestLogger {
     err->test_name = test_name;
     err->file = file;
     err->line = line;
-    err->predicate_error << "Expected:\n\t" << term_colour(TERM_MAGENTA) << json_escape(expected);
+    err->predicate_error << "Expected:\n\t"
+                         << "(" << expected.size() << ")" << term_colour(TERM_MAGENTA) << '"'
+                         << json_escape(expected) << '"';
     err->predicate_error << term_normal() << "\nBut got:\n\t";
-    err->predicate_error << term_colour(TERM_MAGENTA) << json_escape(actual);
+    err->predicate_error << "(" << actual.size() << ")" << term_colour(TERM_MAGENTA) << '"'
+                         << json_escape(actual) << '"';
+    err->predicate_error << term_normal() << std::endl;
+    return fail(*err, assert);
+  }
+
+  TestStream expect_equal(bool assert, const char* expected_, std::string actual,
+                          const char* expected_str, const char* actual_str, int line,
+                          const char* file) {
+    std::string expected = expected_;
+    if (expected == actual) return TestStream(nullptr, nullptr);
+    errors.emplace_back(new ErrorMessage);
+    auto& err = errors.back();
+    err->test_name = test_name;
+    err->file = file;
+    err->line = line;
+    err->predicate_error << "Expected:\n\t"
+                         << "(" << expected.size() << ")" << term_colour(TERM_MAGENTA) << '"'
+                         << json_escape(expected) << '"';
+    err->predicate_error << term_normal() << "\nBut got:\n\t";
+    err->predicate_error << "(" << actual.size() << ")" << term_colour(TERM_MAGENTA) << '"'
+                         << json_escape(actual) << '"';
     err->predicate_error << term_normal() << std::endl;
     return fail(*err, assert);
   }


### PR DESCRIPTION
This change drastically improves TermInfoBuf and its testing. I now have tests that near comprehensively generate content over a range of inputs that should be a super set of the vt100 mode escape sequences seen here: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Single-character-functions and the latest code passes all of these tests. Additionally to ensure Unicode characters are not unduly mutated (they shouldn't be because escape sequences tend to be 7-bit) we've also added explicit Unicode support so that all Unicode is entirely unfettered.

 