### PR TITLE
CI: add Fedora 38

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,7 +134,7 @@ jobs:
               build_cmd: debuild -us -uc
               test_cmd: dpkg -i *.deb && cd tests && wake runTests
               install_src_glob: build/*.deb build/*.xz build/*.changes build/*.dsc
-              
+
               - target: fedora_38
               dockerfile: fedora-38
               extra_docker_build_args: ''

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,6 +134,14 @@ jobs:
               build_cmd: debuild -us -uc
               test_cmd: dpkg -i *.deb && cd tests && wake runTests
               install_src_glob: build/*.deb build/*.xz build/*.changes build/*.dsc
+              
+              - target: fedora_38
+              dockerfile: fedora-38
+              extra_docker_build_args: ''
+              extra_docker_run_args: ''
+              build_cmd: rpmbuild -ta --define "_rpmdir /build" wake_*.tar.xz
+              test_cmd: rpm -i x86_64/*.rpm && cd tests && wake runTests
+              install_src_glob: build/x86_64/*.rpm
 
             - target: vscode
               dockerfile: wasm
@@ -328,6 +336,12 @@ jobs:
           with:
             name: release_ubuntu_22_04
             path: ubuntu_22_04
+      
+        - name: Download Fedora 38
+          uses: actions/download-artifact@v3
+          with:
+            name: release_fedora_38
+            path: fedora_38
 
         - name: Rename artifacts
           run: |
@@ -338,6 +352,7 @@ jobs:
             cp rocky_9/wake-*-1.x86_64.rpm rocky_9-wake-${VERSION}-1.x86_64.rpm
             cp debian_bullseye/wake_*-1_amd64.deb debian-bullseye-wake_${VERSION}-1_amd64.deb
             cp ubuntu_22_04/wake_*-1_amd64.deb ubuntu-22-04-wake_${VERSION}-1_amd64.deb
+            cp fedora_38/wake-*-1.x86_64.rpm fedora_38-wake-${VERSION}-1.x86_64.rpm
 
         - name: Create Release
           # v1.2.1 -> 919008cf3f741b179569b7a6fb4d8860689ab7f0
@@ -353,4 +368,5 @@ jobs:
               rocky_9-wake-*-1.x86_64.rpm
               debian-bullseye-wake_*-1_amd64.deb
               ubuntu-22-04-wake_*-1_amd64.deb
+              fedora_38-wake-*-1.x86_64.rpm
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,7 +135,7 @@ jobs:
               test_cmd: dpkg -i *.deb && cd tests && wake runTests
               install_src_glob: build/*.deb build/*.xz build/*.changes build/*.dsc
 
-              - target: fedora_38
+            - target: fedora_38
               dockerfile: fedora-38
               extra_docker_build_args: ''
               extra_docker_run_args: ''

--- a/.github/workflows/dockerfiles/fedora-38
+++ b/.github/workflows/dockerfiles/fedora-38
@@ -1,0 +1,9 @@
+FROM fedora:38
+
+RUN echo fastestmirror=1 >> /etc/dnf/dnf.conf
+RUN dnf clean all
+RUN dnf update -y
+RUN dnf install -y rpm-build rpm-devel rpmlint make python39 bash diffutils patch rpmdevtools m4 tar xz dash git which make gcc gcc-c++ fuse fuse-devel gmp-devel ncurses-devel sqlite-devel re2-devel squashfuse
+RUN rpmdev-setuptree
+
+WORKDIR /build

--- a/src/json/utf8.cpp
+++ b/src/json/utf8.cpp
@@ -21,6 +21,7 @@
 
 #include "utf8.h"
 
+#include <cstdint>
 #include <string>
 
 enum {

--- a/src/json/utf8.h
+++ b/src/json/utf8.h
@@ -18,6 +18,7 @@
 #ifndef UTF8_H
 #define UTF8_H
 
+#include <cstdint>
 #include <string>
 
 bool push_utf8(std::string &result, uint32_t c);


### PR DESCRIPTION
I end up using Fedora a lot with Wake and I assume others do as well. This will help make sure things don't break in Fedora.

This PR might fail at first as @V-FEXrt and @JakeSiFive have not merged in the Fedora 38 related patches to master.