### PR TITLE
Fix failure to handle large messages

### DIFF
--- a/src/job_cache/job_cache_impl_common.cpp
+++ b/src/job_cache/job_cache_impl_common.cpp
@@ -270,7 +270,10 @@ void send_json_message(int fd, const JAST &json) {
   while (start < json_str.size()) {
     int res = write(fd, json_str.data() + start, json_str.size() - start);
     if (res == -1) {
-      if (errno == EINTR) {
+      // If we get interuppted by a signal, or we get hit by a block, retry.
+      // Today we don't use non-blocking sockets but when we did this was required.
+      // It's strictly more correct for the function to do this so we keep it.
+      if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
         continue;
       }
       log_fatal("write(%d): %s", fd, strerror(errno));


### PR DESCRIPTION
This change does a couple things

1) It makes communication between the daemon and client blocking. It wasn't blocking before because we based this code off of some code that I wrote ages ago that didn't use epoll at first and instead would just busy read from each client until it could get something. I switched to epoll forever ago in that code but the non-blocking accept stayed with it for some reason. This doesn't present an issue unless you fill up the kernel's buffer for the socket which never happens on small messages.
2) The code on both sides is now hardened so that in theory its compatible with non-blocking sockets. Hopefully we don't have to rely on that code as it essentially busy waits until it gets a read which is not great. I'm not sure if Linux will reschedule on blocking read with a non-blocking socket or not. So it could be anywhere from a total waste to negligible since the reads and writes are fairly tightly linked a single reschedule should clear everything up...either way we should avoid it but handle the error correctly so that we don't have to think about this sort of issue in code abstracted from the type of file descriptor being used.
