### PR TITLE
Mark environment-sensitive jobs as unsharable

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -106,7 +106,10 @@ def setVersion release file =
         sed "s/@VERSION@/%{release}/g" "%{in.getPathName}" > "%{file}.tmp"
         mv "%{file}.tmp" "%{file}"
         %"
-    shellJob script (in, Nil) | getJobOutput
+    makeShellPlan script (in, Nil)
+    | setPlanLabel "release: replace placeholder with version number"
+    | runJob
+    | getJobOutput
 
 # Create a release tarball
 def tarball Unit =
@@ -170,7 +173,11 @@ def tarball Unit =
             tar, "--mtime={time}", "--transform=s@^@wake-{release}/@",
             "--owner=0", "--group=0", "--numeric-owner", "-cJf",
             "wake_{release}.tar.xz", files
-        job cmd (manifest, testManifest, spec, srcs)
+        makeExecPlan cmd (manifest, testManifest, spec, srcs)
+        | setPlanLabel "release: package wake source tarball"
+        # Since this includes the current time, it's not going to benefit from caching.
+        | setPlanKeep False
+        | runJob
         | getJobOutput
     Pass (tarball, changelog, Nil)
 
@@ -185,7 +192,11 @@ export def static _: Result Path Error =
         which "tar", "--mtime={time}", "--transform=s@^tmp/@wake-{release}/@",
         "--owner=0", "--group=0", "--numeric-owner", "-cJf",
         "wake-static_{release}.tar.xz", map getPathName files | sortBy scmp
-    job cmd files
+    makeExecPlan cmd files
+    | setPlanLabel "release: package wake-static tarball"
+    # Since this includes the current time, it's not going to benefit from caching.
+    | setPlanKeep False
+    | runJob
     | getJobOutput
 
 from test_wake import topic wakeTestBinary

--- a/extensions/vscode/vscode.wake
+++ b/extensions/vscode/vscode.wake
@@ -73,6 +73,8 @@ export def vscode _: Result Path Error =
         | setPlanLabel "npm ci: Install npm dependencies"
         | editPlanEnvironment (addEnvironmentPath emsdkBinDir)
         | setPlanDirectory @here
+        # NPM installs its dependencies from the web, and so can't be fully sandboxed.
+        | setPlanShare False
         | runJob
         | getJobOutputs
 

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -71,10 +71,18 @@ export def makeRunner name score pre post (Runner _ _ run) =
   Runner name score doit
 
 export data Persistence =
-  ReRun	# Job should be re-executed on every runJob call
-  Once	# Job should only be run once in a given wake execution
-  Keep	# Job should output be reusable between wake invocations
-  Share	# Job should output be shared between workspaces
+  # Job should be re-executed on every runJob call.
+  #
+  # In this case, no job deduplication is performed and so it must
+  # *not* write any files (stdout/stderr are fine) or be guaranteed to only be
+  # encountered once in any wake execution anyway.
+  ReRun
+  # Job should only be run once in a given wake execution.
+  Once
+  # Job should output be reusable between wake invocations.
+  Keep
+  # Job should output be shared between workspaces.
+  Share
 
 # A Plan describes a not-yet-executed Job
 tuple Plan =
@@ -112,6 +120,9 @@ export def getPlanOnce  p = isOnce  (getPlanPersistence p)
 export def getPlanKeep  p = isKeep  (getPlanPersistence p)
 export def getPlanShare p = isShare (getPlanPersistence p)
 
+# If `Once` is set to `False`, no job deduplication is performed and so it must
+# *not* write any files (stdout/stderr are fine) or be guaranteed to only be
+# encountered once in any wake execution anyway.
 export def setPlanOnce  v p = editPlanOnce  (\_ v) p
 export def setPlanKeep  v p = editPlanKeep  (\_ v) p
 export def setPlanShare v p = editPlanShare (\_ v) p
@@ -125,6 +136,10 @@ export def setPlanEnvVar (name: String) (value: String) (plan: Plan): Plan =
   editPlanEnvironment ("{name}={value}", _) plan
 
 # Helper methods that maintain the invariant that: Share => Keep => Once
+
+# If `Once` is set to `False`, no job deduplication is performed and so it must
+# *not* write any files (stdout/stderr are fine) or be guaranteed to only be
+# encountered once in any wake execution anyway.
 export def editPlanOnce (f: Boolean => Boolean): Plan => Plan =
   def helper = match _
     ReRun if   f False = Once

--- a/tests/job-cache/basic-fetch/test.wake
+++ b/tests/job-cache/basic-fetch/test.wake
@@ -6,7 +6,7 @@ export def test (_: List String): Result (List String) Error =
     require Pass source = source "some-input.txt"
     require Pass outputs =
         makePlan "basic_test" (source,) "cat some-input.txt > test.txt && cat some-input.txt >> test.txt"
-        | setPlanOnce False
+        | setPlanKeep False
         | runJob
         | getJobOutputs
     Pass (map (_.getPathName) outputs)

--- a/tests/job-cache/basic-fetch/test.wake
+++ b/tests/job-cache/basic-fetch/test.wake
@@ -6,7 +6,6 @@ export def test (_: List String): Result (List String) Error =
     require Pass source = source "some-input.txt"
     require Pass outputs =
         makePlan "basic_test" (source,) "cat some-input.txt > test.txt && cat some-input.txt >> test.txt"
-        | setPlanKeep False
         | runJob
         | getJobOutputs
     Pass (map (_.getPathName) outputs)

--- a/tests/job-cache/basic-fetch/test.wake
+++ b/tests/job-cache/basic-fetch/test.wake
@@ -3,9 +3,10 @@ from wake import _
 publish source = "some-input.txt",
 
 export def test (_: List String): Result (List String) Error =
-  require Pass source = source "some-input.txt"
-  require Pass outputs =
-      makePlan "basic_test" (source,) "cat some-input.txt > test.txt && cat some-input.txt >> test.txt"
-      | runJob
-      | getJobOutputs
-  Pass (map (_.getPathName) outputs)
+    require Pass source = source "some-input.txt"
+    require Pass outputs =
+        makePlan "basic_test" (source,) "cat some-input.txt > test.txt && cat some-input.txt >> test.txt"
+        | setPlanOnce False
+        | runJob
+        | getJobOutputs
+    Pass (map (_.getPathName) outputs)

--- a/tests/job-cache/dup-output/test.wake
+++ b/tests/job-cache/dup-output/test.wake
@@ -3,7 +3,7 @@ from wake import _
 export def test (_: List String): Result (List String) Error =
     require Pass outputs =
         makePlan "basic_test" Nil "echo foobar > test1.txt && echo foobar > test2.txt"
-        | setPlanOnce False
+        | setPlanKeep False
         | runJob
         | getJobOutputs
     Pass (map (_.getPathName) outputs)

--- a/tests/job-cache/dup-output/test.wake
+++ b/tests/job-cache/dup-output/test.wake
@@ -1,8 +1,9 @@
 from wake import _
 
 export def test (_: List String): Result (List String) Error =
-  require Pass outputs =
-      makePlan "basic_test" Nil "echo foobar > test1.txt && echo foobar > test2.txt"
-      | runJob
-      | getJobOutputs
-  Pass (map (_.getPathName) outputs)
+    require Pass outputs =
+        makePlan "basic_test" Nil "echo foobar > test1.txt && echo foobar > test2.txt"
+        | setPlanOnce False
+        | runJob
+        | getJobOutputs
+    Pass (map (_.getPathName) outputs)

--- a/tests/job-cache/dup-output/test.wake
+++ b/tests/job-cache/dup-output/test.wake
@@ -3,7 +3,6 @@ from wake import _
 export def test (_: List String): Result (List String) Error =
     require Pass outputs =
         makePlan "basic_test" Nil "echo foobar > test1.txt && echo foobar > test2.txt"
-        | setPlanKeep False
         | runJob
         | getJobOutputs
     Pass (map (_.getPathName) outputs)

--- a/tests/job-cache/symlink-dir/test.wake
+++ b/tests/job-cache/symlink-dir/test.wake
@@ -1,7 +1,7 @@
 export def test (_: List String): Result (List String) Error =
     require Pass outputs =
         makePlan "basic_test" Nil "echo foo > test.txt && mkdir -p bar && ln -s test.txt bar/baz.txt"
-        | setPlanOnce False
+        | setPlanKeep False
         | runJob
         | getJobOutputs
     Pass (map (_.getPathName) outputs)

--- a/tests/job-cache/symlink-dir/test.wake
+++ b/tests/job-cache/symlink-dir/test.wake
@@ -1,7 +1,6 @@
 export def test (_: List String): Result (List String) Error =
     require Pass outputs =
         makePlan "basic_test" Nil "echo foo > test.txt && mkdir -p bar && ln -s test.txt bar/baz.txt"
-        | setPlanKeep False
         | runJob
         | getJobOutputs
     Pass (map (_.getPathName) outputs)

--- a/tests/job-cache/symlink-dir/test.wake
+++ b/tests/job-cache/symlink-dir/test.wake
@@ -1,6 +1,7 @@
 export def test (_: List String): Result (List String) Error =
-  require Pass outputs =
-      makePlan "basic_test" Nil "echo foo > test.txt && mkdir -p bar && ln -s test.txt bar/baz.txt"
-      | runJob
-      | getJobOutputs
-  Pass (map (_.getPathName) outputs)
+    require Pass outputs =
+        makePlan "basic_test" Nil "echo foo > test.txt && mkdir -p bar && ln -s test.txt bar/baz.txt"
+        | setPlanOnce False
+        | runJob
+        | getJobOutputs
+    Pass (map (_.getPathName) outputs)

--- a/tests/runtime/symlinks/test.wake
+++ b/tests/runtime/symlinks/test.wake
@@ -6,14 +6,14 @@ export def goodLink Unit =
         datFile Unit
     makeExecPlan ("ln", "-s", "datFile", "goodLink", Nil) (dat, Nil)
     | setPlanLabel "test (symlinks): goodLink"
-    | setPlanKeep False
+    | setPlanShare False
     | runJob
     | getJobOutput
 
 export def badLink Unit =
     makeExecPlan ("ln", "-s", "badFile", "badLink", Nil) Nil
     | setPlanLabel "test (symlinks): badLink"
-    | setPlanKeep False
+    | setPlanShare False
     | runJob
     | getJobOutput
 
@@ -25,7 +25,7 @@ export def shouldWork Unit =
     makeExecPlan ("cat", "goodLink", Nil) (link, dat, Nil)
     | setPlanLabel "test (symlinks): cat goodLink"
     | editPlanEnvironment (setEnvironment "TEST" "1")
-    | setPlanKeep False
+    | setPlanShare False
     | runJob
     | getJobInputs
 
@@ -35,7 +35,7 @@ export def shouldFail1 Unit =
     makeExecPlan ("cat", "goodLink", Nil) (link, Nil)
     | setPlanLabel "test (symlinks): cat goodLink shouldFail"
     | editPlanEnvironment (setEnvironment "TEST" "2")
-    | setPlanKeep False
+    | setPlanShare False
     | runJob
     | getJobInputs
 

--- a/tests/runtime/symlinks/test.wake
+++ b/tests/runtime/symlinks/test.wake
@@ -45,7 +45,7 @@ export def shouldFail2 Unit =
     makeExecPlan ("cat", "goodLink", Nil) (dat, Nil)
     | setPlanLabel "test (symlinks): cat goodLink shouldFail2"
     | editPlanEnvironment (setEnvironment "TEST" "3")
-    | setPlanKeep False
+    | setPlanShare False
     | runJob
     | getJobInputs
 

--- a/tests/runtime/symlinks/test.wake
+++ b/tests/runtime/symlinks/test.wake
@@ -6,12 +6,14 @@ export def goodLink Unit =
         datFile Unit
     makeExecPlan ("ln", "-s", "datFile", "goodLink", Nil) (dat, Nil)
     | setPlanLabel "test (symlinks): goodLink"
+    | setPlanOnce False
     | runJob
     | getJobOutput
 
 export def badLink Unit =
     makeExecPlan ("ln", "-s", "badFile", "badLink", Nil) Nil
     | setPlanLabel "test (symlinks): badLink"
+    | setPlanOnce False
     | runJob
     | getJobOutput
 
@@ -23,6 +25,7 @@ export def shouldWork Unit =
     makeExecPlan ("cat", "goodLink", Nil) (link, dat, Nil)
     | setPlanLabel "test (symlinks): cat goodLink"
     | editPlanEnvironment (setEnvironment "TEST" "1")
+    | setPlanOnce False
     | runJob
     | getJobInputs
 
@@ -32,6 +35,7 @@ export def shouldFail1 Unit =
     makeExecPlan ("cat", "goodLink", Nil) (link, Nil)
     | setPlanLabel "test (symlinks): cat goodLink shouldFail"
     | editPlanEnvironment (setEnvironment "TEST" "2")
+    | setPlanOnce False
     | runJob
     | getJobInputs
 
@@ -41,6 +45,7 @@ export def shouldFail2 Unit =
     makeExecPlan ("cat", "goodLink", Nil) (dat, Nil)
     | setPlanLabel "test (symlinks): cat goodLink shouldFail2"
     | editPlanEnvironment (setEnvironment "TEST" "3")
+    | setPlanOnce False
     | runJob
     | getJobInputs
 

--- a/tests/runtime/symlinks/test.wake
+++ b/tests/runtime/symlinks/test.wake
@@ -6,14 +6,14 @@ export def goodLink Unit =
         datFile Unit
     makeExecPlan ("ln", "-s", "datFile", "goodLink", Nil) (dat, Nil)
     | setPlanLabel "test (symlinks): goodLink"
-    | setPlanOnce False
+    | setPlanKeep False
     | runJob
     | getJobOutput
 
 export def badLink Unit =
     makeExecPlan ("ln", "-s", "badFile", "badLink", Nil) Nil
     | setPlanLabel "test (symlinks): badLink"
-    | setPlanOnce False
+    | setPlanKeep False
     | runJob
     | getJobOutput
 
@@ -25,7 +25,7 @@ export def shouldWork Unit =
     makeExecPlan ("cat", "goodLink", Nil) (link, dat, Nil)
     | setPlanLabel "test (symlinks): cat goodLink"
     | editPlanEnvironment (setEnvironment "TEST" "1")
-    | setPlanOnce False
+    | setPlanKeep False
     | runJob
     | getJobInputs
 
@@ -35,7 +35,7 @@ export def shouldFail1 Unit =
     makeExecPlan ("cat", "goodLink", Nil) (link, Nil)
     | setPlanLabel "test (symlinks): cat goodLink shouldFail"
     | editPlanEnvironment (setEnvironment "TEST" "2")
-    | setPlanOnce False
+    | setPlanKeep False
     | runJob
     | getJobInputs
 
@@ -45,7 +45,7 @@ export def shouldFail2 Unit =
     makeExecPlan ("cat", "goodLink", Nil) (dat, Nil)
     | setPlanLabel "test (symlinks): cat goodLink shouldFail2"
     | editPlanEnvironment (setEnvironment "TEST" "3")
-    | setPlanOnce False
+    | setPlanKeep False
     | runJob
     | getJobInputs
 

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -139,6 +139,7 @@ export def runUnitTests _: Result Unit Error =
         | setPlanLabel "testing: {testName}"
         | setPlanStdout logNever
         | setPlanStderr logNever
+        | setPlanOnce False
         | runJob
 
     def removeCarriageReturns = replace `\r` ""
@@ -220,6 +221,7 @@ def runTest (testScript: Path): Result Unit Error =
         | setPlanLocalOnly True # On OS/X you cannot mount fuse within fuse
         | setPlanStdout logNever
         | setPlanStderr logNever
+        | setPlanOnce False
         | runJob
 
     require Pass jobStdout =

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -139,7 +139,7 @@ export def runUnitTests _: Result Unit Error =
         | setPlanLabel "testing: {testName}"
         | setPlanStdout logNever
         | setPlanStderr logNever
-        | setPlanKeep False
+        | setPlanShare False
         | runJob
 
     def removeCarriageReturns = replace `\r` ""
@@ -221,7 +221,7 @@ def runTest (testScript: Path): Result Unit Error =
         | setPlanLocalOnly True # On OS/X you cannot mount fuse within fuse
         | setPlanStdout logNever
         | setPlanStderr logNever
-        | setPlanKeep False
+        | setPlanShare False
         | runJob
 
     require Pass jobStdout =

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -139,7 +139,7 @@ export def runUnitTests _: Result Unit Error =
         | setPlanLabel "testing: {testName}"
         | setPlanStdout logNever
         | setPlanStderr logNever
-        | setPlanOnce False
+        | setPlanKeep False
         | runJob
 
     def removeCarriageReturns = replace `\r` ""
@@ -221,7 +221,7 @@ def runTest (testScript: Path): Result Unit Error =
         | setPlanLocalOnly True # On OS/X you cannot mount fuse within fuse
         | setPlanStdout logNever
         | setPlanStderr logNever
-        | setPlanOnce False
+        | setPlanKeep False
         | runJob
 
     require Pass jobStdout =

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -375,6 +375,7 @@ def buildRE2WASM Unit =
         | makePlan "compiling re2" (buildDir, patch, Nil)
         | editPlanEnvironment (addEnvironmentPath emsdk)
         | setPlanDirectory here
+        | setPlanShare False
         | runJob
 
     require Pass outputs =

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -375,7 +375,6 @@ def buildRE2WASM Unit =
         | makePlan "compiling re2" (buildDir, patch, Nil)
         | editPlanEnvironment (addEnvironmentPath emsdk)
         | setPlanDirectory here
-        | setPlanShare False
         | runJob
 
     require Pass outputs =

--- a/vendor/gmp.wake
+++ b/vendor/gmp.wake
@@ -46,6 +46,7 @@ def buildGmpWASM _ =
     | makePlan "compiling gmp" (buildDir, Nil)
     | editPlanEnvironment (addEnvironmentPath emsdk)
     | setPlanDirectory here
+    | setPlanShare False
     | runJob
 
   require Pass outputs = job.getJobOutputs

--- a/vendor/lemon/lemon.wake
+++ b/vendor/lemon/lemon.wake
@@ -89,7 +89,9 @@ def lemon variant (file: Path): Result (Pair Path Path) Error =
         which "gzip", "-nk9", cppfile.getPathName, hfile.getPathName, Nil
 
     def zip =
-        job compress (cppfile, result)
+        makeExecPlan compress (cppfile, result)
+        | setPlanLabel "lemon: compress generated files"
+        | runJob
 
     match zip.getJobStatus
         Exited 0 = Pass (Pair cppfile hfile)

--- a/vendor/re2.wake
+++ b/vendor/re2.wake
@@ -54,6 +54,7 @@ def buildRE2WASM Unit =
         | makePlan "compiling re2" (buildDir, patch, Nil)
         | editPlanEnvironment (addEnvironmentPath emsdk)
         | setPlanDirectory here
+        | setPlanShare False
         | runJob
 
     require Pass outputs =

--- a/vendor/re2c.wake
+++ b/vendor/re2c.wake
@@ -62,7 +62,9 @@ def re2cReal re2c file =
         which "gzip", "-nk9", result.getPathName, Nil
 
     def zip =
-        job compress (result, Nil)
+        makeExecPlan compress (result, Nil)
+        | setPlanLabel "re2c: compress generated file"
+        | runJob
 
     match zip.getJobStatus
         Exited 0 = Pass result
@@ -82,7 +84,9 @@ def gunzip zip =
         gzip -dc "%{zip.getPathName}" > "%{out}.tmp"
         mv "%{out}.tmp" "%{out}"
         %"
-    shellJob script (zip, Nil)
+    makeShellPlan script (zip, Nil)
+    | setPlanLabel "gzip: extract {zip.getPathName}"
+    | runJob
     | getJobOutput
 
 def re2c (file: Path): Result Path Error =

--- a/vendor/sqlite3.wake
+++ b/vendor/sqlite3.wake
@@ -45,7 +45,8 @@ def buildSqlite3WASM _ =
     """
     | makePlan "compiling sqlite3" (buildDir, Nil)
     | editPlanEnvironment (addEnvironmentPath emsdk)
-    | setPlanDirectory here
+    | setPlanDirectory @here
+    | setPlanShare False
     | runJob
 
   require Pass outputs = job.getJobOutputs


### PR DESCRIPTION
Since we've previously only had support for a single, local cache, we've not paid much attention to the difference between `Keep` and `Share` persistence; this PR goes through every job in the repo to evaluate whether it relies on some environmental factor which would prevent sharing.  A few specific notes:

* To be safe, I've gone ahead and not allowed sharing for anything internet-connected, even if it theoretically should point to a frozen file; I've not looked at any third-party licenses to see whether sharing compiled binaries might run afoul of distribution-related clauses (since *nothing* is shared currently, we're not distributing *anything* but the sources currently).
* Our tests were previously cached.  I don't expect that to have broken anything, but it's a bit of an entertaining interaction that could have made debugging issues a bit harder at times.
* Previous PRs had added labels to the majority of jobs, but a few which used the quickstart `job` and `shellJob` helpers were missed; I've expanded those and added labels, but there might certainly be better strings to use.
* I've not done any sort of usage/runtime analysis on jobs to determine if something is quick enough to not bother caching (though at least some of our source/hash/installAs/etc. were already set more tightly).  If we think that's something to do ahead of time I can certainly do a second pass; if we want to wait to get numbers from prototype/production caches to compare, then we can go back through later.