### PR TITLE
Never cache a failed job

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -511,6 +511,7 @@ export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Ru
 
                 # Caching a failed job is a waste of space, never do that
                 require True = status == 0
+                else Pass ""
 
                 job_cache_add jobCacheAddJson
 

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -508,8 +508,10 @@ export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Ru
                     def _ = write ".cache-misses/write.{prefix}.json" "//{label}\n{jobCacheAddJson}"
 
                     True
+
                 # Caching a failed job is a waste of space, never do that
-                require True = status != 0
+                require True = status == 0
+
                 job_cache_add jobCacheAddJson
 
             Pass (RunnerOutput (map getPathName vis) outputs useage)

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -508,7 +508,8 @@ export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Ru
                     def _ = write ".cache-misses/write.{prefix}.json" "//{label}\n{jobCacheAddJson}"
 
                     True
-
+                # Caching a failed job is a waste of space, never do that
+                require True = status != 0
                 job_cache_add jobCacheAddJson
 
             Pass (RunnerOutput (map getPathName vis) outputs useage)


### PR DESCRIPTION
We had the quite silly behavior of caching job failures before which makes no sense. This change eliminates that.