### PR TITLE
format: prepare wake code for formatter

### DIFF
--- a/share/wake/lib/core/json.wake
+++ b/share/wake/lib/core/json.wake
@@ -423,6 +423,7 @@ def mergeValueList (describeCompat: Boolean) (values: List JValue): Result JValu
             if eqFn x y then
                 Pass x
             else
+                # wake-format off
                 compatibilityMessage "N" "n" "ot every type can combine multiple different values. The incompatible values are: {map wrapFn values | formatExamples}"
                 | failWithError
         match values
@@ -508,6 +509,7 @@ def mergeValueList (describeCompat: Boolean) (values: List JValue): Result JValu
             | JArray
             | Pass
         _ _ _ _ _ _ _ =
+            # wake-format off
             compatibilityMessage "V" "v" "alues of different types may not be combined. The incompatible values are: {formatExamples values}"
             | failWithError
 

--- a/share/wake/lib/core/print.wake
+++ b/share/wake/lib/core/print.wake
@@ -61,20 +61,20 @@ export def makeLogLevel2 (name: String) (colour: Option Colour) (intensity: Opti
     def set name code = prim "colour"
     def colourCode = match colour
         None   = 0
-        Some c = 8 + match c
-            Black   = 0
-            Red     = 1
-            Green   = 2
-            Yellow  = 3
-            Blue    = 4
-            Magenta = 5
-            Cyan    = 6
-            White   = 7
+        Some c = match c
+            Black   = 8
+            Red     = 9
+            Green   = 10
+            Yellow  = 11
+            Blue    = 12
+            Magenta = 13
+            Cyan    = 14
+            White   = 15
     def intensityCode = match intensity
         None   = 0
-        Some i = 16 * match i
-            Dim    = 1
-            Bright = 2
+        Some i = match i
+            Dim    = 16
+            Bright = 32
     def _ = set name (colourCode+intensityCode)
     LogLevel name
 

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -221,6 +221,9 @@ export def makePlan (label: String) (visible: List Path) (command: String): Plan
 # Identity function
 def id x = x
 
+def bToInt b =
+  if b then 1 else 0
+
 # Set reasonable defaults for all Plan arguments
 export def makeExecPlan (cmd: List String) (visible: List Path): Plan =
   Plan "" cmd visible environment "." "" logInfo logWarning logEcho Share False Nil (\_ True) defaultUsage id id False
@@ -241,7 +244,7 @@ export def localRunner: Runner =
       Fail e
     Pass (RunnerInput _ cmd vis env dir stdin _ _ predict isatty) =
         def Usage status runtime cputime mem in out = predict
-        def _ = launch job dir stdin env.implode cmd.implode status runtime cputime mem in out (if isatty then 1 else 0)
+        def _ = launch job dir stdin env.implode cmd.implode status runtime cputime mem in out (bToInt isatty)
         match (getJobReality job)
           Pass reality = Pass (RunnerOutput (map getPathName vis) Nil reality)
           Fail f = Fail f
@@ -420,7 +423,7 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
   def build Unit =
     def visStrings =
       map getPathName vis
-    def job = create label dir stdin env.implode cmd.implode hash visStrings.implode (if keep then 1 else 0) echo stdout stderr (if isatty then 1 else 0)
+    def job = create label dir stdin env.implode cmd.implode hash visStrings.implode (bToInt keep) echo stdout stderr (bToInt isatty)
     def prefix = "{str pid}.{str (getJobId job)}"
     def usage = getJobRecord job | getOrElse uusage
     def output = run job (Pass (RunnerInput label cmd vis env dir stdin res prefix usage isatty))
@@ -446,7 +449,7 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
     job
   match keep
     False = build Unit
-    True  = match (cache dir stdin env.implode cmd.implode hash (map getPathName vis).implode (if isatty then 1 else 0))
+    True  = match (cache dir stdin env.implode cmd.implode hash (map getPathName vis).implode (bToInt isatty))
       Pair (job, _) last = confirm True  last job
       Pair Nil      last = confirm False last (build Unit)
 
@@ -491,7 +494,7 @@ export def runJob (p: Plan): Job = match p
         def create label dir stdin env cmd signature visible keep echo stdout stderr isatty = prim "job_create"
         def badfinish job e = prim "job_fail_finish"
         def badlaunch job e = prim "job_fail_launch"
-        def job = create label dir stdin env.implode cmd.implode 0 "" 0 "echo" "info" "error" (if isatty then 1 else 0)
+        def job = create label dir stdin env.implode cmd.implode 0 "" 0 "echo" "info" "error" (bToInt isatty)
         def error =
           def pretty = match _
             Accept _ _ = ""

--- a/tools/lsp-wake/lsp.wake
+++ b/tools/lsp-wake/lsp.wake
@@ -20,12 +20,15 @@ target buildLSP variant: Result (List Path) Error = match variant
     Pair "wasm-cpp14-release" _ =
         require Pass postJS = source "extensions/vscode/lsp-server/wasm/lsp-wake.post.js"
         require Pass preJS = source "extensions/vscode/lsp-server/wasm/lsp-wake.pre.js"
+
+        # wake-format off
         def extraLFlags =
             "-s", 'EXPORTED_FUNCTIONS=_instantiateServer,_instantiateServerCustomStdLib,_processRequest',
             "-s", 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[$cwrap]',
             "-s", 'EXPORT_NAME="wakeLspModule"',
             "--post-js", postJS.getPathName,
             "--pre-js", preJS.getPathName,
+
         tool here Nil variant "lib/wake/lsp-wake" (dst, util,) (postJS, preJS,) extraLFlags
     _ =
         tool here Nil variant "lib/wake/lsp-wake" (dst, util,) Nil Nil

--- a/vendor/emscripten.wake
+++ b/vendor/emscripten.wake
@@ -30,6 +30,7 @@ def emmake = whichInEnvPath "emmake"
 def emscriptenCFlags =
     "-Wall", "-O3", Nil
 
+# wake-format off
 def emscriptenLFlags =
     "-O3",
     "-s", "ALLOW_MEMORY_GROWTH",

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -30,16 +30,17 @@ def buildAs Unit = match (subscribe releaseAs)
             | setPlanStdout logNever
             | runJob
             | getJobStdout
+
+        # The replace accomplish this:
+        # v0.15.0-alpha-4-g6efe8e9-dirty ... for a tag v0.15.0-alpha with +4 commits
+        #  0.15.0~alpha.4+g6efe8e9~dirty ... which sorts correctly for both rpm+deb
+        # ^      ^     ^ ^        ^
         stdout
         | mk_node_semver_safe
         | replace `^v|\n.*` ''
         | replace `-([0-9]{1,3})-` '.\1+'
         | replace `-` '~'
         | Pass
-        # The replace accomplish this:
-        # v0.15.0-alpha-4-g6efe8e9-dirty ... for a tag v0.15.0-alpha with +4 commits
-        #  0.15.0~alpha.4+g6efe8e9~dirty ... which sorts correctly for both rpm+deb
-        # ^      ^     ^ ^        ^
 
 topic releaseOn: String
 def buildOn Unit = match (subscribe releaseOn)
@@ -67,12 +68,12 @@ def buildOn Unit = match (subscribe releaseOn)
 # Capture the parts and insert '-plus-' between the version and the commit. 
 # Do nothing if the version is already safe.
 def mk_node_semver_safe v =
-    def unsafe_version_regex = `^(v?[0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-(.*)`
-    #                            ^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^  ^^^^
-    #                            |                          |        |
-    #                            |                          |        | The "rest", everything after the '-' after the commit number
-    #                            |                          | The number of commits since the tagged version, surrounded by '-'
     #                            | Matches the version tag, which should be 3 numbers separated by '.' with an optional leading 'v'
+    #                            |                          | The number of commits since the tagged version, surrounded by '-'
+    #                            |                          |        | The "rest", everything after the '-' after the commit number
+    #                            |                          |        |
+    #                            vvvvvvvvvvvvvvvvvvvvvvvvvv vvvvvvvv vvvv
+    def unsafe_version_regex = `^(v?[0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-(.*)`
     require True = matches unsafe_version_regex  v
     else v
 


### PR DESCRIPTION
Certain code isn't supported and generally can't be  supported by the formatter.  There will always be cases (do to the infinite nature of recursive grammars) where the programmer know better. This change  handles those cases manually in sifive/wake