### PR TITLE
format: Disable splitting types across multiple lines

### DIFF
--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -366,17 +366,9 @@ def linkKind =
 
 export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
 
-export topic compileC: (
-    Pair
-    String
-    ((extraFlags: List String) => (headers: List Path) => (cfile: Path) => Result (List Path) Error)
-)
+export topic compileC: Pair String ((extraFlags: List String) => (headers: List Path) => (cfile: Path) => Result (List Path) Error)
 
-topic linkO: (
-    Pair
-    String
-    ((extraFlags: List String) => (objects: List Path) => (targ: String) => Result (List Path) Error)
-)
+topic linkO: (Pair String ((extraFlags: List String) => (objects: List Path) => (targ: String) => Result (List Path) Error))
 
 export topic path: String
 

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -2012,21 +2012,25 @@ wcl::doc Emitter::walk_tuple_elt(ctx_t ctx, CSTElement node) {
   MEMO_RET(walk_placeholder(ctx, node));
 }
 
+// Disable walke_type for MVP. The implications of it needs
+// to be first explored before rollout.
 wcl::doc Emitter::walk_type(ctx_t ctx, CSTElement node) {
-  MEMO(ctx, node);
+  return walk_node(ctx.prevent_explode(),  node);
 
-  auto no_nl = walk_node(ctx, node);
-
-  if (!no_nl->has_newline() || node.id() == CST_PAREN) {
-    MEMO_RET(no_nl);
-  }
-
-  MEMO_RET(cat()
-               .lit(wcl::doc::lit("("))
-               .nest(cat().fmt(node, token_traits, fmt().freshline().walk(WALK_NODE)))
-               .freshline()
-               .lit(wcl::doc::lit(")"))
-               .concat(ctx));
+  // MEMO(ctx, node);
+  //
+  // auto no_nl = walk_node(ctx, node);
+  //
+  // if (!no_nl->has_newline() || node.id() == CST_PAREN) {
+  //   MEMO_RET(no_nl);
+  // }
+  //
+  // MEMO_RET(cat()
+  //              .lit(wcl::doc::lit("("))
+  //              .nest(cat().fmt(node, token_traits, fmt().freshline().walk(WALK_NODE)))
+  //              .freshline()
+  //              .lit(wcl::doc::lit(")"))
+  //              .concat(ctx));
 }
 
 wcl::doc Emitter::walk_unary(ctx_t ctx, CSTElement node) {

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -2015,7 +2015,7 @@ wcl::doc Emitter::walk_tuple_elt(ctx_t ctx, CSTElement node) {
 // Disable walke_type for MVP. The implications of it needs
 // to be first explored before rollout.
 wcl::doc Emitter::walk_type(ctx_t ctx, CSTElement node) {
-  return walk_node(ctx.prevent_explode(),  node);
+  return walk_node(ctx.prevent_explode(), node);
 
   // MEMO(ctx, node);
   //


### PR DESCRIPTION
For the MVP, I want to skip splitting types into multiple lines. It has some implications we haven't explored yet and technically isn't supported