### PR TITLE
Fix parsing wake version

### DIFF
--- a/src/runtime/sources.cpp
+++ b/src/runtime/sources.cpp
@@ -201,7 +201,7 @@ std::string check_version(bool workspace, const char *wake_version) {
   int wake_major, wake_minor, wake_patch;
   int repo_major, repo_minor, repo_patch;
   auto repo = parse_numbers(repo_version.c_str(), repo_major, repo_minor, repo_patch);
-  auto wake = parse_numbers(wake_version + 1, wake_major, wake_minor, wake_patch);
+  auto wake = parse_numbers(wake_version, wake_major, wake_minor, wake_patch);
 
   if (!repo.empty()) return repo + " (" + repo_version + ")";
   if (!wake.empty()) return wake + " (" + wake_version + ")";


### PR DESCRIPTION
Fixes #1139 

For some reason we were skipping the first character of the wake version meaning `0.30.0` would be seen as `.30.0` during semver parsing. My thought was that previously it started with `v` and we needed to skip that but I went back to 0.18.0 and even that didn't have a leading `v` so this must be a fairly longstanding bug.

I still don't know why we were skipping so if anyone can give context that would be great, this does fix the issue though.