### PR TITLE
[v32.0.0] Set release date.

### DIFF
--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -2,6 +2,12 @@ wake (@VERSION@-1) unstable; urgency=medium
 
   * Auto-generated release package.
 
+ -- Ashley Coleman <ashley.coleman@sifive.com>  Tue, 04 Apr 2023 12:00:00 -0800
+
+wake (0.31.0-1) unstable; urgency=medium
+
+  * Auto-generated release package.
+
  -- Jake Ehrlich <jake.ehrlich@sifive.com>  Tue, 27 Feb 2023 10:00:00 -0800
 
 wake (0.30.0-1) unstable; urgency=medium


### PR DESCRIPTION
Prep for v32.0.0 release. 

For this release we are moving to SemVer and promoting the old "minor" version to the "major" version.