### PR TITLE
Tweak the defination of simple parts to be more permissive

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -882,3 +882,18 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
   )
 
   json
+
+def anyArray =
+            exists (_.getJArray | isSome) value
+
+def a = rec Nil (if indent > 0 then Some "" else None) lhs
+def a = Some ""
+
+def a =
+  def x =
+    if a then
+      b,
+    else
+      !b
+  require Pass readme = installIn "{dest}/share/doc/wake" "." readmeSource
+  x

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -605,11 +605,7 @@ def tarball Unit =
     require Pass tarball =
         def cmd =
             def gnutar = which "gnutar"
-            def tar =
-                if gnutar ==* "gnutar" then
-                    which "tar"
-                else
-                    gnutar
+            def tar = if gnutar ==* "gnutar" then which "tar" else gnutar
             def files =
                 map getPathName (manifest, testManifest, spec, srcs)
                 | sortBy (_ <* _)
@@ -979,3 +975,16 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
         )
 
     json
+
+def anyArray =
+    exists (_.getJArray | isSome) value
+
+def a =
+    rec Nil (if indent > 0 then Some "" else None) lhs
+
+def a = Some ""
+
+def a =
+    def x = if a then b, else !b
+    require Pass readme = installIn "{dest}/share/doc/wake" "." readmeSource
+    x

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -379,7 +379,7 @@ static inline bool is_simple_apply(wcl::doc_builder& builder, ctx_t ctx, CSTElem
 
   auto parts = collect_apply_parts(node);
 
-  if (parts.size() != 2) {
+  if (parts.size() > 2) {
     return false;
   }
 


### PR DESCRIPTION
- Simple 2 item applies like `Some ""` where each item is a literal or id is now considered a "simple literal"
  - this also means a top level `def x = Some ""` doesn't get newlined/is considered a constant
- Simple 2 part binop like `x < 0` where the lhs/rhs is a literal or id is now considered a "simple binop", and the shape `if simple_binop then simple_literal else simple_literal` is eligible to be on a single line
- `|` or `$` nested inside of parenthesis are now eligible to be on a single line