### PR TITLE
Refine log level changes to maintain use cases

### DIFF
--- a/share/wake/lib/core/print.wake
+++ b/share/wake/lib/core/print.wake
@@ -30,8 +30,7 @@ export def format (anyType: a): String =
 
     p anyType
 
-# LogLevel is a user-opaque type.
-# To construct a LogLevel, use makeLogLevel.
+# To construct a LogLevel
 export data LogLevel =
     LogLevel (name: String)
 

--- a/share/wake/lib/core/print.wake
+++ b/share/wake/lib/core/print.wake
@@ -32,10 +32,8 @@ export def format (anyType: a): String =
 
 # LogLevel is a user-opaque type.
 # To construct a LogLevel, use makeLogLevel.
-data LogLevel =
+export data LogLevel =
     LogLevel (name: String)
-
-from wake export type LogLevel
 
 # getLogLevelName: return the name of the LogLevel
 export def getLogLevelName (LogLevel name): String =
@@ -66,6 +64,10 @@ export def logInfo: LogLevel =
 # logDebug: logged to stdout when run with -d (Blue)
 export def logDebug: LogLevel =
     LogLevel "debug" # (Some Blue)
+
+# logBSP: by default not logged. Used for implementing a bsp in wake.
+export def logBSP: LogLevel =
+    LogLevel "bsp" # (Some Green)
 
 # logNever: not logged to any stream
 export def logNever: LogLevel =

--- a/src/runtime/status.cpp
+++ b/src/runtime/status.cpp
@@ -470,6 +470,9 @@ static int stream_color(std::string name) {
   if (name == "debug") {
     return 4;
   }
+  if (name == "bsp") {
+    return 2;
+  }
   if (name == "null") {
     return 0;
   }

--- a/tools/bsp-wake/main.cpp
+++ b/tools/bsp-wake/main.cpp
@@ -140,6 +140,10 @@ ExecuteWakeProcess::ExecuteWakeProcess() : result(JSON_OBJECT), error(JSON_NULLV
   cmdline.push_back("--quiet");
   cmdline.push_back("--stdout=bsp");
   cmdline.push_back("--stderr=error");
+  cmdline.push_back("--log-header");
+  cmdline.push_back("");
+  cmdline.push_back("--log-header-source-width");
+  cmdline.push_back("0");
   cmdline.push_back("--fd:3=warning");
   if (quiet) {
     cmdline.push_back("--fd:4=info");


### PR DESCRIPTION
This change is needed in order enable some use cases we forgot. The most important one is allowing wake to act as a build server via bsp-wake.