### PR TITLE
Use wake-specific staging mountpoint for squashfs mounts

### DIFF
--- a/src/wakefs/namespace.cpp
+++ b/src/wakefs/namespace.cpp
@@ -191,7 +191,7 @@ static bool do_squashfuse_mount(const std::string &source, const std::string &mo
     return false;
   }
 
-  int err = mkdir_with_parents(mountpoint, 0777);
+  int err = mkdir_with_parents(mountpoint, 0555);
   if (0 != err) {
     std::cerr << "mkdir_with_parents ('" << mountpoint << "'):" << strerror(err) << std::endl;
     return false;
@@ -389,7 +389,7 @@ bool do_mounts(const std::vector<mount_op> &mount_ops, const std::string &fuse_m
       // The prefix will be pivoted to after the final mount op.
       mount_prefix = root_mount_prefix;
       // Re-use if it already exists.
-      if (0 != mkdir(mount_prefix.c_str(), 0777) && errno != EEXIST) {
+      if (0 != mkdir(mount_prefix.c_str(), 0555) && errno != EEXIST) {
         std::cerr << "mkdir (" << mount_prefix << "): " << strerror(errno) << std::endl;
         return false;
       }

--- a/src/wakefs/namespace.cpp
+++ b/src/wakefs/namespace.cpp
@@ -50,7 +50,7 @@ static const std::string root_mount_prefix = "/tmp/.wakebox-mount";
 // Path to place a squashfs mount before it's moved to the real mountpoint.
 // While this location will be mounted-over, it will be uncovered when we do the move.
 // Must not hide 'root_mount_prefix'.
-static const std::string squashfs_staging_location = "/mnt";
+static const std::string squashfs_staging_location = "/tmp/.wakebox-mount-squashfs";
 
 // Path within a squashfs mount containing where its temporary mount should be moved to.
 static const std::string mount_location_data = ".wakebox/mountpoint";
@@ -188,6 +188,12 @@ static bool do_squashfuse_mount(const std::string &source, const std::string &mo
   // The squashfuse executable doesn't give a clear error message when the file is missing.
   if (access(source.c_str(), R_OK | F_OK) != 0) {
     std::cerr << "squashfs mount ('" << source << "'): " << strerror(errno) << std::endl;
+    return false;
+  }
+
+  int err = mkdir_with_parents(mountpoint, 0777);
+  if (0 != err) {
+    std::cerr << "mkdir_with_parents ('" << mountpoint << "'):" << strerror(err) << std::endl;
     return false;
   }
 


### PR DESCRIPTION
When using wakebox's squashfs support, if a user has particular versions of libfuse then they can not mount over a non-empty directory (and this was happing in a namespace, and we moved the mount directly aftewards).

We were using `/mnt`, in this PR we create a dedicated directory to put these squashfs mounts before moving them.

(We stage/move them because within the squashfs it contains a file which must be read to say where to really mount it)