### PR TITLE
Always ship wake with debug information

### DIFF
--- a/share/wake/lib/gcc_wake/gcc.wake
+++ b/share/wake/lib/gcc_wake/gcc.wake
@@ -31,16 +31,16 @@ export def debugLFlags =
     ("-lpthread", "-g", "-pg", Nil)
 
 export def releaseCFlags =
-    ("-Wall", "-Wno-format-security", "-O2", Nil)
+    ("-Wall", "-Wno-format-security", "-g", "-O2", Nil)
 
 export def releaseLFlags =
     ("-lpthread",)
 
 export def staticCFlags =
-    ("-Wall", "-Wno-format-security", "-O2", "-flto", Nil)
+    ("-Wall", "-Wno-format-security", "-g", "-O2", "-flto", Nil)
 
 export def staticLFlags =
-    ("-lpthread", "-flto", "-static", "-s", Nil)
+    ("-lpthread", "-flto", "-static", "-g", Nil)
 
 target pwd _ =
     makeExecPlan ("pwd",) Nil

--- a/share/wake/lib/gcc_wake/gcc.wake
+++ b/share/wake/lib/gcc_wake/gcc.wake
@@ -28,19 +28,19 @@ export def debugCFlags =
     ("-Wall", "-Wextra", "-Wno-format-security", "-O0", "-g", "-pg", Nil)
 
 export def debugLFlags =
-    ("-lpthread", "-g", "-pg", Nil)
+    ("-lpthread", "-g", "-pg", "-Wl,--build-id", Nil)
 
 export def releaseCFlags =
     ("-Wall", "-Wno-format-security", "-g", "-O2", Nil)
 
 export def releaseLFlags =
-    ("-lpthread",)
+    ("-lpthread", "-Wl,--build-id", Nil)
 
 export def staticCFlags =
     ("-Wall", "-Wno-format-security", "-g", "-O2", "-flto", Nil)
 
 export def staticLFlags =
-    ("-lpthread", "-flto", "-static", "-g", Nil)
+    ("-lpthread", "-flto", "-static", "-Wl,--build-id", Nil)
 
 target pwd _ =
     makeExecPlan ("pwd",) Nil


### PR DESCRIPTION
There's no real reason not to have debug information on every type of build. It increases binary size drastically (~20x in the case of wake) but Wake is only ~2.5MB so increasing to ~50MB really just isn't that big of a deal and it saves us a huge amount of headache debugging things sometimes.

Size increases:
wake: 2.53MB -> 49.3MB
wakebox: 0.275MB -> 5.35MB
wake-format: ? -> 40.4MB
fuse-waked: 0.235MB -> 3.37MB
lsp-wake: ? -> 26.6MB
shim-wake: 32.1KB -> 0.159MB
wake-hash: 0.226MB -> 0.803MB
bsp-wake: ? -> 4.59MB

So the total package size will be dominated by the binaries and will be around ~135MB which is still a very acceptable size IMO. If need be there are settings that we can play with to reduce debug information size. We can also split debug information from these binaries and ship it separately if need be. Luckily this kind of thing used to be my day job! That all said, its by far the easiest thing to just keep them colocated which is what this change does.

