### PR TITLE
Fix field documentation formatting for `Usage` and `Plan` tuples

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -35,9 +35,12 @@ export tuple RunnerInput =
   export Directory:   String
   export Stdin:       String
   export Resources:   List String
-  export Prefix:      String        # a unique prefix for this job
-  export Record:      Usage         # previous resource usage
-  export IsAtty:      Boolean       # should job run in psuedoterminal
+  # A unique prefix for this job
+  export Prefix:      String
+  # Previous resource usage
+  export Record:      Usage
+  # Determines if job should run in psuedoterminal
+  export IsAtty:      Boolean
 
 export tuple RunnerOutput =
   export Inputs:  List String
@@ -86,23 +89,40 @@ export data Persistence =
 
 # A Plan describes a not-yet-executed Job
 tuple Plan =
-  export Label:        String       # The label used when showing the command during execution
-  export Command:      List String  # The command-line arguments (the first is the command to run)
-  export Visible:      List Path    # Only these files should be available to the command
-  export Environment:  List String  # KEY=VALUE environment variables fed to the command
-  export Directory:    String       # The directory in which the command should be run
-  export Stdin:        String       # The file to which standard input should be connected
-  export Stdout:       LogLevel     # How should standard output be displayed during a build
-  export Stderr:       LogLevel     # How should standard error be displayed during a build
-  export Echo:         LogLevel     # Echo the command to this stream
-  export Persistence:  Persistence  # See Persistence table above
-  export LocalOnly:    Boolean      # Must run directly in the local workspace; no output detection performed
-  export Resources:    List String  # The resources a runner must provide to the job (licenses/etc)
-  export RunnerFilter: Runner => Boolean # Reject from consideration Runners which the Plan deems inappropriate
-  export Usage:        Usage        # User-supplied usage prediction; overruled by database statistics (if any)
-  export FnInputs:     (List String => List String) # Modify the Runner's reported inputs  (files read)
-  export FnOutputs:    (List String => List String) # Modify the Runner's reported outputs (files created)
-  export IsAtty:       Boolean      # Should job run in psuedoterminal
+  # The label used when showing the command during execution
+  export Label:        String
+  # The command-line arguments (the first is the command to run)
+  export Command:      List String
+  # Only these files should be available to the command
+  export Visible:      List Path
+  # KEY=VALUE environment variables fed to the command
+  export Environment:  List String
+  # The directory in which the command should be run
+  export Directory:    String
+  # The file to which standard input should be connected
+  export Stdin:        String
+  # How should standard output be displayed during a build
+  export Stdout:       LogLevel
+  # How should standard error be displayed during a build
+  export Stderr:       LogLevel
+  # Echo the command to this stream
+  export Echo:         LogLevel
+  # See Persistence table above
+  export Persistence:  Persistence
+  # Must run directly in the local workspace; no output detection performed
+  export LocalOnly:    Boolean
+  # The resources a runner must provide to the job (licenses/etc)
+  export Resources:    List String
+  # Reject from consideration Runners which the Plan deems inappropriate
+  export RunnerFilter: Runner => Boolean
+  # User-supplied usage prediction; overruled by database statistics (if any)
+  export Usage:        Usage
+  # Modify the Runner's reported inputs  (files read)
+  export FnInputs:     (List String => List String)
+  # Modify the Runner's reported outputs (files created)
+  export FnOutputs:    (List String => List String)
+  # Should job run in psuedoterminal
+  export IsAtty:       Boolean
 
 def isOnce: Persistence => Boolean = match _
   ReRun = False


### PR DESCRIPTION
The formatting was incorrect for use with the Wake LSP and VS Code extension (since the implementation of `Usage` and `Plan` predated the existence of those tools). Screenshots showcasing behavior before the fix:

![image](https://user-images.githubusercontent.com/65685447/231582061-dafcc67c-3926-47e7-b694-741a4311959f.png)

![image](https://user-images.githubusercontent.com/65685447/231582134-1340ec6e-dd03-4df1-8af0-d44332f50d5c.png)

Screenshot with field documentation in correct location:

![image](https://user-images.githubusercontent.com/65685447/231582503-fa5171e2-8874-4d62-a583-455f00bd50fb.png)