### PR TITLE
format: Correctly emit bound comments for binops

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1216,3 +1216,37 @@ def x  =
   if cmpFn | isGT
   then 0
   else 0
+
+def x = 
+    a
+    # Comment 1
+    | b
+    | c
+
+def x =
+    a
+    | b
+    # Comment 2
+    | c
+
+def x =
+    a
+    # Comment 1
+    | b
+    # Comment 2
+    | c
+    # Comment 3
+    | d
+    # Comment 4
+    | e
+
+def x =
+    a,
+    # Comment 1
+    b,
+    # Comment 2
+    c,
+    # Comment 3
+    d,
+    # Comment 4
+    e,

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1423,3 +1423,43 @@ def x =
 
 def x =
     if cmpFn | isGT then 0 else 0
+
+def x =
+    a
+    # Comment 1
+    |
+    b
+    | c
+
+def x =
+    a
+    | b
+    # Comment 2
+    |
+    c
+
+def x =
+    a
+    # Comment 1
+    |
+    b
+    # Comment 2
+    |
+    c
+    # Comment 3
+    |
+    d
+    # Comment 4
+    |
+    e
+
+def x =
+    a,
+    # Comment 1
+    b,
+    # Comment 2
+    c,
+    # Comment 3
+    d,
+    # Comment 4
+    e,

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1168,8 +1168,7 @@ wcl::doc Emitter::walk_ascribe(ctx_t ctx, CSTElement node) {
                .format(ctx, node.firstChildElement(), token_traits));
 }
 
-wcl::optional<wcl::doc> Emitter::combine_flat(CSTElement over, ctx_t ctx,
-                                              const std::vector<CSTElement>& parts) {
+wcl::optional<wcl::doc> Emitter::combine_flat(ctx_t ctx, const std::vector<CSTElement>& parts) {
   wcl::doc_builder builder;
   for (size_t i = 0; i < parts.size() - 1; i += 2) {
     CSTElement part = parts[i];
@@ -1187,7 +1186,7 @@ wcl::optional<wcl::doc> Emitter::combine_flat(CSTElement over, ctx_t ctx,
   return {wcl::in_place_t{}, std::move(doc)};
 }
 
-wcl::optional<wcl::doc> Emitter::combine_explode_first(CSTElement ovr, ctx_t ctx,
+wcl::optional<wcl::doc> Emitter::combine_explode_first(ctx_t ctx,
                                                        const std::vector<CSTElement>& parts) {
   wcl::doc_builder builder;
 
@@ -1207,7 +1206,7 @@ wcl::optional<wcl::doc> Emitter::combine_explode_first(CSTElement ovr, ctx_t ctx
   return {wcl::in_place_t{}, std::move(builder).build()};
 }
 
-wcl::optional<wcl::doc> Emitter::combine_explode_last(CSTElement ovr, ctx_t ctx,
+wcl::optional<wcl::doc> Emitter::combine_explode_last(ctx_t ctx,
                                                       const std::vector<CSTElement>& parts) {
   wcl::doc_builder builder;
 
@@ -1222,7 +1221,7 @@ wcl::optional<wcl::doc> Emitter::combine_explode_last(CSTElement ovr, ctx_t ctx,
   return {wcl::in_place_t{}, std::move(builder).build()};
 }
 
-wcl::optional<wcl::doc> Emitter::combine_explode_all(CSTElement ovr, ctx_t ctx,
+wcl::optional<wcl::doc> Emitter::combine_explode_all(ctx_t ctx,
                                                      const std::vector<CSTElement>& parts) {
   wcl::doc_builder builder;
 
@@ -1238,7 +1237,7 @@ wcl::optional<wcl::doc> Emitter::combine_explode_all(CSTElement ovr, ctx_t ctx,
 }
 
 wcl::optional<wcl::doc> Emitter::combine_explode_first_compress(
-    CSTElement ovr, ctx_t ctx, const std::vector<CSTElement>& parts) {
+    ctx_t ctx, const std::vector<CSTElement>& parts) {
   wcl::doc_builder builder;
 
   CSTElement part = parts[0];
@@ -1263,7 +1262,7 @@ wcl::optional<wcl::doc> Emitter::combine_explode_first_compress(
 }
 
 wcl::optional<wcl::doc> Emitter::combine_explode_last_compress(
-    CSTElement ovr, ctx_t ctx, const std::vector<CSTElement>& parts) {
+    ctx_t ctx, const std::vector<CSTElement>& parts) {
   wcl::doc_builder builder;
 
   for (size_t i = 0; i < parts.size() - 1; i += 2) {
@@ -1305,7 +1304,7 @@ wcl::doc Emitter::walk_binary(ctx_t ctx, CSTElement node) {
   }
 
   if (ctx.explode_option == ExplodeOption::Prevent) {
-    auto doc = combine_flat(op_token, ctx.binop(), parts);
+    auto doc = combine_flat(ctx.binop(), parts);
     if (!doc) {
       FMT_ASSERT(false, op_token, "Failed to flat format binop");
     }
@@ -1315,25 +1314,25 @@ wcl::doc Emitter::walk_binary(ctx_t ctx, CSTElement node) {
   if (!ctx.nested_binop && (is_binop_matching_str(op_token, TOKEN_OP_DOLLAR, "$") ||
                             is_binop_matching_str(op_token, TOKEN_OP_OR, "|"))) {
     MEMO_RET(select_best_choice({
-        combine_explode_first(op_token, ctx.binop(), parts),
-        combine_explode_last(op_token, ctx.binop(), parts),
-        combine_explode_all(op_token, ctx.binop(), parts),
+        combine_explode_first(ctx.binop(), parts),
+        combine_explode_last(ctx.binop(), parts),
+        combine_explode_all(ctx.binop(), parts),
     }));
   }
 
   MEMO_RET(select_best_choice({
       // 1
-      combine_flat(op_token, ctx.binop(), parts),
+      combine_flat(ctx.binop(), parts),
       // 2
-      combine_explode_first(op_token, ctx.binop(), parts),
+      combine_explode_first(ctx.binop(), parts),
       // 3
-      combine_explode_last(op_token, ctx.binop(), parts),
+      combine_explode_last(ctx.binop(), parts),
       // 4
-      combine_explode_all(op_token, ctx.binop(), parts),
+      combine_explode_all(ctx.binop(), parts),
       // 5
-      combine_explode_first_compress(op_token, ctx.binop(), parts),
+      combine_explode_first_compress(ctx.binop(), parts),
       // 6
-      combine_explode_last_compress(op_token, ctx.binop(), parts),
+      combine_explode_last_compress(ctx.binop(), parts),
   }));
 }
 

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -123,17 +123,13 @@ class Emitter {
   //     if LTE has any elements choose the element with the smallest height
   //     otherwise choose the element with the smallest width from GT
   //
-  wcl::optional<wcl::doc> combine_flat(CSTElement over, ctx_t ctx,
-                                       const std::vector<CSTElement>& parts);
-  wcl::optional<wcl::doc> combine_explode_first(CSTElement over, ctx_t ctx,
-                                                const std::vector<CSTElement>& parts);
-  wcl::optional<wcl::doc> combine_explode_last(CSTElement over, ctx_t ctx,
-                                               const std::vector<CSTElement>& parts);
-  wcl::optional<wcl::doc> combine_explode_all(CSTElement over, ctx_t ctx,
-                                              const std::vector<CSTElement>& parts);
-  wcl::optional<wcl::doc> combine_explode_first_compress(CSTElement over, ctx_t ctx,
+  wcl::optional<wcl::doc> combine_flat(ctx_t ctx, const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_explode_first(ctx_t ctx, const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_explode_last(ctx_t ctx, const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_explode_all(ctx_t ctx, const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_explode_first_compress(ctx_t ctx,
                                                          const std::vector<CSTElement>& parts);
-  wcl::optional<wcl::doc> combine_explode_last_compress(CSTElement over, ctx_t ctx,
+  wcl::optional<wcl::doc> combine_explode_last_compress(ctx_t ctx,
                                                         const std::vector<CSTElement>& parts);
 
   // Functions to combine apply using various 'full choice' options


### PR DESCRIPTION
Fix comments being added/deleted when bound to a binop. Now collects the in-between binops into the parts list instead of just tracking a reference to the first one.

The output isn't formatted the best but at least the correct content is emitted now.

Ex:

```
def x =
    a
    # Comment 1
    | b
    | c

def x =
    a
    | b
    # Comment 2
    | c
```

was previously emitted as 

```
def x =
    a
    | b
    | c

def x =
    a
    # Comment 2
    |
    b
    # Comment  2
    |
    c
```