### PR TITLE
Make stdin a psuedoterminal when isatty is set

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -999,7 +999,10 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
                     Fail f = Pair (Fail (makeError f)) ""
                     Pass inFile =
                         def outFile = "{build}/{prefix}.out.json"
-                        def cmd = script, "-I", "-p", inFile, "-o", outFile, extraArgs
+                        def always_args = "-I", "-p", inFile, "-o", outFile, extraArgs
+                        def optional_arg =
+                            if isatty then "-i", Nil else Nil
+                        def cmd = script, optional_arg ++ always_args
 
                         def proxy =
                             RunnerInput label cmd Nil (extraEnv ++ environment) "." "" Nil prefix (estimate record) isatty

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -835,7 +835,7 @@ static void launch(JobTable *jobtable) {
       stdin_file_str = task.stdin_file;
     } else if (task.is_atty) {
       create_psuedoterminal(stdin_stream);
-      stdin_file_str = "#" + std::to_string(stdin_stream[0]);
+      stdin_file_str = "#" + std::to_string(stdin_stream[1]);
     }
     std::stringstream prelude;
     prelude << find_execpath() << "/../lib/wake/shim-wake" << '\0'

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -829,9 +829,17 @@ static void launch(JobTable *jobtable) {
     jobtable->imp->pipes[stdout_stream[0]] = entry;
     jobtable->imp->pipes[stderr_stream[0]] = entry;
     clock_gettime(CLOCK_REALTIME, &entry->job->start);
+    std::string stdin_file_str = "/dev/null";
+    int stdin_stream[2];
+    if (!task.stdin_file.empty()) {
+      stdin_file_str = task.stdin_file;
+    } else if (task.is_atty) {
+      create_psuedoterminal(stdin_stream);
+      stdin_file_str = "#" + std::to_string(stdin_stream[0]);
+    }
     std::stringstream prelude;
     prelude << find_execpath() << "/../lib/wake/shim-wake" << '\0'
-            << (task.stdin_file.empty() ? "/dev/null" : task.stdin_file.c_str()) << '\0'
+            << stdin_file_str << '\0'
             << std::to_string(stdout_stream[1]) << '\0' << std::to_string(stderr_stream[1]) << '\0'
             << task.dir << '\0';
     std::string shim = prelude.str() + task.cmdline;

--- a/tools/shim-wake/main.c
+++ b/tools/shim-wake/main.c
@@ -147,10 +147,17 @@ int main(int argc, char **argv) {
     return 127;
   }
 
-  stdin_fd = open(argv[1], O_RDONLY);
-  if (stdin_fd == -1) {
-    fprintf(stderr, "open: %s: %s\n", argv[1], strerror(errno));
-    return 127;
+  // Because we want to be able to read in both file descirptors and
+  // files for stdin, we use a '#' to denote a file descriptor.
+  const char* stdin_file = argv[1];
+  if (stdin_file[0] == '#') {
+    stdin_fd = atoi(stdin_file + 1);
+  } else {
+    stdin_fd = open(stdin_file, O_RDONLY);
+    if (stdin_fd == -1) {
+      fprintf(stderr, "open: %s: %s\n", argv[1], strerror(errno));
+      return 127;
+    }
   }
 
   stdout_fd = atoi(argv[2]);


### PR DESCRIPTION
Sometimes programs check isatty(STDIN_FILENO) in addition to stderr and stdout to determine if they're using a terminal or not. We should support that case as well as we can. We'd need to perform some surgery on shim-wake to support the case where stdin is a file input but it *ALSO* has input. So for now we treat setting stdin to a file to be just that and not a pseudo-terminal.