### PR TITLE
Only set istty=true on StatusBuf on fd 1 and 2

### DIFF
--- a/src/runtime/status.cpp
+++ b/src/runtime/status.cpp
@@ -514,7 +514,7 @@ void status_set_fd(const char *name, int fd) {
   }
   auto &stream = settings[name];
   stream.fd = fd;
-  stream.istty = isatty(fd) == 1;
+  stream.istty = (fd == STDOUT_FILENO || fd == STDERR_FILENO) && isatty(fd) == 1;
   stream.colour = stream_color(name);
   stream.fd_buf = std::make_unique<FdBuf>(fd);
   stream.term_buf = std::make_unique<TermInfoBuf>(stream.fd_buf.get());


### PR DESCRIPTION
We hit some issues where users want some side streams to emit a machine readable format (e.g. without escape sequences) but also want interactive features on the typical streams. Ideally we'd have some more refined way of doing this but this should be good enough for all current use cases.