### PR TITLE
format: Remove special case for constants

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1118,6 +1118,9 @@ def tarball Unit =
     def x = y
     def srcs = allSources # a comment
     def x = y
+
+    def srcs = allSources # a comment
+    def x = y
     x
 
 def tarball Unit =

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -4,7 +4,8 @@
 # -------------
 
 # comment
-def five = 5
+def five =
+    5
 
 # ordinary comment
 
@@ -86,7 +87,8 @@ def name Unit =
 
     another
 
-global export def glob1 = 34
+global export def glob1 =
+    34
 
 # ordinary comment
 def name Unit =
@@ -764,11 +766,14 @@ global export data Let =
 def x + y =
     add x y
 
-export def (argument: a) | (pipeFn: a => b): b = pipeFn argument
+export def (argument: a) | (pipeFn: a => b): b =
+    pipeFn argument
 
-def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) = ""
+def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) =
+    ""
 
-def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) = ""
+def tool (dir: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) (addHeaders: String) =
+    ""
 
 def Pair _ _: Pair Integer String =
     Pair 44 "as"
@@ -952,7 +957,8 @@ def name Unit =
 
 # floating 7
 
-def a b c = 5
+def a b c =
+    5
 
 def a =
     if false then
@@ -992,13 +998,17 @@ def x =
 def x =
     (\a \b \x prim "p") x y
 
-def a = 5
+def a =
+    5
 
-def b = 6
+def b =
+    6
 
-def c = "asdf"
+def c =
+    "asdf"
 
-def d = identifier
+def d =
+    identifier
 
 def longFunc param: Result (List Path) Error =
     match _
@@ -1083,7 +1093,8 @@ def anyArray =
 def a =
     rec Nil (if indent > 0 then Some "" else None) lhs
 
-def a = Some ""
+def a =
+    Some ""
 
 def a =
     def x = if a then b, else !b
@@ -1092,30 +1103,23 @@ def a =
 
     x
 
-def x = "%
-    fun day.
-    happy day.
-%"
+def x =
+    "%
+        fun day.
+        happy day.
+    %"
 
-def x = "%
-    fun day.
-    happy day.
-%"
+def x =
+    "%
+        fun day.
+        happy day.
+    %"
 
-def x = "%
-    fun day.
-    happy day.
-%"
-
-def someFunc a b =
-    def s =
-        "%
-            set -e
-            sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
-            mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
-        %"
-
-    s
+def x =
+    "%
+        fun day.
+        happy day.
+    %"
 
 def someFunc a b =
     def s =
@@ -1157,28 +1161,42 @@ def someFunc a b =
 
     s
 
-def x = "%
-      this is the lowest / prefixed with <space><space>
-      	This line is prefixed with <space><space><tab>
-    	  This line is prefixed with <tab><space><space>
-    	This line is prefixed with <tab>
-        this line is prefixed with <space><space><space><space>
-%"
+def someFunc a b =
+    def s =
+        "%
+            set -e
+            sed "s/blah/%{varName}/g" "%{varName.getVarNameX}" > "%{1 + 2 * 3}.tmp"
+            mv "%{1 + 2 * 3}.tmp" "%{1 + 2 * 3}"
+        %"
 
-def x = """
-    fun day.
-    happy day.
-"""
+    s
 
-def x = """
-    fun day.
-    happy day.
-"""
+def x =
+    "%
+          this is the lowest / prefixed with <space><space>
+          	This line is prefixed with <space><space><tab>
+        	  This line is prefixed with <tab><space><space>
+        	This line is prefixed with <tab>
+            this line is prefixed with <space><space><space><space>
+    %"
 
-def x = """
-    fun day.
-    happy day.
-"""
+def x =
+    """
+        fun day.
+        happy day.
+    """
+
+def x =
+    """
+        fun day.
+        happy day.
+    """
+
+def x =
+    """
+        fun day.
+        happy day.
+    """
 
 def someFunc a b =
     def s =

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1316,6 +1316,8 @@ def tarball Unit =
     def x = y
     def srcs = allSources # a comment
     def x = y
+    def srcs = allSources # a comment
+    def x = y
 
     x
 

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -418,30 +418,6 @@ static inline bool is_simple_apply(wcl::doc_builder& builder, ctx_t ctx, CSTElem
          is_simple_literal(builder, ctx, parts[1], traits);
 }
 
-// determines if the rest of the node
-// - only has one sibling node
-// - and that node is a "simple" thing as defined by is_simple_apply
-static inline bool is_single_apply(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
-                                   const token_traits_map_t& traits) {
-  CSTElement copy = node;
-  if (!copy.isNode()) {
-    copy.nextSiblingNode();
-  }
-
-  size_t node_count = 0;
-  while (!copy.empty()) {
-    node_count++;
-
-    if (!is_simple_apply(builder, ctx, node, traits)) {
-      return false;
-    }
-
-    copy.nextSiblingNode();
-  }
-
-  return node_count == 1;
-}
-
 Emitter::~Emitter() { MEMO_RESET(); }
 
 auto Emitter::rhs_fmt(bool always_newline) {
@@ -466,9 +442,8 @@ auto Emitter::rhs_fmt(bool always_newline) {
             const token_traits_map_t& traits) {
       return count_leading_newlines(token_traits, node) > 0;
    }, full_fmt)
-    // Always newline when requested unless the thing to be formatted is a "single literal".
-    // Used for top-level defs and top-level "constant" defs
-   .pred(ConstPredicate(always_newline), fmt().fmt_if_else(is_single_apply, flat_fmt, full_fmt))
+    // Always newline when requested. Used for top-level defs.
+   .pred(ConstPredicate(always_newline), full_fmt)
 
     // if our hand hand hasn't yet been forced then decide based on how well RHS fits
    .pred(requires_fits_all, fmt().fmt_if_fits_all(flat_fmt, full_fmt))


### PR DESCRIPTION
1. `export def (argument: a) | (pipeFn: a => b): b = pipeFn argument`

and 

2. `def x = Some 5`

are the same from the perspective of the formatter thus they need the same formatting rules.

It is more preferred that 1 format correctly with a newline than 2 format without one so all top level defs will always newline now.