### PR TITLE
Clean up extra file handles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ bin/wakebox:		tools/wakebox/main.cpp src/wakefs/*.cpp vendor/gopt/*.c $(COMMON_O
 lib/wake/fuse-waked:	tools/fuse-waked/main.cpp $(COMMON_OBJS)
 	$(CXX) $(CFLAGS) $(LOCAL_CFLAGS) $(FUSE_CFLAGS) $(CXX_VERSION) $^ -o $@ $(LDFLAGS)  $(CORE_LDFLAGS) $(FUSE_LDFLAGS)
 
-lib/wake/shim-wake:	tools/shim-wake/main.o vendor/blake2/blake2b-ref.o
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(CORE_LDFLAGS)
+lib/wake/shim-wake:	tools/shim-wake/main.o vendor/blake2/blake2b-ref.o src/wcl/filepath.o
+	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(CORE_LDFLAGS)
 
 lib/wake/wake-hash: tools/wake-hash/main.o vendor/blake2/blake2b-ref.o $(COMMON_OBJS)
 	$(CXX) $(CFLAGS) -o $@ $^ $(LOCAL_CFLAGS) $(CXX_VERSION) $(LDFLAGS) $(CORE_LDFLAGS)

--- a/src/wcl/wcl.wake
+++ b/src/wcl/wcl.wake
@@ -18,4 +18,4 @@ package build_wake
 from wake import _
 
 target wcl variant =
-    src @here variant (util, Nil) Nil Nil
+    src @here variant Nil Nil Nil

--- a/tools/shim-wake/main.cpp
+++ b/tools/shim-wake/main.cpp
@@ -31,9 +31,9 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-#include "wcl/filepath.h"
 #include "blake2/blake2.h"
 #include "compat/nofollow.h"
+#include "wcl/filepath.h"
 
 // Can increase to 64 if needed
 #define HASH_BYTES 32
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
     return 127;
   }
   std::vector<int> fds_to_close;
-  for (const auto& entry : *res) {
+  for (const auto &entry : *res) {
     if (!entry) {
       fprintf(stderr, "bad /proc/self/fd/ entry: %s\n", strerror(entry.error()));
       return 127;

--- a/tools/shim-wake/shim.wake
+++ b/tools/shim-wake/shim.wake
@@ -19,4 +19,4 @@ from wake import _
 from gcc_wake import _
 
 target buildShim variant: Result (List Path) Error =
-    tool @here Nil variant "lib/wake/shim-wake" (blake2, compat, Nil) Nil Nil
+    tool @here Nil variant "lib/wake/shim-wake" (blake2, compat, wcl, Nil) Nil Nil


### PR DESCRIPTION
This just causes shim-wake to clean up all its unneeded files before exec-ing to be more hygienic.