### PR TITLE
Add directory_range to wcl

### DIFF
--- a/src/wcl/filepath.cpp
+++ b/src/wcl/filepath.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "filepath.h"
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+namespace wcl {
+
+// assumes that type != DT_UNKNOWN
+static file_type dir_type_conv(unsigned char type) {
+  switch (type) {
+    case DT_BLK:
+      return file_type::block;
+    case DT_CHR:
+      return file_type::character;
+    case DT_DIR:
+      return file_type::directory;
+    case DT_FIFO:
+      return file_type::fifo;
+    case DT_LNK:
+      return file_type::symlink;
+    case DT_REG:
+      return file_type::regular;
+    case DT_SOCK:
+      return file_type::socket;
+  }
+  return file_type::unknown;
+}
+
+static file_type stat_type_conv(mode_t mode) {
+  switch (mode & S_IFMT) {
+    case S_IFBLK:
+      return file_type::block;
+    case S_IFCHR:
+      return file_type::character;
+    case S_IFDIR:
+      return file_type::directory;
+    case S_IFIFO:
+      return file_type::fifo;
+    case S_IFLNK:
+      return file_type::symlink;
+    case S_IFREG:
+      return file_type::regular;
+    case S_IFSOCK:
+      return file_type::socket;
+  }
+  return file_type::unknown;
+}
+
+void directory_iterator::step() {
+  // checking for errors with readdir is a bit tricky.
+  // you have to set errno to zero and see if it changes.
+  errno = 0;
+  dirent *entry = readdir(dir);
+  if (entry == nullptr && errno != 0) {
+    value = some(make_errno<directory_entry>());
+  }
+
+  // if errno is still zero but entry == nullptr then
+  // we've hit the end and want to turn outselves into
+  // the end pointer
+  if (entry == nullptr) {
+    dir = nullptr;
+    dir_path = "";
+    // We set value not just to empty but to an error for EBADF.
+    // This mimics what would happen if you called readdir again
+    // after passing the end of the DIR
+    value = some(make_error<directory_entry, posix_error_t>(EBADF));
+  }
+
+  // Now that we have a good entry we need to construct
+  // the wrapper
+  directory_entry out;
+  out.entry_name = entry->d_name;
+
+  // d_name might be missing so we stat if that
+  // occurs.
+  if (entry->d_type == DT_UNKNOWN) {
+    std::string path = join_paths(dir_path, out.entry_name);
+    struct stat buf;
+    stat(path.c_str(), &buf);
+    out.type = stat_type_conv(buf.st_mode);
+  } else {
+    out.type = dir_type_conv(entry->d_type);
+  }
+
+  // finally if there's nothing holding us back set the value
+  value = some(make_result<directory_entry, posix_error_t>(std::move(out)));
+}
+
+}  // namespace wcl

--- a/src/wcl/filepath.h
+++ b/src/wcl/filepath.h
@@ -17,11 +17,100 @@
 
 #pragma once
 
+#include <dirent.h>
+#include <sys/types.h>
+
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include "result.h"
+
 namespace wcl {
+
+enum class file_type { block, character, directory, fifo, symlink, regular, socket, unknown };
+
+struct directory_entry {
+  std::string entry_name;
+  file_type type;
+};
+
+class directory_range;
+
+class directory_iterator {
+  friend class directory_range;
+
+ private:
+  std::string dir_path;
+  DIR* dir = nullptr;
+  optional<result<directory_entry, posix_error_t>> value;
+
+  // This steps the current entry by one
+  void step();
+  directory_iterator(std::string dir_path, DIR* dir) : dir(dir), value() {}
+
+ public:
+  ~directory_iterator() {}
+  directory_iterator() : dir_path(), dir(nullptr), value() {
+    // The default constructor should behave like something
+    // going past the end of a directory when using readdir
+    value = some(make_error<directory_entry, posix_error_t>(EBADF));
+  }
+  directory_iterator(const directory_iterator&) = delete;
+  directory_iterator(directory_iterator&& other) : dir(other.dir), value(std::move(other.value)) {
+    other.dir = nullptr;
+  }
+
+  const result<directory_entry, posix_error_t>& operator*() {
+    // on our first call we won't have a value set, so set it.
+    if (!value && dir) {
+      step();
+    }
+
+    return *value;
+  }
+
+  directory_iterator& operator++() {
+    step();
+    return *this;
+  }
+
+  bool operator!=(const directory_iterator& other) { return dir == other.dir; }
+};
+
+class directory_range {
+ private:
+  DIR* dir = nullptr;
+  std::string dir_path;
+
+  directory_range(const std::string& path) : dir(nullptr), dir_path(path) {
+    dir = opendir(path.c_str());
+  }
+
+ public:
+  ~directory_range() {
+    if (dir) {
+      closedir(dir);
+    }
+  }
+  directory_range(const directory_range&) = delete;
+  directory_range(directory_range&& dir) : dir(dir.dir), dir_path(std::move(dir_path)) {
+    dir.dir = nullptr;
+  }
+
+  static result<directory_range, posix_error_t> open(const std::string& path) {
+    directory_range out{path};
+    if (out.dir == nullptr) {
+      return make_error<directory_range, posix_error_t>(errno);
+    }
+
+    return make_result<directory_range, posix_error_t>(std::move(out));
+  }
+
+  directory_iterator begin() { return directory_iterator(dir_path, dir); }
+
+  directory_iterator end() { return directory_iterator{}; }
+};
 
 // filepath_iterator breaks up a filepath
 // into its parts. So if you're iterating over

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -15,6 +15,8 @@ PASSED:
   doc_large
   doc_undo
   doc_unicode
+  filepath_dir_range_basic
+  filepath_dir_range_empty
   filepath_make_canonical
   filepath_range_basic
   filepath_range_empty_node

--- a/tools/wake-unit/filepath.cpp
+++ b/tools/wake-unit/filepath.cpp
@@ -299,7 +299,7 @@ TEST(filepath_dir_range_basic) {
   size_t counter = 0;
   for (auto entry : *dir_range) {
     // First assert that the entry has no error
-    ASSERT_TRUE((bool)entry) << "entry: " << entry->name << std::endl;
+    ASSERT_TRUE((bool)entry) << "entry: " << entry->name;
 
     // Now check the type if we can
     EXPECT_TRUE((bool)expected_type.count(entry->name));

--- a/tools/wake-unit/filepath.cpp
+++ b/tools/wake-unit/filepath.cpp
@@ -18,9 +18,16 @@
 #include <wcl/filepath.h>
 #include <wcl/xoshiro_256.h>
 
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string.h>
+
 #include <random>
 #include <string>
 #include <vector>
+#include <map>
+#include <set>
+#include <fstream>
 
 #include "unit.h"
 
@@ -235,4 +242,89 @@ TEST(filepath_make_canonical) {
   EXPECT_EQUAL(wcl::make_canonical("hax/"), "hax");
   EXPECT_EQUAL(wcl::make_canonical("foo/.././bar.z"), "bar.z");
   EXPECT_EQUAL(wcl::make_canonical("foo/../../bar.z"), "../bar.z");
+}
+
+TEST(filepath_dir_range_empty) {
+  ASSERT_TRUE(mkdir("test_dir", 0777) >= 0);
+  auto dir_range = wcl::directory_range::open("test_dir");
+  ASSERT_TRUE((bool)dir_range);
+  for (auto entry : *dir_range) {
+    if (entry && entry->name == ".") continue;
+    if (entry && entry->name == "..") continue;
+    // First assert that the entry has no error
+    ASSERT_TRUE((bool)entry);
+    // Now assert that we shouldn't have found this in the first place!
+    EXPECT_TRUE(false) << " found entry '" << entry->name << "' but epected nothing";
+  }
+  ASSERT_TRUE(rmdir("test_dir") >= 0);
+}
+
+TEST(filepath_dir_range_basic) {
+  // We need a clean dir for our tests
+  ASSERT_TRUE(mkdir("test_dir", 0777) >= 0);
+
+  std::map<std::string, wcl::file_type> expected_type;
+  expected_type["."] = wcl::file_type::directory;
+  expected_type[".."] = wcl::file_type::directory;
+
+  auto touch = [&](std::string entry) {
+    std::ofstream file("test_dir/" + entry);
+    file << " ";
+    file.close();
+    expected_type[entry] = wcl::file_type::regular;
+  };
+
+  auto touch_dir = [&](std::string entry) {
+    std::string dir = "test_dir/" + entry;
+    mkdir(dir.c_str(), 0777);
+    expected_type[entry] = wcl::file_type::directory;
+  };
+
+  auto touch_sym = [&](std::string entry) {
+    std::string path = "test_dir/" + entry;
+    symlink("touch", path.c_str());
+    expected_type[entry] = wcl::file_type::symlink;
+  };
+
+  touch("test1.txt");
+  touch("test2.txt");
+  touch("test3.txt");
+  touch_dir("test1");
+  touch_dir("test2");
+  touch_dir("test3");
+  touch_sym("sym1");
+  touch_sym("sym2");
+
+  auto dir_range = wcl::directory_range::open("test_dir");
+  ASSERT_TRUE((bool)dir_range);
+  size_t counter = 0;
+  for (auto entry : *dir_range) {
+    // First assert that the entry has no error
+    ASSERT_TRUE((bool)entry) << "entry: " << entry->name << std::endl;
+
+    // Now check the type if we can
+    EXPECT_TRUE((bool)expected_type.count(entry->name));
+    if (expected_type.count(entry->name)) {
+      EXPECT_EQUAL(expected_type[entry->name], entry->type) << " on entry '" << entry->name << "'";
+    }
+
+    // And record how many files we found to make sure we found
+    // everything we expected
+    counter++;
+  }
+
+  EXPECT_EQUAL(expected_type.size(), counter);
+
+  // Now clean up
+  for (auto entry : expected_type) {
+    if (entry.first == ".") continue;
+    if (entry.first == "..") continue;
+    std::string path = "test_dir/" + entry.first;
+    if (entry.second == wcl::file_type::directory) {
+      ASSERT_TRUE(rmdir(path.c_str()) >= 0) << "on entry '" << entry.first << "'";
+    } else {
+      ASSERT_TRUE(unlink(path.c_str()) >= 0) << "on entry '" << entry.first << "'";
+    }
+  }
+  rmdir("test_dir");
 }

--- a/tools/wake-unit/filepath.cpp
+++ b/tools/wake-unit/filepath.cpp
@@ -15,19 +15,18 @@
  * limitations under the License.
  */
 
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <wcl/filepath.h>
 #include <wcl/xoshiro_256.h>
 
-#include <sys/stat.h>
-#include <unistd.h>
-#include <string.h>
-
+#include <fstream>
+#include <map>
 #include <random>
+#include <set>
 #include <string>
 #include <vector>
-#include <map>
-#include <set>
-#include <fstream>
 
 #include "unit.h"
 

--- a/tools/wake-unit/unit.h
+++ b/tools/wake-unit/unit.h
@@ -188,6 +188,36 @@ struct TestLogger {
     return fail(*err, assert);
   }
 
+  TestStream expect_equal(bool assert, size_t expected, size_t actual, const char* expected_str,
+                          const char* actual_str, int line, const char* file) {
+    if (expected == actual) return TestStream(nullptr, nullptr);
+    errors.emplace_back(new ErrorMessage);
+    auto& err = errors.back();
+    err->test_name = test_name;
+    err->file = file;
+    err->line = line;
+    err->predicate_error << "Expected:\n\t" << term_colour(TERM_MAGENTA) << expected;
+    err->predicate_error << term_normal() << "\nBut got:\n\t";
+    err->predicate_error << term_colour(TERM_MAGENTA) << actual;
+    err->predicate_error << term_normal() << std::endl;
+    return fail(*err, assert);
+  }
+
+  TestStream expect_equal(bool assert, int64_t expected, int64_t actual, const char* expected_str,
+                          const char* actual_str, int line, const char* file) {
+    if (expected == actual) return TestStream(nullptr, nullptr);
+    errors.emplace_back(new ErrorMessage);
+    auto& err = errors.back();
+    err->test_name = test_name;
+    err->file = file;
+    err->line = line;
+    err->predicate_error << "Expected:\n\t" << term_colour(TERM_MAGENTA) << expected;
+    err->predicate_error << term_normal() << "\nBut got:\n\t";
+    err->predicate_error << term_colour(TERM_MAGENTA) << actual;
+    err->predicate_error << term_normal() << std::endl;
+    return fail(*err, assert);
+  }
+
   TestStream expect_equal(bool assert, std::string expected, std::string actual,
                           const char* expected_str, const char* actual_str, int line,
                           const char* file) {


### PR DESCRIPTION
This change adds a wrapper around posix readdir in order to make iterating directories simpler, more C++-ish, and improve error handling for it.