### PR TITLE
breadcrumb prim, filter subscriber, log cleanup

### DIFF
--- a/share/wake/lib/core/print.wake
+++ b/share/wake/lib/core/print.wake
@@ -100,3 +100,18 @@ export def printlnLevel (LogLevel name) (message: String): Unit =
 #   def Unit = println "{integerToUnicode 0x1f600}"
 export def println: String => Unit =
     printlnLevel logReport
+
+# breadcrumb: Leaves an out of band message in the wake internal log
+#
+# This should primarily be used by core/standard libraries over normal user code.
+# However it can be useful for tracing or debugging wake code out of band. The contents
+# of the log may only be inspected outside of wake and thus any breakcrumbs are
+# "blackholed" from the perspective of wakelang.
+#
+#   # Emit a structured message to 'wake.log'
+#   def _ = breadcrumb "encountered failing event"
+export def breadcrumb (x: String): Unit =
+    def p s = prim "breadcrumb"
+
+    p x
+

--- a/src/runtime/string.cpp
+++ b/src/runtime/string.cpp
@@ -186,7 +186,7 @@ static PRIMFN(prim_breadcrumb) {
   EXPECT(1);
   STRING(request_str, 0);
 
-  wcl::log::info({{"source", "wake"}}, request_str->c_str());
+  wcl::log::info(request_str->c_str())({{"source", "wake"}});
 
   runtime.heap.reserve(reserve_unit());
   RETURN(claim_unit(runtime.heap));

--- a/src/runtime/string.cpp
+++ b/src/runtime/string.cpp
@@ -42,6 +42,7 @@
 #include "util/term.h"
 #include "util/unlink.h"
 #include "value.h"
+#include "wcl/tracing.h"
 #include "wcl/xoshiro_256.h"
 
 static PRIMFN(prim_vcat) {
@@ -175,6 +176,20 @@ static PRIMTYPE(type_read) {
   result[0].unify(Data::typeString);
   result[1].unify(Data::typeString);
   return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(result);
+}
+
+static PRIMTYPE(type_breadcrumb) {
+  return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(Data::typeUnit);
+}
+
+static PRIMFN(prim_breadcrumb) {
+  EXPECT(1);
+  STRING(request_str, 0);
+
+  wcl::log::info({{"source", "wake"}}, request_str->c_str());
+
+  runtime.heap.reserve(reserve_unit());
+  RETURN(claim_unit(runtime.heap));
 }
 
 static PRIMFN(prim_read) {
@@ -673,4 +688,5 @@ void prim_register_string(PrimMap &pmap, StringInfo *info) {
   prim_register(pmap, "unlink", prim_unlink, type_unlink, PRIM_IMPURE);
   prim_register(pmap, "write", prim_write, type_write, PRIM_IMPURE);
   prim_register(pmap, "read", prim_read, type_read, PRIM_ORDERED);
+  prim_register(pmap, "breadcrumb", prim_breadcrumb, type_breadcrumb, PRIM_IMPURE);
 }

--- a/src/wcl/tracing.cpp
+++ b/src/wcl/tracing.cpp
@@ -149,30 +149,24 @@ void FormatSubscriber::receive(const Event& e) {
   s << std::endl;
 }
 
-void UrgentSubscriber::receive(const Event& e) {
-  auto urgent = e.get(URGENT);
-  if (urgent == nullptr) {
-    return;
-  }
-
-  std::ostream* s = &std::cout;
-
-  auto level = e.get(LOG_LEVEL);
-  if (level != nullptr && *level == LOG_LEVEL_ERROR) {
-    s = &std::cerr;
-  }
-
-  if (level != nullptr) {
-    *s << "[" << *level << "]: ";
+void SimpleFormatSubscriber::receive(const Event& e) {
+  if (auto* level = e.get(LOG_LEVEL)) {
+    s << "[" << *level << "]: ";
   }
 
   if (auto* value = e.get(LOG_MESSAGE)) {
-    *s << *value;
+    s << *value;
   } else {
-    *s << "<empty message>";
+    s << "<empty message>";
   }
 
-  *s << std::endl;
+  s << std::endl;
+}
+
+void FilterSubscriber::receive(const Event& e) {
+  if (predicate(e)) {
+    subscriber->receive(e);
+  }
 }
 
 }  // namespace log

--- a/src/wcl/tracing.cpp
+++ b/src/wcl/tracing.cpp
@@ -138,11 +138,41 @@ void FormatSubscriber::receive(const Event& e) {
     s << item.first << "=" << item.second;
   }
 
-  s << "]";
+  s << "] ";
 
   if (auto* value = e.get(LOG_MESSAGE)) {
-    s << " " << *value;
+    s << *value;
+  } else {
+    s << "<empty message>";
   }
+
+  s << std::endl;
+}
+
+void UrgentSubscriber::receive(const Event& e) {
+  auto urgent = e.get(URGENT);
+  if (urgent == nullptr) {
+    return;
+  }
+
+  std::ostream* s = &std::cout;
+
+  auto level = e.get(LOG_LEVEL);
+  if (level != nullptr && *level == LOG_LEVEL_ERROR) {
+    s = &std::cerr;
+  }
+
+  if (level != nullptr) {
+    *s << "[" << *level << "]: ";
+  }
+
+  if (auto* value = e.get(LOG_MESSAGE)) {
+    *s << *value;
+  } else {
+    *s << "<empty message>";
+  }
+
+  *s << std::endl;
 }
 
 }  // namespace log

--- a/src/wcl/tracing.h
+++ b/src/wcl/tracing.h
@@ -26,6 +26,7 @@
 #include <unistd.h>
 
 #include <cstdarg>
+#include <functional>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -88,10 +89,26 @@ class FormatSubscriber : public Subscriber {
   ~FormatSubscriber() override{};
 };
 
-class UrgentSubscriber : public Subscriber {
+class SimpleFormatSubscriber : public Subscriber {
+ private:
+  std::ostream s;
+
  public:
+  SimpleFormatSubscriber(std::streambuf* rdbuf) : s(rdbuf) {}
   void receive(const Event& e) override;
-  ~UrgentSubscriber() override{};
+  ~SimpleFormatSubscriber() override{};
+};
+
+class FilterSubscriber : public Subscriber {
+ private:
+  std::unique_ptr<Subscriber> subscriber;
+  std::function<bool(const Event&)> predicate;
+
+ public:
+  FilterSubscriber(std::unique_ptr<Subscriber> s, std::function<bool(const Event&)> p)
+      : subscriber(std::move(s)), predicate(p) {}
+  void receive(const Event& e) override;
+  ~FilterSubscriber() override{};
 };
 
 void subscribe(std::unique_ptr<Subscriber>);

--- a/src/wcl/tracing.h
+++ b/src/wcl/tracing.h
@@ -88,6 +88,12 @@ class FormatSubscriber : public Subscriber {
   ~FormatSubscriber() override{};
 };
 
+class UrgentSubscriber : public Subscriber {
+ public:
+  void receive(const Event& e) override;
+  ~UrgentSubscriber() override{};
+};
+
 void subscribe(std::unique_ptr<Subscriber>);
 void clear_subscribers();
 

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -316,6 +316,7 @@ int main(int argc, char **argv) {
   std::ofstream log_file("wake.log", std::ios::app);
   auto log_file_defer = wcl::make_defer([&log_file]() { log_file.close(); });
   wcl::log::subscribe(std::make_unique<wcl::log::FormatSubscriber>(log_file.rdbuf()));
+  wcl::log::subscribe(std::make_unique<wcl::log::UrgentSubscriber>());
   wcl::log::info("Initialized logging")();
 
   // Now check for any flags that override config options
@@ -424,6 +425,9 @@ int main(int argc, char **argv) {
         return 1;
       }
     }
+
+    // Since the log is append only, we should clean it up from time to time.
+    unlink("wake.log");
 
     return 0;
   }

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -435,7 +435,12 @@ int main(int argc, char **argv) {
     }
 
     // Since the log is append only, we should clean it up from time to time.
-    unlink("wake.log");
+    // TODO: this is just "unlink_no_fail". Those functions should be moved to
+    // a more generic library
+    if (unlink("wake.log") < 0 && errno != ENOENT) {
+      wcl::log::error("unlink(wake.log): %s", strerror(errno)).urgent()();
+      return 1;
+    }
 
     return 0;
   }


### PR DESCRIPTION
Three smaller improvements to the newly added internal logger

- delete the `wake.log` file on `wake --clean` since its append only  and could get quite large
- "Urgent" filter that emits event to stderr for user notification
- Add a  `breadcrumb` prim so that wake lang can drop debugging hints into the wake internal log