### PR TITLE
describe: Minimize newline output

### DIFF
--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -210,8 +210,9 @@ static void describe_shell(const std::vector<JobReflection> &jobs, bool debug, b
 void describe_human(const std::vector<JobReflection> &jobs) {
   TermInfoBuf tbuf(std::cout.rdbuf());
   std::ostream out(&tbuf);
-  for (auto &job : jobs) {
-    out << term_colour(TERM_GREEN) << "\n\n# " << job.label << "(" << job.job << ")\n";
+  for (size_t i = 0; i < jobs.size(); i++) {
+    const auto &job = jobs[i];
+    out << term_colour(TERM_GREEN) << "# " << job.label << "(" << job.job << ")\n";
     out << term_normal() << "$ " << term_colour(TERM_CYAN);
     for (size_t i = 0; i < job.commandline.size(); i++) {
       const auto &cmd_part = job.commandline[i];
@@ -221,11 +222,16 @@ void describe_human(const std::vector<JobReflection> &jobs) {
         out << " ";
       }
     }
-    out << "\n\n\n" << term_normal();
 
-    // We have to use our speical stream for the output of the program
+    out << "\n" << term_normal();
+
+    // We have to use our special stream for the output of the program
     for (auto &log_line : job.std_writes) {
       out << log_line.first;
+    }
+
+    if (i + 1 < jobs.size()) {
+      out << "\n";
     }
   }
 }


### PR DESCRIPTION
Fixes #1154.

Output jobs with fewer newlines.

```
> ./bin/wake --last
# some plan label 2(675)
$ /usr/bin/dash -c sleep 1; echo 2; echo foo > somefile2;
2

# some plan label 1(674)
$ /usr/bin/dash -c sleep 6; echo 1; echo foo > somefile;
1
```

```
> ./bin/wake --last
....cut.....
# re2c: Get version number(311)
$ /usr/bin/re2c --version
re2c 3.0

# compile: c++ src/parser/syntax.native-cpp14-release.o(314)
$ /usr/bin/c++ -std=c++14 -Wall -Wno-format-security -O2 -Isrc -Ivendor -pthread -c src/parser/syntax.cpp -frandom-seed=src/parser/syntax.native-cpp14-release.o -o src/parser/syntax.native-cpp14-release.o

# compile: c++ src/parser/wakefiles.native-cpp14-release.o(315)
$ /usr/bin/c++ -std=c++14 -Wall -Wno-format-security -O2 -Isrc -Ivendor -pthread -c src/parser/wakefiles.cpp -frandom-seed=src/parser/wakefiles.native-cpp14-release.o -o src/parser/wakefiles.native-cpp14-release.o

# link: cc vendor/lemon/lemon(80)
$ /usr/bin/cc -o vendor/lemon/lemon.native-c11-release vendor/lemon/lemon.native-c11-release.o -std=c11 -lpthread

# compile: c++ src/optimizer/ssa.native-cpp14-release.o(355)
$ /usr/bin/c++ -std=c++14 -Wall -Wno-format-security -O2 -Isrc -Ivendor -c src/optimizer/ssa.cpp -frandom-seed=src/optimizer/ssa.native-cpp14-release.o -o src/optimizer/ssa.native-cpp14-release.o
```
