### PR TITLE
Add option for cache miss on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ contain JSON5 source where the root object may contain the following keys.
 | log_header_align | A boolean that specifies whether or not to align log header output | No | Boolean | Yes | Yes | False
 | max_cache_size | The number of bytes after which the shared cache will start a collection | No | Integer | Yes | Yes | 25GB
 | low_cache_size | The number of bytes that the cache tries to reach during a collection | No | Integer | Yes | Yes | 15 GB
-| cache_miss_on_failure | if `true` shared cache will report a cache miss instead of dying when something goes wrong | No | Boolean | Yes | Yes | False
+| cache_miss_on_failure | if `true` shared cache will report a cache miss instead of terminating when something goes wrong | No | Boolean | Yes | Yes | False
 
 Below is a full example
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ contain JSON5 source where the root object may contain the following keys.
 | log_header_align | A boolean that specifies whether or not to align log header output | No | Boolean | Yes | Yes | False
 | max_cache_size | The number of bytes after which the shared cache will start a collection | No | Integer | Yes | Yes | 25GB
 | low_cache_size | The number of bytes that the cache tries to reach during a collection | No | Integer | Yes | Yes | 15 GB
+| cache_miss_on_failure | if `true` shared cache will report a cache miss instead of dying when something goes wrong | No | Boolean | Yes | Yes | False
 
 Below is a full example
 

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -51,6 +51,7 @@ enum class FindJobError {
 class Cache {
  private:
   wcl::unique_fd socket_fd;
+  bool miss_on_failure = false;
 
   // Daemon parameters
   std::string cache_dir;
@@ -65,7 +66,7 @@ class Cache {
   Cache() = delete;
   Cache(const Cache &) = delete;
 
-  Cache(std::string dir, uint64_t max, uint64_t low);
+  Cache(std::string dir, uint64_t max, uint64_t low, bool miss);
 
   FindJobResponse read(const FindJobRequest &find_request);
   void add(const AddJobRequest &add_request);

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -214,6 +214,7 @@ POLICY_STATIC_DEFINES(LogHeaderSourceWidthPolicy)
 POLICY_STATIC_DEFINES(LabelFilterPolicy)
 POLICY_STATIC_DEFINES(SharedCacheMaxSize)
 POLICY_STATIC_DEFINES(SharedCacheLowSize)
+POLICY_STATIC_DEFINES(SharedCacheMissOnFailure)
 POLICY_STATIC_DEFINES(LogHeaderAlignPolicy)
 
 /********************************************************************
@@ -268,10 +269,17 @@ void SharedCacheLowSize::set(SharedCacheLowSize& p, const JAST& json) {
   }
 }
 
+void SharedCacheMissOnFailure::set(SharedCacheMissOnFailure& p, const JAST& json) {
+  auto json_shared_cache_miss_on_failure = json.expect_boolean();
+  if (json_shared_cache_miss_on_failure) {
+    p.cache_miss_on_failure = *json_shared_cache_miss_on_failure;
+  }
+}
+
 void LogHeaderAlignPolicy::set(LogHeaderAlignPolicy& p, const JAST& json) {
-  auto json_log_header_algih = json.expect_boolean();
-  if (json_log_header_algih) {
-    p.log_header_align = *json_log_header_algih;
+  auto json_log_header_align = json.expect_boolean();
+  if (json_log_header_align) {
+    p.log_header_align = *json_log_header_align;
   }
 }
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -43,7 +43,12 @@ struct WakeConfigOverrides {
   // Determines the size of the cache that collection
   // tries to get us back to.
   wcl::optional<uint64_t> low_cache_size;
+
+  // Determines if log headers should be aligned
   wcl::optional<bool> log_header_align;
+
+  // Determines if job cache should terminate on error or return a cache miss
+  wcl::optional<bool> cache_miss_on_failure;
 };
 
 template <class T>
@@ -181,7 +186,8 @@ struct SharedCacheMissOnFailure {
   type cache_miss_on_failure = false;
   static constexpr type SharedCacheMissOnFailure::*value =
       &SharedCacheMissOnFailure::cache_miss_on_failure;
-  static constexpr Override<input_type> override_value = nullptr;
+  static constexpr Override<input_type> override_value =
+      &WakeConfigOverrides::cache_miss_on_failure;
 
   static void set(SharedCacheMissOnFailure& p, const JAST& json);
   static void set_input(SharedCacheMissOnFailure& p, const input_type& v) { p.*value = v; }

--- a/tests/config/empty/stdout
+++ b/tests/config/empty/stdout
@@ -6,4 +6,5 @@ Wake config:
   label_filter = '.*' (Default)
   max_cache_size = '26843545600' (Default)
   low_cache_size = '16106127360' (Default)
+  cache_miss_on_failure = 'false' (Default)
   log_header_align = 'false' (Default)

--- a/tests/config/extra_keys/stdout
+++ b/tests/config/extra_keys/stdout
@@ -6,4 +6,5 @@ Wake config:
   label_filter = '.*' (Default)
   max_cache_size = '26843545600' (Default)
   low_cache_size = '16106127360' (Default)
+  cache_miss_on_failure = 'false' (Default)
   log_header_align = 'false' (Default)

--- a/tests/config/missing_user_config/stdout
+++ b/tests/config/missing_user_config/stdout
@@ -6,4 +6,5 @@ Wake config:
   label_filter = '.*' (Default)
   max_cache_size = '26843545600' (Default)
   low_cache_size = '16106127360' (Default)
+  cache_miss_on_failure = 'false' (Default)
   log_header_align = 'false' (Default)

--- a/tests/config/nominal/.wakeroot
+++ b/tests/config/nominal/.wakeroot
@@ -4,5 +4,6 @@
   "log_header_source_width": 13,
   "max_cache_size": 1024,
   "low_cache_size": 512,
-  "log_header_align": true
+  "log_header_align": true,
+  "cache_miss_on_failure": true
 }

--- a/tests/config/nominal/stdout
+++ b/tests/config/nominal/stdout
@@ -6,4 +6,5 @@ Wake config:
   label_filter = '.*' (Default)
   max_cache_size = '1024' (WakeRoot)
   low_cache_size = '512' (WakeRoot)
+  cache_miss_on_failure = 'true' (WakeRoot)
   log_header_align = 'true' (WakeRoot)

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -298,7 +298,7 @@ TEST_FUNC(void, fuzz_loop, const FuzzLoopConfig& config, wcl::xoshiro_256 gen) {
 
   mkdir(config.cache_dir.c_str(), 0777);
   mkdir(config.dir.c_str(), 0777);
-  job_cache::Cache cache(config.cache_dir, 1ULL << 24ULL, (1 << 23ULL) + (1 << 22ULL));
+  job_cache::Cache cache(config.cache_dir, 1ULL << 24ULL, (1 << 23ULL) + (1 << 22ULL), false);
 
   std::string out_dir = wcl::join_paths(config.dir, "outputs");
   for (size_t i = 0; i < config.number_of_steps; ++i) {

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -57,6 +57,7 @@ struct CommandLineOptions {
   bool clean;
   bool list_outputs;
   wcl::optional<bool> log_header_align;
+  wcl::optional<bool> cache_miss_on_failure;
 
   const char *percent_str;
   const char *jobs_str;
@@ -152,6 +153,8 @@ struct CommandLineOptions {
       {0, "log-header-source-width", GOPT_ARGUMENT_REQUIRED},
       {0, "log-header-align", GOPT_ARGUMENT_FORBIDDEN},
       {0, "no-log-header-align", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "cache-miss-on-failure", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "no-cache-miss-on-failure", GOPT_ARGUMENT_FORBIDDEN},
       {':', "shebang", GOPT_ARGUMENT_REQUIRED},
       {0, 0, GOPT_LAST}
     };
@@ -219,6 +222,14 @@ struct CommandLineOptions {
 
     if (arg(options, "no-log-header-align")->count) {
       log_header_align = wcl::some(false);
+    }
+
+    if (arg(options, "cache-miss-on-failure")->count) {
+      cache_miss_on_failure = wcl::some(true);
+    }
+
+    if (arg(options, "no-cache-miss-on-failure")->count) {
+      cache_miss_on_failure = wcl::some(false);
     }
 
     auto lhsw_str = arg(options, "log-header-source-width")->argument;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -328,6 +328,7 @@ int main(int argc, char **argv) {
   }
   config_override.log_header_source_width = clo.log_header_source_width;
   config_override.log_header_align = clo.log_header_align;
+  config_override.cache_miss_on_failure = clo.cache_miss_on_failure;
 
   if (!WakeConfig::init(".wakeroot", config_override)) {
     return 1;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -360,7 +360,8 @@ int main(int argc, char **argv) {
   const char *job_cache_dir = getenv("WAKE_EXPERIMENTAL_JOB_CACHE");
   if (job_cache_dir != nullptr) {
     cache = std::make_unique<job_cache::Cache>(job_cache_dir, WakeConfig::get()->max_cache_size,
-                                               WakeConfig::get()->low_cache_size);
+                                               WakeConfig::get()->low_cache_size,
+                                               WakeConfig::get()->cache_miss_on_failure);
     set_job_cache(cache.get());
   }
 


### PR DESCRIPTION
`cache_miss_on_failure` may be set (`true`|`false`) in the wake config to generate a cache miss when something goes wrong with the Daemon JobCache instead of falling over.

This is useful for users with long running builds who would rather  the build take a bit longer overall  verses dying several hours in