### PR TITLE
Support capturing jobs via label glob

### DIFF
--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -156,6 +156,7 @@ struct Database {
   std::vector<JobReflection> explain(const std::string &file, int use);
 
   std::vector<JobReflection> failed();
+  std::vector<JobReflection> labels_matching(const std::string glob);
 
   std::vector<JobReflection> last_exe();
   std::vector<JobReflection> last_use();

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -107,6 +107,7 @@ void print_help(const char *argv0) {
     << "    --clean          Delete all job outputs"                                     << std::endl
     << "    --input  -i FILE Capture jobs which read FILES"                              << std::endl
     << "    --output -o FILE Capture jobs which wrote FILES"                             << std::endl
+    << "    --label     GLOB Capture jobs where label matches GLOB"                      << std::endl
     << "    --job       JOB  Captre the job with the specified job id"                   << std::endl
     << "    --last     -l    See --last-used"                                            << std::endl
     << "    --last-used      Capture all jobs used by last build. Regardless of cache"   << std::endl
@@ -179,6 +180,7 @@ int main(int argc, char **argv) {
     {0, "job", GOPT_ARGUMENT_REQUIRED},
     {'i', "input", GOPT_ARGUMENT_FORBIDDEN},
     {'o', "output", GOPT_ARGUMENT_FORBIDDEN},
+    {0, "label", GOPT_ARGUMENT_FORBIDDEN},
     {'l', "last", GOPT_ARGUMENT_FORBIDDEN},
     {0, "last-used", GOPT_ARGUMENT_FORBIDDEN},
     {0, "last-executed", GOPT_ARGUMENT_FORBIDDEN},
@@ -230,6 +232,7 @@ int main(int argc, char **argv) {
   int profileh = arg(options, "profile-heap")->count;
   bool input = arg(options, "input")->count;
   bool output = arg(options, "output")->count;
+  bool label = arg(options, "label")->count;
   bool last = arg(options, "last")->count;
   bool last_use = last || arg(options, "last-used")->count;
   bool last_exe = arg(options, "last-executed")->count;
@@ -306,6 +309,21 @@ int main(int argc, char **argv) {
   if (shebang && argc < 2) {
     std::cerr << "Shebang invocation requires a script name as the first non-option argument"
               << std::endl;
+    return 1;
+  }
+
+  if (input && argc < 2) {
+    std::cerr << "--input requires at least one FILE" << std::endl;
+    return 1;
+  }
+
+  if (output && argc < 2) {
+    std::cerr << "--ouput requires at least one FILE" << std::endl;
+    return 1;
+  }
+
+  if (label && argc < 2) {
+    std::cerr << "--label requires a GLOB to filter with" << std::endl;
     return 1;
   }
 
@@ -403,7 +421,8 @@ int main(int argc, char **argv) {
   bool targets = argc == 1 && !noargs;
 
   bool nodb = init;
-  bool noparse = nodb || job || output || input || last_use || last_exe || failed || tagdag;
+  bool noparse =
+      nodb || job || output || input || label || last_use || last_exe || failed || tagdag;
   bool notype = noparse || parse;
   bool noexecute = notype || html || tcheck || dumpssa || global || exports || api || targets;
 
@@ -580,6 +599,12 @@ int main(int argc, char **argv) {
     for (int i = 1; i < argc; ++i) {
       describe(db.explain(wcl::make_canonical(wake_cwd + argv[i]), 2), policy);
     }
+  }
+
+  if (label) {
+    std::string glob = argv[1];
+    std::replace(glob.begin(), glob.end(), '*', '%');
+    describe(db.labels_matching(glob), policy);
   }
 
   if (last_use) {

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -604,6 +604,7 @@ int main(int argc, char **argv) {
   if (label) {
     std::string glob = argv[1];
     std::replace(glob.begin(), glob.end(), '*', '%');
+    std::replace(glob.begin(), glob.end(), '?', '_');
     describe(db.labels_matching(glob), policy);
   }
 


### PR DESCRIPTION
Running wake with `--label` allows you to provide a glob  to capture jobs based on the job label. Commandline globbing isn't supported since commandline is stored as a blob not a string. This may be added in the future.

```
> wake --label '*123*'
> wake--label '*re2c*'


# re2c: Get version number(299)
$ /usr/bin/re2c --version


re2c 3.0


# re2c: src/parser/lexer.cpp(320)
$ /usr/bin/re2c -8 --no-generation-date --input-encoding utf8 src/parser/lexer.re -o src/parser/lexer.cpp




# re2c: src/json/jlexer.cpp(332)
$ /usr/bin/re2c -8 --no-generation-date --input-encoding utf8 src/json/jlexer.re -o src/json/jlexer.cpp

> wake --label 'lemon*'


# lemon: m4 src/parser/parser.y.m4(33)
$ /usr/bin/m4 src/parser/parser.y.m4
...
...
```