### PR TITLE
cli: list out unexpected positional args

### DIFF
--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -285,6 +285,11 @@ int main(int argc, char **argv) {
 
   if (noargs && clo.argc > 1) {
     std::cerr << "Unexpected positional arguments on the command-line!" << std::endl;
+    std::cerr << "\t'" << clo.argv[1] << "'";
+    for (int i = 2; i < clo.argc; i++) {
+      std::cerr << " '" << clo.argv[i] << "'";
+    }
+    std::cerr << std::endl;
     return 1;
   }
 

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -285,8 +285,8 @@ int main(int argc, char **argv) {
 
   if (noargs && clo.argc > 1) {
     std::cerr << "Unexpected positional arguments on the command-line!" << std::endl;
-    std::cerr << "\t'" << clo.argv[1] << "'";
-    for (int i = 2; i < clo.argc; i++) {
+    std::cerr << "   ";
+    for (int i = 1; i < clo.argc; i++) {
       std::cerr << " '" << clo.argv[i] << "'";
     }
     std::cerr << std::endl;


### PR DESCRIPTION
When failing an invocation its useful to list out the problematic arguments. When wake is invoked from a tool it might not be immediately obvious what the invocation command like was.

```
./bin/wake -o zero one two three
Unexpected positional arguments on the command-line!
        'one' 'two' 'three'
```