### PR TITLE
modify kernel cache message

### DIFF
--- a/src/parser/wakefiles.cpp
+++ b/src/parser/wakefiles.cpp
@@ -245,9 +245,7 @@ static bool push_files(std::vector<std::string> &out, const std::string &path, i
       profile->start = now;
       profile->alerted_user = true;
 
-      fprintf(profile->dest,
-              "Finding wake files is taking longer than expected. Kernel file cache may be cold. "
-              "(%ld explored).\r",
+      fprintf(profile->dest, "Finding wake files is taking longer than expected (%ld explored).\r",
               profile->explored);
       fflush(profile->dest);
     }

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -676,8 +676,8 @@ int main(int argc, char **argv) {
     auto now = std::chrono::steady_clock::now();
     if (!quiet && is_stdout_tty &&
         std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() > 1000) {
-      std::cout << "Scanning " << i + 1 << "/" << wakefilenames.size()
-                << " wake files. Kernel file cache may be cold.\r" << std::flush;
+      std::cout << "Scanning " << i + 1 << "/" << wakefilenames.size() << " wake files.\r"
+                << std::flush;
       start = now;
       alerted_slow_cache = true;
     }
@@ -713,7 +713,7 @@ int main(int argc, char **argv) {
 
   if (!quiet && alerted_slow_cache && is_stdout_tty) {
     std::cout << "Scanning " << wakefilenames.size() << "/" << wakefilenames.size()
-              << " wake files. Kernel file cache may be cold." << std::endl;
+              << " wake files.\r" << std::endl;
   }
 
   if (in) {


### PR DESCRIPTION
Removes the `Kernel file cache may be cold.` string as it's speculation, they might just have a slow/loaded disk/computer.

Adds an extra `/r` on the remaining message, as I suspect we want all of them to have it so the message disappears at next write?