### PR TITLE
format: | and $ shouldn't force explode in if/else

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1197,3 +1197,19 @@ def tarball Unit =
     require x = y
     require srcs = allSources # a comment
     x
+
+def x  =
+  if cmpFn vi vi1 | isGT 
+  then 
+    def x = y
+
+    x | a | b | c | d
+  else
+    def x = y
+
+    x | a | b | c | d
+
+def x  =
+  if cmpFn | isGT
+  then 0
+  else 0

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1402,3 +1402,24 @@ def tarball Unit =
     require srcs = allSources # a comment
 
     x
+
+def x =
+    if cmpFn vi vi1 | isGT then
+        def x = y
+
+        x
+        | a
+        | b
+        | c
+        | d
+    else
+        def x = y
+
+        x
+        | a
+        | b
+        | c
+        | d
+
+def x =
+    if cmpFn | isGT then 0 else 0

--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -191,6 +191,19 @@ struct NestAction {
   }
 };
 
+template <class F, class FMT>
+struct ChangeContextAction {
+  F f;  // (ctx_t) -> ctx_t
+  FMT formatter;
+
+  ChangeContextAction(F f, FMT formatter) : f(f), formatter(formatter) {}
+
+  ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
+                         const token_traits_map_t& traits) {
+    builder.append(formatter.compose(f(ctx).sub(builder), node, traits));
+  }
+};
+
 template <class FMT>
 struct PreferExplodeAction {
   FMT formatter;

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1544,8 +1544,9 @@ wcl::doc Emitter::walk_if(ctx_t ctx, CSTElement node) {
                   .token(TOKEN_KW_IF)
                   .consume_wsnlc()
                   .space()
-                  .fmt_if_else(is_simple_binop, fmt().walk(WALK_NODE),
-                               fmt().next().newline())  // if cond
+                  .ctx([](ctx_t ctx) { return ctx.binop(); },
+                       fmt().fmt_if_else(is_simple_binop, fmt().walk(WALK_NODE),
+                                         fmt().next().newline()))  // if cond
                   .consume_wsnlc()
                   .space()
                   .token(TOKEN_KW_THEN)
@@ -1572,7 +1573,8 @@ wcl::doc Emitter::walk_if(ctx_t ctx, CSTElement node) {
           .token(TOKEN_KW_IF)
           .consume_wsnlc()
           .space()
-          .walk(is_expression, WALK_NODE)  // if cond
+          .ctx([](ctx_t ctx) { return ctx.binop(); },
+               fmt().walk(is_expression, WALK_NODE))  // if cond
           .consume_wsnlc()
           .space()
           .token(TOKEN_KW_THEN)

--- a/tools/wake-format/formatter.h
+++ b/tools/wake-format/formatter.h
@@ -257,6 +257,11 @@ struct Formatter {
     return {{action, {f}}};
   }
 
+  template <class F, class FMT>
+  Formatter<SeqAction<Action, ChangeContextAction<F, FMT>>> ctx(F f, FMT formatter) {
+    return {{action, {f, formatter}}};
+  }
+
   wcl::doc format(ctx_t ctx, CSTElement node, const token_traits_map_t& traits) {
     wcl::doc_builder builder;
     action.run(builder, ctx, node, traits);


### PR DESCRIPTION
`|` and `$` inside of an `if`/`else` condition shouldn't be considered a "root" binary operation otherwise it formats as

```
def x =
    if cmpFn
    | isGT then
        0
    else
        0
```

This change fixes that and also adds a `ChangeContextAction` instead of a new `binop` formatter function that way `binop` is  easier to delete in the future