### PR TITLE
breadcrumb prim, filter subscriber, log cleanup

### DIFF
--- a/share/wake/lib/core/print.wake
+++ b/share/wake/lib/core/print.wake
@@ -100,3 +100,18 @@ export def printlnLevel (LogLevel name) (message: String): Unit =
 #   def Unit = println "{integerToUnicode 0x1f600}"
 export def println: String => Unit =
     printlnLevel logReport
+
+# breadcrumb: Leaves an out of band message in the wake internal log
+#
+# This should primarily be used by core/standard libraries over normal user code.
+# However it can be useful for tracing or debugging wake code out of band. The contents
+# of the log may only be inspected outside of wake and thus any breakcrumbs are
+# "blackholed" from the perspective of wakelang.
+#
+#   # Emit a structured message to 'wake.log'
+#   def _ = breadcrumb "encountered failing event"
+export def breadcrumb (x: String): Unit =
+    def p s = prim "breadcrumb"
+
+    p x
+

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -73,6 +73,7 @@ static void lock_file(const char *lock_path) {
   if (errno == EAGAIN || errno == EACCES) {
     wcl::log::info("fcntl(F_SETLK, %s): %s -- assuming another daemon exists, closing", lock_path,
                    strerror(errno))();
+    exit(0);
   }
 
   // Something went wrong trying to grab the lock

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -47,7 +47,8 @@ using namespace job_cache;
 static int open_fd(const char *str, int flags, mode_t mode) {
   int fd = open(str, flags, mode);
   if (fd == -1) {
-    wcl::log::fatal("open(%s): %s", str, strerror(errno));
+    wcl::log::error("open(%s): %s", str, strerror(errno)).urgent()();
+    exit(1);
   }
   return fd;
 }
@@ -70,13 +71,13 @@ static void lock_file(const char *lock_path) {
 
   // Some other process has the lock, they are the daemon
   if (errno == EAGAIN || errno == EACCES) {
-    int pid = getpid();
-    wcl::log::exit("fcntl(F_SETLK, %s): %s -- assuming another daemon exists, closing pid=%d",
-                   lock_path, strerror(errno), pid);
+    wcl::log::info("fcntl(F_SETLK, %s): %s -- assuming another daemon exists, closing", lock_path,
+                   strerror(errno))();
   }
 
   // Something went wrong trying to grab the lock
-  wcl::log::fatal("fcntl(F_SETLK, %s): %s", lock_path, strerror(errno));
+  wcl::log::error("fcntl(F_SETLK, %s): %s", lock_path, strerror(errno)).urgent()();
+  exit(1);
 }
 
 static void create_file(const char *tmp_path, const char *final_path, const char *data,
@@ -87,16 +88,19 @@ static void create_file(const char *tmp_path, const char *final_path, const char
   {
     auto create_fd = wcl::unique_fd::open(tmp_path, O_CREAT | O_RDWR, 0644);
     if (!create_fd) {
-      wcl::log::fatal("open(%s): %s", tmp_path, strerror(create_fd.error()));
+      wcl::log::error("open(%s): %s", tmp_path, strerror(create_fd.error())).urgent()();
+      exit(1);
     }
 
     if (write(create_fd->get(), data, size) == -1) {
-      wcl::log::fatal("write(%s): %s", tmp_path, strerror(errno));
+      wcl::log::error("write(%s): %s", tmp_path, strerror(errno)).urgent()();
+      exit(1);
     }
   }
 
   if (rename(tmp_path, final_path) == -1) {
-    wcl::log::fatal("rename(%s, %s): %s", tmp_path, final_path, strerror(errno));
+    wcl::log::error("rename(%s, %s): %s", tmp_path, final_path, strerror(errno)).urgent()();
+    exit(1);
   }
 }
 
@@ -109,7 +113,8 @@ static int open_abstract_domain_socket(const std::string &key) {
   //   5) Later some other code can accept in a loop (with epoll lets say)
   int socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
   if (socket_fd == -1) {
-    wcl::log::fatal("socket(AF_UNIX, SOCK_STREAM, 0): %s", strerror(errno));
+    wcl::log::error("socket(AF_UNIX, SOCK_STREAM, 0): %s", strerror(errno)).urgent()();
+    exit(1);
   }
 
   // By adding a null character to the start of this socket address we're creating
@@ -121,16 +126,18 @@ static int open_abstract_domain_socket(const std::string &key) {
 
   // The length needs to cover the whole path field so we add 1 to size of the key.
   if (bind(socket_fd, reinterpret_cast<const sockaddr *>(&addr), key.size() + 1)) {
-    wcl::log::fatal("bind(key = %s): %s", key.c_str(), strerror(errno));
+    wcl::log::error("bind(key = %s): %s", key.c_str(), strerror(errno)).urgent()();
+    exit(1);
   }
-  wcl::log::info("Successfully bound abstract socket = %s", key.c_str());
+  wcl::log::info("Successfully bound abstract socket = %s", key.c_str())();
 
   // Now we just need to set this socket to listen and we're good!
   // TODO: Decide what the backlog should actually be
   if (listen(socket_fd, 256) == -1) {
-    wcl::log::fatal("listen(%s): %s", key.c_str(), strerror(errno));
+    wcl::log::error("listen(%s): %s", key.c_str(), strerror(errno)).urgent()();
+    exit(1);
   }
-  wcl::log::info("Successfully set abstract socket %s to listen", key.c_str());
+  wcl::log::info("Successfully set abstract socket %s to listen", key.c_str())();
 
   return socket_fd;
 }
@@ -153,7 +160,7 @@ int create_cache_socket(const std::string &dir, const std::string &key) {
 
   // Create the key file that clients can read the domain
   // socket name from.
-  wcl::log::info("key = %s", key.c_str());
+  wcl::log::info("key = %s", key.c_str())();
   std::string gen_path = dir + "/" + key;
   create_file(gen_path.c_str(), key_path.c_str(), key.data(), key.size());
 
@@ -543,7 +550,7 @@ struct CacheDbImpl {
 DaemonCache::DaemonCache(std::string dir, uint64_t max, uint64_t low)
     : rng(wcl::xoshiro_256::get_rng_seed()), max_cache_size(max), low_cache_size(low) {
   wcl::log::info("Launching DaemonCache. dir = %s, max = %lu, low = %lu", dir.c_str(),
-                 max_cache_size, low_cache_size);
+                 max_cache_size, low_cache_size)();
   mkdir_no_fail(dir.c_str());
   chdir_no_fail(dir.c_str());
 
@@ -559,7 +566,7 @@ DaemonCache::DaemonCache(std::string dir, uint64_t max, uint64_t low)
 int DaemonCache::run() {
   auto cleanup = wcl::make_defer([]() {
     unlink_no_fail(".key");
-    wcl::log::info("Exiting run loop.");
+    wcl::log::info("Exiting run loop.")();
   });
 
   poll.add(listen_socket_fd);
@@ -572,7 +579,7 @@ int DaemonCache::run() {
     auto fds = poll.wait(&wait_until, nullptr);
 
     if (fds.empty() && message_parsers.empty()) {
-      wcl::log::info("No initial connection for 10 mins, exiting.");
+      wcl::log::info("No initial connection for 10 mins, exiting.")();
       return 0;
     }
 
@@ -677,7 +684,8 @@ FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {
       auto pair = rewite_path(sandbox_destination);
 
       if (wcl::is_relative(pair.first)) {
-        wcl::log::fatal("'%s' must be an absolute path.", pair.first.c_str());
+        wcl::log::error("'%s' must be an absolute path.", pair.first.c_str()).urgent()();
+        exit(1);
       }
 
       // First make all the needed directories in case the output
@@ -698,7 +706,8 @@ FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {
       auto pair = rewite_path(output_symlink.path);
 
       if (wcl::is_relative(pair.first)) {
-        wcl::log::fatal("'%s' must be an absolute path.", pair.first.c_str());
+        wcl::log::error("'%s' must be an absolute path.", pair.first.c_str()).urgent()();
+        exit(1);
       }
 
       // First make all the needed directories in case the output
@@ -770,7 +779,7 @@ FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {
   msg += '\0';
 
   if (write(evict_stdin, msg.data(), msg.size()) == -1) {
-    wcl::log::warning("Failed to send eviction update: %s", strerror(errno));
+    wcl::log::warning("Failed to send eviction update: %s", strerror(errno))();
   }
 
   return FindJobResponse(wcl::make_some<MatchingJob>(std::move(result)));
@@ -856,7 +865,7 @@ void DaemonCache::add(const AddJobRequest &add_request) {
   msg += '\0';
 
   if (write(evict_stdin, msg.data(), msg.size()) == -1) {
-    wcl::log::warning("Failed to send eviction update: %s", strerror(errno));
+    wcl::log::warning("Failed to send eviction update: %s", strerror(errno))();
   }
 }
 
@@ -868,28 +877,35 @@ void DaemonCache::launch_evict_loop() {
   int stdoutPipe[2];
 
   if (pipe(stdinPipe) < 0) {
-    wcl::log::fatal("Failed to allocate eviction pipe: %s", strerror(errno));
+    wcl::log::error("Failed to allocate eviction pipe: %s", strerror(errno)).urgent()();
+    exit(1);
   }
 
   if (pipe(stdoutPipe) < 0) {
-    wcl::log::fatal("Failed to allocate eviction pipe: %s", strerror(errno));
+    wcl::log::error("Failed to allocate eviction pipe: %s", strerror(errno)).urgent()();
+    exit(1);
   }
 
   int pid = fork();
 
   // error forking
   if (pid < 0) {
-    wcl::log::fatal("Failed to fork eviction process: %s", strerror(errno));
+    wcl::log::error("Failed to fork eviction process: %s", strerror(errno)).urgent()();
+    exit(1);
   }
 
   // child
   if (pid == 0) {
     if (dup2(stdinPipe[read_side], STDIN_FILENO) == -1) {
-      wcl::log::fatal("Failed to dup2 stdin pipe for eviction process: %s", strerror(errno));
+      wcl::log::error("Failed to dup2 stdin pipe for eviction process: %s", strerror(errno))
+          .urgent()();
+      exit(1);
     }
 
     if (dup2(stdoutPipe[write_side], STDOUT_FILENO) == -1) {
-      wcl::log::fatal("Failed to dup2 stdin pipe for eviction process: %s", strerror(errno));
+      wcl::log::error("Failed to dup2 stdin pipe for eviction process: %s", strerror(errno))
+          .urgent()();
+      exit(1);
     }
 
     close(stdinPipe[read_side]);
@@ -927,12 +943,13 @@ void DaemonCache::handle_new_client() {
   // Accept the new client socket.
   int accept_fd = accept4(listen_socket_fd, nullptr, nullptr, SOCK_CLOEXEC);
   if (accept_fd == -1) {
-    wcl::log::fatal("accept(%s): %s", key.c_str(), strerror(errno));
+    wcl::log::error("accept(%s): %s", key.c_str(), strerror(errno)).urgent()();
+    exit(1);
   }
 
   poll.add(accept_fd);
   message_parsers.insert({accept_fd, MessageParser(accept_fd)});
-  wcl::log::info("new client connected: %d", accept_fd);
+  wcl::log::info("new client connected: %d", accept_fd)();
 }
 
 void DaemonCache::handle_msg(int client_fd) {
@@ -944,19 +961,21 @@ void DaemonCache::handle_msg(int client_fd) {
 
   auto it = message_parsers.find(client_fd);
   if (it == message_parsers.end()) {
-    wcl::log::fatal("unreachable: message_parsers out of sync with poll. client_fd = %d",
-                    client_fd);
+    wcl::log::error("unreachable: message_parsers out of sync with poll. client_fd = %d", client_fd)
+        .urgent()();
+    exit(1);
   }
 
   state = it->second.read_messages(msgs);
 
   for (const auto &msg : msgs) {
-    wcl::log::info("msg: %s", msg.c_str());
+    wcl::log::info("msg: %s", msg.c_str())();
 
     JAST json;
     std::stringstream parseErrors;
     if (!JAST::parse(msg, parseErrors, json)) {
-      wcl::log::fatal("DaemonCache::handle_msg(): failed to parse client request");
+      wcl::log::error("DaemonCache::handle_msg(): failed to parse client request").urgent()();
+      exit(1);
     }
 
     if (json.get("method").value == "cache/read") {
@@ -973,20 +992,21 @@ void DaemonCache::handle_msg(int client_fd) {
 
   // If the file was closed, remove from epoll and close it.
   if (state == MessageParserState::StopSuccess) {
-    wcl::log::info("closing client fd = %d", client_fd);
+    wcl::log::info("closing client fd = %d", client_fd)();
     poll.remove(client_fd);
     close(client_fd);
     message_parsers.erase(client_fd);
     if (message_parsers.empty()) {
       exit_now = true;
-      wcl::log::info("All clients disconnected, exiting.");
+      wcl::log::info("All clients disconnected, exiting.")();
     }
     return;
   }
 
   // If there's an error just fail.
   if (state == MessageParserState::StopFail) {
-    wcl::log::fatal("read(%d), key = %s:", client_fd, strerror(errno));
+    wcl::log::error("read(%d), key = %s:", client_fd, strerror(errno)).urgent()();
+    exit(1);
   }
 }
 

--- a/src/job_cache/eviction_policy.cpp
+++ b/src/job_cache/eviction_policy.cpp
@@ -148,7 +148,8 @@ struct LRUEvictionPolicyImpl {
 
       // Unless result is a row something awful has occured.
       if (result != SQLITE_DONE) {
-        wcl::log::fatal("get_last_use result was unexpected: %d", result);
+        wcl::log::error("get_last_use result was unexpected: %d", result).urgent()();
+        exit(1);
       }
 
       insert_last_use.bind_integer(1, job_id);

--- a/src/job_cache/job_cache_impl_common.cpp
+++ b/src/job_cache/job_cache_impl_common.cpp
@@ -42,40 +42,46 @@
 // moves the file or directory, crashes on error
 void rename_no_fail(const char *old_path, const char *new_path) {
   if (rename(old_path, new_path) < 0) {
-    wcl::log::fatal("rename(%s, %s): %s", old_path, new_path, strerror(errno));
+    wcl::log::error("rename(%s, %s): %s", old_path, new_path, strerror(errno)).urgent()();
+    exit(1);
   }
 }
 
 // Ensures the the given directory has been created
 void mkdir_no_fail(const char *dir) {
   if (mkdir(dir, 0777) < 0 && errno != EEXIST) {
-    wcl::log::fatal("mkdir(%s): %s", dir, strerror(errno));
+    wcl::log::error("mkdir(%s): %s", dir, strerror(errno)).urgent()();
+    exit(1);
   }
 }
 
 void chdir_no_fail(const char *dir) {
   if (chdir(dir) < 0) {
-    wcl::log::fatal("chdir(%s): %s", dir, strerror(errno));
+    wcl::log::error("chdir(%s): %s", dir, strerror(errno)).urgent()();
+    exit(1);
   }
 }
 
 void symlink_no_fail(const char *target, const char *symlink_path) {
   if (symlink(target, symlink_path) == -1) {
-    wcl::log::fatal("symlink(%s, %s): %s", target, symlink_path, strerror(errno));
+    wcl::log::error("symlink(%s, %s): %s", target, symlink_path, strerror(errno)).urgent()();
+    exit(1);
   }
 }
 
 // Ensures the given file has been deleted
 void unlink_no_fail(const char *file) {
   if (unlink(file) < 0 && errno != ENOENT) {
-    wcl::log::fatal("unlink(%s): %s", file, strerror(errno));
+    wcl::log::error("unlink(%s): %s", file, strerror(errno)).urgent()();
+    exit(1);
   }
 }
 
 // Ensures the the given directory no longer exists
 void rmdir_no_fail(const char *dir) {
   if (rmdir(dir) < 0 && errno != ENOENT) {
-    wcl::log::fatal("rmdir(%s): %s", dir, strerror(errno));
+    wcl::log::error("rmdir(%s): %s", dir, strerror(errno)).urgent()();
+    exit(1);
   }
 }
 
@@ -93,20 +99,25 @@ static void copy(int src_fd, int dst_fd) {
   struct stat buf = {};
   // There's a race here between the fstat and the copy_file_range
   if (fstat(src_fd, &buf) < 0) {
-    wcl::log::fatal("fstat(src_fd = %d): %s", src_fd, strerror(errno));
+    wcl::log::error("fstat(src_fd = %d): %s", src_fd, strerror(errno)).urgent()();
+    exit(1);
   }
 
   // TODO: This is very slow because FdBuf is very slow
   // TODO: This will read large files into memory which is very bad
   std::vector<char> data_buf(buf.st_size);
   if (!in.read(data_buf.data(), buf.st_size)) {
-    wcl::log::fatal("copy.read(src_fd = %d, NULL, dst_fd = %d, size = %d): %s", src_fd, dst_fd,
-                    buf.st_size, strerror(errno));
+    wcl::log::error("copy.read(src_fd = %d, NULL, dst_fd = %d, size = %d): %s", src_fd, dst_fd,
+                    buf.st_size, strerror(errno))
+        .urgent()();
+    exit(1);
   }
 
   if (!out.write(data_buf.data(), buf.st_size)) {
-    wcl::log::fatal("copy.write(src_fd = %d, NULL, dst_fd = %d, size = %d): %s", src_fd, dst_fd,
-                    buf.st_size, strerror(errno));
+    wcl::log::error("copy.write(src_fd = %d, NULL, dst_fd = %d, size = %d): %s", src_fd, dst_fd,
+                    buf.st_size, strerror(errno))
+        .urgent()();
+    exit(1);
   }
 }
 
@@ -128,11 +139,14 @@ static void copy(int src_fd, int dst_fd) {
   struct stat buf = {};
   // There's a race here between the fstat and the copy_file_range
   if (fstat(src_fd, &buf) < 0) {
-    wcl::log::fatal("fstat(src_fd = %d): %s", src_fd, strerror(errno));
+    wcl::log::error("fstat(src_fd = %d): %s", src_fd, strerror(errno)).urgent()();
+    exit(1);
   }
   if (copy_file_range(src_fd, nullptr, dst_fd, nullptr, buf.st_size, 0) < 0) {
-    wcl::log::fatal("copy_file_range(src_fd = %d, NULL, dst_fd = %d, size = %ld, 0): %s", src_fd,
-                    dst_fd, buf.st_size, strerror(errno));
+    wcl::log::error("copy_file_range(src_fd = %d, NULL, dst_fd = %d, size = %ld, 0): %s", src_fd,
+                    dst_fd, buf.st_size, strerror(errno))
+        .urgent()();
+    exit(1);
   }
 }
 
@@ -154,15 +168,18 @@ static void copy(int src_fd, int dst_fd) {
   struct stat buf = {};
   // There's a race here between the fstat and the copy_file_range
   if (fstat(src_fd, &buf) < 0) {
-    wcl::log::fatal("fstat(src_fd = %d): %s", src_fd, strerror(errno));
+    wcl::log::error("fstat(src_fd = %d): %s", src_fd, strerror(errno)).urgent()();
+    exit(1);
   }
   off_t idx = 0;
   size_t size = buf.st_size;
   do {
     intptr_t written = sendfile(dst_fd, src_fd, &idx, size);
     if (written < 0) {
-      wcl::log::fatal("sendfile(src_fd = %d, NULL, dst_fd = %d, size = %d, 0): %s", src_fd, dst_fd,
-                      buf.st_size, strerror(errno));
+      wcl::log::error("sendfile(src_fd = %d, NULL, dst_fd = %d, size = %d, 0): %s", src_fd, dst_fd,
+                      buf.st_size, strerror(errno))
+          .urgent()();
+      exit(1);
     }
     idx = written;
     size -= written;
@@ -175,16 +192,19 @@ static void copy(int src_fd, int dst_fd) {
 void copy_or_reflink(const char *src, const char *dst, mode_t mode, int extra_flags) {
   auto src_fd = wcl::unique_fd::open(src, O_RDONLY);
   if (!src_fd) {
-    wcl::log::fatal("open(%s): %s", src, strerror(src_fd.error()));
+    wcl::log::error("open(%s): %s", src, strerror(src_fd.error())).urgent()();
+    exit(1);
   }
   auto dst_fd = wcl::unique_fd::open(dst, O_WRONLY | O_CREAT | extra_flags, mode);
   if (!dst_fd) {
-    wcl::log::fatal("open(%s): %s", dst, strerror(dst_fd.error()));
+    wcl::log::error("open(%s): %s", dst, strerror(dst_fd.error())).urgent()();
+    exit(1);
   }
 
   if (ioctl(dst_fd->get(), FICLONE, src_fd->get()) < 0) {
     if (errno != EINVAL && errno != EOPNOTSUPP && errno != EXDEV) {
-      wcl::log::fatal("ioctl(%s, FICLONE, %s): %s", dst, src, strerror(errno));
+      wcl::log::error("ioctl(%s, FICLONE, %s): %s", dst, src, strerror(errno)).urgent()();
+      exit(1);
     }
     copy(src_fd->get(), dst_fd->get());
   }
@@ -195,11 +215,13 @@ void copy_or_reflink(const char *src, const char *dst, mode_t mode, int extra_fl
 void copy_or_reflink(const char *src, const char *dst, mode_t mode, int extra_flags) {
   auto src_fd = wcl::unique_fd::open(src, O_RDONLY);
   if (!src_fd) {
-    wcl::log::fatal("open(%s): %s", src, strerror(src_fd.error()));
+    wcl::log::error("open(%s): %s", src, strerror(src_fd.error())).urgent()();
+    exit(1);
   }
   auto dst_fd = wcl::unique_fd::open(dst, O_WRONLY | O_CREAT | extra_flags, mode);
   if (!dst_fd) {
-    wcl::log::fatal("open(%s): %s", dst, strerror(dst_fd.error()));
+    wcl::log::error("open(%s): %s", dst, strerror(dst_fd.error())).urgent()();
+    exit(1);
   }
 
   copy(src_fd->get(), dst_fd->get());
@@ -212,18 +234,22 @@ void remove_backing_files(const std::string &dir, int64_t job_id) {
   std::string job_dir = wcl::join_paths(dir, wcl::to_hex(&group_id), std::to_string(job_id));
   auto dir_range = wcl::directory_range::open(job_dir);
   if (!dir_range) {
-    wcl::log::fatal("opendir(%s): %s", job_dir.c_str(), strerror(dir_range.error()));
+    wcl::log::error("opendir(%s): %s", job_dir.c_str(), strerror(dir_range.error())).urgent()();
+    exit(1);
   }
 
   // loop over the directory now and delete any files as we go.
   for (const auto &entry : *dir_range) {
     if (!entry) {
-      wcl::log::fatal("readdir(%s): %s", job_dir.c_str(), strerror(entry.error()));
+      wcl::log::error("readdir(%s): %s", job_dir.c_str(), strerror(entry.error())).urgent()();
+      exit(1);
     }
     if (entry->name == "." || entry->name == "..") continue;
     if (entry->type != wcl::file_type::regular) {
-      wcl::log::fatal("remove_backing_files(%s): found non-regular entry: %s", job_dir.c_str(),
-                      entry->name.c_str());
+      wcl::log::error("remove_backing_files(%s): found non-regular entry: %s", job_dir.c_str(),
+                      entry->name.c_str())
+          .urgent()();
+      exit(1);
     }
     unlink_no_fail(entry->name.c_str());
   }
@@ -276,7 +302,8 @@ void send_json_message(int fd, const JAST &json) {
       if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
         continue;
       }
-      wcl::log::fatal("write(%d): %s", fd, strerror(errno));
+      wcl::log::error("write(%d): %s", fd, strerror(errno)).urgent()();
+      exit(1);
     }
 
     start += res;

--- a/src/job_cache/types.cpp
+++ b/src/job_cache/types.cpp
@@ -38,7 +38,8 @@ static Hash256 do_hash_file(const char *file, int fd) {
   blake2b_final(&S, &hash[0], sizeof(hash));
 
   if (got < 0) {
-    wcl::log::fatal("job-cache hash read(%s): %s", file, strerror(errno));
+    wcl::log::error("job-cache hash read(%s): %s", file, strerror(errno)).urgent()();
+    exit(1);
   }
 
   return Hash256::from_hash(&hash);
@@ -288,8 +289,10 @@ AddJobRequest AddJobRequest::from_implicit(const JAST &json) {
   AddJobRequest req;
   req.wakeroot = json.get("wakeroot").value;
   if (wcl::is_relative(req.wakeroot)) {
-    wcl::log::fatal("AddJobRequest::from_implicit: wakeroot cannot be relative. found: '%s'",
-                    req.wakeroot.c_str());
+    wcl::log::error("AddJobRequest::from_implicit: wakeroot cannot be relative. found: '%s'",
+                    req.wakeroot.c_str())
+        .urgent()();
+    exit(1);
   }
   req.cwd = json.get("cwd").value;
   if (wcl::is_relative(req.cwd)) {
@@ -308,8 +311,10 @@ AddJobRequest AddJobRequest::from_implicit(const JAST &json) {
   req.obytes = std::stoull(json.get("obytes").value);
   req.client_cwd = json.get("client_cwd").value;
   if (wcl::is_relative(req.client_cwd)) {
-    wcl::log::fatal("AddJobRequest::from_implicit: client_cwd cannot be relative. found: '%s'",
-                    req.client_cwd.c_str());
+    wcl::log::error("AddJobRequest::from_implicit: client_cwd cannot be relative. found: '%s'",
+                    req.client_cwd.c_str())
+        .urgent()();
+    exit(1);
   }
 
   // Read the input files
@@ -353,7 +358,8 @@ AddJobRequest AddJobRequest::from_implicit(const JAST &json) {
       src = wcl::join_paths(req.client_cwd, src);
     }
     if (lstat(src.c_str(), &buf) < 0) {
-      wcl::log::fatal("lstat(%s): %s", src.c_str(), strerror(errno));
+      wcl::log::error("lstat(%s): %s", src.c_str(), strerror(errno)).urgent()();
+      exit(1);
     }
 
     // Handle output directory
@@ -375,7 +381,8 @@ AddJobRequest AddJobRequest::from_implicit(const JAST &json) {
       static thread_local char link[4097];
       int size = readlink(src.c_str(), link, sizeof(link));
       if (size == -1) {
-        wcl::log::fatal("readlink(%s): %s", src.c_str(), strerror(errno));
+        wcl::log::error("readlink(%s): %s", src.c_str(), strerror(errno)).urgent()();
+        exit(1);
       }
       sym.path = output_file.second.get("path").value;
       // Canonicalize output symlink paths to sandbox-absolute paths.
@@ -403,7 +410,8 @@ AddJobRequest AddJobRequest::from_implicit(const JAST &json) {
 
     auto fd = wcl::unique_fd::open(output.source.c_str(), O_RDONLY);
     if (!fd) {
-      wcl::log::fatal("open(%s): %s", output.source.c_str(), strerror(fd.error()));
+      wcl::log::error("open(%s): %s", output.source.c_str(), strerror(fd.error())).urgent()();
+      exit(1);
     }
     output.hash = do_hash_file(output.source.c_str(), fd->get());
     output.mode = buf.st_mode;
@@ -416,8 +424,10 @@ AddJobRequest AddJobRequest::from_implicit(const JAST &json) {
 AddJobRequest::AddJobRequest(const JAST &json) {
   wakeroot = json.get("wakeroot").value;
   if (wcl::is_relative(wakeroot)) {
-    wcl::log::fatal("AddJobRequest::AddJobRequest: wakeroot cannot be relative. found: '%s'",
-                    wakeroot.c_str());
+    wcl::log::error("AddJobRequest::AddJobRequest: wakeroot cannot be relative. found: '%s'",
+                    wakeroot.c_str())
+        .urgent()();
+    exit(1);
   }
   cwd = json.get("cwd").value;
   if (wcl::is_relative(cwd)) {
@@ -436,8 +446,10 @@ AddJobRequest::AddJobRequest(const JAST &json) {
   obytes = std::stoull(json.get("obytes").value);
   client_cwd = json.get("client_cwd").value;
   if (wcl::is_relative(client_cwd)) {
-    wcl::log::fatal("AddJobRequest::AddJobRequest: client_cwd cannot be relative. found: '%s'",
-                    client_cwd.c_str());
+    wcl::log::error("AddJobRequest::AddJobRequest: client_cwd cannot be relative. found: '%s'",
+                    client_cwd.c_str())
+        .urgent()();
+    exit(1);
   }
 
   // Read the input files
@@ -547,8 +559,10 @@ JAST AddJobRequest::to_json() const {
 FindJobRequest::FindJobRequest(const JAST &find_job_json) {
   wakeroot = find_job_json.get("wakeroot").value;
   if (wcl::is_relative(wakeroot)) {
-    wcl::log::fatal("FindJobRequest::FindJobRequest: wakeroot cannot be relative. found: '%s'",
-                    wakeroot.c_str());
+    wcl::log::error("FindJobRequest::FindJobRequest: wakeroot cannot be relative. found: '%s'",
+                    wakeroot.c_str())
+        .urgent()();
+    exit(1);
   }
   cwd = find_job_json.get("cwd").value;
   if (wcl::is_relative(cwd)) {
@@ -559,8 +573,10 @@ FindJobRequest::FindJobRequest(const JAST &find_job_json) {
   stdin_str = find_job_json.get("stdin").value;
   client_cwd = find_job_json.get("client_cwd").value;
   if (wcl::is_relative(client_cwd)) {
-    wcl::log::fatal("FindJobRequest::FindJobRequest: client_cwd cannot be relative. found: '%s'",
-                    client_cwd.c_str());
+    wcl::log::error("FindJobRequest::FindJobRequest: client_cwd cannot be relative. found: '%s'",
+                    client_cwd.c_str())
+        .urgent()();
+    exit(1);
   }
 
   // Read the input files, and compute the directory hashes as we go.

--- a/src/runtime/string.cpp
+++ b/src/runtime/string.cpp
@@ -186,7 +186,7 @@ static PRIMFN(prim_breadcrumb) {
   EXPECT(1);
   STRING(request_str, 0);
 
-  wcl::log::info({{"source", "wake"}}, request_str->c_str());
+  wcl::log::info(request_str->c_str())({{"source", "wake"}});
 
   runtime.heap.reserve(reserve_unit());
   RETURN(claim_unit(runtime.heap));

--- a/src/runtime/string.cpp
+++ b/src/runtime/string.cpp
@@ -42,6 +42,7 @@
 #include "util/term.h"
 #include "util/unlink.h"
 #include "value.h"
+#include "wcl/tracing.h"
 #include "wcl/xoshiro_256.h"
 
 static PRIMFN(prim_vcat) {
@@ -175,6 +176,20 @@ static PRIMTYPE(type_read) {
   result[0].unify(Data::typeString);
   result[1].unify(Data::typeString);
   return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(result);
+}
+
+static PRIMTYPE(type_breadcrumb) {
+  return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(Data::typeUnit);
+}
+
+static PRIMFN(prim_breadcrumb) {
+  EXPECT(1);
+  STRING(request_str, 0);
+
+  wcl::log::info({{"source", "wake"}}, request_str->c_str());
+
+  runtime.heap.reserve(reserve_unit());
+  RETURN(claim_unit(runtime.heap));
 }
 
 static PRIMFN(prim_read) {
@@ -673,4 +688,5 @@ void prim_register_string(PrimMap &pmap, StringInfo *info) {
   prim_register(pmap, "unlink", prim_unlink, type_unlink, PRIM_IMPURE);
   prim_register(pmap, "write", prim_write, type_write, PRIM_IMPURE);
   prim_register(pmap, "read", prim_read, type_read, PRIM_ORDERED);
+  prim_register(pmap, "breadcrumb", prim_breadcrumb, type_breadcrumb, PRIM_IMPURE);
 }

--- a/src/wcl/tracing.cpp
+++ b/src/wcl/tracing.cpp
@@ -37,15 +37,12 @@ void subscribe(std::unique_ptr<Subscriber> subscriber) {
 
 void clear_subscribers() { subscribers.clear(); }
 
-void publish(Event e) {
-  for (const auto& subscriber : subscribers) {
-    subscriber->receive(e);
-  }
+Event event() {
+  Event e({});
+  return e;
 }
 
-static void log_message(const char* level,
-                        std::initializer_list<std::pair<const std::string, std::string>> list,
-                        const char* fmt, va_list args) {
+Event Event::message(const char* fmt, va_list args) && {
   va_list copy;
   va_copy(copy, args);
 
@@ -57,97 +54,80 @@ static void log_message(const char* level,
   std::string out = buffer.data();
   out += '\n';
 
-  time_t t = time(NULL);
+  items[LOG_MESSAGE] = std::move(out);
+  return std::move(*this);
+}
+
+Event Event::message(const char* fmt, ...) && {
+  va_list args;
+  va_start(args, fmt);
+  auto defer = make_defer([&]() { va_end(args); });
+  return std::move(*this).message(fmt, args);
+}
+
+Event Event::urgent() && {
+  items[URGENT] = "1";
+  return std::move(*this);
+}
+
+Event Event::time() && {
+  time_t t = ::time(NULL);
   struct tm tm = *localtime(&t);
   char time_buffer[20 + 1];
   strftime(time_buffer, sizeof(time_buffer), "%F %T", &tm);
+  items[LOG_TIME] = time_buffer;
 
-  Event e(list);
-  e.items[LOG_LEVEL] = level;
-  e.items[LOG_MESSAGE] = std::move(out);
-  e.items[LOG_PID] = std::to_string(getpid());
-  e.items[LOG_TIME] = time_buffer;
-
-  publish(e);
+  return std::move(*this);
 }
 
-void info(const char* fmt, ...) {
+Event Event::pid() && {
+  items[LOG_PID] = std::to_string(getpid());
+  return std::move(*this);
+}
+
+Event Event::info() && {
+  items[LOG_LEVEL] = LOG_LEVEL_INFO;
+  return std::move(*this);
+}
+
+Event Event::warning() && {
+  items[LOG_LEVEL] = LOG_LEVEL_WARNING;
+  return std::move(*this);
+}
+
+Event Event::error() && {
+  items[LOG_LEVEL] = LOG_LEVEL_ERROR;
+  return std::move(*this);
+}
+
+void Event::operator()() && {
+  for (const auto& subscriber : subscribers) {
+    subscriber->receive(*this);
+  }
+}
+
+Event info(const char* fmt, ...) {
   va_list args;
   va_start(args, fmt);
   auto defer = make_defer([&]() { va_end(args); });
-  log_message(LOG_LEVEL_INFO, {}, fmt, args);
+
+  return event().info().pid().time().message(fmt, args);
 }
 
-void info(std::initializer_list<std::pair<const std::string, std::string>> list, const char* fmt,
-          ...) {
+Event warning(const char* fmt, ...) {
   va_list args;
   va_start(args, fmt);
   auto defer = make_defer([&]() { va_end(args); });
-  log_message(LOG_LEVEL_INFO, list, fmt, args);
+
+  return event().warning().pid().time().message(fmt, args);
 }
 
-void warning(const char* fmt, ...) {
+Event error(const char* fmt, ...) {
   va_list args;
   va_start(args, fmt);
   auto defer = make_defer([&]() { va_end(args); });
-  log_message(LOG_LEVEL_WARNING, {}, fmt, args);
-}
 
-void warning(std::initializer_list<std::pair<const std::string, std::string>> list, const char* fmt,
-             ...) {
-  va_list args;
-  va_start(args, fmt);
-  auto defer = make_defer([&]() { va_end(args); });
-  log_message(LOG_LEVEL_WARNING, list, fmt, args);
-}
-
-void error(const char* fmt, ...) {
-  va_list args;
-  va_start(args, fmt);
-  auto defer = make_defer([&]() { va_end(args); });
-  log_message(LOG_LEVEL_ERROR, {}, fmt, args);
-}
-
-void error(std::initializer_list<std::pair<const std::string, std::string>> list, const char* fmt,
-           ...) {
-  va_list args;
-  va_start(args, fmt);
-  auto defer = make_defer([&]() { va_end(args); });
-  log_message(LOG_LEVEL_ERROR, list, fmt, args);
-}
-
-void fatal(const char* fmt, ...) {
-  va_list args;
-  va_start(args, fmt);
-  auto defer = make_defer([&]() { va_end(args); });
-  log_message(LOG_LEVEL_FATAL, {}, fmt, args);
-  ::exit(1);
-}
-
-void fatal(std::initializer_list<std::pair<const std::string, std::string>> list, const char* fmt,
-           ...) {
-  va_list args;
-  va_start(args, fmt);
-  auto defer = make_defer([&]() { va_end(args); });
-  log_message(LOG_LEVEL_FATAL, list, fmt, args);
-  ::exit(1);
-}
-
-void exit(const char* fmt, ...) {
-  va_list args;
-  va_start(args, fmt);
-  auto defer = make_defer([&]() { va_end(args); });
-  log_message(LOG_LEVEL_EXIT, {}, fmt, args);
-  ::exit(0);
-}
-
-void exit(std::initializer_list<std::pair<const std::string, std::string>> list, const char* fmt,
-          ...) {
-  va_list args;
-  va_start(args, fmt);
-  auto defer = make_defer([&]() { va_end(args); });
-  log_message(LOG_LEVEL_EXIT, list, fmt, args);
-  ::exit(0);
+  return event().error().pid().time().message(fmt, args);
 }
 
 void FormatSubscriber::receive(const Event& e) {
@@ -172,25 +152,6 @@ void FormatSubscriber::receive(const Event& e) {
   if (auto* value = e.get(LOG_MESSAGE)) {
     s << " " << *value;
   }
-}
-
-void FatalEventSubscriber::receive(const Event& e) {
-  auto level = e.get(LOG_LEVEL);
-  if (level == nullptr) {
-    return;
-  }
-
-  if (*level != LOG_LEVEL_FATAL) {
-    return;
-  }
-
-  auto msg = e.get(LOG_MESSAGE);
-  if (msg == nullptr) {
-    s << "Fatal log was triggered without a message" << std::endl;
-    return;
-  }
-
-  s << *msg;
 }
 
 }  // namespace log

--- a/src/wcl/tracing.cpp
+++ b/src/wcl/tracing.cpp
@@ -138,11 +138,41 @@ void FormatSubscriber::receive(const Event& e) {
     s << item.first << "=" << item.second;
   }
 
-  s << "]";
+  s << "] ";
 
   if (auto* value = e.get(LOG_MESSAGE)) {
-    s << " " << *value;
+    s << *value;
+  } else {
+    s << "<empty message>";
   }
+
+  s << std::endl;
+}
+
+void UrgentSubscriber::receive(const Event& e) {
+  auto urgent = e.get(URGENT);
+  if (urgent == nullptr) {
+    return;
+  }
+
+  std::ostream* s = &std::cout;
+
+  auto level = e.get(LOG_LEVEL);
+  if (level != nullptr && *level == LOG_LEVEL_ERROR) {
+    s = &std::cerr;
+  }
+
+  if (level != nullptr) {
+    *s << "[" << *level << "]: ";
+  }
+
+  if (auto* value = e.get(LOG_MESSAGE)) {
+    *s << *value;
+  } else {
+    *s << "<empty message>";
+  }
+
+  *s << std::endl;
 }
 
 }  // namespace log

--- a/src/wcl/tracing.h
+++ b/src/wcl/tracing.h
@@ -42,9 +42,8 @@ static constexpr const char* LOG_PID = "pid";
 static constexpr const char* LOG_LEVEL_INFO = "info";
 static constexpr const char* LOG_LEVEL_WARNING = "warning";
 static constexpr const char* LOG_LEVEL_ERROR = "error";
-static constexpr const char* LOG_LEVEL_FATAL = "fatal";
-static constexpr const char* LOG_LEVEL_EXIT = "exit";
 static constexpr const char* LOG_MESSAGE = "message";
+static constexpr const char* URGENT = "urgent";
 
 struct Event {
   std::unordered_map<std::string, std::string> items;
@@ -59,6 +58,20 @@ struct Event {
 
     return &it->second;
   }
+
+  Event message(const char* fmt, ...) && __attribute__((format(printf, 2, 3)));
+  Event message(const char* fmt, va_list args) &&;
+
+  Event urgent() && __attribute__((warn_unused_result));
+  Event time() && __attribute__((warn_unused_result));
+  Event pid() && __attribute__((warn_unused_result));
+
+  Event info() && __attribute__((warn_unused_result));
+  Event warning() && __attribute__((warn_unused_result));
+  Event error() && __attribute__((warn_unused_result));
+
+  void operator()() &&;
+  // TODO: initializer list operator()
 };
 
 // Abstract
@@ -78,40 +91,17 @@ class FormatSubscriber : public Subscriber {
   ~FormatSubscriber() override{};
 };
 
-class FatalEventSubscriber : public Subscriber {
- private:
-  std::ostream s;
-
- public:
-  FatalEventSubscriber(std::streambuf* rdbuf) : s(rdbuf) {}
-  void receive(const Event& e) override;
-  ~FatalEventSubscriber() override{};
-};
-
 void subscribe(std::unique_ptr<Subscriber>);
 void clear_subscribers();
 
-void publish(Event e);
+Event event() __attribute__((warn_unused_result));
 
-void info(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
-void info(std::initializer_list<std::pair<const std::string, std::string>> list, const char* fmt,
-          ...) __attribute__((format(printf, 2, 3)));
-
-void warning(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
-void warning(std::initializer_list<std::pair<const std::string, std::string>> list, const char* fmt,
-             ...) __attribute__((format(printf, 2, 3)));
-
-void error(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
-void error(std::initializer_list<std::pair<const std::string, std::string>> list, const char* fmt,
-           ...) __attribute__((format(printf, 2, 3)));
-
-void fatal(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
-void fatal(std::initializer_list<std::pair<const std::string, std::string>> list, const char* fmt,
-           ...) __attribute__((format(printf, 2, 3)));
-
-void exit(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
-void exit(std::initializer_list<std::pair<const std::string, std::string>> list, const char* fmt,
-          ...) __attribute__((format(printf, 2, 3)));
+Event info(const char* fmt, ...) __attribute__((format(printf, 1, 2)))
+__attribute__((warn_unused_result));
+Event warning(const char* fmt, ...) __attribute__((format(printf, 1, 2)))
+__attribute__((warn_unused_result));
+Event error(const char* fmt, ...) __attribute__((format(printf, 1, 2)))
+__attribute__((warn_unused_result));
 
 }  // namespace log
 }  // namespace wcl

--- a/src/wcl/tracing.h
+++ b/src/wcl/tracing.h
@@ -88,6 +88,12 @@ class FormatSubscriber : public Subscriber {
   ~FormatSubscriber() override{};
 };
 
+class UrgentSubscriber : public Subscriber {
+ public:
+  void receive(const Event& e) override;
+  ~UrgentSubscriber() override{};
+};
+
 void subscribe(std::unique_ptr<Subscriber>);
 void clear_subscribers();
 

--- a/src/wcl/tracing.h
+++ b/src/wcl/tracing.h
@@ -65,13 +65,10 @@ struct Event {
   Event urgent() && __attribute__((warn_unused_result));
   Event time() && __attribute__((warn_unused_result));
   Event pid() && __attribute__((warn_unused_result));
-
-  Event info() && __attribute__((warn_unused_result));
-  Event warning() && __attribute__((warn_unused_result));
-  Event error() && __attribute__((warn_unused_result));
+  Event level(const char* level) && __attribute__((warn_unused_result));
 
   void operator()() &&;
-  // TODO: initializer list operator()
+  void operator()(std::initializer_list<std::pair<const std::string, std::string>> list) &&;
 };
 
 // Abstract

--- a/tools/job-cache/main.cpp
+++ b/tools/job-cache/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
   }
 
   wcl::log::subscribe(std::make_unique<wcl::log::FormatSubscriber>(std::cout.rdbuf()));
-  wcl::log::info("Initialized logging for job cache daemon");
+  wcl::log::info("Initialized logging for job cache daemon")();
 
   std::string cache_dir = std::string(argv[1]);
   uint64_t low_cache_size = std::stoull(argv[2]);

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -316,6 +316,7 @@ int main(int argc, char **argv) {
   std::ofstream log_file("wake.log", std::ios::app);
   auto log_file_defer = wcl::make_defer([&log_file]() { log_file.close(); });
   wcl::log::subscribe(std::make_unique<wcl::log::FormatSubscriber>(log_file.rdbuf()));
+  wcl::log::subscribe(std::make_unique<wcl::log::UrgentSubscriber>());
   wcl::log::info("Initialized logging")();
 
   // Now check for any flags that override config options
@@ -424,6 +425,9 @@ int main(int argc, char **argv) {
         return 1;
       }
     }
+
+    // Since the log is append only, we should clean it up from time to time.
+    unlink("wake.log");
 
     return 0;
   }

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -316,8 +316,7 @@ int main(int argc, char **argv) {
   std::ofstream log_file("wake.log", std::ios::app);
   auto log_file_defer = wcl::make_defer([&log_file]() { log_file.close(); });
   wcl::log::subscribe(std::make_unique<wcl::log::FormatSubscriber>(log_file.rdbuf()));
-  wcl::log::subscribe(std::make_unique<wcl::log::FatalEventSubscriber>(std::cerr.rdbuf()));
-  wcl::log::info("Initialized logging");
+  wcl::log::info("Initialized logging")();
 
   // Now check for any flags that override config options
   WakeConfigOverrides config_override;


### PR DESCRIPTION
Three smaller improvements to the newly added internal logger

- delete the `wake.log` file on `wake --clean` since its append only  and could get quite large
- Add a filter subscriber for stdout and stderr for when a log should go to both the terminal and  the log file
- Add a  `breadcrumb` prim so that wake lang can drop debugging hints into the wake internal log