### PR TITLE
Implement an LRU eviction policy for wake's shared cache

### DIFF
--- a/src/job_cache/db_helpers.h
+++ b/src/job_cache/db_helpers.h
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2023 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// NOTE: PLEASE DO NOT INCLUDE THIS OUTSIDE OF .cpp FILE IN THIS DIR!!!
+//       IMPORTANTLY DO NOT INCLUDE THEM IN HEADERS IN THIS DIR!!!
+//       This file exposes sqlite3 which right now is abstracted away.
+#include <sqlite3.h>
+
+#include <random>
+#include <string>
+
+#include "job_cache_impl_common.h"
+#include "logging.h"
+#include "wcl/filepath.h"
+
+namespace job_cache {
+
+class Database {
+ private:
+  sqlite3 *db = nullptr;
+
+  // This is fairly critical to getting strong concurency.
+  // Specifically adding in exponetial back off plus randomization.
+  static inline int wait_handle(void *, int retries) {
+    // We don't ever want to wait more than ~4 seconds.
+    // If we wait more than ~4 seconds we fail.
+    constexpr int start_pow_2 = 6;
+    constexpr int end_pow_2 = 22;
+    if (retries > end_pow_2 - start_pow_2) return 0;
+
+    useconds_t base_wait = 1 << start_pow_2;
+    std::random_device rd;
+    // Wait exponetially longer the more times
+    // we've had to retry.
+    useconds_t wait = base_wait << retries;
+    // Randomize so we don't all retry at the same time.
+    wait += rd() & (wait - 1);
+    // Finally sleep, without waking up exactly when we're done.
+    // but we should never sleep longer than twice as long as we
+    // had to this way.
+    usleep(wait);
+
+    // Tell sqlite to retry
+    return 1;
+  }
+
+ public:
+  Database(const Database &) = delete;
+  Database(Database &&) = delete;
+  Database() = delete;
+  ~Database() {
+    if (db && sqlite3_close(db) != SQLITE_OK) {
+      log_fatal("Could not close database: %s", sqlite3_errmsg(db));
+    }
+  }
+  Database(const std::string &cache_dir) {
+    // We want to keep a sql file that has proper syntax highlighting
+    // around instead of embeding the schema. In order to acomplish this
+    // we use C++11 raw strings and the preprocessor. Unfortuently
+    // since starting a sql file with `R("` causes it to all highlight
+    // as a string we need to work around that. In sql `--` is a comment
+    // starter but in C++ its decrement. We take advantage of this by
+    // adding `--dummy, R("` to the start of the sql file which allows
+    // it to be valid and have no effect in both languages. Thus
+    // this dummy variable is needed at the import site. Additionally
+    // because the comma is lower precedence than the '=' operator we
+    // have to put parens around the include to get this trick to work.
+    // clang-format off
+    int dummy = 0;
+    const char* cache_schema = (
+        #include "schema.sql"
+    );
+    // clang-format on
+
+    // Make sure the cache directory exists
+    mkdir_no_fail(cache_dir.c_str());
+
+    std::string db_path = wcl::join_paths(cache_dir, "/cache.db");
+    if (sqlite3_open_v2(db_path.c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                        nullptr) != SQLITE_OK) {
+      log_fatal("error: %s", sqlite3_errmsg(db));
+    }
+
+    if (sqlite3_busy_handler(db, wait_handle, nullptr)) {
+      log_fatal("error: failed to set sqlite3_busy_handler: %s", sqlite3_errmsg(db));
+    }
+
+    char *fail = nullptr;
+
+    int ret = sqlite3_exec(db, cache_schema, nullptr, nullptr, &fail);
+
+    if (ret == SQLITE_BUSY) {
+      log_fatal(
+          "warning: It appears another process is holding the database open, check `ps` for "
+          "suspended wake instances");
+    }
+    if (ret != SQLITE_OK) {
+      log_fatal("error: failed init stmt: %s: %s", fail, sqlite3_errmsg(db));
+    }
+  }
+
+  sqlite3 *get() const { return db; }
+};
+
+class PreparedStatement {
+ private:
+  std::shared_ptr<job_cache::Database> db = nullptr;
+  sqlite3_stmt *query_stmt = nullptr;
+  std::string why = "";
+
+ public:
+  PreparedStatement() = delete;
+  PreparedStatement(const PreparedStatement &) = delete;
+  PreparedStatement(PreparedStatement &&pstmt) {
+    db = pstmt.db;
+    query_stmt = pstmt.query_stmt;
+    pstmt.db = nullptr;
+    query_stmt = nullptr;
+  }
+  PreparedStatement &operator=(PreparedStatement &&pstmt) {
+    db = pstmt.db;
+    query_stmt = pstmt.query_stmt;
+    pstmt.db = nullptr;
+    query_stmt = nullptr;
+    return *this;
+  }
+
+  PreparedStatement(std::shared_ptr<job_cache::Database> db, const std::string &sql_str) : db(db) {
+    if (sqlite3_prepare_v2(db->get(), sql_str.c_str(), sql_str.size(), &query_stmt, nullptr) !=
+        SQLITE_OK) {
+      log_fatal("error: failed to prepare statement: %s", sqlite3_errmsg(db->get()));
+    }
+  }
+
+  ~PreparedStatement() {
+    if (query_stmt) {
+      int ret = sqlite3_finalize(query_stmt);
+      if (ret != SQLITE_OK) {
+        log_fatal("sqlite3_finalize: %s", sqlite3_errmsg(db->get()));
+      }
+      query_stmt = nullptr;
+    }
+  }
+
+  void set_why(std::string why) { this->why = std::move(why); }
+
+  void bind_integer(int64_t index, int64_t value) {
+    int ret = sqlite3_bind_int64(query_stmt, index, value);
+    if (ret != SQLITE_OK) {
+      log_fatal("%s: sqlite3_bind_int64(%d, %d): %s", why.c_str(), index, value,
+                sqlite3_errmsg(db->get()));
+    }
+  }
+
+  void bind_double(int64_t index, double value) {
+    int ret = sqlite3_bind_double(query_stmt, index, value);
+    if (ret != SQLITE_OK) {
+      log_fatal("%s: sqlite3_bind_double(%d, %d): %s", why.c_str(), index, value,
+                sqlite3_errmsg(db->get()));
+    }
+  }
+
+  void bind_string(int64_t index, const std::string &value) {
+    int ret = sqlite3_bind_text(query_stmt, index, value.c_str(), value.size(), SQLITE_TRANSIENT);
+    if (ret != SQLITE_OK) {
+      log_fatal("%s: sqlite3_bind_text(%d, %s): %s", why.c_str(), index, value.c_str(),
+                sqlite3_errmsg(sqlite3_db_handle(query_stmt)));
+    }
+  }
+
+  int64_t read_integer(int64_t index) { return sqlite3_column_int64(query_stmt, index); }
+
+  double read_double(int64_t index) { return sqlite3_column_double(query_stmt, index); }
+
+  std::string read_string(int64_t index) {
+    const char *str = reinterpret_cast<const char *>(sqlite3_column_text(query_stmt, index));
+    size_t size = sqlite3_column_bytes(query_stmt, index);
+    return std::string(str, size);
+  }
+
+  void reset() {
+    int ret;
+
+    ret = sqlite3_reset(query_stmt);
+    if (ret == SQLITE_LOCKED) {
+      log_fatal("error: sqlite3_reset: SQLITE_LOCKED");
+    }
+
+    if (ret != SQLITE_OK) {
+      log_fatal("error: %s; sqlite3_reset: %s", why.c_str(), sqlite3_errmsg(db->get()));
+    }
+
+    if (sqlite3_clear_bindings(query_stmt) != SQLITE_OK) {
+      log_fatal("error: %s; sqlite3_clear_bindings: %s", why.c_str(), sqlite3_errmsg(db->get()));
+    }
+  }
+
+  int step() {
+    int ret;
+    ret = sqlite3_step(query_stmt);
+    if (ret != SQLITE_DONE && ret != SQLITE_ROW) {
+      log_fatal("error: %s; sqlite3_step: %s", why.c_str(), sqlite3_errmsg(db->get()));
+    }
+    return ret;
+  }
+};
+
+class Transaction {
+ private:
+  PreparedStatement begin_txn_query;
+  PreparedStatement commit_txn_query;
+
+ public:
+  static constexpr const char *sql_begin_txn = "begin immediate transaction";
+  static constexpr const char *sql_commit_txn = "commit transaction";
+
+  Transaction(std::shared_ptr<job_cache::Database> db)
+      : begin_txn_query(db, sql_begin_txn), commit_txn_query(db, sql_commit_txn) {
+    begin_txn_query.set_why("Could not begin a transaction");
+    commit_txn_query.set_why("Could not commit a transaction");
+  }
+
+  template <class F>
+  void run(F f) {
+    begin_txn_query.step();
+    f();
+    commit_txn_query.step();
+  }
+};
+
+}  // namespace job_cache

--- a/src/job_cache/eviction_policy.cpp
+++ b/src/job_cache/eviction_policy.cpp
@@ -239,7 +239,9 @@ void LRUEvictionPolicy::write(int job_id) {
   }
 }
 
-LRUEvictionPolicy::LRUEvictionPolicy() {}
+LRUEvictionPolicy::LRUEvictionPolicy(uint64_t max, uint64_t low)
+    : max_cache_size(max), low_cache_size(low) {}
+
 LRUEvictionPolicy::~LRUEvictionPolicy() {}
 
 int eviction_loop(const std::string& cache_dir, std::unique_ptr<EvictionPolicy> policy) {

--- a/src/job_cache/eviction_policy.cpp
+++ b/src/job_cache/eviction_policy.cpp
@@ -24,13 +24,20 @@
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
+#include <wcl/defer.h>
 
 #include <algorithm>
+#include <future>
 #include <iostream>
 #include <memory>
+#include <thread>
 #include <vector>
 
+#include "db_helpers.h"
 #include "eviction_command.h"
+#include "job_cache_impl_common.h"
+
+namespace job_cache {
 
 enum class CommandParserState { Continue, StopSuccess, StopFail };
 
@@ -44,9 +51,7 @@ struct CommandParser {
 
     while (true) {
       uint8_t buffer[4096] = {};
-
       ssize_t count = read(STDIN_FILENO, static_cast<void*>(buffer), 4096);
-
       // Pipe has been closed. Stop processing
       if (count == 0) {
         return CommandParserState::StopSuccess;
@@ -54,7 +59,6 @@ struct CommandParser {
 
       // An error occured during read
       if (count < 0) {
-        std::cerr << "Failed to read from stdin: " << strerror(errno) << std::endl;
         return CommandParserState::StopFail;
       }
 
@@ -80,8 +84,166 @@ struct CommandParser {
   }
 };
 
-int eviction_loop(std::unique_ptr<EvictionPolicy> policy) {
-  policy->init();
+struct LRUEvictionPolicyImpl {
+  std::string cache_dir;
+  job_cache::PreparedStatement update_size;
+  job_cache::PreparedStatement get_size;
+  job_cache::PreparedStatement update_last_use;
+  job_cache::PreparedStatement find_least_recently_used;
+  job_cache::PreparedStatement remove_least_recently_used;
+  job_cache::Transaction transact;
+
+  // TODO: Right now we're using `obytes` as a proxy for the size of a job
+  //       but this is an over aproximation of the storage cost really.
+
+  // Update size to account for new job. Also return the size
+  // so we can know if we should trigger a collection or not
+  static constexpr const char* update_size_query =
+      "update total_size set size = size + (select sum(o.obytes) "
+      "from jobs j, job_output_info o "
+      "where j.job_id = ? and j.job_id = o.job)";
+
+  // Unconditionally returns the current total_size
+  static constexpr const char* get_size_query =
+      "select size from total_size where total_size_id = 0";
+
+  // Takes two arguments, first is the latest time as an integer.
+  // second is the job_id to update.
+  static constexpr const char* update_last_use_query =
+      "insert into lru_stats (job_id, last_use) values (?, ?) "
+      "on conflict (job_id) do update set last_use=?2";
+
+  // This is meant to be used as part of a transaction with remove_least_recently_used.
+  // It simply returns the job_ids in last use order.
+  static constexpr const char* find_least_recently_used_query =
+      "select l.last_use, o.obytes, j.job_id "
+      "from lru_stats l, jobs j, job_output_info o "
+      "where l.job_id = j.job_id and o.job = j.job_id "
+      "order by l.last_use";
+
+  // This query is meant to be used as part of a transaction with find_least_recently_used.
+  // It removes all jobs that have a last use time less than a certain amount.
+  static constexpr const char* remove_least_recently_used_query =
+      "delete from jobs where job_id in (select job_id from lru_stats where last_use <= ?)";
+
+  LRUEvictionPolicyImpl(std::string dir, std::shared_ptr<job_cache::Database> db)
+      : cache_dir(dir),
+        update_size(db, update_size_query),
+        get_size(db, get_size_query),
+        update_last_use(db, update_last_use_query),
+        find_least_recently_used(db, find_least_recently_used_query),
+        remove_least_recently_used(db, remove_least_recently_used_query),
+        transact(db) {
+    update_size.set_why("Could not update total size");
+    get_size.set_why("Could not get total size");
+    update_last_use.set_why("Could not update last use");
+    find_least_recently_used.set_why("Could not find least recently used");
+    remove_least_recently_used.set_why("Could not remove least recently used");
+  }
+
+  uint64_t add_job_size(uint64_t job_id) {
+    uint64_t out = 0;
+    transact.run([this, &out, job_id]() {
+      update_size.bind_integer(1, job_id);
+      update_size.step();
+      update_size.reset();
+      out = get_size.read_integer(0);
+      get_size.reset();
+    });
+    return out;
+  }
+
+  void mark_new_use(uint64_t job_id) {
+    timespec tp;
+    clock_gettime(CLOCK_MONOTONIC, &tp);
+    update_last_use.bind_integer(1, job_id);
+    update_last_use.bind_integer(2, tp.tv_nsec);
+    update_last_use.step();
+    update_last_use.reset();
+  }
+
+  void cleanup(uint64_t bytes_to_remove) {
+    std::vector<int64_t> jobs_to_remove;
+    transact.run([this, &jobs_to_remove, bytes_to_remove]() {
+      uint64_t last_use;
+      uint64_t to_remove = bytes_to_remove;
+
+      {
+        auto reset1 = wcl::make_defer([this]() { find_least_recently_used.reset(); });
+
+        // First find the use time that we want to remove from
+        while (true) {
+          find_least_recently_used.step();
+
+          // Since we entered this loop we know we need to remove at least
+          // the next job so mark its last_use, and mark its job ids
+          // for file removal later.
+          last_use = find_least_recently_used.read_integer(0);
+          uint64_t obytes = find_least_recently_used.read_integer(1);
+          jobs_to_remove.push_back(find_least_recently_used.read_integer(2));
+
+          // If obytes is more than to_remove then we can break because
+          // this will put us over our bytes_to_remove.
+          if (obytes < to_remove) {
+            break;
+          }
+
+          // Otherwise mark these bytes and keep working.
+          to_remove -= obytes;
+        }
+      }
+
+      // Next actully remove those jobs from the database
+      // even though the files haven't been deleted yet.
+      // Note that just because we delete jobs from the database
+      // before we delete the files backing them doesn't mean that
+      // we can't see a race. It's perfectly valid for a read to
+      // occur before we do this transaction but for the reads of
+      // the backing files to occur *after* this transaction completes.
+      // Still, doing things in this order reduces the chance of a
+      // failed read occuring.
+      auto reset2 = wcl::make_defer([this]() { remove_least_recently_used.reset(); });
+      remove_least_recently_used.bind_integer(1, last_use);
+      remove_least_recently_used.step();
+    });
+
+    // Now we remove the threads in the background.
+    // TODO: Figure out how many cores we actully have and use a multiple of that
+    // NOTE: We don't wait for this to finish
+    std::async(std::launch::async, [dir = cache_dir, jobs_to_remove = std::move(jobs_to_remove)]() {
+      remove_backing_files(dir, jobs_to_remove, 8, 128);
+    });
+  }
+};
+
+void LRUEvictionPolicy::init(const std::string& cache_dir) {
+  auto db = std::make_unique<job_cache::Database>(cache_dir);
+  impl = std::make_unique<LRUEvictionPolicyImpl>(cache_dir, std::move(db));
+}
+
+void LRUEvictionPolicy::read(int job_id) { impl->mark_new_use(job_id); }
+
+// TODO: Make this configurable...right now its just set at 16GB...because
+//       that seems vaugely sensible.
+constexpr uint64_t max_db_size = 1ULL << 34ULL;
+
+// TODO: Same. I'm just sort of guessing that deleting a GB at
+//       at a time is sensible. No real clue.
+constexpr uint64_t low_water_mark = max_db_size - (1ULL << 30);
+
+void LRUEvictionPolicy::write(int job_id) {
+  impl->mark_new_use(job_id);
+  uint64_t size = impl->add_job_size(job_id);
+  if (size > max_db_size) {
+    impl->cleanup(max_db_size - low_water_mark);
+  }
+}
+
+LRUEvictionPolicy::LRUEvictionPolicy() {}
+LRUEvictionPolicy::~LRUEvictionPolicy() {}
+
+int eviction_loop(const std::string& cache_dir, std::unique_ptr<EvictionPolicy> policy) {
+  policy->init(cache_dir);
 
   CommandParser cmd_parser;
   CommandParserState state;
@@ -103,7 +265,6 @@ int eviction_loop(std::unique_ptr<EvictionPolicy> policy) {
           policy->write(cmd->job_id);
           break;
         default:
-          std::cerr << "Unhandled command type" << std::endl;
           exit(EXIT_FAILURE);
       }
     }
@@ -111,3 +272,5 @@ int eviction_loop(std::unique_ptr<EvictionPolicy> policy) {
 
   exit(state == CommandParserState::StopSuccess ? EXIT_SUCCESS : EXIT_FAILURE);
 }
+
+}  // namespace job_cache

--- a/src/job_cache/eviction_policy.h
+++ b/src/job_cache/eviction_policy.h
@@ -53,9 +53,12 @@ struct LRUEvictionPolicyImpl;
 class LRUEvictionPolicy : public EvictionPolicy {
   // We need to touch the database so we use pimpl to hide the implementation
   std::unique_ptr<LRUEvictionPolicyImpl> impl;
+  uint64_t max_cache_size;
+  uint64_t low_cache_size;
 
  public:
-  LRUEvictionPolicy();
+  explicit LRUEvictionPolicy(uint64_t max_cache_size, uint64_t low_cache_size);
+  LRUEvictionPolicy() = delete;
   LRUEvictionPolicy(const LRUEvictionPolicy&) = delete;
   LRUEvictionPolicy(LRUEvictionPolicy&&) = delete;
   virtual ~LRUEvictionPolicy();

--- a/src/job_cache/eviction_policy.h
+++ b/src/job_cache/eviction_policy.h
@@ -25,15 +25,19 @@
 #include <memory>
 #include <string>
 
+namespace job_cache {
+
 struct EvictionPolicy {
-  virtual void init() = 0;
+  virtual void init(const std::string& cache_dir) = 0;
   virtual void read(int id) = 0;
   virtual void write(int id) = 0;
   virtual ~EvictionPolicy() {}
 };
 
 struct NilEvictionPolicy : EvictionPolicy {
-  virtual void init() override { std::cerr << "NilEvictionPolicy::init()" << std::endl; }
+  virtual void init(const std::string& cache_dir) override {
+    std::cerr << "NilEvictionPolicy::init()" << std::endl;
+  }
 
   virtual void read(int id) override {
     std::cerr << "NilEvictionPolicy::read(" << id << ")" << std::endl;
@@ -44,4 +48,25 @@ struct NilEvictionPolicy : EvictionPolicy {
   }
 };
 
-int eviction_loop(std::unique_ptr<EvictionPolicy> policy);
+struct LRUEvictionPolicyImpl;
+
+class LRUEvictionPolicy : public EvictionPolicy {
+  // We need to touch the database so we use pimpl to hide the implementation
+  std::unique_ptr<LRUEvictionPolicyImpl> impl;
+
+ public:
+  LRUEvictionPolicy();
+  LRUEvictionPolicy(const LRUEvictionPolicy&) = delete;
+  LRUEvictionPolicy(LRUEvictionPolicy&&) = delete;
+  virtual ~LRUEvictionPolicy();
+
+  virtual void init(const std::string& cache_dir) override;
+
+  virtual void read(int id) override;
+
+  virtual void write(int id) override;
+};
+
+int eviction_loop(const std::string& cache_dir, std::unique_ptr<EvictionPolicy> policy);
+
+}  // namespace job_cache

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -50,373 +50,15 @@
 #include <thread>
 #include <unordered_map>
 
+#include "db_helpers.h"
 #include "eviction_command.h"
 #include "eviction_policy.h"
+#include "job_cache_impl_common.h"
 #include "logging.h"
 
 namespace {
 
 using namespace job_cache;
-
-// moves the file or directory, crashes on error
-static void rename_no_fail(const char *old_path, const char *new_path) {
-  if (rename(old_path, new_path) < 0) {
-    log_fatal("rename(%s, %s): %s", old_path, new_path, strerror(errno));
-  }
-}
-
-// Ensures the the given directory has been created
-static void mkdir_no_fail(const char *dir) {
-  if (mkdir(dir, 0777) < 0 && errno != EEXIST) {
-    log_fatal("mkdir(%s): %s", dir, strerror(errno));
-  }
-}
-
-static void symlink_no_fail(const char *target, const char *symlink_path) {
-  if (symlink(target, symlink_path) == -1) {
-    log_fatal("symlink(%s, %s): %s", target, symlink_path, strerror(errno));
-  }
-}
-
-// Ensures the given file has been deleted
-static void unlink_no_fail(const char *file) {
-  if (unlink(file) < 0 && errno != ENOENT) {
-    log_fatal("unlink(%s): %s", file, strerror(errno));
-  }
-}
-
-// Ensures the the given directory no longer exists
-static void rmdir_no_fail(const char *dir) {
-  if (rmdir(dir) < 0 && errno != ENOENT) {
-    log_fatal("rmdir(%s): %s", dir, strerror(errno));
-  }
-}
-
-// For apple and emscripten fallback on a dumb slow implementation
-#if defined(__APPLE__) || defined(__EMSCRIPTEN__)
-
-static void copy(int src_fd, int dst_fd) {
-  FdBuf src(src_fd);
-  FdBuf dst(dst_fd);
-  std::ostream out(&dst);
-  std::istream in(&src);
-
-  struct stat buf = {};
-  // There's a race here between the fstat and the copy_file_range
-  if (fstat(src_fd, &buf) < 0) {
-    log_fatal("fstat(src_fd = %d): %s", src_fd, strerror(errno));
-  }
-
-  // TODO: This is very slow because FdBuf is very slow
-  // TODO: This will read large files into memory which is very bad
-  std::vector<char> data_buf(buf.st_size);
-  if (!in.read(data_buf.data(), buf.st_size)) {
-    log_fatal("copy.read(src_fd = %d, NULL, dst_fd = %d, size = %d): %s", src_fd, dst_fd,
-              buf.st_size, strerror(errno));
-  }
-
-  if (!out.write(data_buf.data(), buf.st_size)) {
-    log_fatal("copy.write(src_fd = %d, NULL, dst_fd = %d, size = %d): %s", src_fd, dst_fd,
-              buf.st_size, strerror(errno));
-  }
-}
-
-// For modern linux use copy_file_range
-#elif __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 27
-
-#include <linux/fs.h>
-
-// This function just uses `copy_file_range` to make
-// an efficent copy. It is however not atomic because
-// we have to `fstat` before we call `copy_file_range`.
-// This means that if an external party decides to mutate
-// the file (espeically changing its size) then this function
-// will not work as intended. External parties *are* allowed to
-// unlink this file but they're not allowed to modify it in any
-// other way or else this function will race with that external
-// modification.
-static void copy(int src_fd, int dst_fd) {
-  struct stat buf = {};
-  // There's a race here between the fstat and the copy_file_range
-  if (fstat(src_fd, &buf) < 0) {
-    log_fatal("fstat(src_fd = %d): %s", src_fd, strerror(errno));
-  }
-  if (copy_file_range(src_fd, nullptr, dst_fd, nullptr, buf.st_size, 0) < 0) {
-    log_fatal("copy_file_range(src_fd = %d, NULL, dst_fd = %d, size = %d, 0): %s", src_fd, dst_fd,
-              buf.st_size, strerror(errno));
-  }
-}
-
-// For older linux distros use Linux's sendfile
-#else
-
-#include <sys/sendfile.h>
-// This function just uses `sendfile` to make
-// an efficent copy. It is however not atomic because
-// we have to `fstat` before we call `sendfile`.
-// This means that if an external party decides to mutate
-// the file (espeically changing its size) then this function
-// will not work as intended. External parties *are* allowed to
-// unlink this file but they're not allowed to modify it in any
-// other way or else this function will race with that external
-// modification.
-
-static void copy(int src_fd, int dst_fd) {
-  struct stat buf = {};
-  // There's a race here between the fstat and the copy_file_range
-  if (fstat(src_fd, &buf) < 0) {
-    log_fatal("fstat(src_fd = %d): %s", src_fd, strerror(errno));
-  }
-  off_t idx = 0;
-  size_t size = buf.st_size;
-  do {
-    intptr_t written = sendfile(dst_fd, src_fd, &idx, size);
-    if (written < 0) {
-      log_fatal("sendfile(src_fd = %d, NULL, dst_fd = %d, size = %d, 0): %s", src_fd, dst_fd,
-                buf.st_size, strerror(errno));
-    }
-    idx = written;
-    size -= written;
-  } while (size != 0);
-}
-#endif
-
-#ifdef FICLONE
-
-static void copy_or_reflink(const char *src, const char *dst, mode_t mode = 0644,
-                            int extra_flags = 0) {
-  auto src_fd = wcl::unique_fd::open(src, O_RDONLY);
-  if (!src_fd) {
-    log_fatal("open(%s): %s", src, strerror(src_fd.error()));
-  }
-
-  auto dst_fd = wcl::unique_fd::open(dst, O_WRONLY | O_CREAT | extra_flags, mode);
-  if (!dst_fd) {
-    log_fatal("open(%s): %s", dst, strerror(dst_fd.error()));
-  }
-
-  if (ioctl(dst_fd->get(), FICLONE, src_fd->get()) < 0) {
-    if (errno != EINVAL && errno != EOPNOTSUPP && errno != EXDEV) {
-      log_fatal("ioctl(%s, FICLONE, %d): %s", dst, src, strerror(errno));
-    }
-    copy(src_fd->get(), dst_fd->get());
-  }
-}
-
-#else
-
-static mode_t copy_or_reflink(const char *src, const char *dst, mode_t mode = 0644,
-                              int extra_flags = 0) {
-  auto src_fd = wcl::unique_fd::open(src, O_RDONLY);
-  if (!src_fd) {
-    log_fatal("open(%s): %s", src, strerror(src_fd.error()));
-  }
-
-  auto dst_fd = wcl::unique_fd::open(dst, O_WRONLY | O_CREAT | extra_flags, mode);
-  if (!dst_fd) {
-    log_fatal("open(%s): %s", dst, strerror(dst_fd.error()));
-  }
-
-  copy(src_fd->get(), dst_fd->get());
-
-  return mode;
-}
-
-#endif
-
-// This is fairly critical to getting strong concurency.
-// Specifically adding in exponetial back off plus randomization.
-static int wait_handle(void *, int retries) {
-  // We don't ever want to wait more than ~4 seconds.
-  // If we wait more than ~4 seconds we fail.
-  constexpr int start_pow_2 = 6;
-  constexpr int end_pow_2 = 22;
-  if (retries > end_pow_2 - start_pow_2) return 0;
-
-  useconds_t base_wait = 1 << start_pow_2;
-  std::random_device rd;
-  // Wait exponetially longer the more times
-  // we've had to retry.
-  useconds_t wait = base_wait << retries;
-  // Randomize so we don't all retry at the same time.
-  wait += rd() & (wait - 1);
-  // Finally sleep, without waking up exactly when we're done.
-  // but we should never sleep longer than twice as long as we
-  // had to this way.
-  usleep(wait);
-
-  // Tell sqlite to retry
-  return 1;
-}
-
-class Database {
- private:
-  sqlite3 *db = nullptr;
-
- public:
-  Database(const Database &) = delete;
-  Database(Database &&) = delete;
-  Database() = delete;
-  ~Database() {
-    static int dystroy_counter = 0;
-    assert(++dystroy_counter == 1);
-    if (sqlite3_close(db) != SQLITE_OK) {
-      log_fatal("Could not close database: %s", sqlite3_errmsg(db));
-    }
-  }
-  Database(const std::string &cache_dir) {
-    static int construct_counter = 0;
-    assert(++construct_counter == 1);
-    // We want to keep a sql file that has proper syntax highlighting
-    // around instead of embeding the schema. In order to acomplish this
-    // we use C++11 raw strings and the preprocessor. Unfortuently
-    // since starting a sql file with `R("` causes it to all highlight
-    // as a string we need to work around that. In sql `--` is a comment
-    // starter but in C++ its decrement. We take advantage of this by
-    // adding `--dummy, R("` to the start of the sql file which allows
-    // it to be valid and have no effect in both languages. Thus
-    // this dummy variable is needed at the import site. Additionally
-    // because the comma is lower precedence than the '=' operator we
-    // have to put parens around the include to get this trick to work.
-    // clang-format off
-    int dummy = 0;
-    const char* cache_schema = (
-        #include "schema.sql"
-    );
-    // clang-format on
-
-    // Make sure the cache directory exists
-    mkdir_no_fail(cache_dir.c_str());
-
-    std::string db_path = wcl::join_paths(cache_dir, "/cache.db");
-    if (sqlite3_open_v2(db_path.c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
-                        nullptr) != SQLITE_OK) {
-      log_fatal("error: %s", sqlite3_errmsg(db));
-    }
-
-    if (sqlite3_busy_handler(db, wait_handle, nullptr)) {
-      log_fatal("error: failed to set sqlite3_busy_handler: %s", sqlite3_errmsg(db));
-    }
-
-    char *fail = nullptr;
-
-    int ret = sqlite3_exec(db, cache_schema, nullptr, nullptr, &fail);
-
-    if (ret == SQLITE_BUSY) {
-      log_fatal(
-          "warning: It appears another process is holding the database open, check `ps` for "
-          "suspended wake instances");
-    }
-    if (ret != SQLITE_OK) {
-      log_fatal("error: failed init stmt: %s: %s", fail, sqlite3_errmsg(db));
-    }
-  }
-
-  sqlite3 *get() const { return db; }
-};
-
-class PreparedStatement {
- private:
-  std::shared_ptr<Database> db = nullptr;
-  sqlite3_stmt *query_stmt = nullptr;
-  std::string why = "";
-
- public:
-  PreparedStatement() = delete;
-  PreparedStatement(const PreparedStatement &) = delete;
-  PreparedStatement(PreparedStatement &&pstmt) {
-    db = pstmt.db;
-    query_stmt = pstmt.query_stmt;
-    pstmt.db = nullptr;
-    query_stmt = nullptr;
-  }
-  PreparedStatement &operator=(PreparedStatement &&pstmt) {
-    db = pstmt.db;
-    query_stmt = pstmt.query_stmt;
-    pstmt.db = nullptr;
-    query_stmt = nullptr;
-    return *this;
-  }
-
-  PreparedStatement(std::shared_ptr<Database> db, const std::string &sql_str) : db(db) {
-    if (sqlite3_prepare_v2(db->get(), sql_str.c_str(), sql_str.size(), &query_stmt, nullptr) !=
-        SQLITE_OK) {
-      log_fatal("error: failed to prepare statement: %s", sqlite3_errmsg(db->get()));
-    }
-  }
-
-  ~PreparedStatement() {
-    if (query_stmt) {
-      int ret = sqlite3_finalize(query_stmt);
-      if (ret != SQLITE_OK) {
-        log_fatal("sqlite3_finalize: %s", sqlite3_errmsg(db->get()));
-      }
-      query_stmt = nullptr;
-    }
-  }
-
-  void set_why(std::string why) { this->why = std::move(why); }
-
-  void bind_integer(int64_t index, int64_t value) {
-    int ret = sqlite3_bind_int64(query_stmt, index, value);
-    if (ret != SQLITE_OK) {
-      log_fatal("%s: sqlite3_bind_int64(%d, %d): %s", why.c_str(), index, value,
-                sqlite3_errmsg(db->get()));
-    }
-  }
-
-  void bind_double(int64_t index, double value) {
-    int ret = sqlite3_bind_double(query_stmt, index, value);
-    if (ret != SQLITE_OK) {
-      log_fatal("%s: sqlite3_bind_double(%d, %d): %s", why.c_str(), index, value,
-                sqlite3_errmsg(db->get()));
-    }
-  }
-
-  void bind_string(int64_t index, const std::string &value) {
-    int ret = sqlite3_bind_text(query_stmt, index, value.c_str(), value.size(), SQLITE_TRANSIENT);
-    if (ret != SQLITE_OK) {
-      log_fatal("%s: sqlite3_bind_text(%d, %s): %s", why.c_str(), index, value.c_str(),
-                sqlite3_errmsg(sqlite3_db_handle(query_stmt)));
-    }
-  }
-
-  int64_t read_integer(int64_t index) { return sqlite3_column_int64(query_stmt, index); }
-
-  double read_double(int64_t index) { return sqlite3_column_double(query_stmt, index); }
-
-  std::string read_string(int64_t index) {
-    const char *str = reinterpret_cast<const char *>(sqlite3_column_text(query_stmt, index));
-    size_t size = sqlite3_column_bytes(query_stmt, index);
-    return std::string(str, size);
-  }
-
-  void reset() {
-    int ret;
-
-    ret = sqlite3_reset(query_stmt);
-    if (ret == SQLITE_LOCKED) {
-      log_fatal("error: sqlite3_reset: SQLITE_LOCKED");
-    }
-
-    if (ret != SQLITE_OK) {
-      log_fatal("error: %s; sqlite3_reset: %s", why.c_str(), sqlite3_errmsg(db->get()));
-    }
-
-    if (sqlite3_clear_bindings(query_stmt) != SQLITE_OK) {
-      log_fatal("error: %s; sqlite3_clear_bindings: %s", why.c_str(), sqlite3_errmsg(db->get()));
-    }
-  }
-
-  int step() {
-    int ret;
-    ret = sqlite3_step(query_stmt);
-    if (ret != SQLITE_DONE && ret != SQLITE_ROW) {
-      log_fatal("error: %s; sqlite3_step: %s", why.c_str(), sqlite3_errmsg(db->get()));
-    }
-    return ret;
-  }
-};
 
 // Database classes
 class InputFiles {
@@ -427,7 +69,7 @@ class InputFiles {
   static constexpr const char *insert_query =
       "insert into input_files (path, hash, job) values (?, ?, ?)";
 
-  InputFiles(std::shared_ptr<Database> db) : add_input_file(db, insert_query) {
+  InputFiles(std::shared_ptr<job_cache::Database> db) : add_input_file(db, insert_query) {
     add_input_file.set_why("Could not insert input file");
   }
 
@@ -448,7 +90,7 @@ class InputDirs {
   static constexpr const char *insert_query =
       "insert into input_dirs (path, hash, job) values (?, ?, ?)";
 
-  InputDirs(std::shared_ptr<Database> db) : add_input_dir(db, insert_query) {
+  InputDirs(std::shared_ptr<job_cache::Database> db) : add_input_dir(db, insert_query) {
     add_input_dir.set_why("Could not insert input directory");
   }
 
@@ -469,7 +111,7 @@ class OutputFiles {
   static constexpr const char *insert_query =
       "insert into output_files (path, hash, mode, job) values (?, ?, ?, ?)";
 
-  OutputFiles(std::shared_ptr<Database> db) : add_output_file(db, insert_query) {
+  OutputFiles(std::shared_ptr<job_cache::Database> db) : add_output_file(db, insert_query) {
     add_output_file.set_why("Could not insert output file");
   }
 
@@ -491,7 +133,7 @@ class OutputDirs {
   static constexpr const char *insert_query =
       "insert into output_dirs (path, mode, job) values (?, ?, ?)";
 
-  OutputDirs(std::shared_ptr<Database> db) : add_output_dir(db, insert_query) {
+  OutputDirs(std::shared_ptr<job_cache::Database> db) : add_output_dir(db, insert_query) {
     add_output_dir.set_why("Could not insert output dir");
   }
 
@@ -512,7 +154,7 @@ class OutputSymlinks {
   static constexpr const char *insert_query =
       "insert into output_symlinks (path, value, job) values (?, ?, ?)";
 
-  OutputSymlinks(std::shared_ptr<Database> db) : add_output_symlink(db, insert_query) {
+  OutputSymlinks(std::shared_ptr<job_cache::Database> db) : add_output_symlink(db, insert_query) {
     add_output_symlink.set_why("Could not insert output file");
   }
 
@@ -527,7 +169,7 @@ class OutputSymlinks {
 
 class JobTable {
  private:
-  std::shared_ptr<Database> db;
+  std::shared_ptr<job_cache::Database> db;
   PreparedStatement add_job;
   PreparedStatement add_output_info;
 
@@ -541,7 +183,7 @@ class JobTable {
       "(job, stdout, stderr, ret, runtime, cputime, mem, ibytes, obytes)"
       "values (?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
-  JobTable(std::shared_ptr<Database> db)
+  JobTable(std::shared_ptr<job_cache::Database> db)
       : db(db), add_job(db, insert_query), add_output_info(db, add_output_info_query) {
     add_job.set_why("Could not insert job");
     add_output_info.set_why("Could not add output info");
@@ -603,29 +245,6 @@ struct RequestedJobFile {
 
 struct JobRequestResult {
   std::vector<RequestedJobFile> requested_files;
-};
-
-class Transaction {
- private:
-  PreparedStatement begin_txn_query;
-  PreparedStatement commit_txn_query;
-
- public:
-  static constexpr const char *sql_begin_txn = "begin immediate transaction";
-  static constexpr const char *sql_commit_txn = "commit transaction";
-
-  Transaction(std::shared_ptr<Database> db)
-      : begin_txn_query(db, sql_begin_txn), commit_txn_query(db, sql_commit_txn) {
-    begin_txn_query.set_why("Could not begin a transaction");
-    commit_txn_query.set_why("Could not commit a transaction");
-  }
-
-  template <class F>
-  void run(F f) {
-    begin_txn_query.step();
-    f();
-    commit_txn_query.step();
-  }
 };
 
 class SelectMatchingJobs {
@@ -742,7 +361,7 @@ class SelectMatchingJobs {
       "select stdout, stderr, ret, runtime, cputime, mem, ibytes, obytes from job_output_info "
       "where job = ?";
 
-  SelectMatchingJobs(std::shared_ptr<Database> db)
+  SelectMatchingJobs(std::shared_ptr<job_cache::Database> db)
       : find_jobs(db, sql_find_jobs),
         find_files(db, sql_find_files),
         find_dirs(db, sql_input_dirs),
@@ -864,7 +483,7 @@ namespace job_cache {
 
 struct CacheDbImpl {
  private:
-  std::shared_ptr<Database> db;
+  std::shared_ptr<job_cache::Database> db;
 
  public:
   JobTable jobs;
@@ -877,7 +496,7 @@ struct CacheDbImpl {
   SelectMatchingJobs matching_jobs;
 
   CacheDbImpl(const std::string &_dir)
-      : db(std::make_unique<Database>(_dir)),
+      : db(std::make_unique<job_cache::Database>(_dir)),
         jobs(db),
         input_files(db),
         input_dirs(db),
@@ -1070,7 +689,7 @@ FindJobRequest::FindJobRequest(const JAST &find_job_json) {
 Cache::Cache(std::string _dir) : dir(std::move(_dir)), rng(wcl::xoshiro_256::get_rng_seed()) {
   mkdir_no_fail(dir.c_str());
   impl = std::make_unique<CacheDbImpl>(dir);
-  launch_evict_tool();
+  launch_evict_loop();
 }
 
 wcl::optional<MatchingJob> Cache::read(const FindJobRequest &find_request) {
@@ -1230,7 +849,7 @@ wcl::optional<MatchingJob> Cache::read(const FindJobRequest &find_request) {
   msg += '\0';
 
   if (write(evict_stdin, msg.data(), msg.size()) == -1) {
-    std::cerr << "Failed to send eviction update" << std::endl;
+    log_warning("Failed to send eviction update");
   }
 
   // TODO: We should really return a different thing here
@@ -1315,11 +934,11 @@ void Cache::add(const AddJobRequest &add_request) {
   msg += '\0';
 
   if (write(evict_stdin, msg.data(), msg.size()) == -1) {
-    std::cerr << "Failed to send eviction update" << std::endl;
+    log_warning("Failed to send eviction update");
   }
 }
 
-void Cache::launch_evict_tool() {
+void Cache::launch_evict_loop() {
   const size_t read_side = 0;
   const size_t write_side = 1;
 
@@ -1363,7 +982,7 @@ void Cache::launch_evict_tool() {
 
     // Finally enter the eviction loop, if it exits cleanly
     // go ahead and exit with its result.
-    int result = eviction_loop(std::make_unique<NilEvictionPolicy>());
+    int result = eviction_loop(dir, std::make_unique<LRUEvictionPolicy>());
     exit(result);
   }
 
@@ -1378,7 +997,7 @@ void Cache::launch_evict_tool() {
   }
 }
 
-void Cache::reap_evict_tool() {
+void Cache::reap_evict_loop() {
   close(evict_stdin);
   close(evict_stdout);
   waitpid(evict_pid, nullptr, 0);
@@ -1386,6 +1005,6 @@ void Cache::reap_evict_tool() {
 
 // This has to be here because the destructor code for std::unique_ptr<CacheDbImpl>
 // requires that the CacheDbImpl be complete.
-Cache::~Cache() { reap_evict_tool(); }
+Cache::~Cache() { reap_evict_loop(); }
 
 }  // namespace job_cache

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -686,7 +686,11 @@ FindJobRequest::FindJobRequest(const JAST &find_job_json) {
   }
 }
 
-Cache::Cache(std::string _dir) : dir(std::move(_dir)), rng(wcl::xoshiro_256::get_rng_seed()) {
+Cache::Cache(std::string _dir, uint64_t max, uint64_t low)
+    : dir(std::move(_dir)),
+      rng(wcl::xoshiro_256::get_rng_seed()),
+      max_cache_size(max),
+      low_cache_size(low) {
   mkdir_no_fail(dir.c_str());
   impl = std::make_unique<CacheDbImpl>(dir);
   launch_evict_loop();
@@ -982,7 +986,8 @@ void Cache::launch_evict_loop() {
 
     // Finally enter the eviction loop, if it exits cleanly
     // go ahead and exit with its result.
-    int result = eviction_loop(dir, std::make_unique<LRUEvictionPolicy>());
+    int result =
+        eviction_loop(dir, std::make_unique<LRUEvictionPolicy>(max_cache_size, low_cache_size));
     exit(result);
   }
 

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -162,6 +162,8 @@ class Cache {
   int evict_stdin;
   int evict_stdout;
   int evict_pid;
+  uint64_t max_cache_size;
+  uint64_t low_cache_size;
 
   void launch_evict_loop();
   void reap_evict_loop();
@@ -172,7 +174,7 @@ class Cache {
   Cache() = delete;
   Cache(const Cache &) = delete;
 
-  Cache(std::string _dir);
+  Cache(std::string _dir, uint64_t max, uint64_t low);
 
   wcl::optional<MatchingJob> read(const FindJobRequest &find_request);
   void add(const AddJobRequest &add_request);

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -163,8 +163,8 @@ class Cache {
   int evict_stdout;
   int evict_pid;
 
-  void launch_evict_tool();
-  void reap_evict_tool();
+  void launch_evict_loop();
+  void reap_evict_loop();
 
  public:
   ~Cache();

--- a/src/job_cache/job_cache_impl_common.cpp
+++ b/src/job_cache/job_cache_impl_common.cpp
@@ -76,6 +76,8 @@ void rmdir_no_fail(const char *dir) {
 // For apple and emscripten fallback on a dumb slow implementation
 #if defined(__APPLE__) || defined(__EMSCRIPTEN__)
 
+#include "util/term.h"
+
 static void copy(int src_fd, int dst_fd) {
   FdBuf src(src_fd);
   FdBuf dst(dst_fd);

--- a/src/job_cache/job_cache_impl_common.cpp
+++ b/src/job_cache/job_cache_impl_common.cpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2023 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "job_cache_impl_common.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/file.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <future>
+#include <thread>
+
+#include "logging.h"
+#include "wcl/filepath.h"
+#include "wcl/result.h"
+#include "wcl/unique_fd.h"
+#include "wcl/xoshiro_256.h"
+
+// moves the file or directory, crashes on error
+void rename_no_fail(const char *old_path, const char *new_path) {
+  if (rename(old_path, new_path) < 0) {
+    log_fatal("rename(%s, %s): %s", old_path, new_path, strerror(errno));
+  }
+}
+
+// Ensures the the given directory has been created
+void mkdir_no_fail(const char *dir) {
+  if (mkdir(dir, 0777) < 0 && errno != EEXIST) {
+    log_fatal("mkdir(%s): %s", dir, strerror(errno));
+  }
+}
+
+void symlink_no_fail(const char *target, const char *symlink_path) {
+  if (symlink(target, symlink_path) == -1) {
+    log_fatal("symlink(%s, %s): %s", target, symlink_path, strerror(errno));
+  }
+}
+
+// Ensures the given file has been deleted
+void unlink_no_fail(const char *file) {
+  if (unlink(file) < 0 && errno != ENOENT) {
+    log_fatal("unlink(%s): %s", file, strerror(errno));
+  }
+}
+
+// Ensures the the given directory no longer exists
+void rmdir_no_fail(const char *dir) {
+  if (rmdir(dir) < 0 && errno != ENOENT) {
+    log_fatal("rmdir(%s): %s", dir, strerror(errno));
+  }
+}
+
+// For apple and emscripten fallback on a dumb slow implementation
+#if defined(__APPLE__) || defined(__EMSCRIPTEN__)
+
+static void copy(int src_fd, int dst_fd) {
+  FdBuf src(src_fd);
+  FdBuf dst(dst_fd);
+  std::ostream out(&dst);
+  std::istream in(&src);
+
+  struct stat buf = {};
+  // There's a race here between the fstat and the copy_file_range
+  if (fstat(src_fd, &buf) < 0) {
+    log_fatal("fstat(src_fd = %d): %s", src_fd, strerror(errno));
+  }
+
+  // TODO: This is very slow because FdBuf is very slow
+  // TODO: This will read large files into memory which is very bad
+  std::vector<char> data_buf(buf.st_size);
+  if (!in.read(data_buf.data(), buf.st_size)) {
+    log_fatal("copy.read(src_fd = %d, NULL, dst_fd = %d, size = %d): %s", src_fd, dst_fd,
+              buf.st_size, strerror(errno));
+  }
+
+  if (!out.write(data_buf.data(), buf.st_size)) {
+    log_fatal("copy.write(src_fd = %d, NULL, dst_fd = %d, size = %d): %s", src_fd, dst_fd,
+              buf.st_size, strerror(errno));
+  }
+}
+
+// For modern linux use copy_file_range
+#elif __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 27
+
+#include <linux/fs.h>
+
+// This function just uses `copy_file_range` to make
+// an efficent copy. It is however not atomic because
+// we have to `fstat` before we call `copy_file_range`.
+// This means that if an external party decides to mutate
+// the file (espeically changing its size) then this function
+// will not work as intended. External parties *are* allowed to
+// unlink this file but they're not allowed to modify it in any
+// other way or else this function will race with that external
+// modification.
+static void copy(int src_fd, int dst_fd) {
+  struct stat buf = {};
+  // There's a race here between the fstat and the copy_file_range
+  if (fstat(src_fd, &buf) < 0) {
+    log_fatal("fstat(src_fd = %d): %s", src_fd, strerror(errno));
+  }
+  if (copy_file_range(src_fd, nullptr, dst_fd, nullptr, buf.st_size, 0) < 0) {
+    log_fatal("copy_file_range(src_fd = %d, NULL, dst_fd = %d, size = %d, 0): %s", src_fd, dst_fd,
+              buf.st_size, strerror(errno));
+  }
+}
+
+// For older linux distros use Linux's sendfile
+#else
+
+#include <sys/sendfile.h>
+// This function just uses `sendfile` to make
+// an efficent copy. It is however not atomic because
+// we have to `fstat` before we call `sendfile`.
+// This means that if an external party decides to mutate
+// the file (espeically changing its size) then this function
+// will not work as intended. External parties *are* allowed to
+// unlink this file but they're not allowed to modify it in any
+// other way or else this function will race with that external
+// modification.
+
+static void copy(int src_fd, int dst_fd) {
+  struct stat buf = {};
+  // There's a race here between the fstat and the copy_file_range
+  if (fstat(src_fd, &buf) < 0) {
+    log_fatal("fstat(src_fd = %d): %s", src_fd, strerror(errno));
+  }
+  off_t idx = 0;
+  size_t size = buf.st_size;
+  do {
+    intptr_t written = sendfile(dst_fd, src_fd, &idx, size);
+    if (written < 0) {
+      log_fatal("sendfile(src_fd = %d, NULL, dst_fd = %d, size = %d, 0): %s", src_fd, dst_fd,
+                buf.st_size, strerror(errno));
+    }
+    idx = written;
+    size -= written;
+  } while (size != 0);
+}
+#endif
+
+#ifdef FICLONE
+
+void copy_or_reflink(const char *src, const char *dst, mode_t mode, int extra_flags) {
+  auto src_fd = wcl::unique_fd::open(src, O_RDONLY);
+  if (!src_fd) {
+    log_fatal("open(%s): %s", src, strerror(src_fd.error()));
+  }
+  auto dst_fd = wcl::unique_fd::open(dst, O_WRONLY | O_CREAT | extra_flags, mode);
+  if (!dst_fd) {
+    log_fatal("open(%s): %s", dst, strerror(dst_fd.error()));
+  }
+
+  if (ioctl(dst_fd->get(), FICLONE, src_fd->get()) < 0) {
+    if (errno != EINVAL && errno != EOPNOTSUPP && errno != EXDEV) {
+      log_fatal("ioctl(%s, FICLONE, %d): %s", dst, src, strerror(errno));
+    }
+    copy(src_fd->get(), dst_fd->get());
+  }
+}
+
+#else
+
+void copy_or_reflink(const char *src, const char *dst, mode_t mode, int extra_flags) {
+  auto src_fd = wcl::unique_fd::open(src, O_RDONLY);
+  if (!src_fd) {
+    log_fatal("open(%s): %s", src, strerror(src_fd.error()));
+  }
+  auto dst_fd = wcl::unique_fd::open(dst, O_WRONLY | O_CREAT | extra_flags, mode);
+  if (!dst_fd) {
+    log_fatal("open(%s): %s", dst, strerror(dst_fd.error()));
+  }
+
+  copy(src_fd->get(), dst_fd->get());
+}
+
+#endif
+
+void remove_backing_files(const std::string &dir, int64_t job_id) {
+  uint8_t group_id = job_id & 0xFF;
+  std::string job_dir = wcl::join_paths(dir, wcl::to_hex(&group_id), std::to_string(job_id));
+  auto dir_range = wcl::directory_range::open(job_dir);
+  if (!dir_range) {
+    log_fatal("opendir(%s): %s", job_dir.c_str(), strerror(dir_range.error()));
+  }
+
+  // loop over the directory now and delete any files as we go.
+  for (const auto &entry : *dir_range) {
+    if (!entry) {
+      log_fatal("readdir(%s): %s", job_dir.c_str(), strerror(entry.error()));
+    }
+    if (entry->type != wcl::file_type::regular) {
+      log_fatal("remove_backing_files(%s): found non-regular entry: %s", job_dir.c_str(),
+                entry->name);
+    }
+    unlink_no_fail(entry->name.c_str());
+  }
+}
+
+void remove_backing_files(std::string dir, const std::vector<int64_t> &job_ids,
+                          size_t min_removals_per_thread, size_t max_number_of_threads) {
+  // Calculate a good number of threads to use.
+  size_t actual_num_threads =
+      std::min(max_number_of_threads, std::max(1UL, job_ids.size() / min_removals_per_thread));
+
+  // Calculate how many removals will be done by each task
+  size_t actual_removals_per_thread =
+      job_ids.size() / actual_num_threads + !!(job_ids.size() % actual_num_threads);
+
+  // Kick off each task
+  std::vector<std::future<void>> tasks;
+  auto iter = job_ids.begin();
+  auto end = job_ids.end();
+  while (iter < end) {
+    auto task_end = iter + actual_removals_per_thread;
+    tasks.emplace_back(std::async(std::launch::async, [&dir, iter, task_end, end]() {
+      auto i = iter;
+      for (; i < task_end && i < end; ++i) {
+        remove_backing_files(dir, *i);
+      }
+    }));
+    iter = task_end;
+  }
+
+  // Now join the tasks
+  for (auto &task : tasks) {
+    task.wait();
+  }
+}

--- a/src/job_cache/job_cache_impl_common.cpp
+++ b/src/job_cache/job_cache_impl_common.cpp
@@ -25,6 +25,7 @@
 #include <sys/file.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -211,9 +212,10 @@ void remove_backing_files(const std::string &dir, int64_t job_id) {
     if (!entry) {
       log_fatal("readdir(%s): %s", job_dir.c_str(), strerror(entry.error()));
     }
+    if (entry->name == "." || entry->name == "..") continue;
     if (entry->type != wcl::file_type::regular) {
       log_fatal("remove_backing_files(%s): found non-regular entry: %s", job_dir.c_str(),
-                entry->name);
+                entry->name.c_str());
     }
     unlink_no_fail(entry->name.c_str());
   }

--- a/src/job_cache/job_cache_impl_common.h
+++ b/src/job_cache/job_cache_impl_common.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// This function removes all the baking files of a specific job.
+// While not technically unsafe to use on a job still in the databse
+// this should be avoided.
+void remove_backing_files(const std::string &dir, int64_t job_id);
+
+// Like remove_backing_files(int64_t job_id) but removes many
+// in parallel.
+// NOTE: This should not be used from the wake process itself
+//       because it can spawn threads.
+void remove_backing_files(std::string dir, const std::vector<int64_t> &job_ids,
+                          size_t min_removals_per_thread, size_t max_number_of_threads);
+
+// Tries to reflink src to dst but copies if that fails.
+void copy_or_reflink(const char *src, const char *dst, mode_t mode = 0644, int extra_flags = 0);
+
+// These functions handle errors for us by calling log_fatal
+// if we get an error we don't like.
+void rename_no_fail(const char *old_path, const char *new_path);
+void mkdir_no_fail(const char *dir);
+void symlink_no_fail(const char *target, const char *symlink_path);
+void unlink_no_fail(const char *file);
+void rmdir_no_fail(const char *dir);

--- a/src/job_cache/job_cache_impl_common.h
+++ b/src/job_cache/job_cache_impl_common.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/job_cache/logging.h
+++ b/src/job_cache/logging.h
@@ -48,6 +48,16 @@ void log_info(Args &&...args) {
   fflush(stdout);
 }
 
+// A logging function for logging to stderr but
+// without exiting
+template <class... Args>
+void log_warning(Args &&...args) {
+  log_header(stderr);
+  fprintf(stderr, args...);
+  fprintf(stderr, "\n");
+  fflush(stderr);
+}
+
 // A logging function for logging and then exiting with
 // a failure code.
 template <class... Args>

--- a/src/job_cache/schema.sql
+++ b/src/job_cache/schema.sql
@@ -95,5 +95,21 @@ create table if not exists output_symlinks(
   job            job_id  not null references jobs(job_id) on delete cascade);
 create index if not exists output_symlink_by_job on output_symlinks(job);
 
+-- We need to track the total size to know when to start collecting stuff
+create table if not exists total_size(
+  total_size_id integer primary key,
+  size          integer not null);
+
+insert into total_size (total_size_id, size) select 0, 0 where not exists (select * from total_size);
+
+-- We need to keep track of jobs as the come through so that
+-- have some idea of which ones to keep/not keep
+create table if not exists lru_stats(
+  job_id integer primary key references jobs(job_id) on delete cascade,
+  last_use integer not null);
+
+-- We need to order everything so that we can delete jobs in bulk efficently
+create index if not exists lru_stats_order on lru_stats(last_use);
+
 commit transaction;
 --)"

--- a/src/job_cache/schema.sql
+++ b/src/job_cache/schema.sql
@@ -100,7 +100,7 @@ create table if not exists total_size(
   total_size_id integer primary key,
   size          integer not null);
 
-insert into total_size (total_size_id, size) select 0, 0 where not exists (select * from total_size);
+insert into total_size (total_size_id, size) select 1, 0 where not exists (select * from total_size);
 
 -- We need to keep track of jobs as the come through so that
 -- have some idea of which ones to keep/not keep

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -212,6 +212,8 @@ POLCIY_STATIC_DEFINES(VersionPolicy)
 POLCIY_STATIC_DEFINES(LogHeaderPolicy)
 POLCIY_STATIC_DEFINES(LogHeaderSourceWidthPolicy)
 POLCIY_STATIC_DEFINES(LabelFilterPolicy)
+POLCIY_STATIC_DEFINES(SharedCacheMaxSize)
+POLCIY_STATIC_DEFINES(SharedCacheLowSize)
 
 /********************************************************************
  * Non-Trivial Defaults
@@ -248,6 +250,20 @@ void LogHeaderSourceWidthPolicy::set(LogHeaderSourceWidthPolicy& p, const JAST& 
   auto json_log_header_soruce_width = json.expect_integer();
   if (json_log_header_soruce_width) {
     p.log_header_source_width = *json_log_header_soruce_width;
+  }
+}
+
+void SharedCacheMaxSize::set(SharedCacheMaxSize& p, const JAST& json) {
+  auto json_max_cache_size = json.expect_integer();
+  if (json_max_cache_size) {
+    p.max_cache_size = *json_max_cache_size;
+  }
+}
+
+void SharedCacheLowSize::set(SharedCacheLowSize& p, const JAST& json) {
+  auto json_low_cache_size = json.expect_integer();
+  if (json_low_cache_size) {
+    p.low_cache_size = *json_low_cache_size;
   }
 }
 

--- a/tests/config/empty/stdout
+++ b/tests/config/empty/stdout
@@ -4,3 +4,5 @@ Wake config:
   log_header = '' (WakeRoot)
   log_header_source_width = '0' (WakeRoot)
   label_filter = '.*' (Default)
+  max_cache_size = '26843545600' (Default)
+  low_cache_size = '16106127360' (Default)

--- a/tests/config/extra_keys/stdout
+++ b/tests/config/extra_keys/stdout
@@ -4,3 +4,5 @@ Wake config:
   log_header = '' (WakeRoot)
   log_header_source_width = '0' (WakeRoot)
   label_filter = '.*' (Default)
+  max_cache_size = '26843545600' (Default)
+  low_cache_size = '16106127360' (Default)

--- a/tests/config/missing_user_config/stdout
+++ b/tests/config/missing_user_config/stdout
@@ -4,3 +4,5 @@ Wake config:
   log_header = '' (WakeRoot)
   log_header_source_width = '0' (WakeRoot)
   label_filter = '.*' (Default)
+  max_cache_size = '26843545600' (Default)
+  low_cache_size = '16106127360' (Default)

--- a/tests/config/nominal/.wakeroot
+++ b/tests/config/nominal/.wakeroot
@@ -1,5 +1,7 @@
 {
   "user_config": "./wake_user.json",
   "log_header": "foobar $source: ",
-  "log_header_source_width": 13
+  "log_header_source_width": 13,
+  "max_cache_size": 1024,
+  "low_cache_size": 512
 }

--- a/tests/config/nominal/stdout
+++ b/tests/config/nominal/stdout
@@ -4,3 +4,5 @@ Wake config:
   log_header = 'foobar $source: ' (WakeRoot)
   log_header_source_width = '13' (WakeRoot)
   label_filter = '.*' (Default)
+  max_cache_size = '1024' (WakeRoot)
+  low_cache_size = '512' (WakeRoot)

--- a/tests/job-cache/basic-lru/.wakeroot
+++ b/tests/job-cache/basic-lru/.wakeroot
@@ -1,0 +1,5 @@
+{
+
+  "max_cache_size": 80,
+  "low_cache_size": 50
+}

--- a/tests/job-cache/basic-lru/pass.sh
+++ b/tests/job-cache/basic-lru/pass.sh
@@ -6,14 +6,14 @@ fi
 
 set -e
 WAKE="${1:+$1/wake}"
-rm wake.db || true
-rm -rf .cache-hit || true
-rm -rf .cache-misses || true
-rm -rf .job-cache || true
-rm one.txt || true
-rm two.txt || true
-rm three.txt || true
-rm four.txt || true
+rm wake.db 2> /dev/null || true
+rm -rf .cache-hit 2> /dev/null || true
+rm -rf .cache-misses 2> /dev/null || true
+rm -rf .job-cache 2> /dev/null || true
+rm one.txt 2> /dev/null || true
+rm two.txt 2> /dev/null || true
+rm three.txt 2> /dev/null || true
+rm four.txt 2> /dev/null || true
 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
 rm wake.db
 rm -rf .cache-misses
@@ -25,7 +25,6 @@ rm wake.db
 rm -rf .cache-misses
 
 # We should still be under the limit here. This is to ensure we mark test one as used
-rm -rf .cache-hit || true
 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
 rm wake.db
 rm -rf .cache-misses
@@ -40,7 +39,7 @@ rm wake.db
 rm -rf .cache-misses
 
 # Now make sure we still get a hit on 1
-rm -rf .cache-hit || true
+rm -rf .cache-hit  2> /dev/null || true
 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
 rm wake.db
 if [ -z "$(ls -A .cache-hit)" ]; then

--- a/tests/job-cache/basic-lru/test.wake
+++ b/tests/job-cache/basic-lru/test.wake
@@ -1,0 +1,11 @@
+from wake import _
+
+export def test (lst: List String): Result (List String) Error =
+    require Some x = head lst
+    else failWithError "must provide at least one argument"
+
+    require Pass outputs =
+        makePlan "basic_test" Nil "echo {x}: deadbeefdeadbeef > {x}.txt"
+        | runJob
+        | getJobOutputs
+    Pass (map (_.getPathName) outputs)

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -347,7 +347,8 @@ int main(int argc, char **argv) {
   std::unique_ptr<job_cache::Cache> cache;
   const char *job_cache_dir = getenv("WAKE_EXPERIMENTAL_JOB_CACHE");
   if (job_cache_dir != nullptr) {
-    cache = std::make_unique<job_cache::Cache>(job_cache_dir);
+    cache = std::make_unique<job_cache::Cache>(job_cache_dir, WakeConfig::get()->max_cache_size,
+                                               WakeConfig::get()->low_cache_size);
     set_job_cache(cache.get());
   }
 


### PR DESCRIPTION
What it says on the tin, this implements an LRU eviction policy for wake's shared cache. There are still some TODOs however

1) This is complicated and needs at least a bit of testing as a smoke test if nothing else. Before being confident putting this live I think we need more extensive fuzz testing but at the very least I'd like to see a basic test that exercises the LRU policy.
2) Right now I have the high and low water marks set at 16GB and 8GB, that needs to be configurable somehow and I haven't yet decided how to make that configurable. It would be *super* nice to implement this for testing to solve 1)

Other than those two points, its ready for eyeballs on it.