### PR TITLE
html: Refactor and modernize HTML/CSS/JS

### DIFF
--- a/share/wake/html/main.js
+++ b/share/wake/html/main.js
@@ -84,9 +84,9 @@ function onMouseOut(event) {
 };
 
 document.addEventListener('keypress', function(event) {
-  const char = event.which || event.keyCode;
-  if (char === 43 || char == 61) { ++depth; update(); }
-  if ((char === 45 || char == 95) && depth > 0) { --depth; update(); }
+  const char = event.key;
+  if (char === '+' || char === '=') { ++depth; update(); }
+  if ((char === '-' || char === '_') && depth > 0) { --depth; update(); }
 }, true);
 
 function smoothFromTo(fromX, fromY, destX, destY, step) {

--- a/share/wake/html/main.js
+++ b/share/wake/html/main.js
@@ -25,10 +25,25 @@ tooltip.style.visibility = 'hidden';
 const usecss = document.createElement('div');
 usecss.appendChild(document.createElement('style'));
 
+// The following variables encompass the state for expression selection mode,
+// where pressing + or - on the keyboard while the mouse is hovering over an
+// expression will allow one to select parent or child expressions, which
+// affects the type shown in the tooltip.
+
+/** The current expression selection depth. */
 let depth = 0;
+/** The inner-most (depth 0) element in the expression tree. */
 let inner = null;
+/** The currently-selected element in the expression tree. */
 let select = null;
 
+/** Update the currently selected expression.
+ *
+ * The global variables `depth` and `inner` are essentially the arguments to the
+ * function, used to determine which expression should be selected. `inner` is
+ * the smallest expression that the mouse is hovering over. `depth` is how many
+ * parent expressions to walk up.
+ */
 function update () {
   let next = inner;
   for (let i = 0; i < depth; ++i) {

--- a/share/wake/html/main.js
+++ b/share/wake/html/main.js
@@ -179,13 +179,9 @@ function workspace(node) {
 document.addEventListener('DOMContentLoaded', function main () {
   document.body.appendChild(usecss);
   document.body.appendChild(tooltip);
-  var points = document.querySelectorAll('*');
-  for (let point of points) {
-    if (point.type === 'wake') {
-      const node = JSON.parse(point.innerHTML);
-      document.body.appendChild(workspace(node));
-    }
-  }
+  const wakeData = document.getElementById('wake-data');
+  const node = JSON.parse(wakeData.text);
+  document.body.appendChild(workspace(node));
 });
 
 /* eslint-env browser */

--- a/share/wake/html/main.js
+++ b/share/wake/html/main.js
@@ -53,15 +53,15 @@ function update () {
   select = next;
 }
 
-document.onMouseOver = function (that, event) {
-  inner = that;
+function onMouseOver(event) {
+  inner = event.target;
   depth = 0;
   update();
   tooltip.style.cssText = `position: absolute; top: ${event.pageY + 10}px; left: ${event.pageX}px;`;
   event.stopPropagation();
 };
 
-document.onMouseOut = function (that, event) {
+function onMouseOut(event) {
   inner = null;
   depth = 0;
   update();
@@ -89,8 +89,8 @@ function smoothFromTo(fromX, fromY, destX, destY, step) {
     setTimeout(function () { smoothFromTo(fromX, fromY, destX, destY, step+1); }, stepMs);
 }
 
-document.focusOn = function (that, event) {
-  const target = that.getAttribute('href').substring(1);
+function focusOn(event) {
+  const target = event.currentTarget.getAttribute('href').substring(1);
   const where = document.getElementById(target).getBoundingClientRect();
   const fromX = window.scrollX;
   const fromY = window.scrollY;
@@ -104,8 +104,8 @@ document.focusOn = function (that, event) {
   smoothFromTo(fromX, fromY, destX, destY, 1);
 };
 
-document.onMouseClick = function (that, event) {
-  usecss.firstChild.innerHTML = '*[href=\'#' + that.id + '\'] { background-color: red; }';
+function onMouseClick(event) {
+  usecss.firstChild.innerHTML = '*[href=\'#' + event.currentTarget.id + '\'] { background-color: red; }';
   event.stopPropagation();
 };
 
@@ -121,18 +121,18 @@ function render(root) {
 
     if (node.sourceType) {
       res.setAttribute('sourceType', node.sourceType);
-      res.setAttribute('onmouseover', 'onMouseOver(this, event)');
-      res.setAttribute('onmouseout', 'onMouseOut(this, event)');
+      res.addEventListener('mouseover', onMouseOver);
+      res.addEventListener('mouseout', onMouseOut);
     }
 
     if (node.type === 'VarDef' || node.type === 'VarArg') {
       res.setAttribute('id', root.filename + ':' + node.range.join(':'));
-      res.setAttribute('onclick', 'onMouseClick(this, event)');
+      res.addEventListener('click', onMouseClick);
     }
 
     if (node.target) {
       res.setAttribute('href', '#' + node.target.filename + ':' + node.target.range.join(':'));
-      res.setAttribute('onclick', 'focusOn(this, event)');
+      res.addEventListener('click', focusOn);
     }
 
     let pointer = pRange[0];

--- a/share/wake/html/main.js
+++ b/share/wake/html/main.js
@@ -47,8 +47,8 @@ let select = null;
 function update () {
   let next = inner;
   for (let i = 0; i < depth; ++i) {
-    let parent = next.parentElement;
-    if (!parent.getAttribute('sourceType')) {
+    let parent = next?.parentElement;
+    if (!parent?.getAttribute('sourceType')) {
       depth = i;
       break;
     }

--- a/share/wake/html/style.css
+++ b/share/wake/html/style.css
@@ -39,8 +39,10 @@ pre {
 .Prim       { color: yellow; }
 .Literal    { color: pink; }
 
-*[sourceType]:hover { background-color: hsla(0, 100%, 100%, 0.1); }
-*[focus='true']:hover { background-color: green; }
+.sourceType:hover { background-color: hsla(0, 100%, 100%, 0.1); }
+.focus:hover { background-color: green; }
+
+.highlightUseDef { background-color: red; }
 
 .tooltip {
   display: block;
@@ -49,6 +51,9 @@ pre {
   position: absolute;
   min-width: 200px;
   background-color: #333;
+}
+.tooltip.hidden {
+  visibility: hidden;
 }
 
 a:link {

--- a/share/wake/html/style.css
+++ b/share/wake/html/style.css
@@ -14,9 +14,27 @@
  * limitations under the License.
  */
 
+:root {
+  /* Foreground colors */
+  --color-default: white;
+  --color-program: #999;
+  --color-var-ref: white;
+  --color-var-def: #ee3;
+  --color-var-arg: #55f;
+  --color-prim: yellow;
+  --color-literal: pink;
+
+  /* Background colors */
+  --color-background: black;
+  --color-tooltip-background: #333;
+  --color-focus-background: green;
+  --color-sourcetype-background: hsla(0, 100%, 100%, 0.1);
+  --color-highlight-usedef-background: red;
+}
+
 body {
   hyphens: auto;
-  background-color: black;
+  background-color: var(--color-background);
   font-family: 'Roboto', sans-serif;
 }
 
@@ -25,24 +43,24 @@ th,td {
   border: 1px solid #000;
 }
 
-div { color: white; }
+div { color: var(--color-default); }
 
 pre {
   /* font-family: 'IBM Plex Mono', monospace; */
   font-family: 'Roboto Mono', monospace;
 }
 
-.Program    { color: #999; }
-.VarRef     { color: white; }
-.VarDef     { color: #ee3; }
-.VarArg     { color: #55f; }
-.Prim       { color: yellow; }
-.Literal    { color: pink; }
+.Program    { color: var(--color-program); }
+.VarRef     { color: var(--color-var-ref); }
+.VarDef     { color: var(--color-var-def); }
+.VarArg     { color: var(--color-var-arg); }
+.Prim       { color: var(--color-prim); }
+.Literal    { color: var(--color-literal); }
 
-.sourceType:hover { background-color: hsla(0, 100%, 100%, 0.1); }
-.focus:hover { background-color: green; }
+.sourceType:hover { background-color: var(--color-sourcetype-background); }
+.focus:hover { background-color: var(--color-focus-background); }
 
-.highlightUseDef { background-color: red; }
+.highlightUseDef { background-color: var(--color-highlight-usedef-background); }
 
 .tooltip {
   display: block;
@@ -50,7 +68,7 @@ pre {
   z-index: 5;
   position: absolute;
   min-width: 200px;
-  background-color: #333;
+  background-color: var(--color-tooltip-background);
 }
 .tooltip.hidden {
   visibility: hidden;

--- a/tools/wake/markup.cpp
+++ b/tools/wake/markup.cpp
@@ -195,6 +195,10 @@ void markup_html(const std::string &libdir, std::ostream &os, Expr *root) {
   std::ifstream style(find_execpath() + "/../share/wake/html/style.css");
   std::ifstream utf8(find_execpath() + "/../share/wake/html/utf8.js");
   std::ifstream main(find_execpath() + "/../share/wake/html/main.js");
+  os << "<!DOCTYPE html>" << std::endl;
+  os << "<html lang=\"en\">" << std::endl;
+  os << "<head>" << std::endl;
+  os << "<title>Wake Annotated Source Code</title>" << std::endl;
   os << "<meta charset=\"UTF-8\">" << std::endl;
   os << "<style type=\"text/css\">" << std::endl;
   os << style.rdbuf();
@@ -208,6 +212,9 @@ void markup_html(const std::string &libdir, std::ostream &os, Expr *root) {
   os << "<script id=\"wake-data\" type=\"application/json\">";
   JSONRender(libdir, os).render(root);
   os << "</script>" << std::endl;
+  os << "</head>" << std::endl;
+  os << "<body></body>" << std::endl;
+  os << "</html>" << std::endl;
 }
 
 void format_reexports(std::ostream &os, const char *package, const char *kind,

--- a/tools/wake/markup.cpp
+++ b/tools/wake/markup.cpp
@@ -205,7 +205,7 @@ void markup_html(const std::string &libdir, std::ostream &os, Expr *root) {
   os << "<script type=\"text/javascript\">" << std::endl;
   os << main.rdbuf();
   os << "</script>" << std::endl;
-  os << "<script type=\"wake\">";
+  os << "<script id=\"wake-data\" type=\"application/json\">";
   JSONRender(libdir, os).render(root);
   os << "</script>" << std::endl;
 }


### PR DESCRIPTION
This makes a number of non-functional changes to the `wake --html` output to modernize the code and make it easier to work with (IMO, at least). See the individual commits for more information about each change, but at a high level, this:

- explicitly declares the document to be HTML5, since it's no longer 2010
- relies less on DOM APIs that require parsing strings and instead uses the APIs that let you directly modify elements in a structured way. e.g. `Element.cssText` -> `Element.style`, `Element.setAttribute()` -> `Element.<specific attribute name>`.
- moves almost all styling to CSS, and JS is only used to add or remove CSS class names on elements
- uses the official [`data-`/`dataset` API](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) for setting custom attributes and not making up our own root-namespace attributes
- use [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) (a.k.a. variables), a somewhat recent CSS feature. This will make it a bit easier to support both a light and dark theme, which I will do in a followup PR that I am about to submit.

This should have no functional (nor aesthetic) impact on the generated HTML files.