### PR TITLE
Add logInteractive, remove echo from no-tty, update docs

### DIFF
--- a/share/doc/wake/logging.md
+++ b/share/doc/wake/logging.md
@@ -11,8 +11,6 @@ Wake has a concept of loggers,
 to which text can be written during wake execution by various sources.
 A logger combines a string log level (e.g. "error", "info", "my_custom_level")
 and a display format (color and intensity).
-There can be multiple loggers with the same log level,
-though colors may not display as expected.
 
 |Term Used In this Document | What wake code/libraries call it |
 ----------------------------|----------------------------------|
@@ -23,21 +21,21 @@ though colors may not display as expected.
 
 `wake` has a number of built in loggers in which all start with `log...`.
 You can also make your own logger using `mkLogLevel`.
-You can use this to customize the color you want it to be shown as (if at all)
-and give more fine-grained control over which wake output stream it should go to.
+You can use this to redirect wake output to a dedicated stream which can
+later be filtered on.
 
-
-| wake `def`        | Color/Intensity | log level |
-|-------------------|-----------------|-----------|
-| logDebug          |     Blue        | "debug"   |
-| logInfo           |     Dim         | "info"    |
-| logEcho           |      N/A        | "echo"    |
-| logReport         |    Magenta      | "report"  |
-| logWarning        |    Yellow       | "warning" |
-| logError          |     Red         | "error"   |
-| logNever          |     N/A         | "null"    |
-| mkLogLevel "foo" (Some Green) |  Green     | "foo"     |
-| mkLogLevel2 "bar" (Some Green) (Some Bright) | Bright Green   | "bar"      |
+| wake `def`        | Color/Intensity | log level     |
+|-------------------|-----------------|---------------|
+| logDebug          |     Blue        | "debug"       |
+| logInfo           |     Gray        | "info"        |
+| logEcho           |     Default     | "echo"        |
+| logInteractive    |     Cyan        | "interactive" |
+| logReport         |     Magenta     | "report"      |
+| logWarning        |     Yellow      | "warning"     |
+| logError          |     Red         | "error"       |
+| logNever          |     Default     | "null"        |
+| LogLevel "foo"    |     Default     | "foo"         |
+| LogLevel "bar"    |     Default     | "bar"         |
 
 ## Directing Logger Output
 
@@ -53,30 +51,27 @@ If you match a line in the table, stop!
 This is what will appear on the console as you watch wake execute,
 i.e. what is sent to ``wake`'s stdout:
 
-| log level           | "debug"  | "info"  | "echo"  | "report"  | "warning"  | "error"  | "null"  |  "foo" |
-|---------------------|----------|---------|---------|-----------|------------|----------|---------|--------|
-|--stdout="foo"       |          |         |         |           |            |          |         |    x   |
-|--stdout="foo,info"  |          |    x    |         |           |            |          |         |    x   |
-|--debug              |      x   |    x    |    x    |     x     |      x     |    x     |         |        |
-|--verbose            |          |    x    |    x    |     x     |      x     |    x     |         |        |
-|--quiet              |          |         |         |           |            |    x     |         |        |
-|--no-tty<sup>*</sup> |          |         |    x    |     x     |      x     |    x     |         |        |
-|(default)            |          |         |         |     x     |      x     |    x     |         |        |
-
-<sup>*</sup> `--no-tty` also prevents any coloring from being applied.
+| log level           | "debug"  | "info"  | "echo"  | "interactive" | "report"  | "warning"  | "error"  | "null"  |  "foo" |
+|---------------------|----------|---------|---------|---------------|-----------|------------|----------|---------|--------|
+|--stdout="foo"       |          |         |         |               |           |            |          |         |    x   |
+|--stdout="foo,info"  |          |    x    |         |               |           |            |          |         |    x   |
+|--debug              |    x     |    x    |    x    |    is_atty    |     x     |      x     |    x     |         |        |
+|--verbose            |          |    x    |    x    |    is_atty    |     x     |      x     |    x     |         |        |
+|--quiet              |          |         |         |               |           |            |    x     |         |        |
+|(default)            |          |         |         |    is_atty    |     x     |      x     |    x     |         |        |
 
 Unless overridden with `--stderr=...`,
 the only logger output that ever appears on wake's stderr is from those with log level "error"
 (e.g. `logError`).
 
 The additional command line arguments `--fd:3`, `--fd:4`, `--fd:5` can be used to output to file descriptors 3, 4, 5.
-One example shell command would be, for some wake code that had `mkLogLevel "foo"`:
+One example shell command would be, for some wake code that had `LogLevel "foo"`:
 
 ```
 wake --fd:3="foo" mywakecode 3>foo.txt
 ```
 
-These can be concatenated with commas and include the normal log levels, so to capture both `mkLogLevel "foo"` and `logInfo` to a file:
+These can be concatenated with commas and include the normal log levels, so to capture both `LogLevel "foo"` and `logInfo` to a file:
 
 ```
 wake --fd:3="foo,info" mywakecode 3>foo_and_info.txt

--- a/share/wake/lib/core/print.wake
+++ b/share/wake/lib/core/print.wake
@@ -48,6 +48,10 @@ export def logError: LogLevel =
 export def logWarning: LogLevel =
     LogLevel "warning" # (Some Yellow)
 
+# logInteractive: logged to stdout when wake invoked with a tty (Color)
+export def logInteractive: LogLevel =
+    LogLevel "interactive" # (Some Cyan)
+
 # logReport: logged to stdout unless run with -q (Magenta)
 export def logReport: LogLevel =
     LogLevel "report" # (Some Magenta)

--- a/src/runtime/status.cpp
+++ b/src/runtime/status.cpp
@@ -469,26 +469,32 @@ int status_get_fd(const char *name) {
 }
 
 static int stream_color(std::string name) {
-  if (name == "error") {
+  if (name == STREAM_ERROR) {
     return 1;
   }
-  if (name == "warning") {
+  if (name == STREAM_WARNING) {
     return 3;
   }
-  if (name == "echo") {
+  if (name == STREAM_ECHO) {
     return 0;
   }
-  if (name == "info") {
+  if (name == STREAM_INFO) {
     return 16;
   }
-  if (name == "debug") {
+  if (name == STREAM_LOG) {
     return 4;
   }
-  if (name == "bsp") {
+  if (name == STREAM_BSP) {
     return 2;
   }
-  if (name == "null") {
+  if (name == STREAM_NULL) {
     return 0;
+  }
+  if (name == STREAM_INTERACTIVE) {
+    return 6;
+  }
+  if (name == STREAM_REPORT) {
+    return 5;
   }
 
   return 0;

--- a/src/runtime/status.h
+++ b/src/runtime/status.h
@@ -80,11 +80,14 @@ class StatusBuf : public std::streambuf {
 extern StatusState status_state;
 
 #define STREAM_LOG "debug"
+#define STREAM_BSP "bsp"
 #define STREAM_INFO "info"
+#define STREAM_INTERACTIVE "interactive"
 #define STREAM_REPORT "report"
 #define STREAM_ECHO "echo"
 #define STREAM_WARNING "warning"
 #define STREAM_ERROR "error"
+#define STREAM_NULL "null"
 
 void status_init();
 void status_refresh(bool idle);

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -746,13 +746,22 @@ int main(int argc, char **argv) {
   if (notype) return (ok && !terminalReporter.errors) ? 0 : 1;
 
   /* Setup logging streams */
-  if (noexecute && !clo.fd1) clo.fd1 = "error";
-  if (clo.debug && !clo.fd1) clo.fd1 = "debug,info,echo,report,warning,error";
-  if (clo.verbose && !clo.fd1) clo.fd1 = "info,echo,report,warning,error";
-  if (clo.quiet && !clo.fd1) clo.fd1 = "error";
-  if (!clo.tty && !clo.fd1) clo.fd1 = "echo,report,warning,error";
-  if (!clo.fd1) clo.fd1 = "report,warning,error";
-  if (!clo.fd2) clo.fd2 = "error";
+
+  if (clo.tty) {
+    if (noexecute && !clo.fd1) clo.fd1 = "error";
+    if (clo.debug && !clo.fd1) clo.fd1 = "debug,info,echo,interactive,report,warning,error";
+    if (clo.verbose && !clo.fd1) clo.fd1 = "info,echo,interactive,report,warning,error";
+    if (clo.quiet && !clo.fd1) clo.fd1 = "error";
+    if (!clo.fd1) clo.fd1 = "interactive,report,warning,error";
+    if (!clo.fd2) clo.fd2 = "error";
+  } else {
+    if (noexecute && !clo.fd1) clo.fd1 = "error";
+    if (clo.debug && !clo.fd1) clo.fd1 = "debug,info,echo,report,warning,error";
+    if (clo.verbose && !clo.fd1) clo.fd1 = "info,echo,report,warning,error";
+    if (clo.quiet && !clo.fd1) clo.fd1 = "error";
+    if (!clo.fd1) clo.fd1 = "report,warning,error";
+    if (!clo.fd2) clo.fd2 = "error";
+  }
 
   status_set_bulk_fd(1, clo.fd1);
   status_set_bulk_fd(2, clo.fd2);


### PR DESCRIPTION
- logInteractive is now a log stream that only displays when a tty is set, usually implying a human is running the command
- logEcho doesn't get printed by default when --no-tty is set, most folks don't want echo when setting --no-tty, and CI can add it back manually if they want it
- The logging docs had drifted a bit, they are now updated 