### PR TITLE
Fix default destination of a job's stderr in the logging docs

### DIFF
--- a/share/doc/wake/logging.md
+++ b/share/doc/wake/logging.md
@@ -96,7 +96,7 @@ you can control which loggers these `Job`-specific stdout and stderr are sent to
 This will influence whether they appear on the `wake` process's own stdout,
 stderr, or other arbitrary file descriptors.
 These can be controlled with `setPlanStdout`, `setPlanStderr` before you `runJob`.
-These default to `logInfo` and `logError` respectively.
+These default to `logInfo` and `logWarning` respectively.
 
 Regardless of the logger to which you direct the `Job`'s `Stderr` and `Stdout`,
 `wake` will store all the text in its database,


### PR DESCRIPTION
Thanks for @richardxia for pointing this out!