### PR TITLE
Include name of failing file in dry run

### DIFF
--- a/tools/wake-format/main.cpp
+++ b/tools/wake-format/main.cpp
@@ -270,9 +270,11 @@ int main(int argc, char **argv) {
         continue;
       }
 
-      auto diff = wcl::diff<std::string>(src.begin(), src.end(), fmt.begin(), fmt.end());
-      display_diff(std::cerr, diff);
       dry_run_failed = true;
+
+      auto diff = wcl::diff<std::string>(src.begin(), src.end(), fmt.begin(), fmt.end());
+      std::cerr << std::endl << name << std::endl;
+      display_diff(std::cerr, diff);
     }
 
     if (in_place) {


### PR DESCRIPTION
`wake-format -n ....` now prints the file name of the failing file. This is helpful when formatting several files at once with `-n`

![image](https://github.com/sifive/wake/assets/7253461/ce17bdbb-c56f-4f8f-9353-ef8338a2684c)
