### PR TITLE
Refine log headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ contain JSON5 source where the root object may contain the following keys.
 | user_config | Path to user config for this repo. Allows a different config for each repo. | No       | shell expandable path string | Yes       | No          | `$XDG_CONFIG_HOME/wake.json` if `$XDG_CONFIG_HOME` set, `$HOME/.config/wake.json` otherwise |
 | log_header | A string containing `$stream` and `$source` that will prepend every line of a jobs output | No | An interpolated string | Yes      | Yes | `'[$stream] $source: '`
 | log_header_source_width | An integer that specifies the width of the `$source` variable in `log_header` | No | Positive Integer | Yes | Yes | 25
+| log_header_align | A boolean that specifies whether or not to align log header output | No | Boolean | Yes | Yes | False
 
 Below is a full example
 

--- a/src/json/json5.h
+++ b/src/json/json5.h
@@ -123,6 +123,16 @@ struct JAST {
     }
     return {};
   }
+
+  wcl::optional<bool> expect_boolean() const {
+    if (kind == JSON_TRUE) {
+      return wcl::some(true);
+    }
+    if (kind == JSON_FALSE) {
+      return wcl::some(false);
+    }
+    return {};
+  }
 };
 
 std::ostream &operator<<(std::ostream &os, const JAST &jast);

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -214,6 +214,7 @@ POLCIY_STATIC_DEFINES(LogHeaderSourceWidthPolicy)
 POLCIY_STATIC_DEFINES(LabelFilterPolicy)
 POLCIY_STATIC_DEFINES(SharedCacheMaxSize)
 POLCIY_STATIC_DEFINES(SharedCacheLowSize)
+POLCIY_STATIC_DEFINES(LogHeaderAlignPolicy)
 
 /********************************************************************
  * Non-Trivial Defaults
@@ -264,6 +265,13 @@ void SharedCacheLowSize::set(SharedCacheLowSize& p, const JAST& json) {
   auto json_low_cache_size = json.expect_integer();
   if (json_low_cache_size) {
     p.low_cache_size = *json_low_cache_size;
+  }
+}
+
+void LogHeaderAlignPolicy::set(LogHeaderAlignPolicy& p, const JAST& json) {
+  auto json_log_header_algih = json.expect_boolean();
+  if (json_log_header_algih) {
+    p.log_header_align = *json_log_header_algih;
   }
 }
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -43,6 +43,7 @@ struct WakeConfigOverrides {
   // Determines the size of the cache that collection
   // tries to get us back to.
   wcl::optional<uint64_t> low_cache_size;
+  wcl::optional<bool> log_header_align;
 };
 
 template <class T>
@@ -169,6 +170,28 @@ struct SharedCacheLowSize {
   static void set(SharedCacheLowSize& p, const JAST& json);
   static void set_input(SharedCacheLowSize& p, const input_type& v) { p.*value = v; }
   static void emit(const SharedCacheLowSize& p, std::ostream& os) { os << p.*value; }
+};
+
+struct LogHeaderAlignPolicy {
+  using type = bool;
+  using input_type = type;
+  static constexpr const char* key = "log_header_align";
+  static constexpr bool allowed_in_wakeroot = true;
+  static constexpr bool allowed_in_userconfig = true;
+  type log_header_align = false;
+  static constexpr type LogHeaderAlignPolicy::*value = &LogHeaderAlignPolicy::log_header_align;
+  static constexpr Override<input_type> override_value = &WakeConfigOverrides::log_header_align;
+
+  LogHeaderAlignPolicy() {}
+  static void set(LogHeaderAlignPolicy& p, const JAST& json);
+  static void set_input(LogHeaderAlignPolicy& p, const input_type& v) { p.*value = v; }
+  static void emit(const LogHeaderAlignPolicy& p, std::ostream& os) {
+    if (p.log_header_align) {
+      os << "true";
+    } else {
+      os << "false";
+    }
+  }
 };
 
 /********************************************************************
@@ -300,7 +323,7 @@ struct WakeConfigImpl : public Polcies... {
 
 using WakeConfigImplFull =
     WakeConfigImpl<UserConfigPolicy, VersionPolicy, LogHeaderPolicy, LogHeaderSourceWidthPolicy,
-                   LabelFilterPolicy, SharedCacheMaxSize, SharedCacheLowSize>;
+                   LabelFilterPolicy, SharedCacheMaxSize, SharedCacheLowSize, LogHeaderAlignPolicy>;
 
 struct WakeConfig final : public WakeConfigImplFull {
   static bool init(const std::string& wakeroot_path, const WakeConfigOverrides& overrides);

--- a/src/runtime/status.cpp
+++ b/src/runtime/status.cpp
@@ -170,6 +170,7 @@ void StatusBuf::emit_header() {
   // Now output the format the user requested.
   out << fmt_vec[0];
   const size_t extra_width = WakeConfig::get()->log_header_source_width;
+  const bool should_align = WakeConfig::get()->log_header_align;
   for (size_t i = 1; i < fmt_vec.size(); i += 2) {
     const std::string &var = fmt_vec[i];
 
@@ -193,14 +194,17 @@ void StatusBuf::emit_header() {
     if (var == "stream") {
       // TODO: Make this configurable
       constexpr size_t stream_width = 7;
-      out << std::setw(stream_width);
+      if (should_align) {
+        out << std::setw(stream_width);
+      }
       out << name;
       continue;
     }
 
     if (var == "source") {
-      // TODO: Make this configurable
       std::string tmp_extra;
+
+      // We still cap the maximum length even if we don't align things
       if (extra) {
         if (extra->size() <= extra_width) {
           tmp_extra = *extra;
@@ -211,7 +215,9 @@ void StatusBuf::emit_header() {
           tmp_extra.append(extra->begin(), extra->begin() + extra_width);
         }
       }
-      out << std::setw(extra_width);
+      if (should_align) {
+        out << std::setw(extra_width);
+      }
       out << tmp_extra;
       continue;
     }

--- a/tests/config/empty/stdout
+++ b/tests/config/empty/stdout
@@ -6,3 +6,4 @@ Wake config:
   label_filter = '.*' (Default)
   max_cache_size = '26843545600' (Default)
   low_cache_size = '16106127360' (Default)
+  log_header_align = 'false' (Default)

--- a/tests/config/extra_keys/stdout
+++ b/tests/config/extra_keys/stdout
@@ -6,3 +6,4 @@ Wake config:
   label_filter = '.*' (Default)
   max_cache_size = '26843545600' (Default)
   low_cache_size = '16106127360' (Default)
+  log_header_align = 'false' (Default)

--- a/tests/config/missing_user_config/stdout
+++ b/tests/config/missing_user_config/stdout
@@ -6,3 +6,4 @@ Wake config:
   label_filter = '.*' (Default)
   max_cache_size = '26843545600' (Default)
   low_cache_size = '16106127360' (Default)
+  log_header_align = 'false' (Default)

--- a/tests/config/nominal/.wakeroot
+++ b/tests/config/nominal/.wakeroot
@@ -3,5 +3,6 @@
   "log_header": "foobar $source: ",
   "log_header_source_width": 13,
   "max_cache_size": 1024,
-  "low_cache_size": 512
+  "low_cache_size": 512,
+  "log_header_align": true
 }

--- a/tests/config/nominal/stdout
+++ b/tests/config/nominal/stdout
@@ -6,3 +6,4 @@ Wake config:
   label_filter = '.*' (Default)
   max_cache_size = '1024' (WakeRoot)
   low_cache_size = '512' (WakeRoot)
+  log_header_align = 'true' (WakeRoot)

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -56,6 +56,7 @@ struct CommandLineOptions {
   bool timeline;
   bool clean;
   bool list_outputs;
+  wcl::optional<bool> log_header_align;
 
   const char *percent_str;
   const char *jobs_str;
@@ -149,6 +150,8 @@ struct CommandLineOptions {
       {0, "label-filter", GOPT_ARGUMENT_REQUIRED},
       {0, "log-header", GOPT_ARGUMENT_REQUIRED},
       {0, "log-header-source-width", GOPT_ARGUMENT_REQUIRED},
+      {0, "log-header-align", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "no-log-header-align", GOPT_ARGUMENT_FORBIDDEN},
       {':', "shebang", GOPT_ARGUMENT_REQUIRED},
       {0, 0, GOPT_LAST}
     };
@@ -209,6 +212,14 @@ struct CommandLineOptions {
     fd5 = arg(options, "fd:5")->argument;
     label_filter = arg(options, "label-filter")->argument;
     log_header = arg(options, "log-header")->argument;
+
+    if (arg(options, "log-header-align")->count) {
+      log_header_align = wcl::some(true);
+    }
+
+    if (arg(options, "no-log-header-align")->count) {
+      log_header_align = wcl::some(false);
+    }
 
     auto lhsw_str = arg(options, "log-header-source-width")->argument;
     if (lhsw_str) log_header_source_width = wcl::make_some<int64_t>(std::stol(lhsw_str));

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -312,10 +312,14 @@ int main(int argc, char **argv) {
 
   // Now check for any flags that override config options
   WakeConfigOverrides config_override;
-  if (clo.label_filter)
+  if (clo.label_filter) {
     config_override.label_filter = wcl::some(wcl::make_some<std::string>(clo.label_filter));
-  if (clo.log_header) config_override.log_header = wcl::make_some<std::string>(clo.log_header);
+  }
+  if (clo.log_header) {
+    config_override.log_header = wcl::make_some<std::string>(clo.log_header);
+  }
   config_override.log_header_source_width = clo.log_header_source_width;
+  config_override.log_header_align = clo.log_header_align;
 
   if (!WakeConfig::init(".wakeroot", config_override)) {
     return 1;


### PR DESCRIPTION
This change adds the option to not align your log headers which is on by default. You can turn it back on however.