### PR TITLE
format: remove trailing whitespace from bound comments

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -30,6 +30,41 @@ def name Unit =
   def other = here
 
   # not floating
+  # not floating
+  # not floating
+
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
+def name Unit =
+  def other = here
+
+  # not floating
+  # not floating
+  # not floating
+
+  # not floating
+  # not floating
+
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
+def name Unit =
+  def other = here
+
+  # not floating
+  # not floating
+  # not floating
+
+  # not floating
+  # not floating
+  def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  another
+
+def name Unit =
+  def other = here
+
+  # not floating
   def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   another
 

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -23,7 +23,42 @@ def name Unit =
     def other = @here
 
     # not floating
-    
+
+    def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    another
+
+def name Unit =
+    def other = @here
+
+    # not floating
+    # not floating
+    # not floating
+
+    def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    another
+
+def name Unit =
+    def other = @here
+
+    # not floating
+    # not floating
+    # not floating
+
+    # not floating
+    # not floating
+
+    def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    another
+
+def name Unit =
+    def other = @here
+
+    # not floating
+    # not floating
+    # not floating
+
+    # not floating
+    # not floating
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
 
@@ -37,7 +72,7 @@ def name Unit =
 def name Unit =
     def other = @here
     # not floating
-    
+
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
 
@@ -751,10 +786,10 @@ def loop aaaaa sssss eeeee =
 
 global export tuple Map k v =
     # The ordering function in use, over the key type only.  The `Tree` also
-    
-    
+
+
     # stores a version of this over the full `Pair` type, but some of the data
-    
+
     # manipulations require access to this minimal signature.
     Comparison: k => k => Order
     # The existing `Tree` type provides the storage and most of the manipulation
@@ -816,12 +851,12 @@ def a =
     def b = 5
 
     # comment
-    
+
     def c = 5
 
     def d = 5
     # comment
-    
+
     result
 
 # floating 1

--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -87,7 +87,29 @@ struct TokenAction {
     auto it = traits.find(node);
     if (it != traits.end()) {
       for (auto n : it->second.before_bound) {
-        builder.append(n.fragment().segment().str());
+        if (n.id() == TOKEN_COMMENT) {
+          // Realign indent before writing the comment
+          freshline(builder, ctx);
+          builder.append(n.fragment().segment().str());
+          builder.append(wcl::doc::lit("\n"));
+          continue;
+        }
+
+        if (n.id() == TOKEN_NL) {
+          // Emit newlines without alignment. If this is a standalone newline
+          // then we shouldn't emit any trailing whitespace.
+          builder.append(wcl::doc::lit("\n"));
+          continue;
+        }
+
+        FMT_ASSERT(false, n,
+                   "Token mismatch! Expected <" + std::string(symbolName(TOKEN_COMMENT)) + "|" +
+                       std::string(symbolName(TOKEN_NL)) + ">, Saw <" +
+                       std::string(symbolName(n.id())) + ">");
+      }
+
+      // Realign indent in case we lost alighnment.
+      if (it->second.before_bound.size() > 0) {
         freshline(builder, ctx);
       }
     }
@@ -121,7 +143,29 @@ struct TokenReplaceAction {
     auto it = traits.find(node);
     if (it != traits.end()) {
       for (auto n : it->second.before_bound) {
-        builder.append(n.fragment().segment().str());
+        if (n.id() == TOKEN_COMMENT) {
+          // Realign indent before writing the comment
+          freshline(builder, ctx);
+          builder.append(n.fragment().segment().str());
+          builder.append(wcl::doc::lit("\n"));
+          continue;
+        }
+
+        if (n.id() == TOKEN_NL) {
+          // Emit newlines without alignment. If this is a standalone newline
+          // then we shouldn't emit any trailing whitespace.
+          builder.append(wcl::doc::lit("\n"));
+          continue;
+        }
+
+        FMT_ASSERT(false, n,
+                   "Token mismatch! Expected <" + std::string(symbolName(TOKEN_COMMENT)) + "|" +
+                       std::string(symbolName(TOKEN_NL)) + ">, Saw <" +
+                       std::string(symbolName(n.id())) + ">");
+      }
+
+      // Realign indent in case we lost alighnment.
+      if (it->second.before_bound.size() > 0) {
         freshline(builder, ctx);
       }
     }

--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -75,64 +75,12 @@ struct LiteralAction {
   }
 };
 
-struct TokenAction {
-  cst_id_t token_id;
-  TokenAction(cst_id_t token_id) : token_id(token_id) {}
-  ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
-                         const token_traits_map_t& traits) {
-    FMT_ASSERT(node.id() == token_id, node,
-               "Token mismatch! Expected <" + std::string(symbolName(token_id)) + ">, Saw <" +
-                   std::string(symbolName(node.id())) + ">");
-
-    auto it = traits.find(node);
-    if (it != traits.end()) {
-      for (auto n : it->second.before_bound) {
-        if (n.id() == TOKEN_COMMENT) {
-          // Realign indent before writing the comment
-          freshline(builder, ctx);
-          builder.append(n.fragment().segment().str());
-          builder.append(wcl::doc::lit("\n"));
-          continue;
-        }
-
-        if (n.id() == TOKEN_NL) {
-          // Emit newlines without alignment. If this is a standalone newline
-          // then we shouldn't emit any trailing whitespace.
-          builder.append(wcl::doc::lit("\n"));
-          continue;
-        }
-
-        FMT_ASSERT(false, n,
-                   "Token mismatch! Expected <" + std::string(symbolName(TOKEN_COMMENT)) + "|" +
-                       std::string(symbolName(TOKEN_NL)) + ">, Saw <" +
-                       std::string(symbolName(n.id())) + ">");
-      }
-
-      // Realign indent in case we lost alighnment.
-      if (it->second.before_bound.size() > 0) {
-        freshline(builder, ctx);
-      }
-    }
-
-    builder.append(node.fragment().segment().str());
-
-    if (it != traits.end()) {
-      for (auto n : it->second.after_bound) {
-        space(builder, 1);
-        builder.append(n.fragment().segment().str());
-        newline(builder, 0);
-      }
-    }
-
-    node.nextSiblingElement();
-  }
-};
-
 struct TokenReplaceAction {
   cst_id_t token_id;
-  const char* str;
+  const char* str = nullptr;
 
   TokenReplaceAction(cst_id_t token_id, const char* str) : token_id(token_id), str(str) {}
+  TokenReplaceAction(cst_id_t token_id) : token_id(token_id) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
                          const token_traits_map_t& traits) {
@@ -170,7 +118,11 @@ struct TokenReplaceAction {
       }
     }
 
-    builder.append(str);
+    if (str == nullptr) {
+      builder.append(node.fragment().segment().str());
+    } else {
+      builder.append(str);
+    }
 
     if (it != traits.end()) {
       for (auto n : it->second.after_bound) {

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -93,7 +93,7 @@ struct Formatter {
 
   Formatter<SeqAction<Action, LiteralAction>> lit(wcl::doc lit) { return {{action, {lit}}}; }
 
-  Formatter<SeqAction<Action, TokenAction>> token(cst_id_t id) { return {{action, {id}}}; }
+  Formatter<SeqAction<Action, TokenReplaceAction>> token(cst_id_t id) { return {{action, {id}}}; }
 
   Formatter<SeqAction<Action, TokenReplaceAction>> token(cst_id_t id, const char* str) {
     return {{action, {id, str}}};


### PR DESCRIPTION
Fixes trailing  white space that is  emitted after a  nested floating comment. Also adds more tests around floating  comments to catch other potential breakages