### PR TITLE
use job numbers for wakebox spec and result jsons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ all:		wake.db
 	$(WAKE_ENV) BOOTSTRAP_WAKE=true ./bin/wake build default
 
 clean:
-	rm -f bin/* lib/wake/* */*.o */*/*.o src/json/jlexer.cpp src/parser/lexer.cpp src/parser/parser.cpp src/parser/parser.h src/version.h wake.db
+	rm -f .build/* bin/* lib/wake/* */*.o */*/*.o src/json/jlexer.cpp src/parser/lexer.cpp src/parser/parser.cpp src/parser/parser.h src/version.h wake.db
 	touch bin/stamp lib/wake/stamp
 
 wake.db:	bin/wake bin/wakebox lib/wake/fuse-waked lib/wake/shim-wake lib/wake/wake-hash

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -978,8 +978,7 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
 
             Pair (Pass proxy) inFile
 
-    def resultPath specPath =
-        replace `spec-` "result-" specPath
+    def resultPath specPath = replace `spec-` "result-" specPath
 
     def post = match _
         Pair (Fail f) _ = Fail f

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -97,7 +97,7 @@ tuple Plan =
     # The label used when showing the command during execution. This is recommended for efficient
     # debugging and locating job information. For example, the label will show up in the terminal during
     # job execution, in a job's progress bar in the terminal, when running the `wake --last` command,
-    # and in the `<..>.spec` and `<...>.result` files in the `.build` directory.
+    # and in the `spec-<jobid>.json` and `result-<jobid>.json` files in the `.build` directory.
     export Label: String
     # The command-line arguments (the first is the command to run)
     export Command: List String
@@ -963,14 +963,14 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
                 | rmap getPathName
             else Pair (Fail (makeError "Failed to 'mkdir .build'.")) ""
 
-            def specFilePath = "{build}/{prefix}.spec"
+            def specFilePath = "{build}/spec-{prefix}.json"
 
             require Pass inFile =
                 write specFilePath (prettyJSON json)
                 | rmap getPathName
             else Pair (Fail (makeError "Failed to 'write {specFilePath}'.")) ""
 
-            def outFile = "{build}/{prefix}.result"
+            def outFile = resultPath inFile
             def cmd = script, "-I", "-p", inFile, "-o", outFile, extraArgs
 
             def proxy =
@@ -978,12 +978,15 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
 
             Pair (Pass proxy) inFile
 
+    def resultPath specPath =
+        replace `spec-` "result-" specPath
+
     def post = match _
         Pair (Fail f) _ = Fail f
         Pair (Pass (RunnerOutput _ _ (Usage x _ _ _ _ _))) inFile if x != 0 =
             Fail (makeError "Non-zero exit status ({str x}) for JSON runner {script} on {inFile}")
         Pair (Pass _) inFile =
-            def outFile = replace `\.spec$` ".result" inFile
+            def outFile = resultPath inFile
             def json = parseJSONFile (Path outFile "BadHash")
 
             match json

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -97,7 +97,7 @@ tuple Plan =
     # The label used when showing the command during execution. This is recommended for efficient
     # debugging and locating job information. For example, the label will show up in the terminal during
     # job execution, in a job's progress bar in the terminal, when running the `wake --last` command,
-    # and in the `<..>.in.json` and `<...>.out.json` files in the `.build` directory.
+    # and in the `<..>.spec` and `<...>.result` files in the `.build` directory.
     export Label: String
     # The command-line arguments (the first is the command to run)
     export Command: List String
@@ -536,9 +536,6 @@ export def virtualRunner: Runner =
 
     Runner "virtual" (\_ Pass 0.0) doit
 
-def pid =
-    prim "pid"
-
 def implode l =
     cat (foldr (_, "\0", _) Nil l)
 
@@ -572,7 +569,7 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
             stderr
             (bToInt isatty)
 
-        def prefix = "{str pid}.{str (getJobId job)}"
+        def prefix = str (getJobId job)
 
         def usage =
             getJobRecord job
@@ -937,8 +934,6 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
         _ if !ok = Pair (Fail (makeError "Runner {script} is not executable")) ""
         Pass (RunnerInput label command visible environment directory stdin res prefix record isatty) =
             def Usage status runtime cputime membytes inbytes outbytes = record
-            def pmkdir m p = prim "mkdir"
-            def pwrite m p d = prim "write"
 
             def json =
                 JObject (
@@ -963,39 +958,38 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
                     Nil
                 )
 
-            match (pmkdir 0755 ".build")
-                Fail f = Pair (Fail (makeError f)) ""
-                Pass build = match (pwrite 0644 "{build}/{prefix}.in.json" (prettyJSON json))
-                    Fail f = Pair (Fail (makeError f)) ""
-                    Pass inFile =
-                        def outFile = "{build}/{prefix}.out.json"
-                        def cmd = script, "-I", "-p", inFile, "-o", outFile, extraArgs
+            require Pass build =
+                mkdir ".build"
+                | rmap getPathName
+            else Pair (Fail (makeError "Failed to 'mkdir .build'.")) ""
 
-                        def proxy =
-                            RunnerInput label cmd Nil (extraEnv ++ environment) "." "" Nil prefix (estimate record) isatty
+            def specFilePath = "{build}/{prefix}.spec"
 
-                        Pair (Pass proxy) inFile
+            require Pass inFile =
+                write specFilePath (prettyJSON json)
+                | rmap getPathName
+            else Pair (Fail (makeError "Failed to 'write {specFilePath}'.")) ""
+
+            def outFile = "{build}/{prefix}.result"
+            def cmd = script, "-I", "-p", inFile, "-o", outFile, extraArgs
+
+            def proxy =
+                RunnerInput label cmd Nil (extraEnv ++ environment) "." "" Nil prefix (estimate record) isatty
+
+            Pair (Pass proxy) inFile
 
     def post = match _
         Pair (Fail f) _ = Fail f
         Pair (Pass (RunnerOutput _ _ (Usage x _ _ _ _ _))) inFile if x != 0 =
             Fail (makeError "Non-zero exit status ({str x}) for JSON runner {script} on {inFile}")
         Pair (Pass _) inFile =
-            def unlink f =
-                def fn _ = prim "unlink"
-
-                match (getenv "WAKEBOX_KEEP_IO_FILES")
-                    Some "1" = Unit
-                    _ = fn f
-
-            def outFile = replace `\.in\.json$` ".out.json" inFile
+            def outFile = replace `\.spec$` ".result" inFile
             def json = parseJSONFile (Path outFile "BadHash")
-            def _ = unlink inFile
 
             match json
                 Fail f = Fail f
                 Pass content =
-                    def _ = unlink outFile
+                    def _ = markFileCleanable outFile
 
                     def field name = match _ _
                         _ (Fail f) = Fail f

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -200,3 +200,19 @@ target hashcode (f: String): String =
         match job.isJobOk hash
             True (x, Nil) = x
             _ _ = "BadHash"
+
+# Allow an untracked file to be removed via `wake --clean`
+export target markFileCleanable (filepath: String): Result Unit Error =
+    def hashPlan cmd =
+        Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun Nil hashUsage id id False
+
+    def job =
+        hashPlan ("<hash>", filepath, Nil)
+        | setPlanLabel "hash: {filepath}"
+        | setPlanFnOutputs (\_ filepath, Nil)
+        | runJobWith localRunner
+
+    if job.isJobOk then
+        Pass Unit
+    else
+        failWithError "Failed to hash {filepath}"

--- a/tools/wakebox/main.cpp
+++ b/tools/wakebox/main.cpp
@@ -193,7 +193,7 @@ int run_batch(const char *params_path, bool has_output, bool use_stdin_file, boo
   }
 
   // Open the output file
-  int out_fd = open(result_path, O_WRONLY | O_CREAT | O_CLOEXEC, 0664);
+  int out_fd = open(result_path, O_WRONLY | O_CREAT | O_CLOEXEC | O_TRUNC, 0664);
   if (out_fd < 0) {
     std::cerr << "open " << result_path << ": " << strerror(errno) << std::endl;
     return 1;


### PR DESCRIPTION
If you set `WAKEBOX_KEEP_IO_FILES=1` you'd see files in a `.build` directory that look like
``` 
$ ls .build/
2272028.29.in.json
2272028.29.out.json
2272028.301.in.json
2272028.301.out.json
2272028.302.in.json
....
```
These files correspond to the input specification (`*.in.json`) and result (`*.out.json`) for each wakebox job.

The first element is the process id of wake on the current machine, this is often not useful information to a user.
The second element is the job id from the database, that users see in `wake --last/--failed`
In this PR: 
* remove the PID from the filenames
* remove in/out.json filename suffixes, replace with spec/result
* the tracking of the files are adjusted to allow `wake --clean` to remove them
* `WAKEBOX_KEEP_IO_FILES` option is removed, the spec/result files now always kept

After changes:
```
$ ls .build
result-29.json
result-301.json
result-302.json
spec-29.json
spec-301.json
spec-302.json
....
```