### PR TITLE
Update `write` documentation

### DIFF
--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -46,7 +46,9 @@ target writeImp inputs mode path content =
     | runJobWith writeRunner
     | getJobOutput
 
-# Create all directories and the named file
+# Create all directories and the named file. The `content` string is written verbatim with no
+# processing. For example, a final terminating newline character is not appended to the end of
+# the string.
 export def write (path: String) (content: String): Result Path Error =
     def spath = simplify path
 


### PR DESCRIPTION
This is a small change to clarify the behavior of `write` to mention that it does no processing. Specifically, it does not write a final terminating `\n` character. This should make it a small amount more clear to users.