### PR TITLE
implement last-used and move old functionality to last-executed

### DIFF
--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -157,7 +157,8 @@ struct Database {
 
   std::vector<JobReflection> failed();
 
-  std::vector<JobReflection> last();
+  std::vector<JobReflection> last_exe();
+  std::vector<JobReflection> last_use();
 
   std::vector<JobEdge> get_edges();
   std::vector<JobTag> get_tags();


### PR DESCRIPTION
Running `--last` or `--last-used` will include all jobs where `used_id == the highest run_id`. This creates a stable output that ignore the cache status when capturing jobs.

`--last-executed` functions as `--last` used to where only jobs that *executed* in the last run are captured.