### PR TITLE
format: don't split long patterns

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -639,6 +639,9 @@ def f0 = match aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = x+1
   x b = x+0
 
+def x = match p
+  Something aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aa bb cc dd = 0
+
 export def vfoldl (combiningFn: accum => element => accum): accum => Vector element => accum =
     def loop accumulator v s e =
         if s == e then

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -792,15 +792,15 @@ def f0 =
         (x: Integer) (False: Boolean) -> x + 0
 
 def f0 =
-    match (
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    )
-        (
-            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        ) -> x + 1
+    match aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+            x + 1
         x b -> x + 0
+
+def x =
+    match p
+        Something aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aa bb cc dd ->
+            0
 
 export def vfoldl (combiningFn: accum => element => accum): accum => Vector element => accum =
     def loop accumulator v s e =

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -490,13 +490,15 @@ auto Emitter::pattern_fmt(cst_id_t stop_at) {
   auto part_fmt = fmt().walk(is_expression, WALK_NODE).consume_wsnlc();
   auto all_flat = fmt().join(part_fmt).fmt_while([stop_at](cst_id_t id) { return id != stop_at; },
                                                  fmt().space().join(part_fmt));
-  auto all_explode =
-      fmt()
-          .lit(wcl::doc::lit("("))
-          .nest(fmt().freshline().join(part_fmt).fmt_while(
-              [stop_at](cst_id_t id) { return id != stop_at; }, fmt().freshline().join(part_fmt)))
-          .freshline()
-          .lit(wcl::doc::lit(")"));
+  // TODO: disable for MVP. Needs to be explored further for correctness.
+  // auto all_explode =
+  //     fmt().prefer_explode(fmt()
+  //         .lit(wcl::doc::lit("("))
+  //         .nest(fmt().freshline().join(part_fmt).fmt_while(
+  //             [stop_at](cst_id_t id) { return id != stop_at; }, fmt().freshline().join(part_fmt)))
+  //         .freshline()
+  //         .lit(wcl::doc::lit(")")));
+
   // 4 Cases
   // 1) The "flat format" doesn't have a newline and fits()
   // 2) The "flat format" doesn't have a newline and doesn't fits()
@@ -512,7 +514,7 @@ auto Emitter::pattern_fmt(cst_id_t stop_at) {
 
   return fmt().fmt_try_else(
       [](const wcl::doc_builder& builder, ctx_t ctx, wcl::doc doc) { return doc->has_newline(); },
-      all_flat, fmt().fmt_if_fits_all(all_flat, all_explode));
+      all_flat, fmt().fmt_if_fits_all(all_flat, all_flat /*all_explode*/));
 }
 
 wcl::doc Emitter::layout(CST cst) {

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -495,7 +495,8 @@ auto Emitter::pattern_fmt(cst_id_t stop_at) {
   //     fmt().prefer_explode(fmt()
   //         .lit(wcl::doc::lit("("))
   //         .nest(fmt().freshline().join(part_fmt).fmt_while(
-  //             [stop_at](cst_id_t id) { return id != stop_at; }, fmt().freshline().join(part_fmt)))
+  //             [stop_at](cst_id_t id) { return id != stop_at; },
+  //             fmt().freshline().join(part_fmt)))
   //         .freshline()
   //         .lit(wcl::doc::lit(")")));
 


### PR DESCRIPTION
https://github.com/sifive/wake/pull/1218 but for patterns.

Same justification. Focusing on the MVP and it has some implications that need to be explored before wide rollout.