### PR TITLE
Cleanup more files on clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ all:		wake.db
 	$(WAKE_ENV) BOOTSTRAP_WAKE=true ./bin/wake build default
 
 clean:
-	rm -f .build/* bin/* lib/wake/* */*.o */*/*.o src/json/jlexer.cpp src/parser/lexer.cpp src/parser/parser.cpp src/parser/parser.h src/version.h wake.db
+	rm -f .build/* bin/* lib/wake/* */*.o */*/*.o src/json/jlexer.cpp src/parser/lexer.cpp src/parser/parser.cpp src/parser/parser.h src/version.h wake.db $(shell find . -name "wake.log") $(shell find . -name "manifest.wake") wake_*.tar.xz
 	touch bin/stamp lib/wake/stamp
 
 wake.db:	bin/wake bin/wakebox lib/wake/fuse-waked lib/wake/shim-wake lib/wake/wake-hash


### PR DESCRIPTION
`make clean` currently leaves a lot of files on disk that should be cleaned up. It has caused me headache more than once. Update it to remove troublesome files and the new log file recently added.