### PR TITLE
Increase robustness of job cache client

### DIFF
--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -167,28 +167,26 @@ wcl::optional<wcl::unique_fd> try_connect(std::string dir) {
   return wcl::make_some<wcl::unique_fd>(std::move(socket_fd));
 }
 
-Cache::Cache(std::string dir, uint64_t max, uint64_t low) {
-  mkdir_no_fail(dir.c_str());
-
-  // launch the daemon
-  if (daemonize(dir.c_str())) {
-    // We are the daemon, launch the cache
-
+// Launch the job cache daemon
+void Cache::launch_daemon() {
+  // We are the daemon, launch the cache
+  if (daemonize(cache_dir.c_str())) {
     std::string job_cache = wcl::make_canonical(find_execpath() + "/../bin/job-cache");
-    std::string low_str = std::to_string(low);
-    std::string max_str = std::to_string(max);
-    execl(job_cache.c_str(), "job-cached", dir.c_str(), low_str.c_str(), max_str.c_str(), nullptr);
+    std::string low_str = std::to_string(low_threshold);
+    std::string max_str = std::to_string(max_size);
+    execl(job_cache.c_str(), "job-cached", cache_dir.c_str(), low_str.c_str(), max_str.c_str(),
+          nullptr);
 
     wcl::log::fatal("exec(%s): %s", job_cache.c_str(), strerror(errno));
   }
+}
 
-  // connect to the daemon with backoff.
-  // TODO: Put this into a function so that we can call it again if
-  // the daemon fails unexpectedly.
+// Connect to the job cache daemon with backoff.
+void Cache::backoff_try_connect() {
   wcl::xoshiro_256 rng(wcl::xoshiro_256::get_rng_seed());
   useconds_t backoff = 1000;
   for (int i = 0; i < 10; i++) {
-    auto fd_opt = try_connect(dir);
+    auto fd_opt = try_connect(cache_dir);
     if (!fd_opt) {
       std::uniform_int_distribution<useconds_t> variance(0, backoff);
       usleep(backoff + variance(rng));
@@ -201,8 +199,81 @@ Cache::Cache(std::string dir, uint64_t max, uint64_t low) {
   }
 
   if (!socket_fd.valid()) {
-    wcl::log::fatal("could not connect to daemon. dir = %s", dir.c_str());
+    wcl::log::fatal("could not connect to daemon. dir = %s", cache_dir.c_str());
   }
+}
+
+Cache::Cache(std::string dir, uint64_t max, uint64_t low) {
+  cache_dir = dir;
+  mkdir_no_fail(cache_dir.c_str());
+
+  launch_daemon();
+  backoff_try_connect();
+}
+
+FindJobResponse Cache::retry_read(const FindJobRequest &find_request, const char *err_msg) {
+  wcl::log::info("Relaunching the daemon.");
+  launch_daemon();
+
+  wcl::log::info("Reconnecting to daemon.");
+  backoff_try_connect();
+
+  JAST request(JSON_OBJECT);
+  request.add("method", "cache/read");
+  request.add("params", find_request.to_json());
+
+  // serialize the request, send it, deserialize the response, return it
+  send_json_message(socket_fd.get(), request);
+  MessageParser parser(socket_fd.get());
+  std::vector<std::string> messages;
+
+  while (true) {
+    MessageParserState state = parser.read_messages(messages);
+
+    if (state == MessageParserState::StopFail) {
+      if (false) {
+        return FindJobResponse(wcl::optional<MatchingJob>{});
+      }
+
+      wcl::log::info("retry failed. msg = %s", err_msg);
+      wcl::log::fatal("Cache::read(): failed receiving message");
+    }
+
+    if (state == MessageParserState::StopSuccess && messages.empty()) {
+      if (false) {
+        return FindJobResponse(wcl::optional<MatchingJob>{});
+      }
+
+      wcl::log::info("retry failed. msg = %s", err_msg);
+      wcl::log::fatal("Cache::read(): daemon exited without responding");
+    }
+
+    // MessageParser tries to avoid this but we should defend against
+    // the case where no error has yet occured but messages is still empty.
+    if (state == MessageParserState::Continue && messages.empty()) {
+      continue;
+    }
+
+    if (messages.size() != 1) {
+      wcl::log::info("message.size() == %lu", messages.size());
+      for (const auto &message : messages) {
+        wcl::log::info("message.size() = %lu, message = '%s'", message.size(), message.c_str());
+      }
+      wcl::log::fatal("Cache::read(): daemon responded with too many results");
+    }
+
+    break;
+  }
+
+  wcl::log::info("Cache::read(): message rx: %s", messages[0].c_str());
+
+  JAST json;
+  std::stringstream parseErrors;
+  if (!JAST::parse(messages[0], parseErrors, json)) {
+    wcl::log::fatal("Cache::read(): failed to parse daemon response");
+  }
+
+  return FindJobResponse(json);
 }
 
 FindJobResponse Cache::read(const FindJobRequest &find_request) {
@@ -219,17 +290,11 @@ FindJobResponse Cache::read(const FindJobRequest &find_request) {
     MessageParserState state = parser.read_messages(messages);
 
     if (state == MessageParserState::StopFail) {
-      // TODO: Try to reconnect to the daemon, launching our own if need be.
-      //       if that fails then depending on user preference either fail
-      //       or return a cache miss.
-      wcl::log::fatal("Cache::read(): failed receiving message");
+      return retry_read(find_request, "Cache::read(): failed receiving message");
     }
 
     if (state == MessageParserState::StopSuccess && messages.empty()) {
-      // TODO: Try to reconnect to the daemon, launching our own if need be.
-      //       if that fails then depending on user preference either fail
-      //       or return a cache miss.
-      wcl::log::fatal("Cache::read(): daemon exited without responding");
+      return retry_read(find_request, "Cache::read(): daemon exited without responding");
     }
 
     // MessageParser tries to avoid this but we should defend against

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -38,7 +38,6 @@
 namespace job_cache {
 
 enum class ConnectError {
-  FailedToLaunchDaemon,
   TooManyAttempts,
 };
 

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -58,7 +58,7 @@ class Cache {
   uint64_t max_size;
   uint64_t low_threshold;
 
-  wcl::optional<ConnectError> launch_daemon();
+  void launch_daemon();
   wcl::optional<ConnectError> backoff_try_connect(int attempts);
   wcl::result<FindJobResponse, FindJobError> read_impl(const FindJobRequest &find_request);
 

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -28,6 +28,7 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include <wcl/optional.h>
+#include <wcl/result.h>
 #include <wcl/unique_fd.h>
 
 #include <string>
@@ -35,6 +36,13 @@
 #include "types.h"
 
 namespace job_cache {
+
+enum class FindJobError {
+  FailedMessageReceive,
+  NoResponse,
+  TooManyResponses,
+  FailedParseResponse,
+};
 
 class Cache {
  private:
@@ -46,8 +54,8 @@ class Cache {
   uint64_t low_threshold;
 
   void launch_daemon();
-  void backoff_try_connect();
-  FindJobResponse retry_read(const FindJobRequest &find_request, const char *err_msg);
+  void backoff_try_connect(int attempts);
+  wcl::result<FindJobResponse, FindJobError> read_impl(const FindJobRequest &find_request);
 
  public:
   Cache() = delete;

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -40,6 +40,15 @@ class Cache {
  private:
   wcl::unique_fd socket_fd;
 
+  // Daemon parameters
+  std::string cache_dir;
+  uint64_t max_size;
+  uint64_t low_threshold;
+
+  void launch_daemon();
+  void backoff_try_connect();
+  FindJobResponse retry_read(const FindJobRequest &find_request, const char *err_msg);
+
  public:
   Cache() = delete;
   Cache(const Cache &) = delete;

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -37,6 +37,11 @@
 
 namespace job_cache {
 
+enum class ConnectError {
+  FailedToLaunchDaemon,
+  TooManyAttempts,
+};
+
 enum class FindJobError {
   FailedMessageReceive,
   NoResponse,
@@ -53,8 +58,8 @@ class Cache {
   uint64_t max_size;
   uint64_t low_threshold;
 
-  void launch_daemon();
-  void backoff_try_connect(int attempts);
+  wcl::optional<ConnectError> launch_daemon();
+  wcl::optional<ConnectError> backoff_try_connect(int attempts);
   wcl::result<FindJobResponse, FindJobError> read_impl(const FindJobRequest &find_request);
 
  public:


### PR DESCRIPTION
This is a repush of https://github.com/sifive/wake/pull/1279 rebased and re-targeted to master. There was a bunch of merge conflict I didn't want to deal with so I'll just close that PR after comments from it are resolved here.

Job cache client now attempts to recover from several failure modes related to the job cache daemon. Launching and connecting to the daemon is reattempted several times with backoff. Cache read requests are also retried including relaunching and reconnecting to the daemon with backoff. After a set number of attempts the retries will give up and fail. Currently on failure wake will exit with code `1` however the scaffolding is in place so that wake can later be configured to just return a cache miss on failure