### PR TITLE
Fix VS Code extension not loading

### DIFF
--- a/tools/lsp-wake/lsp.wake
+++ b/tools/lsp-wake/lsp.wake
@@ -24,7 +24,6 @@ target buildLSP variant: Result (List Path) Error = match variant
             "-s", 'EXPORTED_FUNCTIONS=_instantiateServer,_instantiateServerCustomStdLib,_processRequest',
             "-s", 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[$cwrap]',
             "-s", 'EXPORT_NAME="wakeLspModule"',
-            "-s", 'ENVIRONMENT="web"',
             "--post-js", postJS.getPathName,
             "--pre-js", preJS.getPathName,
         tool here Nil variant "lib/wake/lsp-wake" (dst, util,) (postJS, preJS,) extraLFlags


### PR DESCRIPTION
Error received when using extension versions v0.31.0 and v0.30.0:
```
Request initialize failed with message: not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)
```
This PR attempts to fix this issue.