### PR TITLE
Add more keywords to VS Code syntax highlighting

### DIFF
--- a/extensions/vscode/syntaxes/wake.tmLanguage.json
+++ b/extensions/vscode/syntaxes/wake.tmLanguage.json
@@ -29,7 +29,7 @@
 		"keyword": {
 			"patterns": [{
 				"name": "keyword.control.wake",
-				"match": "\\b(_|def|tuple|data|global|target|publish|subscribe|prim|if|then|else|here|match|require|package|import|export|from|type|topic|unary|binary)\\b"
+				"match": "\\b(_|def|tuple|data|global|target|publish|subscribe|prim|if|then|else|here|@here|@line|@file|@!|match|require|package|import|export|from|type|topic|unary|binary)\\b"
 			}]
 		},
 		"operator": {


### PR DESCRIPTION
Some newer keywords like `@here`, `@file`, etc. as defined in https://github.com/sifive/wake/blob/master/src/parser/lexer.re were missing from the VS Code extension's syntax highlighting for Wake.

I had noticed that `@here` wasn't highlighted correctly in a Wake file:

![image](https://github.com/sifive/wake/assets/65685447/d1cb45c4-6811-4710-a904-2c5fad838cb5)

No testing was done by me. I simply edited the regex and checked that `!` and `@` were not special regex operators, and as far as I can tell, they are not and are just literal character matches.