### PR TITLE
Improve shared cache fuzz testing

### DIFF
--- a/src/job_cache/message_parser.h
+++ b/src/job_cache/message_parser.h
@@ -50,6 +50,11 @@ struct MessageParser {
 
       // An error occured during read
       if (count < 0) {
+        // Under some circumstances a connection can be closed by the client
+        // in such a way that ECONNRESET is returned. This should be treated
+        // as equivlient to a close which would normally appear as the count == 0
+        // case above.
+        if (errno == ECONNRESET) return MessageParserState::StopSuccess;
         // There are some failures that could occur that just require us to retry.
         // EINTR could occur on any fd type but EAGAIN and EWOULDBLOCK should
         // only occur if the user gave us a non-blocking socket.

--- a/src/wcl/xoshiro_256.cpp
+++ b/src/wcl/xoshiro_256.cpp
@@ -22,11 +22,11 @@
 
 #include "xoshiro_256.h"
 
-#include <cstring>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <cstring>
 #include <iostream>
 #include <tuple>
 

--- a/src/wcl/xoshiro_256.cpp
+++ b/src/wcl/xoshiro_256.cpp
@@ -22,6 +22,7 @@
 
 #include "xoshiro_256.h"
 
+#include <cstring>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -38,13 +39,13 @@ std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> xoshiro_256::get_rng_seed() {
 
   int rng_fd = open("/dev/urandom", O_RDONLY, 0644);
   if (rng_fd == -1) {
-    std::cerr << "Failed to open /dev/urandom" << std::endl;
+    std::cerr << "Failed to open /dev/urandom: " << strerror(errno) << std::endl;
     exit(1);
   }
 
   uint8_t seed_data[32] = {0};
   if (read(rng_fd, seed_data, sizeof(seed_data)) < 0) {
-    std::cerr << "Failed to read /dev/urandom" << std::endl;
+    std::cerr << "Failed to read /dev/urandom: " << strerror(errno) << std::endl;
     exit(1);
   }
   close(rng_fd);

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -155,8 +155,7 @@ export def runUnitTests _: Result Unit Error =
     require Pass _ = match testJob.isJobOk
         True  = Pass Unit
         False =
-            def _ = println jobStdout
-            def _ = printlnLevel logError jobStderr
+            def _ = println jobStderr
             Fail (makeError "Test failed ({format testJob.getJobStatus}). See above for details")
 
     require Pass _ = match expectedStderr

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -155,7 +155,8 @@ export def runUnitTests _: Result Unit Error =
     require Pass _ = match testJob.isJobOk
         True  = Pass Unit
         False =
-            def _ = println jobStderr
+            def _ = println jobStdout
+            def _ = printlnLevel logError jobStderr
             Fail (makeError "Test failed ({format testJob.getJobStatus}). See above for details")
 
     require Pass _ = match expectedStderr

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -32,7 +32,6 @@ PASSED:
   filepath_range_two_slash
   filepath_relative_to
   job_cache_basic_fuzz
-  job_cache_basic_par_fuzz
   option_assign1
   option_assign2
   option_copy

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -32,6 +32,7 @@ PASSED:
   filepath_range_two_slash
   filepath_relative_to
   job_cache_basic_fuzz
+  job_cache_basic_par_fuzz
   option_assign1
   option_assign2
   option_copy

--- a/tests/wake-unit/unit-test.sh
+++ b/tests/wake-unit/unit-test.sh
@@ -6,3 +6,5 @@ TERM=xterm-256color script --return --quiet -c "$1 --no-color" /dev/null
 
 rm -rf job_cache_test
 rm -rf .job_cache_test
+rm -rf job_cache_test2
+rm -rf .job_cache_test2

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -319,6 +319,7 @@ TEST_FUNC(void, fuzz_loop, const FuzzLoopConfig& config, wcl::xoshiro_256 gen) {
   }
 }
 
+/*
 TEST(job_cache_basic_fuzz) {
   wcl::xoshiro_256 gen(wcl::xoshiro_256::get_rng_seed());
   FuzzLoopConfig config;

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -365,6 +365,10 @@ TEST(job_cache_huge_message_fuzz) {
 }
 */
 
+// This test should work but running it causes Circle CI
+// and github actions to kill our tests for some
+// reason.
+/*
 TEST(job_cache_basic_par_fuzz) {
   FuzzLoopConfig config;
   config.max_out = 5;

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -325,7 +325,7 @@ TEST(job_cache_basic_fuzz) {
   config.max_path_size = 16;
   config.max_out = 5;
   config.max_vis = 5;
-  config.number_of_steps = 10000;
+  config.number_of_steps = 1000;
   config.cache_dir = ".job_cache_test";
   config.dir = "job_cache_test";
   TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -319,7 +319,6 @@ TEST_FUNC(void, fuzz_loop, const FuzzLoopConfig& config, wcl::xoshiro_256 gen) {
   }
 }
 
-
 TEST(job_cache_basic_fuzz) {
   wcl::xoshiro_256 gen(wcl::xoshiro_256::get_rng_seed());
   FuzzLoopConfig config;

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -372,7 +372,7 @@ TEST(job_cache_basic_par_fuzz) {
   config.cache_dir = ".job_cache_test";
   config.dir = "job_cache_test";
   std::vector<std::future<void>> futs;
-  for (int i = 0; i < 500; ++i) {
+  for (int i = 0; i < 50; ++i) {
     // Each thread will exit on ASSERT fail logging the error
     // and will correctly log failed EXPECTS. Because we wait
     // on all futures in this test there is no way for this to

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -319,19 +319,20 @@ TEST_FUNC(void, fuzz_loop, const FuzzLoopConfig& config, wcl::xoshiro_256 gen) {
   }
 }
 
-/*
+
 TEST(job_cache_basic_fuzz) {
   wcl::xoshiro_256 gen(wcl::xoshiro_256::get_rng_seed());
   FuzzLoopConfig config;
   config.max_path_size = 16;
   config.max_out = 5;
   config.max_vis = 5;
-  config.number_of_steps = 1000;
+  config.number_of_steps = 10000;
   config.cache_dir = ".job_cache_test";
   config.dir = "job_cache_test";
   TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
 }
 
+/*
 // This test appears to work but it takes quite a long time and
 // causes a lot of filesystem churn. Just test this on your own
 // occasionally as a debugging/repro tool for those kinds of issues.

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -3,12 +3,12 @@
 #include <wcl/filepath.h>
 
 #include <fstream>
+#include <future>
 #include <map>
 #include <random>
 #include <sstream>
-#include <vector>
 #include <thread>
-#include <future>
+#include <vector>
 
 #include "job_cache/job_cache.h"
 #include "unit.h"
@@ -170,12 +170,14 @@ struct TestJob {
     //       kind.
     for (int i = 0; i < number_of_inputs; ++i) {
       out.input_files.emplace_back();
-      out.input_files.back().path = generate_long_string('/', gen.unique_name(), file_path_size(gen));
+      out.input_files.back().path =
+          generate_long_string('/', gen.unique_name(), file_path_size(gen));
       out.input_files.back().content = gen.unique_name();
     }
     for (int i = 0; i < number_of_outputs; ++i) {
       out.output_files.emplace_back();
-      out.output_files.back().path = generate_long_string('/', gen.unique_name(), file_path_size(gen));
+      out.output_files.back().path =
+          generate_long_string('/', gen.unique_name(), file_path_size(gen));
       out.output_files.back().content = gen.unique_name();
     }
 
@@ -363,7 +365,6 @@ TEST(job_cache_huge_message_fuzz) {
 }
 */
 
-
 TEST(job_cache_basic_par_fuzz) {
   FuzzLoopConfig config;
   config.max_out = 5;
@@ -387,7 +388,6 @@ TEST(job_cache_basic_par_fuzz) {
     }));
   }
   for (auto& fut : futs) {
-    if (fut.valid())
-      fut.wait();
+    if (fut.valid()) fut.wait();
   }
 }

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -366,10 +366,6 @@ TEST(job_cache_huge_message_fuzz) {
 }
 */
 
-// This test should work but running it causes Circle CI
-// and github actions to kill our tests for some
-// reason.
-/*
 TEST(job_cache_basic_par_fuzz) {
   FuzzLoopConfig config;
   config.max_out = 5;
@@ -378,7 +374,7 @@ TEST(job_cache_basic_par_fuzz) {
   config.cache_dir = ".job_cache_test";
   config.dir = "job_cache_test";
   std::vector<std::future<void>> futs;
-  for (int i = 0; i < 20; ++i) {
+  for (int i = 0; i < 2; ++i) {
     // Each thread will exit on ASSERT fail logging the error
     // and will correctly log failed EXPECTS. Because we wait
     // on all futures in this test there is no way for this to

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -325,7 +325,7 @@ TEST(job_cache_basic_fuzz) {
   config.max_path_size = 16;
   config.max_out = 5;
   config.max_vis = 5;
-  config.number_of_steps = 10000;
+  config.number_of_steps = 5000;
   config.cache_dir = ".job_cache_test";
   config.dir = "job_cache_test";
   TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -7,10 +7,23 @@
 #include <random>
 #include <sstream>
 #include <vector>
+#include <thread>
+#include <future>
 
 #include "job_cache/job_cache.h"
 #include "unit.h"
+#include "util/mkdir_parents.h"
+#include "wcl/filepath.h"
 #include "wcl/xoshiro_256.h"
+
+struct FuzzLoopConfig {
+  int max_vis;
+  int max_out;
+  int max_path_size;
+  size_t number_of_steps;
+  std::string cache_dir;
+  std::string dir;
+};
 
 // Later features
 // 1) Add a mode for testing without eviction, demanding everything is a hit
@@ -32,6 +45,16 @@ struct TestFile {
   std::string path;
   std::string content;
 };
+
+std::string generate_long_string(char sep, std::string seed, int target_size) {
+  while (seed.size() <= size_t(target_size)) {
+    auto copy = seed;
+    seed += sep;
+    seed += copy;
+  }
+  seed.resize(target_size);
+  return seed;
+}
 
 struct TestJob {
   std::string cwd;
@@ -78,6 +101,9 @@ struct TestJob {
     JAST outputs(JSON_ARRAY);
     for (const auto& file : output_files) {
       std::string src = wcl::join_paths(in_dir, file.path);
+      auto pab = wcl::parent_and_base(src);
+      std::string parent_dir = pab->first;
+      mkdir_with_parents(parent_dir, 0777);
       std::ofstream out(src);
       out << file.content;
       out.close();
@@ -123,7 +149,7 @@ struct TestJob {
     return job_cache::FindJobRequest(request);
   }
 
-  static TestJob gen(wcl::xoshiro_256& gen) {
+  static TestJob gen(const FuzzLoopConfig& config, wcl::xoshiro_256& gen) {
     TestJob out;
 
     // Generate our primary key
@@ -133,8 +159,9 @@ struct TestJob {
     out.stdin = gen.unique_name();
 
     // Generate our input and output files
-    std::uniform_int_distribution<> number_of_inputs_dist(0, 5);
-    std::uniform_int_distribution<> number_of_outputs_dist(0, 5);
+    std::uniform_int_distribution<> number_of_inputs_dist(0, config.max_vis);
+    std::uniform_int_distribution<> number_of_outputs_dist(0, config.max_out);
+    std::uniform_int_distribution<> file_path_size(16, config.max_path_size);
     int number_of_inputs = number_of_inputs_dist(gen);
     int number_of_outputs = number_of_outputs_dist(gen);
 
@@ -143,12 +170,12 @@ struct TestJob {
     //       kind.
     for (int i = 0; i < number_of_inputs; ++i) {
       out.input_files.emplace_back();
-      out.input_files.back().path = gen.unique_name();
+      out.input_files.back().path = generate_long_string('/', gen.unique_name(), file_path_size(gen));
       out.input_files.back().content = gen.unique_name();
     }
     for (int i = 0; i < number_of_outputs; ++i) {
       out.output_files.emplace_back();
-      out.output_files.back().path = gen.unique_name();
+      out.output_files.back().path = generate_long_string('/', gen.unique_name(), file_path_size(gen));
       out.output_files.back().content = gen.unique_name();
     }
 
@@ -230,12 +257,13 @@ struct Pool {
   // TODO: When this is thread safe
   //       1) It will need to return a copy not a reference
   //       2) It will need to aquire the read/write lock early
-  const T& step(wcl::xoshiro_256& gen) {
+  template <class... Args>
+  const T& step(wcl::xoshiro_256& gen, Args&&... gen_args) {
     std::uniform_real_distribution<> dist(0.0, 1.0);
 
     // If we're empty we can't reuse anything
     if (pool.size() <= reuse_threshold) {
-      pool.emplace_back(T::gen(gen));
+      pool.emplace_back(T::gen(std::forward<Args>(gen_args)..., gen));
       return pool.back();
     }
 
@@ -257,23 +285,22 @@ struct Pool {
     }
 
     // Otherwise we need to generate a new thing and add it to the pool
-    pool.emplace_back(T::gen(gen));
+    pool.emplace_back(T::gen(std::forward<Args>(gen_args)..., gen));
     return pool.back();
   }
 };
 
-TEST_FUNC(void, fuzz_loop, size_t number_of_steps, std::string cache_dir, std::string dir,
-          wcl::xoshiro_256 gen) {
+TEST_FUNC(void, fuzz_loop, const FuzzLoopConfig& config, wcl::xoshiro_256 gen) {
   Pool<TestJob> job_pool;
 
-  mkdir(cache_dir.c_str(), 0777);
-  mkdir(dir.c_str(), 0777);
-  job_cache::Cache cache(cache_dir, 1ULL << 24ULL, (1 << 23ULL) + (1 << 22ULL));
+  mkdir(config.cache_dir.c_str(), 0777);
+  mkdir(config.dir.c_str(), 0777);
+  job_cache::Cache cache(config.cache_dir, 1ULL << 24ULL, (1 << 23ULL) + (1 << 22ULL));
 
-  std::string out_dir = wcl::join_paths(dir, "outputs");
-  for (size_t i = 0; i < number_of_steps; ++i) {
+  std::string out_dir = wcl::join_paths(config.dir, "outputs");
+  for (size_t i = 0; i < config.number_of_steps; ++i) {
     // First find the job that we care about
-    const TestJob& job = job_pool.step(gen);
+    const TestJob& job = job_pool.step(gen, config);
     auto find_job_request = job.generate_find_request(out_dir);
     auto result = cache.read(find_job_request);
     if (result.match) {
@@ -284,7 +311,7 @@ TEST_FUNC(void, fuzz_loop, size_t number_of_steps, std::string cache_dir, std::s
         ASSERT_EQUAL(buffer.str(), file.content);
       }
     } else {
-      auto add_job_request = job.generate_add_request(dir);
+      auto add_job_request = job.generate_add_request(config.dir);
       cache.add(add_job_request);
     }
   }
@@ -292,5 +319,75 @@ TEST_FUNC(void, fuzz_loop, size_t number_of_steps, std::string cache_dir, std::s
 
 TEST(job_cache_basic_fuzz) {
   wcl::xoshiro_256 gen(wcl::xoshiro_256::get_rng_seed());
-  TEST_FUNC_CALL(fuzz_loop, 10000, ".job_cache_test", "job_cache_test", std::move(gen));
+  FuzzLoopConfig config;
+  config.max_path_size = 16;
+  config.max_out = 5;
+  config.max_vis = 5;
+  config.number_of_steps = 10000;
+  config.cache_dir = ".job_cache_test";
+  config.dir = "job_cache_test";
+  TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
+}
+
+// This test appears to work but it takes quite a long time and
+// causes a lot of filesystem churn. Just test this on your own
+// occasionally as a debugging/repro tool for those kinds of issues.
+/*
+TEST(job_cache_large_message_fuzz) {
+  wcl::xoshiro_256 gen(wcl::xoshiro_256::get_rng_seed());
+  FuzzLoopConfig config;
+  config.max_path_size = 200;
+  config.max_out = 16000;
+  config.max_vis = 16000;
+  config.number_of_steps = 100;
+  config.cache_dir = ".job_cache_test";
+  config.dir = "job_cache_test";
+  TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
+}
+*/
+
+// This test appears to work but it takes *FOREVER* and doesn't represent
+// a very likely case. Still it might be worth running this on your own
+// sometimes to make sure everything is working well
+/*
+TEST(job_cache_huge_message_fuzz) {
+  wcl::xoshiro_256 gen(wcl::xoshiro_256::get_rng_seed());
+  FuzzLoopConfig config;
+  config.max_path_size = 3500;
+  config.max_out = 100000;
+  config.max_vis = 100000;
+  config.number_of_steps = 20;
+  config.cache_dir = ".job_cache_test";
+  config.dir = "job_cache_test";
+  TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
+}
+*/
+
+
+TEST(job_cache_basic_par_fuzz) {
+  FuzzLoopConfig config;
+  config.max_out = 5;
+  config.max_vis = 5;
+  config.number_of_steps = 1000;
+  config.cache_dir = ".job_cache_test";
+  config.dir = "job_cache_test";
+  std::vector<std::future<void>> futs;
+  for (int i = 0; i < 500; ++i) {
+    // Each thread will exit on ASSERT fail logging the error
+    // and will correctly log failed EXPECTS. Because we wait
+    // on all futures in this test there is no way for this to
+    // leave a thread running after the return of this call.
+    // However it is unfortunate that if one thread fails,
+    // these others will keep running to completion. Additionally
+    // if the program dies/crashes all threads die in the current
+    // position without failures from other threads being logged.
+    futs.emplace_back(std::async([&]() {
+      wcl::xoshiro_256 gen(wcl::xoshiro_256::get_rng_seed());
+      TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
+    }));
+  }
+  for (auto& fut : futs) {
+    if (fut.valid())
+      fut.wait();
+  }
 }

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -369,11 +369,11 @@ TEST(job_cache_basic_par_fuzz) {
   FuzzLoopConfig config;
   config.max_out = 5;
   config.max_vis = 5;
-  config.number_of_steps = 1000;
+  config.number_of_steps = 500;
   config.cache_dir = ".job_cache_test";
   config.dir = "job_cache_test";
   std::vector<std::future<void>> futs;
-  for (int i = 0; i < 50; ++i) {
+  for (int i = 0; i < 20; ++i) {
     // Each thread will exit on ASSERT fail logging the error
     // and will correctly log failed EXPECTS. Because we wait
     // on all futures in this test there is no way for this to
@@ -391,3 +391,35 @@ TEST(job_cache_basic_par_fuzz) {
     if (fut.valid()) fut.wait();
   }
 }
+
+// This test should work but it takes quite a long time and fails
+// CI due to either a timeout, or for using too much disk space. It
+// fails even the number of threads is set to 50 instead of 500.
+/*
+TEST(job_cache_large_par_fuzz) {
+  FuzzLoopConfig config;
+  config.max_out = 5;
+  config.max_vis = 5;
+  config.number_of_steps = 1000;
+  config.cache_dir = ".job_cache_test";
+  config.dir = "job_cache_test";
+  std::vector<std::future<void>> futs;
+  for (int i = 0; i < 500; ++i) {
+    // Each thread will exit on ASSERT fail logging the error
+    // and will correctly log failed EXPECTS. Because we wait
+    // on all futures in this test there is no way for this to
+    // leave a thread running after the return of this call.
+    // However it is unfortunate that if one thread fails,
+    // these others will keep running to completion. Additionally
+    // if the program dies/crashes all threads die in the current
+    // position without failures from other threads being logged.
+    futs.emplace_back(std::async([&]() {
+      wcl::xoshiro_256 gen(wcl::xoshiro_256::get_rng_seed());
+      TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
+    }));
+  }
+  for (auto& fut : futs) {
+    if (fut.valid()) fut.wait();
+  }
+}
+*/

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -16,11 +16,12 @@
 #include "wcl/filepath.h"
 #include "wcl/xoshiro_256.h"
 
+// Set sane defaults to avoid subtle errors
 struct FuzzLoopConfig {
-  int max_vis;
-  int max_out;
-  int max_path_size;
-  size_t number_of_steps;
+  int max_vis = 5;
+  int max_out = 5;
+  int max_path_size = 16;
+  size_t number_of_steps = 1;
   std::string cache_dir;
   std::string dir;
 };

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -325,7 +325,7 @@ TEST(job_cache_basic_fuzz) {
   config.max_path_size = 16;
   config.max_out = 5;
   config.max_vis = 5;
-  config.number_of_steps = 5000;
+  config.number_of_steps = 10000;
   config.cache_dir = ".job_cache_test";
   config.dir = "job_cache_test";
   TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
@@ -368,13 +368,14 @@ TEST(job_cache_huge_message_fuzz) {
 
 TEST(job_cache_basic_par_fuzz) {
   FuzzLoopConfig config;
+  config.max_path_size = 16;
   config.max_out = 5;
   config.max_vis = 5;
   config.number_of_steps = 500;
-  config.cache_dir = ".job_cache_test";
-  config.dir = "job_cache_test";
+  config.cache_dir = ".job_cache_test2";
+  config.dir = "job_cache_test2";
   std::vector<std::future<void>> futs;
-  for (int i = 0; i < 2; ++i) {
+  for (int i = 0; i < 20; ++i) {
     // Each thread will exit on ASSERT fail logging the error
     // and will correctly log failed EXPECTS. Because we wait
     // on all futures in this test there is no way for this to
@@ -393,12 +394,11 @@ TEST(job_cache_basic_par_fuzz) {
   }
 }
 
-// This test should work but it takes quite a long time and fails
-// CI due to either a timeout, or for using too much disk space. It
-// fails even the number of threads is set to 50 instead of 500.
+// This test should work but it takes quite a long time.
 /*
 TEST(job_cache_large_par_fuzz) {
   FuzzLoopConfig config;
+  config.max_path_size = 16;
   config.max_out = 5;
   config.max_vis = 5;
   config.number_of_steps = 1000;


### PR DESCRIPTION
This change improves shared caching fuzzing to be a bit more flexible. We can now test parallelism and large message sizes which will catch the new issues we've seen thus far that basic_fuzz_testing didn't catch. Additionally there was one minor bug fix with regards to how ECONNRESET was handled.