### PR TITLE
format: Prevent explode in def pattern

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -623,6 +623,8 @@ def x + y = add x y
 def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) =
     ""
 
+def tool (dir: String)    (addHeaders:    String)   (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String)  (addHeaders: String) (addHeaders: String) (addHeaders: String)     =    ""
+
 def Pair _ _:                      Pair Integer String = Pair 44 "as"
 
 def f0 = match _ _

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -623,6 +623,8 @@ def x + y = add x y
 def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) =
     ""
 
+def Pair _ _:                      Pair Integer String = Pair 44 "as"
+
 def f0 = match _ _
   (x: Integer) (True:  Boolean) = x+1
   (x: Integer) (False: Boolean) = x+0

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -725,6 +725,9 @@ def x + y =
 
 def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) = ""
 
+def Pair _ _: Pair Integer String =
+    Pair 44 "as"
+
 def f0 =
     match _ _
         (x: Integer) (True: Boolean) = x + 1

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -725,6 +725,8 @@ def x + y =
 
 def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) = ""
 
+def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) = ""
+
 def Pair _ _: Pair Integer String =
     Pair 44 "as"
 

--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -185,14 +185,37 @@ struct NestAction {
 };
 
 template <class FMT>
-struct ExplodeAction {
+struct PreferExplodeAction {
   FMT formatter;
 
-  ExplodeAction(FMT formatter) : formatter(formatter) {}
+  PreferExplodeAction(FMT formatter) : formatter(formatter) {}
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
                          const token_traits_map_t& traits) {
-    builder.append(formatter.compose(ctx.explode().sub(builder), node, traits));
+    builder.append(formatter.compose(ctx.prefer_explode().sub(builder), node, traits));
+  }
+};
+
+template <class FMT>
+struct PreventExplodeAction {
+  FMT formatter;
+
+  PreventExplodeAction(FMT formatter) : formatter(formatter) {}
+
+  ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
+                         const token_traits_map_t& traits) {
+    builder.append(formatter.compose(ctx.prevent_explode().sub(builder), node, traits));
+  }
+};
+template <class FMT>
+struct AllowExplodeAction {
+  FMT formatter;
+
+  AllowExplodeAction(FMT formatter) : formatter(formatter) {}
+
+  ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
+                         const token_traits_map_t& traits) {
+    builder.append(formatter.compose(ctx.allow_explode().sub(builder), node, traits));
   }
 };
 

--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -207,6 +207,7 @@ struct PreventExplodeAction {
     builder.append(formatter.compose(ctx.prevent_explode().sub(builder), node, traits));
   }
 };
+
 template <class FMT>
 struct AllowExplodeAction {
   FMT formatter;

--- a/tools/wake-format/catters.h
+++ b/tools/wake-format/catters.h
@@ -74,13 +74,35 @@ struct NestCatter {
 };
 
 template <class CTR>
-struct ExplodeCatter {
+struct PreferExplodeCatter {
   CTR catter;
 
-  ExplodeCatter(CTR catter) : catter(catter) {}
+  PreferExplodeCatter(CTR catter) : catter(catter) {}
 
   ALWAYS_INLINE void cat(wcl::doc_builder& builder, ctx_t ctx) {
-    builder.append(catter.concat(ctx.explode().sub(builder)));
+    builder.append(catter.concat(ctx.prefer_explode().sub(builder)));
+  }
+};
+
+template <class CTR>
+struct PreventExplodeCatter {
+  CTR catter;
+
+  PreventExplodeCatter(CTR catter) : catter(catter) {}
+
+  ALWAYS_INLINE void cat(wcl::doc_builder& builder, ctx_t ctx) {
+    builder.append(catter.concat(ctx.prevent_explode().sub(builder)));
+  }
+};
+
+template <class CTR>
+struct AllowExplodeCatter {
+  CTR catter;
+
+  AllowExplodeCatter(CTR catter) : catter(catter) {}
+
+  ALWAYS_INLINE void cat(wcl::doc_builder& builder, ctx_t ctx) {
+    builder.append(catter.concat(ctx.allow_explode().sub(builder)));
   }
 };
 

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -50,7 +50,17 @@ struct ConcatFormatter {
   }
 
   template <class CTR>
-  ConcatFormatter<SeqCatter<Catter, ExplodeCatter<CTR>>> explode(CTR ctr) {
+  ConcatFormatter<SeqCatter<Catter, PreferExplodeCatter<CTR>>> prefer_explode(CTR ctr) {
+    return {{catter, {ctr}}};
+  }
+
+  template <class CTR>
+  ConcatFormatter<SeqCatter<Catter, PreventExplodeCatter<CTR>>> prevent_explode(CTR ctr) {
+    return {{catter, {ctr}}};
+  }
+
+  template <class CTR>
+  ConcatFormatter<SeqCatter<Catter, AllowExplodeCatter<CTR>>> allow_explode(CTR ctr) {
     return {{catter, {ctr}}};
   }
 
@@ -105,7 +115,17 @@ struct Formatter {
   }
 
   template <class FMT>
-  Formatter<SeqAction<Action, ExplodeAction<FMT>>> explode(FMT formatter) {
+  Formatter<SeqAction<Action, PreferExplodeAction<FMT>>> prefer_explode(FMT formatter) {
+    return {{action, {formatter}}};
+  }
+
+  template <class FMT>
+  Formatter<SeqAction<Action, PreventExplodeAction<FMT>>> prevent_explode(FMT formatter) {
+    return {{action, {formatter}}};
+  }
+
+  template <class FMT>
+  Formatter<SeqAction<Action, AllowExplodeAction<FMT>>> allow_explode(FMT formatter) {
     return {{action, {formatter}}};
   }
 


### PR DESCRIPTION
Fixes 

`def Pair _ _:                      Pair Integer String = Pair 44 "as"`

not getting the white space removed without causing 

```
def tool (dir: String)  (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String)  (addHeaders: String) (addHeaders: String) (addHeaders: String) = ""
```
to explode into the invalid

```
def tool
(dir: String)
(addHeaders: String)
(addHeaders: String)
(addHeaders: String)
(addHeaders: String)
(addHeaders: String)
(addHeaders: String)
(addHeaders: String)
(addHeaders: String)
(addHeaders: String)
(addHeaders: String) = ""
```