### PR TITLE
format: always newline top level publish/target

### DIFF
--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -431,24 +431,31 @@ def t1 =
         # comment
         n -> 2 + t (n - 1)
 
-publish wakeTestBinary = defaultWake, Nil
+publish wakeTestBinary =
+    defaultWake, Nil
 
-publish animal = "Cat", Nil
+publish animal =
+    "Cat", Nil
 
-publish animal = replace `u` "o" "Mouse", Nil
+publish animal =
+    replace `u` "o" "Mouse", Nil
 
-publish compileC = makeCompileC "native-c11-debug" (which "cc") (c11Flags ++ debugCFlags)
+publish compileC =
+    makeCompileC "native-c11-debug" (which "cc") (c11Flags ++ debugCFlags)
 
-publish path = match (getenv "WAKE_PATH")
-    Some x -> tokenize `:` x
-    None -> Nil
+publish path =
+    match (getenv "WAKE_PATH")
+        Some x -> tokenize `:` x
+        None -> Nil
 
-publish path = match sysname
-    "Darwin" -> "/opt/local/bin", "/usr/local/bin", Nil
-    "FreeBSD" -> "/usr/local/bin", Nil
-    _ -> Nil
+publish path =
+    match sysname
+        "Darwin" -> "/opt/local/bin", "/usr/local/bin", Nil
+        "FreeBSD" -> "/usr/local/bin", Nil
+        _ -> Nil
 
-publish compileC = emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags))
+publish compileC =
+    emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags))
 
 publish compileC =
     emccFn
@@ -478,10 +485,11 @@ def hello = # comment
 target runOnce cmd env dir stdin \ res usage finputs foutputs vis keep run echo stdout stderr label =
     runAlways cmd env dir stdin res usage finputs foutputs vis keep run echo stdout stderr label
 
-global export target fib n = match n
-    0 -> 1
-    1 -> 1
-    _ -> fib (n - 1) + fib (n - 2)
+global export target fib n =
+    match n
+        0 -> 1
+        1 -> 1
+        _ -> fib (n - 1) + fib (n - 2)
 
 def buildRE2WASM Unit =
     def version = "2021-08-01"
@@ -715,9 +723,11 @@ export def static _: Result Path Error =
 from test_wake import topic wakeTestBinary
 from test_wake import topic wakeUnitTestBinary
 
-publish wakeTestBinary = defaultWake, Nil
+publish wakeTestBinary =
+    defaultWake, Nil
 
-publish wakeUnitTestBinary = buildWakeUnit, Nil
+publish wakeUnitTestBinary =
+    buildWakeUnit, Nil
 
 def defaultWake Unit =
     require Pass wakeVisible = doInstall "tmp" "default"

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1812,7 +1812,7 @@ wcl::doc Emitter::walk_publish(ctx_t ctx, CSTElement node) {
                .space()
                .token(TOKEN_P_EQUALS)
                .consume_wsnlc()
-               .join(rhs_fmt())
+               .join(rhs_fmt(true))
                .consume_wsnlc()
                .format(ctx, node.firstChildElement(), token_traits));
 }
@@ -1954,7 +1954,7 @@ wcl::doc Emitter::walk_target(ctx_t ctx, CSTElement node) {
                        fmt().token(TOKEN_P_BSLASH).ws().walk(WALK_NODE).space().consume_wsnlc())
                .token(TOKEN_P_EQUALS)
                .consume_wsnlc()
-               .join(rhs_fmt())
+               .join(rhs_fmt(true))
                .consume_wsnlc()
                .format(ctx, node.firstChildElement(), token_traits));
 }


### PR DESCRIPTION
Since `target` and  `publish` can only be top level (per the  grammar) we just always newline after the `=`