### PR TITLE
Remove macos from our CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -224,27 +224,6 @@ jobs:
             name: release_${{ matrix.target }}
             path: release/${{ matrix.target }}
 
-    macos_10_15:
-        name: MacOS 10.15 Build
-        runs-on: macos-10.15
-
-        steps:
-            - name: Clone wake
-              uses: actions/checkout@v2
-              with:
-                fetch-depth: 0
-
-            - name: Install deps
-              run: |
-                brew install --cask osxfuse
-                brew install re2 || brew install re2 --head
-
-            - name: Build wake
-              run: make all -j3
-
-            - name: Test wake
-              run: make test
-
     docs:
       runs-on: ubuntu-latest
       needs: tarball


### PR DESCRIPTION
The github mac builders are no longer working. It's time to remove it and drop macos support. At this time we don't plan on actively removing mac support but it isn't going to be tested for now.