### PR TITLE
Add result type to wcl

### DIFF
--- a/src/wcl/optional.h
+++ b/src/wcl/optional.h
@@ -197,4 +197,21 @@ class optional : public optional_base_t<T> {
   const T* operator->() const { return &this->value; }
 };
 
+// `some` is used when you want to wrap a known value in an optinal
+// and don't want to mess with template arguments.
+// Example: some(10) would be of type wcl::optional<int>
+template <class T>
+inline optional<T> some(T&& x) {
+  return optional<T>{in_place_t{}, std::forward<T>(x)};
+}
+
+// `make_some` is the more general older brother of `some` which
+// demands that you tell it the output type you want to use but allows
+// you to construct the value in place using an constructor of that type.
+template <class T, class... Args>
+inline optional<T> make_some(Args&&... args) {
+  return optional<T>{in_place_t{}, std::forward<Args>(args)...};
+}
+
+
 }  // namespace wcl

--- a/src/wcl/optional.h
+++ b/src/wcl/optional.h
@@ -213,5 +213,4 @@ inline optional<T> make_some(Args&&... args) {
   return optional<T>{in_place_t{}, std::forward<Args>(args)...};
 }
 
-
 }  // namespace wcl

--- a/src/wcl/result.h
+++ b/src/wcl/result.h
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2023 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <errno.h>
+#include <cstdint>
+#include <utility>
+
+#include "optional.h"
+
+namespace wcl {
+
+// This is a helpful rename of `int`
+// to indicate that the error type is
+// a posix error value as returned by
+// errno from some internal function.
+using posix_error_t = int;
+
+// this helps us tell apart the error and non-error case.
+class in_place_error_t {};
+
+static constexpr uint64_t max(uint64_t a, uint64_t b) { return (a < b) ? b : a; }
+
+template <class T, class E, bool copy>
+class result_base {};
+
+// wcl::result demands that the error and value be movable
+// 1) a non-movable value is essentially never useful because
+//    it cannot be returned except by out parameter which is
+//    the whole pattern we're trying to avoid.
+// 2) there is no "default" error or value so default constructing
+//    a `result` doesn't make much sense and thus we need a valid
+//    semantics for moving a `result` for both underlying values.
+
+// furthermore, a `result` is only copyable if both the error and
+// value type are copyable because otherwise we would be missing
+// a valid copy constructor for one of them!
+
+// This is the copyable case which would be used for things like
+// std::string, int, std::vector, etc... this would not be used for
+// std::unique_ptr however.
+// NOTE: On both of these we had to set the alignment to the max alignment
+//       of the two values.
+template <class T, class E>
+class alignas(max(alignof(T), alignof(E))) result_base<T, E, true> {
+ protected:
+  union {
+    T value;
+    E error_;
+  };
+  bool is_error = true;
+
+ public:
+  ~result_base() {
+    if (is_error) {
+      error_.~E();
+    } else {
+      value.~T();
+    }
+  }
+  result_base() = delete;
+  result_base(const result_base& other) {
+    is_error = other.is_error;
+    if (is_error) {
+      new (&error_) E(other.error_);
+    } else {
+      new (&value) T(other.value);
+    }
+  }
+
+  result_base(result_base&& other) {
+    is_error = other.is_error;
+    // NOTE: On move we just use the move constructors
+    // of each value and we don't call their destructors yet.
+    // So if you move a result, it will keeps its errorness
+    // but the underlying value may be changed. This is
+    // distinct from wcl::optional which reverts the state
+    // the default state on move rather than leaving itself
+    // a populated state.
+    if (is_error) {
+      new (&error_) E(std::move(other.error_));
+    } else {
+      new (&value) T(std::move(other.value));
+    }
+  }
+
+  result_base& operator=(const result_base& other) {
+    if (is_error) {
+      error_.~E();
+    } else {
+      value.~T();
+    }
+
+    is_error = other.is_error;
+    if (other.is_error) {
+      new (&error_) E(other.error_);
+    } else {
+      new (&value) T(other.value);
+    }
+
+    return *this;
+  }
+
+  result_base& operator=(result_base&& other) {
+    if (is_error) {
+      error_.~E();
+    } else {
+      value.~T();
+    }
+
+    is_error = other.is_error;
+    if (other.is_error) {
+      new (&error_) E(std::move(other.error_));
+    } else {
+      new (&value) T(std::move(other.value));
+    }
+
+    return *this;
+  }
+
+  template <class... Args>
+  result_base(in_place_t, Args&&... args) : value(std::forward<Args>(args)...), is_error(false) {}
+
+  template <class... Args>
+  result_base(in_place_error_t, Args&&... args)
+      : error_(std::forward<Args>(args)...), is_error(true) {}
+};
+
+// Same reasons as above but here we don't require copyable
+// errors or values. This is very useful for things like
+// std::unique_ptr
+template <class T, class E>
+class alignas(max(alignof(T), alignof(E))) result_base<T, E, false> {
+ protected:
+  union {
+    T value;
+    E error_;
+  };
+  bool is_error = true;
+
+ public:
+  ~result_base() {
+    if (is_error) {
+      error_.~E();
+    } else {
+      value.~T();
+    }
+  }
+  result_base() = delete;
+  result_base(const result_base& other) = delete;
+  result_base(result_base&& other) {
+    is_error = other.is_error;
+    // on move we just use the move constructors
+    // of each value and we don't call their destructors yet.
+    // so if you move a result, it will keeps its errorness
+    // but the underlying value may be changed.
+    if (is_error) {
+      new (&error_) E(std::move(other.error_));
+    } else {
+      new (&value) T(std::move(other.value));
+    }
+  }
+
+  result_base& operator=(const result_base& other) = delete;
+
+  result_base& operator=(result_base&& other) {
+    if (is_error) {
+      error_.~E();
+    } else {
+      value.~T();
+    }
+
+    is_error = other.is_error;
+    if (other.is_error) {
+      new (&error_) E(std::move(other.error_));
+    } else {
+      new (&value) T(std::move(other.value));
+    }
+  }
+
+  template <class... Args>
+  result_base(in_place_t, Args&&... args) : value(std::forward<Args>(args)...), is_error(false) {}
+
+  template <class... Args>
+  result_base(in_place_error_t, Args&&... args)
+      : error_(std::forward<Args>(args)...), is_error(true) {}
+};
+
+template <class T, class E>
+using result_base_t =
+    result_base<T, E, std::is_copy_constructible<T>::value && std::is_copy_constructible<E>::value>;
+
+// Now we make the actual wrapper class that gives us our final public interface
+template <class T, class E>
+class result : public result_base_t<T, E> {
+ public:
+  template <class... Args>
+  result(in_place_t x, Args&&... args) : result_base_t<T, E>(x, std::forward<Args>(args)...) {}
+  template <class... Args>
+  result(in_place_error_t x, Args&&... args)
+      : result_base_t<T, E>(x, std::forward<Args>(args)...) {}
+
+  result() = default;
+  result(const result&) = default;
+  result(result&&) = default;
+  ~result() = default;
+
+  result& operator=(const result&) = default;
+  result& operator=(result&&) = default;
+
+  explicit operator bool() const { return !this->is_error; }
+
+  T& operator*() { return this->value; }
+
+  const T& operator*() const { return this->value; }
+
+  T* operator->() { return &this->value; }
+
+  const T* operator->() const { return &this->value; }
+
+  E& error() { return this->error_; }
+
+  const E& error() const { return this->error_; }
+};
+
+// Creates a result value from an existing object. Does not
+// require the value type which can be infered, but the error
+// type must be specified. result_value<posix_error_t>("foo")
+// would have type wcl::result<const char *, posix_error_t>
+// for instance.
+template <class E, class T>
+result<T, E> result_value(T&& x) {
+  return result<T, E>{in_place_t{}, std::forward<T>(x)};
+}
+
+// `make_result` is the more general sibling of `result_value`
+// that allows you to construct the value in place using any
+// constructor. Both types must be specified when using this.
+template <class T, class E, class... Args>
+result<T, E> make_result(Args&&... args) {
+  return result<T, E>{in_place_t{}, std::forward<Args>(args)...};
+}
+
+// Creates a result error from an existing object. Only requires the
+// value type and not the error type which can be infered.
+template <class T, class E>
+result<T, E> result_error(E&& err) {
+  return result<T, E>{in_place_error_t{}, std::forward<E>(err)};
+}
+
+// `make_error` is the more general sibling of `result_error`.
+template <class T, class E, class... Args>
+result<T, E> make_error(Args&&... args) {
+  return result<T, E>{in_place_error_t{}, std::forward<Args>(args)...};
+}
+
+// It's very common that you just want to wrap errno in a result when
+// dealing with posix functions. This just does that for you in a
+// single function. You must specify the value type however as that
+// cannot be infered.
+template <class T>
+result<T, posix_error_t> make_errno() {
+  return result<T, posix_error_t>{in_place_error_t{}, errno};
+}
+
+}  // namespace wcl

--- a/src/wcl/result.h
+++ b/src/wcl/result.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <errno.h>
+
 #include <cstdint>
 #include <utility>
 

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -34,6 +34,18 @@ PASSED:
   option_no_construct
   option_none_is_none
   option_some
+  result_assign1
+  result_assign2
+  result_copy
+  result_destructs
+  result_err_is_err
+  result_forward_error
+  result_forward_value
+  result_inplace_error
+  result_inplace_value
+  result_move
+  result_no_construct
+  result_value
   sanity_check1
   sanity_check2
   shell_escape_empty_string

--- a/tools/wake-unit/diff.cpp
+++ b/tools/wake-unit/diff.cpp
@@ -218,7 +218,7 @@ TEST(diff_fuzz2_large) {
   uint64_t seedV = 0xdeadbeefdeadbeef;
   std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> seed = {seedV, seedV, seedV, seedV};
   wcl::xoshiro_256 rng(seed);
-  std::uniform_int_distribution<int> length(500, 3000);
+  std::uniform_int_distribution<int> length(300, 1500);
   std::uniform_int_distribution<int> values(0, 20);
 
   for (int i = 0; i < 10; ++i) {

--- a/tools/wake-unit/result.cpp
+++ b/tools/wake-unit/result.cpp
@@ -63,7 +63,6 @@ TEST(result_copy) {
   EXPECT_EQUAL(10, *value2);
 }
 
-
 TEST(result_move) {
   wcl::result<int, int> err1 = wcl::result_error<int>(10);
   wcl::result<int, int> err2(std::move(err1));
@@ -79,35 +78,36 @@ TEST(result_move) {
 
   // We want to make sure we can make result move only things.
   {
-  wcl::result<std::unique_ptr<int>, int> move_only1(wcl::in_place_t{}, std::make_unique<int>(10));
-  wcl::result<std::unique_ptr<int>, int> move_only2(std::move(move_only1));
-  EXPECT_TRUE((bool)move_only1);
-  ASSERT_TRUE((bool)move_only2);
-  EXPECT_EQUAL(10, *move_only2->get());
-  EXPECT_FALSE(move_only2->get() == nullptr);
-  EXPECT_FALSE((*move_only2).get() == nullptr);
-  EXPECT_EQUAL(nullptr, move_only1->get());
-  EXPECT_EQUAL(nullptr, (*move_only1).get());
-  const auto& ref = move_only2;
-  EXPECT_FALSE(ref->get() == nullptr);
-  EXPECT_FALSE((*ref).get() == nullptr);
-  const auto& ref2 = move_only1;
-  EXPECT_TRUE(ref2->get() == nullptr);
-  EXPECT_TRUE((*ref2).get() == nullptr);
+    wcl::result<std::unique_ptr<int>, int> move_only1(wcl::in_place_t{}, std::make_unique<int>(10));
+    wcl::result<std::unique_ptr<int>, int> move_only2(std::move(move_only1));
+    EXPECT_TRUE((bool)move_only1);
+    ASSERT_TRUE((bool)move_only2);
+    EXPECT_EQUAL(10, *move_only2->get());
+    EXPECT_FALSE(move_only2->get() == nullptr);
+    EXPECT_FALSE((*move_only2).get() == nullptr);
+    EXPECT_EQUAL(nullptr, move_only1->get());
+    EXPECT_EQUAL(nullptr, (*move_only1).get());
+    const auto& ref = move_only2;
+    EXPECT_FALSE(ref->get() == nullptr);
+    EXPECT_FALSE((*ref).get() == nullptr);
+    const auto& ref2 = move_only1;
+    EXPECT_TRUE(ref2->get() == nullptr);
+    EXPECT_TRUE((*ref2).get() == nullptr);
   }
 
   // We also want to know the same for errors
   {
-  wcl::result<int, std::unique_ptr<int>> move_only1(wcl::in_place_error_t{}, std::make_unique<int>(10));
-  wcl::result<int, std::unique_ptr<int>> move_only2(std::move(move_only1));
-  EXPECT_FALSE((bool)move_only1);
-  EXPECT_FALSE((bool)move_only2);
-  EXPECT_EQUAL(10, *move_only2.error().get());
-  EXPECT_FALSE(move_only2.error().get() == nullptr);
-  EXPECT_TRUE(move_only1.error().get() == nullptr);
-  const auto& ref = move_only2;
-  EXPECT_FALSE(ref.error().get() == nullptr);
-  EXPECT_FALSE(ref.error().get() == nullptr);
+    wcl::result<int, std::unique_ptr<int>> move_only1(wcl::in_place_error_t{},
+                                                      std::make_unique<int>(10));
+    wcl::result<int, std::unique_ptr<int>> move_only2(std::move(move_only1));
+    EXPECT_FALSE((bool)move_only1);
+    EXPECT_FALSE((bool)move_only2);
+    EXPECT_EQUAL(10, *move_only2.error().get());
+    EXPECT_FALSE(move_only2.error().get() == nullptr);
+    EXPECT_TRUE(move_only1.error().get() == nullptr);
+    const auto& ref = move_only2;
+    EXPECT_FALSE(ref.error().get() == nullptr);
+    EXPECT_FALSE(ref.error().get() == nullptr);
   }
 }
 

--- a/tools/wake-unit/result.cpp
+++ b/tools/wake-unit/result.cpp
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2023 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <wcl/result.h>
+
+#include <algorithm>
+#include <memory>
+#include <random>
+
+#include "unit.h"
+
+TEST(result_err_is_err) {
+  wcl::result<int, int> err = wcl::result_error<int>(10);
+  EXPECT_FALSE((bool)err);
+  EXPECT_EQUAL(10, err.error());
+}
+
+TEST(result_value) {
+  wcl::result<int, int> value = wcl::result_value<int>(10);
+  ASSERT_TRUE((bool)value);
+  EXPECT_EQUAL(10, *value);
+}
+
+TEST(result_inplace_value) {
+  wcl::result<std::pair<int, int>, int> pair = wcl::make_result<std::pair<int, int>, int>(10, 10);
+  ASSERT_TRUE((bool)pair);
+  EXPECT_EQUAL(std::make_pair(10, 10), *pair);
+}
+
+TEST(result_inplace_error) {
+  wcl::result<int, std::pair<int, int>> pair = wcl::make_error<int, std::pair<int, int>>(10, 10);
+  ASSERT_FALSE((bool)pair);
+  EXPECT_EQUAL(std::make_pair(10, 10), pair.error());
+}
+
+TEST(result_copy) {
+  wcl::result<int, int> err1 = wcl::result_error<int>(10);
+  wcl::result<int, int> err2(err1);
+  EXPECT_FALSE((bool)err1);
+  EXPECT_FALSE((bool)err2);
+  EXPECT_EQUAL(10, err1.error());
+  EXPECT_EQUAL(10, err2.error());
+
+  wcl::result<int, int> value1 = wcl::result_value<int>(10);
+  wcl::result<int, int> value2(value1);
+  ASSERT_TRUE((bool)value1);
+  EXPECT_EQUAL(10, *value1);
+  ASSERT_TRUE((bool)value2);
+  EXPECT_EQUAL(10, *value2);
+}
+
+
+TEST(result_move) {
+  wcl::result<int, int> err1 = wcl::result_error<int>(10);
+  wcl::result<int, int> err2(std::move(err1));
+  EXPECT_FALSE((bool)err1);
+  EXPECT_FALSE((bool)err2);
+  EXPECT_EQUAL(10, err2.error());
+
+  wcl::result<int, int> value1 = wcl::result_value<int>(10);
+  wcl::result<int, int> value2(std::move(value1));
+  ASSERT_TRUE((bool)value1);
+  ASSERT_TRUE((bool)value2);
+  EXPECT_EQUAL(10, *value2);
+
+  // We want to make sure we can make result move only things.
+  {
+  wcl::result<std::unique_ptr<int>, int> move_only1(wcl::in_place_t{}, std::make_unique<int>(10));
+  wcl::result<std::unique_ptr<int>, int> move_only2(std::move(move_only1));
+  EXPECT_TRUE((bool)move_only1);
+  ASSERT_TRUE((bool)move_only2);
+  EXPECT_EQUAL(10, *move_only2->get());
+  EXPECT_FALSE(move_only2->get() == nullptr);
+  EXPECT_FALSE((*move_only2).get() == nullptr);
+  EXPECT_EQUAL(nullptr, move_only1->get());
+  EXPECT_EQUAL(nullptr, (*move_only1).get());
+  const auto& ref = move_only2;
+  EXPECT_FALSE(ref->get() == nullptr);
+  EXPECT_FALSE((*ref).get() == nullptr);
+  const auto& ref2 = move_only1;
+  EXPECT_TRUE(ref2->get() == nullptr);
+  EXPECT_TRUE((*ref2).get() == nullptr);
+  }
+
+  // We also want to know the same for errors
+  {
+  wcl::result<int, std::unique_ptr<int>> move_only1(wcl::in_place_error_t{}, std::make_unique<int>(10));
+  wcl::result<int, std::unique_ptr<int>> move_only2(std::move(move_only1));
+  EXPECT_FALSE((bool)move_only1);
+  EXPECT_FALSE((bool)move_only2);
+  EXPECT_EQUAL(10, *move_only2.error().get());
+  EXPECT_FALSE(move_only2.error().get() == nullptr);
+  EXPECT_TRUE(move_only1.error().get() == nullptr);
+  const auto& ref = move_only2;
+  EXPECT_FALSE(ref.error().get() == nullptr);
+  EXPECT_FALSE(ref.error().get() == nullptr);
+  }
+}
+
+TEST(result_forward_value) {
+  wcl::result<std::pair<int, int>, int> opair(wcl::in_place_t{}, 10, 10);
+  EXPECT_TRUE((bool)opair);
+  EXPECT_EQUAL(std::make_pair(10, 10), *opair);
+}
+
+TEST(result_forward_error) {
+  wcl::result<int, std::pair<int, int>> opair(wcl::in_place_error_t{}, 10, 10);
+  EXPECT_FALSE((bool)opair);
+  EXPECT_EQUAL(std::make_pair(10, 10), opair.error());
+}
+
+struct NoCopy {
+  NoCopy() = delete;
+  NoCopy(const NoCopy&) = delete;
+  NoCopy(NoCopy&&) = default;
+  ~NoCopy() {
+    std::cerr << "You weren't ever supposed to be able to construct such a thing!!!" << std::endl;
+    exit(1);
+  }
+};
+
+TEST(result_no_construct) {
+  wcl::result<NoCopy, int> error = wcl::result_error<NoCopy>(10);
+  wcl::result<int, NoCopy> value = wcl::result_value<NoCopy>(10);
+  EXPECT_TRUE((bool)value);
+  EXPECT_FALSE((bool)error);
+}
+
+struct SetOnDestruct {
+  const char*& msg;
+  const char* on_destruct = nullptr;
+
+  SetOnDestruct() = delete;
+  SetOnDestruct(const char*& msg, const char* on_destruct) : msg(msg), on_destruct(on_destruct) {}
+
+  ~SetOnDestruct() { msg = on_destruct; }
+};
+
+class ConstructDestructCount {
+ private:
+  int* count = nullptr;
+
+ public:
+  ConstructDestructCount() = default;
+  ConstructDestructCount(int& count) : count(&count) { ++*this->count; }
+  ConstructDestructCount(const ConstructDestructCount& other) : count(other.count) {
+    ++*this->count;
+  }
+  ConstructDestructCount(ConstructDestructCount&& other) : count(other.count) {
+    other.count = nullptr;
+  }
+  ConstructDestructCount& operator=(const ConstructDestructCount& other) {
+    if (count) --*count;
+    count = other.count;
+    ++*count;
+    return *this;
+  }
+  ConstructDestructCount& operator=(ConstructDestructCount&& other) {
+    if (count) --*count;
+    count = other.count;
+    other.count = nullptr;
+    return *this;
+  }
+  ~ConstructDestructCount() {
+    if (count) --*count;
+  }
+  void swap(ConstructDestructCount& other) { std::swap(count, other.count); }
+};
+
+TEST(result_destructs) {
+  const char* msg;
+  const char* expected = "this is the expected string";
+  int counter = 0;
+
+  // First some really basic tests
+  {
+    wcl::result<SetOnDestruct, int> msg_setter(wcl::in_place_t{}, msg, expected);
+    wcl::result<ConstructDestructCount, int> ocounter(wcl::in_place_t{}, counter);
+  }
+  EXPECT_EQUAL(msg, expected);
+  ASSERT_EQUAL(0, counter);
+
+  {
+    wcl::result<int, SetOnDestruct> msg_setter(wcl::in_place_error_t{}, msg, expected);
+    wcl::result<int, ConstructDestructCount> ocounter(wcl::in_place_error_t{}, counter);
+  }
+  EXPECT_EQUAL(msg, expected);
+  ASSERT_EQUAL(0, counter);
+
+  // Now some basic assignment tests.
+  {
+    wcl::result<ConstructDestructCount, int> counter1(wcl::in_place_t{}, counter);
+    EXPECT_EQUAL(1, counter);
+    wcl::result<ConstructDestructCount, int> counter2(wcl::in_place_error_t{}, 10);
+    EXPECT_EQUAL(1, counter);
+    counter2 = counter1;
+    EXPECT_EQUAL(2, counter);
+    EXPECT_TRUE((bool)counter2);
+    EXPECT_TRUE((bool)counter1);
+  }
+  ASSERT_EQUAL(0, counter);
+  {
+    wcl::result<ConstructDestructCount, int> counter1(wcl::in_place_t{}, counter);
+    EXPECT_EQUAL(1, counter);
+    wcl::result<ConstructDestructCount, int> counter2(wcl::in_place_error_t{}, 10);
+    EXPECT_EQUAL(1, counter);
+    counter2 = std::move(counter1);
+    EXPECT_EQUAL(1, counter);
+    EXPECT_TRUE((bool)counter2);
+    EXPECT_TRUE((bool)counter1);
+  }
+  ASSERT_EQUAL(0, counter);
+
+  // Now do something complicated to really stress the counter.
+  {
+    std::vector<wcl::result<ConstructDestructCount, int>> counters;
+    for (int i = 0; i < 1000; ++i) {
+      counters.emplace_back(wcl::in_place_t{}, counter);
+    }
+    EXPECT_EQUAL(1000, counter);
+    std::mt19937 gen;
+    for (int i = 0; i < 10; ++i) std::shuffle(counters.begin(), counters.end(), gen);
+    EXPECT_EQUAL(1000, counter);
+  }
+  ASSERT_EQUAL(0, counter);
+}
+
+TEST(result_assign1) {
+  // Basic copy
+  wcl::result<int, int> some1(wcl::in_place_t{}, 10);
+  wcl::result<int, int> some2(wcl::in_place_error_t{}, 10);
+  EXPECT_FALSE((bool)some2);
+  some2 = some1;
+  ASSERT_TRUE((bool)some1);
+  ASSERT_TRUE((bool)some2);
+  EXPECT_EQUAL(*some1, *some2);
+}
+
+TEST(result_assign2) {
+  // Basic copy
+  int counter = 0;
+  {
+    wcl::result<ConstructDestructCount, int> some1(wcl::in_place_t{}, counter);
+    wcl::result<ConstructDestructCount, int> some2(wcl::in_place_error_t{}, 10);
+
+    EXPECT_TRUE((bool)some1);
+    EXPECT_FALSE((bool)some2);
+    EXPECT_EQUAL(1, counter);
+
+    some2 = some1;
+    EXPECT_TRUE((bool)some1);
+    EXPECT_TRUE((bool)some2);
+    EXPECT_EQUAL(2, counter);
+
+    some1 = some2;
+    EXPECT_TRUE((bool)some1);
+    EXPECT_TRUE((bool)some2);
+    EXPECT_EQUAL(2, counter);
+
+    some1 = wcl::result_error<ConstructDestructCount>(10);
+    EXPECT_TRUE((bool)some2);
+    EXPECT_FALSE((bool)some1);
+    EXPECT_EQUAL(1, counter);
+  }
+  EXPECT_EQUAL(0, counter);
+}


### PR DESCRIPTION
This change adds a `result` type for better error handling in wake. This is in line with modern C++ code bases like llvm/clang, tensorflow, etc... and matches rust and funny enough wake's error handling style.

This is part of a series of changes that will end in adding an LRU eviction policy to shared caching. The next change, which I wanted this change for, will be to add a better read-dir library next.