### PR TITLE
Show stdout+stderr as part of debug

### DIFF
--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -252,7 +252,7 @@ void describe(const std::vector<JobReflection> &jobs, DescribePolicy policy) {
       break;
     }
     case DescribePolicy::DEBUG: {
-      describe_metadata(jobs, true, false);
+      describe_metadata(jobs, true, true);
       break;
     }
     case DescribePolicy::VERBOSE: {


### PR DESCRIPTION
When reaching for a stack trace via `--debug` a user likely also wants stdout/stderr to be output. This was previously achieved with `-dv` but now that you can only set one describe policy this handle was lost.

This change switches `debug` policy to align with `debug verbose` so that no fidelity is lost