### PR TITLE
PID namespace for wakebox isolation

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -805,17 +805,11 @@ export def getJobStatus (job: Job): Status = match (getJobReport job)
         else
             Signaled (-status)
 
-# Implement FUSE-based Runner
-# The FUSE runner on linux supports a few isolation options via resources:
-# - "isolate/user": the Job will appear to run as root
-# - "isolate/host": make the hostname appear to be "build.local"
-# - "isolate/net": disables network access
-# - "isolate/workspace": makes the build appear run in /var/cache/wake
-#    ... if /var/cache/wake does not exist, a directory 'build/wake' is
-#        used relative to where wake has been installed
+# Location of the wake executable
 export def wakePath: String =
-    prim "execpath" # location of the wake executable
+    prim "execpath"
 
+# Implement FUSE-based Runner
 export def fuseRunner: Runner =
     def fuse = "{wakePath}/wakebox"
     def score _ = Pass 2.0
@@ -895,6 +889,8 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
                     "stdin" :-> JString stdin,
                     "resources" :-> res | map JString | JArray,
                     "version" :-> JString version,
+                    "isolate-network" :-> JBoolean False,
+                    "isolate-pids" :-> JBoolean False,
                     "mount-ops" :-> JArray (JObject ("type" :-> JString "workspace", "destination" :-> JString ".", Nil), Nil),
                     "usage" :-> JObject (
                         "status" :-> JInteger status,

--- a/src/wakefs/daemon_client.cpp
+++ b/src/wakefs/daemon_client.cpp
@@ -52,7 +52,7 @@ daemon_client::daemon_client(const std::string &base_dir)
       visibles_path(mount_path + "/.i." + std::to_string(getpid())) {}
 
 // The arg 'visible' is destroyed/moved in the interest of performance with large visible lists.
-bool daemon_client::connect(std::vector<std::string> &visible) {
+bool daemon_client::connect(std::vector<std::string> &visible, bool close_live_file) {
   int err = mkdir_with_parents(mount_path, 0775);
   if (0 != err) {
     std::cerr << "mkdir_with_parents ('" << mount_path << "'):" << strerror(err) << std::endl;
@@ -99,13 +99,13 @@ bool daemon_client::connect(std::vector<std::string> &visible) {
   }
 
   // subdir_live_file remains open until we terminate.
-  // For non-linux systems the live file will be leaked into every child process.
+  // Without a PID namespace the live file will be leaked into every child process.
   int flags = O_CREAT | O_RDWR | O_EXCL;
-#ifdef __linux__
-  // On linux systems we only allow wakebox itself to hold the live file.
-  // A PID namespace will be created to re-parent and reap all child processes.
-  flags |= O_CLOEXEC;
-#endif
+  if (close_live_file) {
+    // Only allow wakebox itself to hold the live file.
+    // A PID namespace should be created to re-parent and reap all child processes.
+    flags |= O_CLOEXEC;
+  }
   live_fd = open(subdir_live_file.c_str(), flags, 0644);
   if (live_fd == -1) {
     std::cerr << "open " << subdir_live_file << ": " << strerror(errno) << std::endl;

--- a/src/wakefs/fuse.cpp
+++ b/src/wakefs/fuse.cpp
@@ -195,7 +195,7 @@ bool run_in_fuse(fuse_args &args, int &status, std::string &result_json) {
 #ifdef __linux__
     if (args.isolate_pids) {
       pidns_args nsargs = {command, args.environment};
-      exec_in_pidns(&nsargs);
+      exec_in_pidns(nsargs);
     } else {
 #endif
       int err = execve_wrapper(command, args.environment);

--- a/src/wakefs/fuse.h
+++ b/src/wakefs/fuse.h
@@ -84,4 +84,7 @@ bool json_as_struct(const std::string &json, json_args &result);
 
 bool run_in_fuse(fuse_args &args, int &retcode, std::string &result_json);
 
+int execve_wrapper(const std::vector<std::string> &command,
+                   const std::vector<std::string> &environment);
+
 #endif

--- a/src/wakefs/fuse.h
+++ b/src/wakefs/fuse.h
@@ -43,7 +43,7 @@ struct daemon_client {
 
   daemon_client(const std::string &base_dir);
 
-  bool connect(std::vector<std::string> &visible);
+  bool connect(std::vector<std::string> &visible, bool close_live_file);
   bool disconnect(std::string &result);
 
  protected:
@@ -61,13 +61,14 @@ struct json_args {
   std::string hostname;
   std::string domainname;
   bool isolate_network;
+  bool isolate_pids;
 
   int userid;
   int groupid;
 
   std::vector<mount_op> mount_ops;
 
-  json_args() : isolate_network(false), userid(0), groupid(0) {}
+  json_args() : isolate_network(false), isolate_pids(false), userid(0), groupid(0) {}
 };
 
 struct fuse_args : public json_args {

--- a/src/wakefs/namespace.cpp
+++ b/src/wakefs/namespace.cpp
@@ -518,7 +518,7 @@ bool setup_user_namespaces(int id_user, int id_group, bool isolate_network,
   exit(-WTERMSIG(status));
 }
 
-[[noreturn]] void exec_in_pidns(pidns_args& nsargs) {
+[[noreturn]] void exec_in_pidns(pidns_args &nsargs) {
   alignas(16) uint8_t stack_buf[4096];
   void *child_stack = reinterpret_cast<void *>(stack_buf + sizeof(child_stack));
 

--- a/src/wakefs/namespace.cpp
+++ b/src/wakefs/namespace.cpp
@@ -518,21 +518,21 @@ bool setup_user_namespaces(int id_user, int id_group, bool isolate_network,
   exit(-WTERMSIG(status));
 }
 
-[[noreturn]] void exec_in_pidns(pidns_args *nsargs) {
+[[noreturn]] void exec_in_pidns(pidns_args& nsargs) {
   alignas(16) uint8_t stack_buf[4096];
   void *child_stack = reinterpret_cast<void *>(stack_buf + sizeof(child_stack));
 
   // Create a new thread in a PID namespace, calling pidns_init.
-  pid_t child_pid = clone(pidns_init, child_stack, CLONE_NEWPID | SIGCHLD, nsargs);
+  pid_t child_pid = clone(pidns_init, child_stack, CLONE_NEWPID | SIGCHLD, &nsargs);
   if (child_pid == -1) {
-    std::cerr << "clone " << nsargs->command[0] << ": " << strerror(errno) << std::endl;
+    std::cerr << "clone " << nsargs.command[0] << ": " << strerror(errno) << std::endl;
     exit(1);
   }
 
   // While we wait, the subdir_live_file for the fuse daemon will be held open.
   int status = 1;
   if (waitpid(child_pid, &status, 0) == -1) {
-    std::cerr << "waitpid (clone) " << nsargs->command[0] << std::endl;
+    std::cerr << "waitpid (clone) " << nsargs.command[0] << std::endl;
     exit(1);
   }
 

--- a/src/wakefs/namespace.cpp
+++ b/src/wakefs/namespace.cpp
@@ -433,6 +433,14 @@ bool get_workspace_dir(const std::vector<mount_op> &mount_ops,
 
 bool setup_user_namespaces(int id_user, int id_group, bool isolate_network,
                            const std::string &hostname, const std::string &domainname) {
+  // Later we will create a PID namespace.
+  // TODO explain this, if it works in CI.
+  int err = mount("proc", "/proc", "proc", 0, nullptr);
+  if (errno != EPERM && err == -1) {
+    std::cerr << "mount('proc', '/proc', 'proc', 0, nullptr): " << strerror(errno) << std::endl;
+    exit(1);
+  }
+
   uid_t real_euid = geteuid();
   gid_t real_egid = getegid();
 
@@ -465,4 +473,70 @@ bool setup_user_namespaces(int id_user, int id_group, bool isolate_network,
   return true;
 }
 
+[[noreturn]] int pidns_init(void *arg) {
+  // We should be in a new PID namespace now, label the process in 'ps'.
+  prctl(PR_SET_NAME, "wb-pid-ns", 0, 0, 0);
+
+  // A fresh mount of procfs over the previous namespace's /proc.
+  // which we can only do as we're already in a mount namespace.
+  // Note that this is not a bind mount of an existing /proc.
+  // The new procfs will have the correct data for the new PID namespace, rather
+  // than leaking process ids from the exterior namespace.
+  int err = mount("proc", "/proc", "proc", 0, nullptr);
+  if (err == -1) {
+    std::cerr << "mount('proc', '/proc', 'proc', 0, nullptr): " << strerror(errno) << std::endl;
+    exit(1);
+  }
+
+  pid_t pid = fork();
+  if (pid == 0) {
+    // Execute the user-specified command.
+    const auto *args = reinterpret_cast<const pidns_args *>(arg);
+    err = execve_wrapper(args->command, args->environment);
+    std::cerr << "execve " << args->command[0] << ": " << strerror(err) << std::endl;
+    exit(1);
+  }
+
+  // Wait for child processes, we are init(1) in this PID namespace.
+  int status;
+  while ((pid = waitpid(-1, &status, 0)) != 0) {
+    if (pid == -1) {
+      if (errno == ECHILD) {
+        break;  // all children have terminated
+      }
+      std::cerr << "waitpid: " << strerror(errno) << std::endl;
+      exit(1);
+    }
+  }
+
+  if (WIFEXITED(status)) {
+    exit(WEXITSTATUS(status));
+  }
+  exit(-WTERMSIG(status));
+}
+
+[[noreturn]] void exec_in_pidns(pidns_args *nsargs) {
+  alignas(16) uint8_t stack_buf[4096];
+  void *child_stack = reinterpret_cast<void *>(stack_buf + sizeof(child_stack));
+
+  // Create a new thread in a PID namespace, calling pidns_init.
+  pid_t child_pid = clone(pidns_init, child_stack, CLONE_NEWPID | SIGCHLD, nsargs);
+  if (child_pid == -1) {
+    std::cerr << "clone " << nsargs->command[0] << ": " << strerror(errno) << std::endl;
+    exit(1);
+  }
+
+  // While we wait, the subdir_live_file for the fuse daemon will be held open.
+  int status = 1;
+  if (waitpid(child_pid, &status, 0) == -1) {
+    std::cerr << "waitpid (clone) " << nsargs->command[0] << std::endl;
+    exit(1);
+  }
+
+  if (WIFEXITED(status)) {
+    exit(WEXITSTATUS(status));
+  } else {
+    exit(-WTERMSIG(status));
+  }
+}
 #endif

--- a/src/wakefs/namespace.h
+++ b/src/wakefs/namespace.h
@@ -45,7 +45,7 @@ struct pidns_args {
 
 [[noreturn]] int pidns_init(void *arg);
 
-[[noreturn]] void exec_in_pidns(pidns_args *nsargs);
+[[noreturn]] void exec_in_pidns(pidns_args& nsargs);
 
 #endif
 

--- a/src/wakefs/namespace.h
+++ b/src/wakefs/namespace.h
@@ -38,6 +38,15 @@ bool setup_user_namespaces(int id_user, int id_group, bool isolate_network,
 bool do_mounts(const std::vector<mount_op> &mount_ops, const std::string &fuse_mount_path,
                std::vector<std::string> &environments);
 
+struct pidns_args {
+  const std::vector<std::string> &command;
+  const std::vector<std::string> &environment;
+};
+
+[[noreturn]] int pidns_init(void *arg);
+
+[[noreturn]] void exec_in_pidns(pidns_args *nsargs);
+
 #endif
 
 #endif

--- a/src/wakefs/namespace.h
+++ b/src/wakefs/namespace.h
@@ -45,7 +45,7 @@ struct pidns_args {
 
 [[noreturn]] int pidns_init(void *arg);
 
-[[noreturn]] void exec_in_pidns(pidns_args& nsargs);
+[[noreturn]] void exec_in_pidns(pidns_args &nsargs);
 
 #endif
 


### PR DESCRIPTION
Introduces a PID namespace for wakebox (linux-only).

Wakebox was leaking the existence of a file via `/proc/self/fd`. 
The file was used to let the `fuse-waked` daemon know when all users of it's fuse mountpoint had closed, by wakebox leaving the file open as child processes forked.
The file was not actually accessible by wakebox's payload command however, as it is hidden by the mount table changes where we bind-mount `workspace/.fuse/$UID.$GID` onto `workspace/`.

The motivation of this change, is that some payload commands actually try to read the files symlinked via `/proc/self/fd`, so those payloads would encounter the unexpected situation of a file that _is_ open, but where the path is not accessible.

Changes (linux only): 
* the live file for fuse-waked is closed on exec
* instead of exec-ing the payload command directly, a `clone()` is called with a flag to create a new PID namespace
* the function started by clone() is PID1, mounts a new procfs, fork/execs the payload command, and then waits for _all_ children to terminate. Any orphaned children are re-parented to this new PID1.

The process tree view from inside wakebox (on linux)
```
$ wakebox ps
    PID TTY          TIME CMD
      1 pts/96   00:00:00 wb-pid-ns
      2 pts/96   00:00:00 ps

$ wakebox ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0  15008   216 pts/96   S+   15:52   0:00 wakebox ps aux
root           2  0.0  0.0  44704  3448 pts/96   R+   15:52   0:00 ps aux
```

Open files according to the payload command:
```
# Before this PR:
$ old-wakebox bash -c "ls -l /proc/self/fd"
total 0
lrwx------. 1 root root 64 Feb 16 16:00 0 -> /dev/pts/96
lrwx------. 1 root root 64 Feb 16 16:00 1 -> /dev/pts/96
lrwx------. 1 root root 64 Feb 16 16:00 2 -> /dev/pts/96
lr-x------. 1 root root 64 Feb 16 16:00 3 -> /proc/1234566/fd
lrwx------. 1 root root 64 Feb 16 16:00 4 -> /home/user/wake/.fuse/1000.1000/.l.1234567

# This PR applied:
$ wakebox bash -c "ls -l /proc/self/fd"
total 0
lrwx------. 1 root root 64 Feb 16 16:01 0 -> /dev/pts/96
lrwx------. 1 root root 64 Feb 16 16:01 1 -> /dev/pts/96
lrwx------. 1 root root 64 Feb 16 16:01 2 -> /dev/pts/96
lr-x------. 1 root root 64 Feb 16 16:01 3 -> /proc/2/fd
```