### PR TITLE
mstr: Fix extra prepended spaces on interpolation

### DIFF
--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -27,7 +27,6 @@
 #include <algorithm>
 #include <set>
 #include <sstream>
-#include <iostream>
 
 #include "expr.h"
 #include "parser/cst.h"
@@ -1153,7 +1152,7 @@ static Expr *dst_interpolate(CSTElement intp) {
 
   MultiLineStringIndentationFSM fsm;
   CSTElement i = intp.firstChildNode();
-  while(!i.empty()) {
+  while (!i.empty()) {
     fsm.accept(i);
     i.nextSiblingNode();
     i.nextSiblingNode();

--- a/src/dst/todst.cpp
+++ b/src/dst/todst.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <set>
 #include <sstream>
+#include <iostream>
 
 #include "expr.h"
 #include "parser/cst.h"
@@ -1151,11 +1152,14 @@ static Expr *dst_interpolate(CSTElement intp) {
   std::string total;
 
   MultiLineStringIndentationFSM fsm;
-  for (CSTElement i = intp.firstChildNode(); !i.empty(); i.nextSiblingNode()) {
-    if (args.size() % 2 == 0) fsm.accept(i);
+  CSTElement i = intp.firstChildNode();
+  while(!i.empty()) {
+    fsm.accept(i);
+    i.nextSiblingNode();
+    i.nextSiblingNode();
   }
 
-  for (CSTElement i = intp.firstChildNode(); !i.empty(); i.nextSiblingNode()) {
+  for (i = intp.firstChildNode(); !i.empty(); i.nextSiblingNode()) {
     if (args.size() % 2 == 0) {
       Literal *lit = dst_literal(i, fsm.prefix.size());
       if (regexp) total.append(lit->value);


### PR DESCRIPTION
Fixes https://github.com/sifive/wake/issues/1106

Interpolated multiline strings would have prepended spaces in the resulting string. This is because the loop 

```
std::vector<Expr *> args;
for (CSTElement i = intp.firstChildNode(); !i.empty(); i.nextSiblingNode()) {
  if (args.size() % 2 == 0) fsm.accept(i);
}
```

intended for `fsm.accept(i)` to be called every other iteration but it was called every  iteration since `args` wasn't being appended to.

Example:

```
export def hax2 = "%
  fun day.
  happy day. %{str 123}
%"
```

Before fix:
```
> ./bin/wake -x 'hax2'
" fun day.\n happy day. 123"
```

After fix:
```
> ./bin/wake -x 'hax2'
"fun day.\nhappy day. 123"
```