### PR TITLE
html: Add new dark and light themes.

### DIFF
--- a/share/wake/html/main.js
+++ b/share/wake/html/main.js
@@ -197,11 +197,36 @@ function workspace(node) {
   return res;
 }
 
+function createThemeToggle() {
+  const prefersDark = matchMedia('prefers-color-scheme: dark');
+  document.documentElement.className = prefersDark ? 'dark' : 'light';
+
+  const themeToggle = document.createElement('div');
+  themeToggle.innerHTML = `
+    <label>Light<input type="radio" name="style" value="light"${prefersDark ? '' : ' checked'}>
+    <label>Dark<input type="radio" name="style" value="dark"${prefersDark ? ' checked' : ''}>
+  `;
+
+  const onChange = (e) => {
+    e.preventDefault();
+    document.documentElement.className = e.target.value;
+  }
+  themeToggle.querySelectorAll('input')
+    .forEach(e => e.addEventListener('change', onChange));
+
+  themeToggle.style.position = 'fixed';
+  themeToggle.style.top = '10px';
+  themeToggle.style.right = '10px';
+
+  return themeToggle;
+}
+
 document.addEventListener('DOMContentLoaded', function main () {
   document.body.appendChild(tooltip);
   const wakeData = document.getElementById('wake-data');
   const node = JSON.parse(wakeData.text);
   document.body.appendChild(workspace(node));
+  document.body.appendChild(createThemeToggle());
 });
 
 /* eslint-env browser */

--- a/share/wake/html/main.js
+++ b/share/wake/html/main.js
@@ -198,21 +198,32 @@ function workspace(node) {
 }
 
 function createThemeToggle() {
-  const prefersDark = matchMedia('prefers-color-scheme: dark');
-  document.documentElement.className = prefersDark ? 'dark' : 'light';
+  // If the user previously chose a theme, default to that theme.
+  // Otherwise, check the browser/OS preferences for dark vs. light theme.
+  let colorTheme = window.localStorage?.getItem('wakeColorTheme');
+  colorTheme ||= matchMedia('prefers-color-scheme: dark') ? 'dark' : 'light';
+
+  document.documentElement.className = colorTheme;
 
   const themeToggle = document.createElement('div');
   themeToggle.innerHTML = `
-    <label>Light<input type="radio" name="style" value="light"${prefersDark ? '' : ' checked'}>
-    <label>Dark<input type="radio" name="style" value="dark"${prefersDark ? ' checked' : ''}>
+    <label>Light<input type="radio" name="style" value="light">
+    <label>Dark<input type="radio" name="style" value="dark">
   `;
 
   const onChange = (e) => {
     e.preventDefault();
     document.documentElement.className = e.target.value;
+    window.localStorage?.setItem('wakeColorTheme', e.target.value);
   }
   themeToggle.querySelectorAll('input')
-    .forEach(e => e.addEventListener('change', onChange));
+    .forEach(elem => {
+      elem.addEventListener('change', onChange);
+
+      if (elem.value === colorTheme) {
+        elem.checked = true;
+      }
+    });
 
   themeToggle.style.position = 'fixed';
   themeToggle.style.top = '10px';

--- a/share/wake/html/main.js
+++ b/share/wake/html/main.js
@@ -207,8 +207,8 @@ function createThemeToggle() {
 
   const themeToggle = document.createElement('div');
   themeToggle.innerHTML = `
-    <label>Light<input type="radio" name="style" value="light">
-    <label>Dark<input type="radio" name="style" value="dark">
+    <label>Light<input type="radio" name="style" value="light" /></label>
+    <label>Dark<input type="radio" name="style" value="dark" /></label>
   `;
 
   const onChange = (e) => {

--- a/share/wake/html/style.css
+++ b/share/wake/html/style.css
@@ -16,20 +16,38 @@
 
 :root {
   /* Foreground colors */
-  --color-default: white;
-  --color-program: #999;
-  --color-var-ref: white;
-  --color-var-def: #ee3;
-  --color-var-arg: #55f;
-  --color-prim: yellow;
-  --color-literal: pink;
+  --color-default: #1c1735;
+  --color-program: #5f588a;
+  --color-var-ref: #1c1735;
+  --color-var-def: #895400;
+  --color-var-arg: #0056b5;
+  --color-prim: #5e6500;
+  --color-literal: #70007f;
 
   /* Background colors */
-  --color-background: black;
-  --color-tooltip-background: #333;
-  --color-focus-background: green;
+  --color-background: #f1f0f6;
+  --color-tooltip-background: #c6c5d2;
+  --color-focus-background: #a2d491;
+  --color-sourcetype-background: hsla(0, 100%, 0%, 0.1);
+  --color-highlight-usedef-background: #f68ba2;
+}
+
+:root.dark {
+  /* Foreground colors */
+  --color-default: #e2e0f4;
+  --color-program: #918bbc;
+  --color-var-ref: #e2e0f4;
+  --color-var-def: #f1bf51;
+  --color-var-arg: #65aeff;
+  --color-prim: #c6ce3e;
+  --color-literal: #fea7ff;
+
+  /* Background colors */
+  --color-background: #1c1a24;
+  --color-tooltip-background: #302e44;
+  --color-focus-background: #005600;
   --color-sourcetype-background: hsla(0, 100%, 100%, 0.1);
-  --color-highlight-usedef-background: red;
+  --color-highlight-usedef-background: #88193d;
 }
 
 body {


### PR DESCRIPTION
This builds off https://github.com/sifive/wake/pull/1179 by adding new dark and light color themes for the generated HTML pages. I added a theme toggle to the top right of the page, but I otherwise default to your OS's settings (and failing that, it defaults to the light theme).

I originally attempted to colors from popular open source themes like Solarized and Dracula, but none of them worked well for the several colored background highlights that are used in the wake generated HTML. I ended up making up my own theme using purple as the primary tint and basing the remainder of the colors off the original hues that wake used. I lightened the background color and darkened the text colors, since the original wake styles used pure black and pure white, which causes excessive contrast and can actually reduce readability. I also adjusted the foreground colors so that they have appropriate contrast with the background colors, e.g. not so dark that they are insufficiently contrasted with the background, and not so light that they are a painful to read due to excessive contrast.

I'm happy to tweak the colors if anyone has any preferences or requests.

## Dark theme
<img width="1261" alt="Screen Shot 2023-03-29 at 1 40 28 PM" src="https://user-images.githubusercontent.com/1002748/228662442-fffa4484-30be-4428-b7a7-24e06623247d.png">

## Light theme
<img width="1269" alt="Screen Shot 2023-03-29 at 1 40 42 PM" src="https://user-images.githubusercontent.com/1002748/228662438-14725814-b9e3-45ca-bff1-928864682cbc.png">
