### PR TITLE
remove Plan's LocalOnly and RunnerFilter

### DIFF
--- a/share/doc/wake/quickref.md
+++ b/share/doc/wake/quickref.md
@@ -250,8 +250,7 @@ Runners are responsible for executing a Plan to run an external program. There a
 Runners are chosen for a given Plan based on the value returned by their `score` function and the plan's `RunnerFilter` field. Multiple runners may be able to run a given Plan, so the `score` function selects the most appropriate one. 
 
 * In `runJob`,  `subscribe runner` is called to retrieve the list of all published runners. The `RunnerFilter` function inside the Plan tuple can be set to filter out runners that the plan wants to exclude from consideration. Then the `score` function of each runner is called and runners that return Fail or a score <= 0.0 are excluded. Of the remaining runners, the one with the highest score is picked.
-* Local runners can only run when the Plan tuple has `LocalOnly` set to true
-* Default runners can only run when the Plan tuple has `LocalOnly` set to false
+* The local runners can only be used via `runJobWith localRunner`, or a custom wrapper.
 
 Runners are created using `makeRunner`. `makeRunner` is defined as follows:
 

--- a/share/wake/lib/gcc_wake/gcc.wake
+++ b/share/wake/lib/gcc_wake/gcc.wake
@@ -42,13 +42,6 @@ export def staticCFlags =
 export def staticLFlags =
     ("-lpthread", "-flto", "-static", "-s", Nil)
 
-target pwd _ =
-    makeExecPlan ("pwd",) Nil
-    | setPlanLabel "pwd: Get workspace directory"
-    | setPlanLocalOnly True
-    | runJob
-    | getJobStdout
-
 def doCompileC variant gcc flags headers cfile =
     def obj = replace `\.c(pp)?$` ".{variant}.o" cfile.getPathName
     def cmdline = gcc, flags ++ ("-c", cfile.getPathName, "-frandom-seed={obj}", "-o", obj, Nil)
@@ -69,13 +62,9 @@ def doCompileC variant gcc flags headers cfile =
     require True = emitCompileCmd
     else out
 
-    require Pass pwd_out = pwd Unit
-
-    def dir = replace `[\n]` "" pwd_out
-
     def outJson =
         JObject (
-            "directory" :-> JString dir,
+            "directory" :-> JString workspace,
             "arguments" :-> JArray $ map JString cmdline,
             "file" :-> JString "cfile.getPathName",
         )

--- a/share/wake/lib/gcc_wake/pkgconfig.wake
+++ b/share/wake/lib/gcc_wake/pkgconfig.wake
@@ -54,11 +54,10 @@ target pkgConfigImp flags pkgs =
     def result =
         makeExecPlan cmdline Nil
         | setPlanLabel "pkg-config: {pkgs | catWith " "}"
-        | setPlanLocalOnly True
         | setPlanStdout logNever
         | setPlanStderr logDebug
         | editPlanEnvironment addenv
-        | runJob
+        | runJobWith localRunner
 
     require Some output =
         result.getJobStdout

--- a/share/wake/lib/system/incremental.wake
+++ b/share/wake/lib/system/incremental.wake
@@ -38,7 +38,6 @@ def targz output paths =
 
     require Pass tar =
         makePlan "incremental snapshot: {output}" paths script
-        | setPlanLocalOnly True
         | setPlanFnOutputs (\_ output, Nil)
         | runJobWith localRunner
         | getJobOutput

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -75,9 +75,8 @@ export def installAs (dest: String) (file: Path): Result Path Error =
     makeExecPlan cmd inputs
     | setPlanLabel "installAs: {dest} {file.getPathName}"
     | setPlanEnvironment Nil
-    | setPlanLocalOnly True
     | setPlanFnOutputs foutputs
-    | runJob
+    | runJobWith localRunner
     | getJobOutput
 
 # Copy a file from one directory subtree to another

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -118,13 +118,9 @@ tuple Plan =
     export Echo: LogLevel
     # See Persistence table above
     export Persistence: Persistence
-    # <Deprecated>
-    export LocalOnly: Boolean
     # The resources a runner must provide to the job (licenses/etc).
     # These strings are uninterpreted and are only meaningful to the right runners.
     export Resources: List String
-    # Reject from consideration Runners which the Plan deems inappropriate
-    export RunnerFilter: Runner => Boolean
     # User-supplied usage prediction; overruled by database statistics (if any)
     export Usage: Usage
     # Modify the Runner's reported inputs (files read). For advanced use only.
@@ -231,7 +227,7 @@ export def editPlanShare (f: Boolean => Boolean): Plan => Plan =
 
 # Get a unique hash-code for the job
 export def getPlanHash (plan: Plan): Integer =
-    def Plan _ cmd _ env dir stdin _ _ _ _ _ _ _ _ _ _ isAtty = plan
+    def Plan _ cmd _ env dir stdin _ _ _ _ _ _ _ _ isAtty = plan
     def isAttyStr = if isAtty then "true" else "false"
     def sig = cat (isAttyStr, "\0\0", implode cmd, "\0\0", implode env, "\0\0", dir, "\0\0", stdin,)
 
@@ -266,24 +262,7 @@ def bToInt b =
 
 # Set reasonable defaults for all Plan arguments
 export def makeExecPlan (cmd: List String) (visible: List Path): Plan =
-    Plan
-    ""
-    cmd
-    visible
-    environment
-    "."
-    ""
-    logInfo
-    logWarning
-    logEcho
-    Share
-    False
-    Nil
-    (\_ True)
-    defaultUsage
-    id
-    id
-    False
+    Plan "" cmd visible environment "." "" logInfo logWarning logEcho Share Nil defaultUsage id id False
 
 export def makeShellPlan (script: String) (visible: List Path): Plan =
     makeExecPlan (which "dash", "-c", script, Nil) visible
@@ -314,7 +293,7 @@ export def localRunner: Runner =
                 Pass reality = Pass (RunnerOutput (map getPathName vis) Nil reality)
                 Fail f = Fail f
 
-    def score plan = if plan.getPlanLocalOnly then Pass 1.0 else Fail "cannot detect outputs"
+    def score _ = Pass 1.0
 
     Runner "local" score doit
 
@@ -356,12 +335,6 @@ def getPath input =
     jField elem "path"
     | jString
 
-target pwd Unit =
-    makePlan "get pwd" Nil "pwd"
-    | runJobWith localRunner
-    | getJobStdout
-    | rmap (replace `\n` "")
-
 # wakeroot is the absolute sandbox-path from which input and output files will
 # be interpreted as being relative to if they're in fact relative.
 export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Runner): Runner =
@@ -376,8 +349,6 @@ export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Ru
 
             Fail e
         Pass (RunnerInput label cmd vis env dir stdin _ prefix _ _) =
-            require Pass client_cwd = pwd Unit
-
             def mkVisJson (Path path hash) =
                 JObject ("path" :-> JString path, "hash" :-> JString hash,)
 
@@ -392,7 +363,7 @@ export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Ru
                     "envrionment" :-> JString env.implode,
                     "stdin" :-> JString stdin,
                     "input_files" :-> jobCacheVisible,
-                    "client_cwd" :-> JString client_cwd,
+                    "client_cwd" :-> JString workspace,
                     "dir_redirects" :-> JObject (wakeroot :-> JString "./",),
                 )
 
@@ -523,7 +494,7 @@ export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Ru
                     "obytes" :-> JInteger obytes,
                     "stdout" :-> JString stdout,
                     "stderr" :-> JString stderr,
-                    "client_cwd" :-> JString client_cwd,
+                    "client_cwd" :-> JString workspace,
                 )
 
             # We put this in a def so that it does not block the return below.
@@ -663,7 +634,7 @@ target runOnce cmd env dir stdin \ res usage finputs foutputs vis keep run echo 
 export topic runner: Runner
 
 publish runner =
-    localRunner, defaultRunner, Nil
+    defaultRunner, Nil
 
 def runJobImp label cmd env dir stdin res usage finputs foutputs vis pers run (LogLevel echo) (LogLevel stdout) (LogLevel stderr) isatty =
     if isOnce pers then
@@ -703,7 +674,7 @@ def runJobImp label cmd env dir stdin res usage finputs foutputs vis pers run (L
         label
         isatty
 
-export def runJobWith (Runner _ _ run) (Plan label cmd vis env dir stdin stdout stderr echo pers _ res _ usage finputs foutputs isatty) =
+export def runJobWith (Runner _ _ run) (Plan label cmd vis env dir stdin stdout stderr echo pers res usage finputs foutputs isatty) =
     runJobImp label cmd env dir stdin res usage finputs foutputs vis pers run echo stdout stderr isatty
 
 data RunnerOption =
@@ -712,10 +683,9 @@ data RunnerOption =
 
 # Run the job!
 export def runJob (p: Plan): Job = match p
-    Plan label cmd vis env dir stdin stdout stderr echo pers _lo res rf usage finputs foutputs isatty =
+    Plan label cmd vis env dir stdin stdout stderr echo pers res usage finputs foutputs isatty =
         # Transform the 'List Runner' into 'List RunnerOption'
         def qualify runner = match runner
-            Runner name _ _ if ! rf runner = Reject "{name}: rejected by Plan"
             Runner name scorefn fn = match (scorefn p)
                 Pass x if x <=. 0.0 = Reject "{name}: non-positive score"
                 Pass x = Accept x fn
@@ -901,7 +871,7 @@ export def wakePath: String =
 
 export def fuseRunner: Runner =
     def fuse = "{wakePath}/wakebox"
-    def score plan = if plan.getPlanLocalOnly then Fail "would hide workspace" else Pass 1.0
+    def score _ = Pass 2.0
 
     makeJSONRunnerPlan fuse score
     | editJSONRunnerPlanExtraEnv (editEnvironment "DEBUG_FUSE_WAKE" (\_ getenv "DEBUG_FUSE_WAKE"))

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -153,7 +153,7 @@ def computeHashes (files: List String): List String =
     # Ok now we know we have a non-empty set of files that actully need to be hashed.
     # We pass all of these to wake-hash and it does its thing
     def hashPlan cmd =
-        Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun True Nil (\_ True) hashUsage id id False
+        Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun Nil hashUsage id id False
 
     def add f h = prim "add_hash"
 
@@ -185,7 +185,7 @@ target hashcode (f: String): String =
         reuse
     else
         def hashPlan cmd =
-            Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun True Nil (\_ True) hashUsage id id False
+            Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun Nil hashUsage id id False
 
         def job =
             hashPlan ("<hash>", f, Nil)

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -32,7 +32,7 @@ def got_sources =
 # Find files
 # WARNING! Use of this method can make a build unreproducible.
 # Depending on when the method is invoked, the results may vary!
-# This method is ntended to be used by the outputFn of LocalOnly Jobs.
+# This method is intended to be used by the outputFn of localRunner Jobs.
 export def files (dir: String) (regexp: RegExp): List String =
     def p d r = prim "files"
 
@@ -172,7 +172,6 @@ export def claimFileAsPathIn (outputDirectory: Path) (existingFile: String) (des
 
         makeExecPlan cmdline visible
         | setPlanLabel "claim: {existingFile} -> {desiredWorkspacePath}"
-        | setPlanLocalOnly True
         | setPlanPersistence Once
         | setPlanFnOutputs (\_ desiredWorkspacePath, Nil)
         | runJobWith localRunner

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -139,9 +139,8 @@ export def runUnitTests _: Result Unit Error =
         | setPlanLabel "testing: {testName}"
         | setPlanStdout logNever
         | setPlanStderr logNever
-        | setPlanLocalOnly True
         | setPlanShare False
-        | runJob
+        | runJobWith localRunner
 
     def removeCarriageReturns = replace `\r` ""
 
@@ -219,12 +218,11 @@ def runTest (testScript: Path): Result Unit Error =
         makeExecPlan ("./{testScript.getPathName.inTestDir}", wakeDir.inTestDir, Nil) (visibleFiles ++ wakeVisible)
         | setPlanDirectory testDirectory
         | setPlanLabel "testing: {testName}"
-        | setPlanLocalOnly True # On OS/X you cannot mount fuse within fuse
         | setPlanEnvironment ("HOME={testDirectory}",)
         | setPlanStdout logNever
         | setPlanStderr logNever
         | setPlanShare False
-        | runJob
+        | runJobWith localRunner # On OS/X you cannot mount fuse within fuse
 
     require Pass jobStdout =
         testJob.getJobStdout

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -28,9 +28,8 @@ def buildAs Unit = match (subscribe releaseAs)
             makeExecPlan cmdline Nil
             | setPlanLabel "buildAs: git describe"
             | setPlanKeep False
-            | setPlanLocalOnly True
             | setPlanStdout logNever
-            | runJob
+            | runJobWith localRunner
             | getJobStdout
 
         # The replace accomplish this:
@@ -55,9 +54,8 @@ def buildOn Unit = match (subscribe releaseOn)
             makeExecPlan cmdline Nil
             | setPlanLabel "buildOn: git show"
             | setPlanKeep False
-            | setPlanLocalOnly True
             | setPlanStdout logNever
-            | runJob
+            | runJobWith localRunner
             | getJobStdout
 
         Pass (replace `\n.*` '' stdout)


### PR DESCRIPTION
This removes 2 fields from `Plan`
* `LocalOnly`
* `RunnerFilter`

This is a breaking change.


Some jobs relied on using `LocalOnly`, they have been transitioned to using `runJobWith localRunner` and some were removed.

Documentation received some very light updates.

The `runJob` score function becomes unable to select the localRunner, as it's no longer published to the runner topic.
A user who still needs this could in theory decide to publish a wrapper of the localRunner to that topic, that looks at some otherwise opaque Resource strings to determine if it should be used instead of the fuseRunner.