### PR TITLE
Log when an eviction occurs

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -914,6 +914,11 @@ void DaemonCache::launch_evict_loop() {
     close(stdoutPipe[read_side]);
     close(stdoutPipe[write_side]);
 
+    // We use stdout as a comunication line so we re-map logging of eviction to stderr
+    wcl::log::clear_subscribers();
+    wcl::log::subscribe(std::make_unique<wcl::log::FormatSubscriber>(std::cerr.rdbuf()));
+    wcl::log::info("Reinitialized logging for eviction loop")();
+
     // Finally enter the eviction loop, if it exits cleanly
     // go ahead and exit with its result.
     int result =

--- a/src/job_cache/job_cache_impl_common.cpp
+++ b/src/job_cache/job_cache_impl_common.cpp
@@ -229,7 +229,7 @@ void copy_or_reflink(const char *src, const char *dst, mode_t mode, int extra_fl
 
 #endif
 
-void remove_backing_files(const std::string &dir, int64_t job_id) {
+void remove_job_backing_files(const std::string &dir, int64_t job_id) {
   uint8_t group_id = job_id & 0xFF;
   std::string job_dir = wcl::join_paths(dir, wcl::to_hex(&group_id), std::to_string(job_id));
   auto dir_range = wcl::directory_range::open(job_dir);
@@ -266,10 +266,9 @@ void remove_backing_files(const std::string &dir, int64_t job_id) {
 
 void remove_backing_files(std::string dir,
                           const std::vector<std::pair<int64_t, std::string>> &job_ids,
-                          size_t min_removals_per_thread, size_t max_number_of_threads) {
+                          size_t max_number_of_threads) {
   // Calculate a good number of threads to use.
-  size_t actual_num_threads =
-      std::min(max_number_of_threads, std::max(1UL, job_ids.size() / min_removals_per_thread));
+  size_t actual_num_threads = std::min(max_number_of_threads, std::max(1UL, job_ids.size()));
 
   // Calculate how many removals will be done by each task
   size_t actual_removals_per_thread =
@@ -285,7 +284,7 @@ void remove_backing_files(std::string dir,
       auto i = iter;
       for (; i < task_end && i < end; ++i) {
         wcl::log::info("evicted job with cmd = %s", i->second.c_str())();
-        remove_backing_files(dir, i->first);
+        remove_job_backing_files(dir, i->first);
       }
     }));
     iter = task_end;

--- a/src/job_cache/job_cache_impl_common.h
+++ b/src/job_cache/job_cache_impl_common.h
@@ -35,7 +35,8 @@ void remove_backing_files(const std::string &dir, int64_t job_id);
 // in parallel.
 // NOTE: This should not be used from the wake process itself
 //       because it can spawn threads.
-void remove_backing_files(std::string dir, const std::vector<int64_t> &job_ids,
+void remove_backing_files(std::string dir,
+                          const std::vector<std::pair<int64_t, std::string>> &job_ids,
                           size_t min_removals_per_thread, size_t max_number_of_threads);
 
 // Tries to reflink src to dst but copies if that fails.

--- a/src/job_cache/job_cache_impl_common.h
+++ b/src/job_cache/job_cache_impl_common.h
@@ -29,7 +29,7 @@
 // This function removes all the baking files of a specific job.
 // While not technically unsafe to use on a job still in the databse
 // this should be avoided.
-void remove_backing_files(const std::string &dir, int64_t job_id);
+void remove_job_backing_files(const std::string &dir, int64_t job_id);
 
 // Like remove_backing_files(int64_t job_id) but removes many
 // in parallel.
@@ -37,7 +37,7 @@ void remove_backing_files(const std::string &dir, int64_t job_id);
 //       because it can spawn threads.
 void remove_backing_files(std::string dir,
                           const std::vector<std::pair<int64_t, std::string>> &job_ids,
-                          size_t min_removals_per_thread, size_t max_number_of_threads);
+                          size_t max_number_of_threads);
 
 // Tries to reflink src to dst but copies if that fails.
 void copy_or_reflink(const char *src, const char *dst, mode_t mode = 0644, int extra_flags = 0);


### PR DESCRIPTION
This change causes the shared cache .stderr file to log evictions. It would be nicer to log to .stdout but that is being used as a communication channel between the job-cache daemon and the eviction child process. We should be able to switch the eviction child process over to a thread now which would resolve this issue.