### PR TITLE
Adjust documentation for `Plan'`s `FnOutputs` field

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -170,8 +170,8 @@ export def getPlanShare p =
 export def setPlanFilterOutputs (filterFn: (file: String) => Boolean): Plan => Plan =
     # This implementation prevents any unintentional abuse of the FnOutputs field, which can be used to
     # actually add files. This method here only supports filtering.
-    def fnOutputs (files: List String): List String =
-        filter filterFn files
+    def fnOutputs (files: List String): List String = filter filterFn files
+
     setPlanFnOutputs fnOutputs
 
 # If `Once` is set to `False`, no job deduplication is performed and so it must


### PR DESCRIPTION
This adjustment is triggered by some feedback in a private repository:

> It's usually better to filter the `getJobOutputs` than it is to override `setPlanFnOutputs`. This method has some side effects (pretty sure it prevents them from being hashed at all) and is better if you want to hide files rather than simply not caring about them -- which is likely only the case if you're working on something low-level.

and

> I'd say that `setPlanFnOutputs` should be discouraged unless there is a real need to deceive the database. If we're just filtering which files are visible to downstream jobs it should happen after `getJobOutputs`.

> It used to be that we had to use `setPlanFnOutputs` a lot more, which is why so many examples exist, but as our systems have improved it should be unusual in new code.

> The API of `setPlanFnOutputs` is really the issue, as we should be communicating visibility vs hashing separately, but we've put off refactoring the `Plan` tuple for a long time now

Since using the field `FnOutputs` in a `Plan` to filter what files is discouraged since it has the additional effect of hiding files from the database, I have updated the field's documentation to state so. This is hopefully to help provide some more clear documentation to limit setting this in a `Plan` via `setPlanFnOutputs`. The main goal is to provide some indication that it shouldn't be used.

It's unlikely I got the documentation correct, but I took a stab. Some key things to look at that I'm weary about:

1. Most of the fields in `Plan` mention `Runner` rather than `Job`. However, my documentation refers to jobs since the `Outputs` field in `Job` is the only thing I know of that is often filtered (limitation of my knowledge). So this is something I'm not sure I got right.
2. Should the documentation for `FnInputs` also contain such a disclaimer?