### PR TITLE
format: specifiy internal newlines based on structure

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1106,3 +1106,13 @@ def doInstall dest kind =
     def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
     require Pass bin = val
     Pass outputs
+
+def tarball Unit =
+    def srcs = allSources | s # a comment
+    def x = y
+    x
+
+def tarball Unit =
+    require srcs = allSources | s # a comment
+    require x = y
+    x

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1110,9 +1110,28 @@ def doInstall dest kind =
 def tarball Unit =
     def srcs = allSources | s # a comment
     def x = y
+    def srcs = allSources # a comment
+    def x = y
+    def srcs = allSources # a comment
+    def x = y
     x
 
 def tarball Unit =
     require srcs = allSources | s # a comment
     require x = y
+    require srcs = allSources # a comment
+    require x = y
+    require srcs = allSources # a comment
+    require x = y
+    require Pass binfiles2 = binfilesResult2
+    else blah # a comment
+    require x = y
+    require Pass binfiles2 = binfilesResult2 # a comment
+    else blah # a comment
+    require x = y
+    require Pass binfiles2 = binfilesResult2 # a comment
+    else blah
+    require srcs = allSources # a comment
+    require x = y
+    require srcs = allSources # a comment
     x

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1062,3 +1062,47 @@ def someFunc a b =
         mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         """
     s
+
+# Install wake into a target location
+def doInstall dest kind =
+    require Pass variant = toVariant kind
+    require Pass datfiles =
+        sources "{here}/share" `.*`
+    def binfilesResult = all variant
+    def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
+    # a comment
+    def a b = c
+    def a b =
+      def c = d
+      d
+    def a b =
+      def c = d
+      d
+    def a b =
+      def c = d
+      d
+    require Pass datinstall =
+        findFailFn (installIn dest ".") datfiles
+    # comment
+    require Pass readmeSource =
+        source "README.md"
+    require Pass readme =
+        installIn "{dest}/share/doc/wake" "." readmeSource
+    require Pass binfiles = binfilesResult
+    require Pass binfiles2 = binfilesResult2
+    else blah
+    require Pass bininstall =
+        findFailFn releaseBin binfiles
+    require Pass binfiles2 =
+        def a = b
+        a
+    require Pass binfiles2 = binfilesResult2
+    require Pass binfiles2 = binfilesResult2
+    def outputs = readme, bininstall ++ datinstall
+    Pass outputs
+
+def doInstall dest kind =
+    def binfilesResult = all variant
+    def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
+    require Pass bin = val
+    Pass outputs

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1275,6 +1275,10 @@ def tarball Unit =
         | s # a comment
 
     def x = y
+    def srcs = allSources # a comment
+    def x = y
+    def srcs = allSources # a comment
+    def x = y
 
     x
 
@@ -1284,5 +1288,28 @@ def tarball Unit =
         | s # a comment
 
     require x = y
+    require srcs = allSources # a comment
+    require x = y
+    require srcs = allSources # a comment
+    require x = y
+
+    require Pass binfiles2 = binfilesResult2
+    else
+        blah # a comment
+
+    require x = y
+
+    require Pass binfiles2 = binfilesResult2 # a comment
+    else
+        blah # a comment
+
+    require x = y
+
+    require Pass binfiles2 = binfilesResult2 # a comment
+    else blah
+
+    require srcs = allSources # a comment
+    require x = y
+    require srcs = allSources # a comment
 
     x

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1268,3 +1268,21 @@ def doInstall dest kind =
     require Pass bin = val
 
     Pass outputs
+
+def tarball Unit =
+    def srcs =
+        allSources
+        | s # a comment
+
+    def x = y
+
+    x
+
+def tarball Unit =
+    require srcs =
+        allSources
+        | s # a comment
+
+    require x = y
+
+    x

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -10,31 +10,25 @@ def five = 5
 
 def name Unit =
     def other = @here
+
     def other =
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another
 
 def name Unit =
     def other = @here
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    another
 
-def name Unit =
-    def other = @here
-
-    # not floating
-
-    def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     another
 
 def name Unit =
     def other = @here
 
     # not floating
-    # not floating
-    # not floating
 
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another
 
 def name Unit =
@@ -44,10 +38,8 @@ def name Unit =
     # not floating
     # not floating
 
-    # not floating
-    # not floating
-
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another
 
 def name Unit =
@@ -59,7 +51,22 @@ def name Unit =
 
     # not floating
     # not floating
+
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    another
+
+def name Unit =
+    def other = @here
+
+    # not floating
+    # not floating
+    # not floating
+
+    # not floating
+    # not floating
+    def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another
 
 def name Unit =
@@ -67,13 +74,16 @@ def name Unit =
 
     # not floating
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another
 
 def name Unit =
     def other = @here
+
     # not floating
 
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another
 
 global export def glob1 = 34
@@ -82,6 +92,7 @@ global export def glob1 = 34
 def name Unit =
     def other = @here
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another
 
 # wake-format off
@@ -95,27 +106,32 @@ def name Unit =
     # wake-format off
     def other = here
     def other = @here
+
     another
 
 def name Unit =
     def other = @here
+
     # wake-format off
     def other = here
     def other = @here
+
     another
 
 def name Unit =
     def other = @here
+
     # wake-format off
     def other = here
-
     def other = @here
+
     another
 
 def name Unit =
     # ordinary comment
     def other = @here
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another
 
 def t1 =
@@ -211,6 +227,7 @@ def t10 =
 def name Unit = # wake-format off
     def other = here
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another
 
 def t3 =
@@ -294,6 +311,7 @@ def wakeToTestDir Unit =
     match (subscribe wakeTestBinary)
         buildTestWake, Nil =
             require Pass (Pair path visible) = buildTestWake Unit
+
             Pass (Pair (simplify "{path}/..") visible)
         Nil = Pass (Pair "{wakePath}" Nil)
         _ = Fail (makeError "Two wake binaries declared for testing!")
@@ -306,6 +324,7 @@ def wakeToTestDir Unit =
                 # comment
                 (Pair path visible)
             ) = buildTestWake Unit
+
             Pass (Pair (simplify "{path}/..") visible)
         Nil = Pass (Pair "{wakePath}" Nil)
         _ = Fail (makeError "Two wake binaries declared for testing!")
@@ -481,7 +500,6 @@ def buildRE2WASM Unit =
     def emsdk = replace `/[^/]*$` "" emmake
 
     require Pass patch = source "{@here}/re2.patch"
-
     require Pass buildDir = vendorBuildDir Unit
 
     def job =
@@ -501,11 +519,8 @@ def buildRE2WASM Unit =
     require Pass outputs = job.getJobOutputs
 
     def headers = filter (matches `.*\.h` _.getPathName) outputs
-
     def objects = filter (matches `.*\.o` _.getPathName) outputs
-
     def cflags = "-I{@here}/.build/re2-{version}", Nil
-
     def lflags = Nil
 
     Pass (SysLib "1.0" headers objects cflags lflags)
@@ -528,6 +543,7 @@ export def build: List String => Result String Error =
             | rmap (\_ "TARBALL")
         kind, Nil =
             require Pass variant = toVariant kind
+
             all variant
             | rmap (\_ "BUILD")
         _ = Fail "no target specified (try: build default/debug/tarball)".makeError
@@ -558,31 +574,38 @@ def all variant =
     require Pass x =
         map (_ variant) targets
         | findFail
+
     Pass (flatten x)
 
 # Install wake into a target location
 def doInstall dest kind =
     require Pass variant = toVariant kind
     require Pass datfiles = sources "{@here}/share" `.*`
+
     def binfilesResult = all variant
     def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
+
     require Pass datinstall = findFailFn (installIn dest ".") datfiles
     require Pass readmeSource = source "README.md"
     require Pass readme = installIn "{dest}/share/doc/wake" "." readmeSource
     require Pass binfiles = binfilesResult
     require Pass bininstall = findFailFn releaseBin binfiles
+
     def outputs = readme, bininstall ++ datinstall
+
     Pass outputs
 
 # Replace @VERSION@ with 'release'
 def setVersion release file =
     require Pass in = source "{file}.in"
+
     def script =
         "%
             set -e
             sed "s/@VERSION@/%{release}/g" "%{in.getPathName}" > "%{file}.tmp"
             mv "%{file}.tmp" "%{file}"
         %"
+
     shellJob script (in, Nil)
     | getJobOutput
 
@@ -590,29 +613,38 @@ def setVersion release file =
 def tarball Unit =
     def releaseResult = buildAs Unit
     def timeResult = buildOn Unit
+
     require Pass release = releaseResult
     require Pass time = timeResult
+
     # Create debian + RedHat package files
     require Pass changelog = setVersion release "debian/changelog"
     require Pass spec = setVersion release "wake.spec"
+
     # Identify those sources files to include in the tarball
     require Pass allSources = sources "." `.*`
+
     def srcs =
         allSources
         | filter (!matches `(debian/|wake.spec).*` _.getPathName) # omit packaging files
         | filter (!matches `(\.circleci/|\.github/).*|\.dockerignore` _.getPathName) # omit CI files
         | filter (!matches `(.*/)*\.gitignore` _.getPathName) # omit git files
+
+
     def Pair testPaths wakePaths = splitBy (matches `tests/.*` _.getPathName) srcs
+
     def wakeSourcesString =
         wakePaths
         | map (_.getPathName.format)
         | foldr (_, ",\n  ", _) Nil
         | cat
+
     def testSourcesString =
         testPaths
         | map (getPathName _ | format | replace `^"tests/` '"{here}/')
         | foldr (_, ",\n  ", _) Nil
         | cat
+
     def manifestStr =
         "%
             # Generated by 'wake tarball Unit':
@@ -624,6 +656,7 @@ def tarball Unit =
             publish source =
               %{wakeSourcesString}Nil
         %"
+
     def testsManifestStr =
         "%
             # Generated by 'wake tarball Unit':
@@ -633,9 +666,11 @@ def tarball Unit =
             publish source =
               %{testSourcesString}Nil
         %"
+
     # Create a manifest which describes the release and source files
     require Pass manifest = write "manifest.wake" manifestStr
     require Pass testManifest = write "tests/manifest.wake" testsManifestStr
+
     # Execute tar to create a tarball of manifest + sources
     require Pass tarball =
         def cmd =
@@ -644,6 +679,7 @@ def tarball Unit =
             def files =
                 map getPathName (manifest, testManifest, spec, srcs)
                 | sortBy (_ <* _)
+
             tar,
             "--mtime={time}",
             "--transform=s@^@wake-{release}/@",
@@ -653,17 +689,21 @@ def tarball Unit =
             "-cJf",
             "wake_{release}.tar.xz",
             files
+
         job cmd (manifest, testManifest, spec, srcs)
         | getJobOutput
+
     Pass (tarball, changelog, Nil)
 
 export def static _: Result Path Error =
     def filesResult = doInstall "tmp" "static"
     def releaseResult = buildAs Unit
     def timeResult = buildOn Unit
+
     require Pass release = releaseResult
     require Pass time = timeResult
     require Pass files = filesResult
+
     def cmd =
         which "tar",
         "--mtime={time}",
@@ -674,6 +714,7 @@ export def static _: Result Path Error =
         "-cJf",
         "wake-static_{release}.tar.xz",
         map getPathName files | sortBy (_ <* _)
+
     job cmd files
     | getJobOutput
 
@@ -753,8 +794,11 @@ export def vfoldl (combiningFn: accum => element => accum): accum => Vector elem
             accumulator
         else
             def element = vget v s
+
             loop (combiningFn accumulator element) v (s + 1) e
+
     def top a (Vector v s e) = loop a v s e
+
     top
 
 def loop a s e =
@@ -854,8 +898,8 @@ def a =
     # comment
 
     def c = 5
-
     def d = 5
+
     # comment
 
     result
@@ -869,8 +913,10 @@ def a =
 # comment 3
 def name Unit =
     def other = @here
+
     def other =
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another # comment
 
 # floating 3a
@@ -883,15 +929,19 @@ def name Unit =
 # comment 3
 def name Unit =
     def other = @here
+
     def other =
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another # comment
 
 # comment 3
 def name Unit =
     def other = @here
+
     def other =
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     another # comment
 
 # floating 6
@@ -905,6 +955,7 @@ def a =
         5
     else
         require Pass a = b
+
         a
 
 tuple A B =
@@ -950,6 +1001,7 @@ def longFunc param: Result (List Path) Error =
         Nil = Nil,
         a, b =
             def f = funcB b
+
             match f
                 Some x = x
                 None = x
@@ -966,15 +1018,18 @@ export def mapPartial (f: a => Option b): (list: List a) => List b =
         h, t =
             # don't wait on f to process tail:
             def sub = loop t
+
             match (f h)
                 Some x = x, sub
                 None = sub
+
     loop
 
 target writeImp inputs mode path content =
     def writeRunner =
         def imp m p c = prim "write"
         def pre input = Pair input Unit
+
         def post = match _
             Pair (Fail f) _ = Fail f
             Pair (Pass output) Unit =
@@ -983,7 +1038,9 @@ target writeImp inputs mode path content =
                 else match (imp mode path content)
                     Fail f = Fail (makeError f)
                     Pass path = Pass (editRunnerOutputOutputs (path, _) output)
+
         makeRunner "write" (\_ Pass 0.0) pre post virtualRunner
+
     makeExecPlan ("<write>", str mode, path, Nil) inputs
     | setPlanOnce False
     | setPlanEnvironment Nil

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1213,3 +1213,60 @@ def someFunc a b =
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         """
     s
+# Install wake into a target location
+def doInstall dest kind =
+    require Pass variant = toVariant kind
+    require Pass datfiles = sources "{@here}/share" `.*`
+
+    def binfilesResult = all variant
+    def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
+
+    # a comment
+    def a b = c
+
+    def a b =
+        def c = d
+
+        d
+
+    def a b =
+        def c = d
+
+        d
+
+    def a b =
+        def c = d
+
+        d
+
+    require Pass datinstall = findFailFn (installIn dest ".") datfiles
+
+    # comment
+    require Pass readmeSource = source "README.md"
+    require Pass readme = installIn "{dest}/share/doc/wake" "." readmeSource
+    require Pass binfiles = binfilesResult
+
+    require Pass binfiles2 = binfilesResult2
+    else blah
+
+    require Pass bininstall = findFailFn releaseBin binfiles
+
+    require Pass binfiles2 =
+        def a = b
+
+        a
+
+    require Pass binfiles2 = binfilesResult2
+    require Pass binfiles2 = binfilesResult2
+
+    def outputs = readme, bininstall ++ datinstall
+
+    Pass outputs
+
+def doInstall dest kind =
+    def binfilesResult = all variant
+    def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
+
+    require Pass bin = val
+
+    Pass outputs

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -630,7 +630,6 @@ def tarball Unit =
         | filter (!matches `(\.circleci/|\.github/).*|\.dockerignore` _.getPathName) # omit CI files
         | filter (!matches `(.*/)*\.gitignore` _.getPathName) # omit git files
 
-
     def Pair testPaths wakePaths = splitBy (matches `tests/.*` _.getPathName) srcs
 
     def wakeSourcesString =
@@ -784,8 +783,7 @@ def f0 =
         (
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        )
-        = x + 1
+        ) = x + 1
         x b = x + 0
 
 export def vfoldl (combiningFn: accum => element => accum): accum => Vector element => accum =

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -675,6 +675,7 @@ def tarball Unit =
         def cmd =
             def gnutar = which "gnutar"
             def tar = if gnutar ==* "gnutar" then which "tar" else gnutar
+
             def files =
                 map getPathName (manifest, testManifest, spec, srcs)
                 | sortBy (_ <* _)
@@ -1081,7 +1082,9 @@ def a = Some ""
 
 def a =
     def x = if a then b, else !b
+
     require Pass readme = installIn "{dest}/share/doc/wake" "." readmeSource
+
     x
 
 def x = "%
@@ -1106,6 +1109,7 @@ def someFunc a b =
             sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         %"
+
     s
 
 def someFunc a b =
@@ -1115,6 +1119,7 @@ def someFunc a b =
             sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         %"
+
     s
 
 def someFunc a b =
@@ -1124,6 +1129,7 @@ def someFunc a b =
             sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         %"
+
     s
 
 def someFunc a b =
@@ -1133,6 +1139,7 @@ def someFunc a b =
             sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         %"
+
     s
 
 def someFunc a b =
@@ -1142,6 +1149,7 @@ def someFunc a b =
             sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         %"
+
     s
 
 def x = "%
@@ -1174,6 +1182,7 @@ def someFunc a b =
             sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         """
+
     s
 
 def someFunc a b =
@@ -1183,6 +1192,7 @@ def someFunc a b =
             sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         """
+
     s
 
 def someFunc a b =
@@ -1192,6 +1202,7 @@ def someFunc a b =
             sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         """
+
     s
 
 def someFunc a b =
@@ -1201,6 +1212,7 @@ def someFunc a b =
             sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         """
+
     s
 
 def someFunc a b =
@@ -1210,7 +1222,9 @@ def someFunc a b =
             sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
             mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
         """
+
     s
+
 # Install wake into a target location
 def doInstall dest kind =
     require Pass variant = toVariant kind

--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -65,6 +65,13 @@ struct FreshlineAction {
   }
 };
 
+struct BreaklineAction {
+  ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
+                         const token_traits_map_t& traits) {
+    breakline(builder, ctx);
+  }
+};
+
 struct LiteralAction {
   wcl::doc lit;
   LiteralAction(wcl::doc lit) : lit(lit) {}

--- a/tools/wake-format/catters.h
+++ b/tools/wake-format/catters.h
@@ -43,6 +43,10 @@ struct FreshlineCatter {
   ALWAYS_INLINE void cat(wcl::doc_builder& builder, ctx_t ctx) { freshline(builder, ctx); }
 };
 
+struct BreaklineCatter {
+  ALWAYS_INLINE void cat(wcl::doc_builder& builder, ctx_t ctx) { breakline(builder, ctx); }
+};
+
 struct LiteralCatter {
   wcl::doc lit;
   LiteralCatter(wcl::doc lit) : lit(lit) {}

--- a/tools/wake-format/common.h
+++ b/tools/wake-format/common.h
@@ -68,3 +68,15 @@ inline void freshline(wcl::doc_builder& builder, ctx_t ctx) {
     assert(false);
   }
 }
+
+inline void breakline(wcl::doc_builder& builder, ctx_t ctx) {
+  auto merged = ctx.sub(builder);
+
+  // The current line has characters and thus isn't "finished"
+  // add a newline to upgrade it to a line.
+  if (merged->last_width() != 0) {
+    newline(builder, 0);
+  }
+
+  newline(builder, 0);
+}

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1811,8 +1811,8 @@ wcl::doc Emitter::walk_require(ctx_t ctx, CSTElement node) {
 
   MEMO_RET(fmt()
                .join(pre_body_fmt)
-               // Returns true if the body should be separated from the currently require
-               .fmt_if_else(
+               // Returns true if the body should be separated from the current require
+               .fmt_if(
                    [this, node, pre_body_fmt](const wcl::doc_builder& builder, ctx_t ctx,
                                               const CSTElement& inner,
                                               const token_traits_map_t& traits) {
@@ -1846,7 +1846,8 @@ wcl::doc Emitter::walk_require(ctx_t ctx, CSTElement node) {
 
                      return false;
                    },
-                   fmt().breakline().freshline(), fmt().freshline())
+                   fmt().breakline())
+               .freshline()
                .walk(WALK_NODE)
                .consume_wsnlc()
                .format(ctx, node.firstChildElement(), token_traits));

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1292,6 +1292,18 @@ wcl::doc Emitter::walk_block(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
   FMT_ASSERT(node.id() == CST_BLOCK, node, "Expected CST_BLOCK");
 
+  // collect all children nodes into a list
+  // track each node with a yes/no needs preceding newline flag
+  // mark first node as not needing a preceding newline
+  // mark last node as needing a preceding newline
+  // loop over the second node to the second to last node
+  //   newline if the current node is non-human flat
+  //   else newline if previous node is non-human flat
+  //   else don't newline
+  // loop over all nodes
+  //   newlining when flag set
+  //   emitting the node
+
   auto parts = collect_block_parts(node);
 
   std::unordered_map<CSTElement, bool> requires_preceding_nl = {};
@@ -1789,7 +1801,16 @@ wcl::doc Emitter::walk_require(ctx_t ctx, CSTElement node) {
 
   MEMO_RET(fmt()
                .join(pre_body_fmt)
-               // Returns true if the body should be separated from the current require
+               // Returns true if the body should be separated from the current
+               // require based on the following rules.
+               //
+               // 1 emit the current node
+               // 2 breakine() if the next node isn't a require
+               // 3 else breakline() if the next node starts with a comment
+               // 4 else breakline() if the current node is non-human flat
+               // 5 else breakline() if the next node is non-human flat
+               // 6 else don't breakline()
+               // 7 emit the next node
                .fmt_if(
                    [this, node, pre_body_fmt](const wcl::doc_builder& builder, ctx_t ctx,
                                               const CSTElement& inner,

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -302,6 +302,19 @@ static wcl::doc binop_rhs_separator(const CSTElement& op) {
   }
 }
 
+static std::vector<CSTElement> collect_block_parts(CSTElement node) {
+  if (node.id() != CST_BLOCK) {
+    return {};
+  }
+
+  std::vector<CSTElement> parts = {};
+  for (CSTElement i = node.firstChildNode(); !i.empty(); i.nextSiblingNode()) {
+    parts.push_back(i);
+  }
+
+  return parts;
+}
+
 static std::vector<CSTElement> collect_left_binary(CSTElement collect_over, CSTElement node) {
   if (node.id() != CST_BINARY) {
     return {node};
@@ -1121,72 +1134,6 @@ wcl::doc Emitter::walk_ascribe(ctx_t ctx, CSTElement node) {
                .ws()
                .walk(WALK_NODE)
                .format(ctx, node.firstChildElement(), token_traits));
-}
-
-static std::vector<CSTElement> collect_block_parts(CSTElement node) {
-  if (node.id() != CST_BLOCK) {
-    return {};
-  }
-
-  std::vector<CSTElement> parts = {};
-  for (CSTElement i = node.firstChildNode(); !i.empty(); i.nextSiblingNode()) {
-    parts.push_back(i);
-  }
-
-  return parts;
-}
-
-static std::vector<CSTElement> collect_left_binary(CSTElement collect_over, CSTElement node) {
-  if (node.id() != CST_BINARY) {
-    return {node};
-  }
-
-  // NOTE: The 'node' variant functions are being used here which is differnt than everywhere else
-  // This is fine since COMMENTS are bound to the nodes and this func only needs to process nodes
-  CSTElement left = node.firstChildNode();
-  CSTElement op = left;
-  op.nextSiblingNode();
-  CSTElement right = op;
-  right.nextSiblingNode();
-
-  if (!(op.id() == CST_OP && op.firstChildElement().id() == collect_over.id() &&
-        op.firstChildElement().fragment().segment().str() ==
-            collect_over.fragment().segment().str())) {
-    return {node};
-  }
-
-  auto collect = collect_left_binary(collect_over, left);
-  collect.push_back(right);
-
-  return collect;
-}
-
-static std::vector<CSTElement> collect_right_binary(CSTElement collect_over, CSTElement node) {
-  if (node.id() != CST_BINARY) {
-    return {node};
-  }
-
-  // NOTE: The 'node' variant functions are being used here which is differnt than everywhere else
-  // This is fine since COMMENTS are bound to the nodes and this func only needs to process nodes
-  CSTElement left = node.firstChildNode();
-  CSTElement op = left;
-  op.nextSiblingNode();
-  CSTElement right = op;
-  right.nextSiblingNode();
-
-  if (!(op.id() == CST_OP && op.firstChildElement().id() == collect_over.id() &&
-        op.firstChildElement().fragment().segment().str() ==
-            collect_over.fragment().segment().str())) {
-    return {node};
-  }
-
-  std::vector<CSTElement> collect = {left};
-  auto right_collect = collect_right_binary(collect_over, right);
-
-  collect.insert(collect.end(), right_collect.begin(), right_collect.end());
-
-  return collect;
->>>>>>> eb7171e0 (save work)
 }
 
 wcl::optional<wcl::doc> Emitter::combine_flat(CSTElement over, ctx_t ctx,

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -40,7 +40,10 @@ struct ConcatFormatter {
   }
 
   ConcatFormatter<SeqCatter<Catter, NewlineCatter>> newline() { return {{catter, {}}}; }
+
   ConcatFormatter<SeqCatter<Catter, FreshlineCatter>> freshline() { return {{catter, {}}}; }
+
+  ConcatFormatter<SeqCatter<Catter, BreaklineCatter>> breakline() { return {{catter, {}}}; }
 
   ConcatFormatter<SeqCatter<Catter, LiteralCatter>> lit(wcl::doc lit) { return {{catter, {lit}}}; }
 
@@ -97,9 +100,33 @@ struct Formatter {
 
   Formatter<SeqAction<Action, SpaceAction>> space(uint8_t count = 1) { return {{action, {count}}}; }
 
+  // Unconditionally inserts a \n
   Formatter<SeqAction<Action, NewlineAction>> newline() { return {{action, {}}}; }
 
+  // Moves to the next "best" position for a "fresh line"
+  //
+  // A freshline is defined as a line with exactly nest level * space per nest whitespaces
+  // The minimal amount of emission to complete this is done.
+  //
+  // Ex: (assume nest level = 1, space = 4)
+  //
+  // line = ""  -> emits "    " so line = "    "
+  // line = "    text" -> emits "\n    " so line = "    "
+  // line = "  " -> emits "  " so line = "    "
   Formatter<SeqAction<Action, FreshlineAction>> freshline() { return {{action, {}}}; }
+
+  // Ensures a "break" between the previous emitted content and the emit pointer.
+  // The previous content does not require a newline as it is auto detected.
+  // Each call to breakline will increase the break size by one
+  //
+  // A break is defined as two lines with a \n between them (Ex: line\n\nline\n)
+  // The minimal amount of emission to complete this is done.
+  //
+  // Ex:
+  // line = "text"  -> emits "\n\n"
+  // line = "text\n"  -> emits "\n"
+  // line = "text\n\n" -> emits "\n"
+  Formatter<SeqAction<Action, BreaklineAction>> breakline() { return {{action, {}}}; }
 
   Formatter<SeqAction<Action, LiteralAction>> lit(wcl::doc lit) { return {{action, {lit}}}; }
 


### PR DESCRIPTION
Newlines are now emitted inside of a def/require body based on the following rules.

1) multi-line def/requires get a newline
2) the “return” item gets a newline
3) a commented item gets a newline
4) changing def<->require gets a newline
4) anything else doesn't
