### PR TITLE
Make job cache more self-healing

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -623,7 +623,7 @@ void DaemonCache::remove_corrupt_job(int64_t job_id) {
   if (!dir_res) {
     // We can keep going even with this failure but we need to at least log it
     wcl::log::error("cleaning corrupt job: wcl::directory_range::open(%s): %s", job_dir.c_str(),
-                    strerror(dir_res.error()));
+                    strerror(dir_res.error()))();
     return;
   }
 
@@ -632,7 +632,7 @@ void DaemonCache::remove_corrupt_job(int64_t job_id) {
     if (!entry) {
       // It isn't critical that we remove this so just log the error and move on
       wcl::log::error("cleaning corrupt job: bad entry in %s: %s", job_dir.c_str(),
-                      strerror(entry.error()));
+                      strerror(entry.error()))();
       return;
     }
     to_delete.emplace_back(wcl::join_paths(job_dir, entry->name));

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -282,6 +282,7 @@ class JobTable {
   std::shared_ptr<job_cache::Database> db;
   PreparedStatement add_job;
   PreparedStatement add_output_info;
+  PreparedStatement remove_job;
 
  public:
   static constexpr const char *insert_query =
@@ -293,10 +294,16 @@ class JobTable {
       "(job, stdout, stderr, ret, runtime, cputime, mem, ibytes, obytes)"
       "values (?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
+  static constexpr const char *remove_job_query = "delete from jobs where job_id = ?";
+
   JobTable(std::shared_ptr<job_cache::Database> db)
-      : db(db), add_job(db, insert_query), add_output_info(db, add_output_info_query) {
+      : db(db),
+        add_job(db, insert_query),
+        add_output_info(db, add_output_info_query),
+        remove_job(db, remove_job_query) {
     add_job.set_why("Could not insert job");
     add_output_info.set_why("Could not add output info");
+    remove_job.set_why("Could not remove job");
   }
 
   int64_t insert(const std::string &cwd, const std::string &cmd, const std::string &env,
@@ -327,6 +334,12 @@ class JobTable {
     add_output_info.bind_integer(9, obytes);
     add_output_info.step();
     add_output_info.reset();
+  }
+
+  void remove(int64_t job_id) {
+    remove_job.bind_integer(1, job_id);
+    remove_job.step();
+    remove_job.reset();
   }
 };
 
@@ -596,6 +609,44 @@ int DaemonCache::run() {
   return 0;
 }
 
+void DaemonCache::remove_corrupt_job(int64_t job_id) {
+  // First remove this job from the database so that we don't get hung up on it anymore
+  impl->jobs.remove(job_id);
+
+  // Find this job directory so we can remove all the file
+  uint8_t group_id = job_id & 0xFF;
+  std::string job_dir = wcl::join_paths(wcl::to_hex(&group_id), std::to_string(job_id));
+
+  // Iterate over these files collecting the paths to delete
+  std::vector<std::string> to_delete;
+  auto dir_res = wcl::directory_range::open(job_dir);
+  if (!dir_res) {
+    // We can keep going even with this failure but we need to at least log it
+    wcl::log::error("cleaning corrupt job: wcl::directory_range::open(%s): %s", job_dir.c_str(),
+                    strerror(dir_res.error()));
+    return;
+  }
+
+  // Find all the entries to remove
+  for (const auto &entry : *dir_res) {
+    if (!entry) {
+      // It isn't critical that we remove this so just log the error and move on
+      wcl::log::error("cleaning corrupt job: bad entry in %s: %s", job_dir.c_str(),
+                      strerror(entry.error()));
+      return;
+    }
+    to_delete.emplace_back(wcl::join_paths(job_dir, entry->name));
+  }
+
+  // Unlink them all
+  for (const auto &file : to_delete) {
+    unlink_no_fail(file.c_str());
+  }
+
+  // Remove the files
+  rmdir_no_fail(job_dir.c_str());
+}
+
 FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {
   wcl::optional<std::pair<int, MatchingJob>> matching_job;
 
@@ -634,6 +685,7 @@ FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {
     int ret = link(cur_file.c_str(), tmp_file.c_str());
     if (ret < 0 && errno != EEXIST) {
       success = false;
+      remove_corrupt_job(job_id);
       break;
     }
     to_copy.emplace_back(std::make_tuple(std::move(tmp_file), output_file.path, output_file.mode));

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -613,7 +613,7 @@ void DaemonCache::remove_corrupt_job(int64_t job_id) {
   // First remove this job from the database so that we don't get hung up on it anymore
   impl->jobs.remove(job_id);
 
-  // Find this job directory so we can remove all the file
+  // Find this job directory so we can remove all the files
   uint8_t group_id = job_id & 0xFF;
   std::string job_dir = wcl::join_paths(wcl::to_hex(&group_id), std::to_string(job_id));
 
@@ -640,11 +640,13 @@ void DaemonCache::remove_corrupt_job(int64_t job_id) {
 
   // Unlink them all
   for (const auto &file : to_delete) {
-    unlink_no_fail(file.c_str());
+    // We don't want to fail if this fails for some reason, so just
+    // ignore the error.
+    unlink(file.c_str());
   }
 
-  // Remove the files
-  rmdir_no_fail(job_dir.c_str());
+  // Remove the files, but don't fail if the rmdir fails
+  rmdir(job_dir.c_str());
 }
 
 FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {

--- a/src/job_cache/daemon_cache.h
+++ b/src/job_cache/daemon_cache.h
@@ -54,6 +54,7 @@ class DaemonCache {
 
   FindJobResponse read(const FindJobRequest &find_request);
   void add(const AddJobRequest &add_request);
+  void remove_corrupt_job(int64_t job_id);
 
   void handle_new_client();
   void handle_msg(int fd);

--- a/src/job_cache/eviction_policy.cpp
+++ b/src/job_cache/eviction_policy.cpp
@@ -246,7 +246,8 @@ static void garbage_collect_job(std::string job_dir) {
   }
 }
 
-static void garbage_collect_group(const std::unordered_set<int64_t> jobs,int64_t max_job, int group_id) {
+static void garbage_collect_group(const std::unordered_set<int64_t> jobs, int64_t max_job,
+                                  int group_id) {
   auto group_dir = std::to_string(group_id);
   auto dir_res = wcl::directory_range::open(group_dir);
   if (!dir_res) {

--- a/src/job_cache/eviction_policy.cpp
+++ b/src/job_cache/eviction_policy.cpp
@@ -221,11 +221,12 @@ struct LRUEvictionPolicyImpl {
 };
 
 static void garbage_collect_job(std::string job_dir) {
+  wcl::log::info("found orphaned job folder: %s", job_dir.c_str())();
   auto dir_res = wcl::directory_range::open(job_dir);
   if (!dir_res) {
     // We can keep going even with this failure but we need to at least log it
     wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
-                    job_dir.c_str(), strerror(dir_res.error()));
+                    job_dir.c_str(), strerror(dir_res.error()))();
     return;
   }
 
@@ -234,7 +235,7 @@ static void garbage_collect_job(std::string job_dir) {
     if (!entry) {
       // If one entry has a failure we can just keep going to try and remove more entries
       wcl::log::error("cleaning corrupt job: bad entry in %s: %s", job_dir.c_str(),
-                      strerror(entry.error()));
+                      strerror(entry.error()))();
       continue;
     }
     std::string file = wcl::join_paths(job_dir, entry->name);
@@ -251,7 +252,7 @@ static void garbage_collect_group(const std::unordered_set<int64_t> jobs, int gr
   if (!dir_res) {
     // We can keep going even with this failure but we need to at least log it
     wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
-                    group_dir.c_str(), strerror(dir_res.error()));
+                    group_dir.c_str(), strerror(dir_res.error()))();
     return;
   }
 
@@ -260,7 +261,7 @@ static void garbage_collect_group(const std::unordered_set<int64_t> jobs, int gr
     if (!entry) {
       // It isn't critical that we remove this so just log the error and move on
       wcl::log::error("cleaning corrupt job: bad entry in %s: %s", group_dir.c_str(),
-                      strerror(entry.error()));
+                      strerror(entry.error()))();
       return;
     }
     int64_t job_id = std::stoll(entry->name);

--- a/src/job_cache/eviction_policy.h
+++ b/src/job_cache/eviction_policy.h
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
 namespace job_cache {
 
@@ -55,6 +56,7 @@ class LRUEvictionPolicy : public EvictionPolicy {
   std::unique_ptr<LRUEvictionPolicyImpl> impl;
   uint64_t max_cache_size;
   uint64_t low_cache_size;
+  std::thread gc_thread;
 
  public:
   explicit LRUEvictionPolicy(uint64_t max_cache_size, uint64_t low_cache_size);

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -332,7 +332,6 @@ TEST(job_cache_basic_fuzz) {
   TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
 }
 
-/*
 // This test appears to work but it takes quite a long time and
 // causes a lot of filesystem churn. Just test this on your own
 // occasionally as a debugging/repro tool for those kinds of issues.
@@ -347,8 +346,7 @@ TEST(job_cache_large_message_fuzz) {
   config.cache_dir = ".job_cache_test";
   config.dir = "job_cache_test";
   TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
-}
-*/
+}*/
 
 // This test appears to work but it takes *FOREVER* and doesn't represent
 // a very likely case. Still it might be worth running this on your own


### PR DESCRIPTION
This change adds two functions to the job cache

1) If a corrupted job is detected, instead of just returning a cache miss, we clean up that job so future checks won't fail
2) If a folder storing the hashed files of a job exists in the folder but does not exist in the database, we clean up the folder