### PR TITLE
format: Fix various broken rules

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -258,6 +258,8 @@ def x =
     else
         ""
     ""
+target someLongTargetName (variable1: Pair (Option String) Path) (variable2: String) (variable3: String) (variable4: String): Result (List Path) Error =
+    Pass Nil
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake, Nil =
@@ -1218,6 +1220,12 @@ def tarball Unit =
     require x = y
     require srcs = allSources # a comment
     x
+
+def x =
+ def y = 0
+ from a import b
+ def z = 0
+ 1
 
 def x  =
   if cmpFn vi vi1 | isGT 

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -241,6 +241,24 @@ def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     Nil = Pass (Pair "{wakePath}" Nil)
     _ = Fail (makeError "Two wake binaries declared for testing!")
 
+def x (var:String):Value =
+    x
+
+def x = """
+
+String with
+no indents
+%{someVar}
+
+and extra spacing
+"""
+
+def x = 
+    require aaaaaa, bbbbb, ccccc, ddddd, eeeee, fffff, ggggg, hhhhh, iiiii, jjjjj, kkkkk, lllll, mmmmm, nnnnn, Nil = args
+    else
+        ""
+    ""
+
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
     buildTestWake, Nil =
         require (

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -318,6 +318,26 @@ def wakeToTestDir Unit =
         Nil -> Pass (Pair "{wakePath}" Nil)
         _ -> Fail (makeError "Two wake binaries declared for testing!")
 
+def x (var: String): Value =
+    x
+
+def x =
+    """
+
+        String with
+        no indents
+        %{someVar}
+
+        and extra spacing
+    """
+
+def x =
+    require aaaaaa, bbbbb, ccccc, ddddd, eeeee, fffff, ggggg, hhhhh, iiiii, jjjjj, kkkkk, lllll, mmmmm, nnnnn, Nil =
+        args
+    else ""
+
+    ""
+
 def wakeToTestDir Unit =
     match (subscribe wakeTestBinary)
         buildTestWake, Nil ->

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -338,6 +338,9 @@ def x =
 
     ""
 
+target someLongTargetName (variable1: Pair (Option String) Path) (variable2: String) (variable3: String) (variable4: String): Result (List Path) Error =
+    Pass Nil
+
 def wakeToTestDir Unit =
     match (subscribe wakeTestBinary)
         buildTestWake, Nil ->
@@ -1422,6 +1425,15 @@ def tarball Unit =
     require srcs = allSources # a comment
 
     x
+
+def x =
+    def y = 0
+
+    from a import b
+
+    def z = 0
+
+    1
 
 def x =
     if cmpFn vi vi1 | isGT then

--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -409,6 +409,7 @@ struct MatchAction {
 
   ALWAYS_INLINE void run(wcl::doc_builder& builder, ctx_t ctx, CSTElement& node,
                          const token_traits_map_t& traits) {
-    assert(c.run(builder, ctx, node, traits));
+    FMT_ASSERT(c.run(builder, ctx, node, traits), node,
+               "Match failed! See <" + std::string(symbolName(node.id())) + ">");
   }
 };

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1876,7 +1876,7 @@ wcl::doc Emitter::walk_require(ctx_t ctx, CSTElement node) {
           .token(TOKEN_KW_REQUIRE)
           .ws()
           .fmt_if_else(CST_BINARY,
-                       // Binops must not explode inside of a require unwrap.
+                       // Binops must not explode inside of a require pattern.
                        fmt().ctx([](ctx_t x) { return x.binop(); },
                                  fmt().prevent_explode(fmt().walk(is_expression, WALK_NODE))),
                        fmt().walk(WALK_NODE))


### PR DESCRIPTION
Certain repos were crashing the formatter or emitting invalid code on format. This change fixes (nearly) all the breakages.

Broken rules:

1) Missing a space in an ascribe caused an assert
2) Really long require patterns would explode (as expected) but if the pattern is a binop (like `require a, b, Nil = blah`) then exploding isn't legal syntax. Explode is now disable in requires for binops. In the same vein, target patterns are prevented from exploding
3) Multiline strings without indentation caused an assert because it was always assumed that a TOKEN_WS would exists. This case now probably indents
4) An overly restrictive assertion that CST_BLOCKs only contain CST_DEF was removed as they may also contain imports

There is a subtle but with `"% ... %"` strings that I haven't figured out yet. It seems that a `"` inside the string is parsed as `TOKEN_WS` which is incorrect and breaks the formatter. I'm not going to account for that with a formatter rule though. For now I'm just hand rewriting those specific cases to `""" ... """"` strings since they are identical minus this one bug. (I honestly think its just time to pull the plug on `"%%"` strings TBH