### PR TITLE
Add runner hash

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -366,7 +366,7 @@ export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String E
                     "stdin" :-> JString stdin,
                     "input_files" :-> jobCacheVisible,
                     "client_cwd" :-> JString workspace,
-                    "hash" :-> JString hashKey,
+                    "runner_hash" :-> JString hashKey,
                     "dir_redirects" :-> JObject (wakeroot :-> JString "./",),
                 )
 
@@ -486,7 +486,7 @@ export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String E
                     "command_line" :-> JString cmd.implode,
                     "envrionment" :-> JString env.implode,
                     "stdin" :-> JString stdin,
-                    "hash" :-> JString hashKey,
+                    "runner_hash" :-> JString hashKey,
                     "input_files" :-> jobCacheReadFiles,
                     "input_dirs" :-> JArray Nil, # TODO: This will need some fuse work to make good on
                     "output_files" :-> jobCacheOutputFiles,

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -337,7 +337,7 @@ def getPath input =
 
 # wakeroot is the absolute sandbox-path from which input and output files will
 # be interpreted as being relative to if they're in fact relative.
-export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Runner): Runner =
+export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String Error) (wakeroot: String) ((Runner name score baseDoIt): Runner): Runner =
     def virtual job stdout stderr status runtime cputime membytes ibytes obytes = prim "job_virtual"
     def badlaunch job error = prim "job_fail_launch"
     def job_cache_read str = prim "job_cache_read"
@@ -354,6 +354,8 @@ export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Ru
 
             def jobCacheVisible = JArray (map mkVisJson vis)
 
+            require Pass hashKey = hashFn runnerInput
+
             def jobCacheJsonIn =
                 prettyJSON
                 $ JObject (
@@ -364,6 +366,7 @@ export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Ru
                     "stdin" :-> JString stdin,
                     "input_files" :-> jobCacheVisible,
                     "client_cwd" :-> JString workspace,
+                    "hash" :-> JString hashKey,
                     "dir_redirects" :-> JObject (wakeroot :-> JString "./",),
                 )
 
@@ -483,6 +486,7 @@ export def mkJobCacheRunner (wakeroot: String) ((Runner name score baseDoIt): Ru
                     "command_line" :-> JString cmd.implode,
                     "envrionment" :-> JString env.implode,
                     "stdin" :-> JString stdin,
+                    "hash" :-> JString hashKey,
                     "input_files" :-> jobCacheReadFiles,
                     "input_dirs" :-> JArray Nil, # TODO: This will need some fuse work to make good on
                     "output_files" :-> jobCacheOutputFiles,
@@ -843,7 +847,7 @@ export def defaultRunner: Runner =
     # works in relative paths to make different runs consistent. Ideally
     # you'd have a more complex sandbox that kept the wakeroot at a
     # consistent place across runs.
-    mkJobCacheRunner "/workspace" fuseRunner
+    mkJobCacheRunner (\_ Pass "") "/workspace" fuseRunner
 
 # A plan describing how to construct a JSONRunner
 # RawScript: the path to the script to run jobs with

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -442,7 +442,8 @@ class SelectMatchingJobs {
       "  and   commandline = ?"
       "  and   environment = ?"
       "  and   stdin = ?"
-      "  and   bloom_filter & ~? = 0";
+      "  and   bloom_filter & ~? = 0"
+      "  and   runner_hash = ?";
 
   // When we find a match we check all of its input files and input directories
   static constexpr const char *sql_find_files = "select * from input_files where job = ?";
@@ -481,6 +482,7 @@ class SelectMatchingJobs {
     find_jobs.bind_string(2, find_job_request.command_line);
     find_jobs.bind_string(3, find_job_request.envrionment);
     find_jobs.bind_string(4, find_job_request.stdin_str);
+    find_jobs.bind_string(6, find_job_request.hash);
 
     // The bloom filter of a matching job has to be a subset of this one
     uint64_t bloom_integer = *reinterpret_cast<const uint64_t *>(find_job_request.bloom.data());

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -482,7 +482,7 @@ class SelectMatchingJobs {
     find_jobs.bind_string(2, find_job_request.command_line);
     find_jobs.bind_string(3, find_job_request.envrionment);
     find_jobs.bind_string(4, find_job_request.stdin_str);
-    find_jobs.bind_string(6, find_job_request.hash);
+    find_jobs.bind_string(6, find_job_request.runner_hash);
 
     // The bloom filter of a matching job has to be a subset of this one
     uint64_t bloom_integer = *reinterpret_cast<const uint64_t *>(find_job_request.bloom.data());
@@ -867,7 +867,7 @@ void DaemonCache::add(const AddJobRequest &add_request) {
   {
     impl->transact.run([this, &add_request, &job_id]() {
       job_id = impl->jobs.insert(add_request.cwd, add_request.command_line, add_request.envrionment,
-                                 add_request.stdin_str, add_request.bloom, add_request.hash);
+                                 add_request.stdin_str, add_request.bloom, add_request.runner_hash);
 
       // Add additional info
       impl->jobs.insert_output_info(job_id, add_request.stdout_str, add_request.stderr_str,

--- a/src/job_cache/schema.sql
+++ b/src/job_cache/schema.sql
@@ -20,7 +20,9 @@ create table if not exists jobs(
   commandline  blob    not null,
   environment  blob    not null,
   stdin        text    not null,
-  bloom_filter integer);
+  bloom_filter integer not null,
+  runner_hash  text    not null,
+);
 create index if not exists job on jobs(directory, commandline, environment, stdin);
 
 -- This table stores all the details about a job that aren't known until

--- a/src/job_cache/schema.sql
+++ b/src/job_cache/schema.sql
@@ -21,9 +21,8 @@ create table if not exists jobs(
   environment  blob    not null,
   stdin        text    not null,
   bloom_filter integer not null,
-  runner_hash  text    not null,
-);
-create index if not exists job on jobs(directory, commandline, environment, stdin);
+  runner_hash  text    not null);
+create index if not exists job on jobs(directory, commandline, environment, stdin, runner_hash);
 
 -- This table stores all the details about a job that aren't known until
 -- after the job has finished executing. As of right now it has no reason

--- a/src/job_cache/types.cpp
+++ b/src/job_cache/types.cpp
@@ -301,7 +301,7 @@ AddJobRequest AddJobRequest::from_implicit(const JAST &json) {
   req.command_line = json.get("command_line").value;
   req.envrionment = json.get("envrionment").value;
   req.stdin_str = json.get("stdin").value;
-  req.hash = json.get("hash").value;
+  req.runner_hash = json.get("runner_hash").value;
   req.stdout_str = json.get("stdout").value;
   req.stderr_str = json.get("stderr").value;
   req.status = std::stoi(json.get("status").value);
@@ -573,7 +573,7 @@ FindJobRequest::FindJobRequest(const JAST &find_job_json) {
   envrionment = find_job_json.get("envrionment").value;
   stdin_str = find_job_json.get("stdin").value;
   client_cwd = find_job_json.get("client_cwd").value;
-  hash = find_job_json.get("runner_hash").value;
+  runner_hash = find_job_json.get("runner_hash").value;
   if (wcl::is_relative(client_cwd)) {
     wcl::log::error("FindJobRequest::FindJobRequest: client_cwd cannot be relative. found: '%s'",
                     client_cwd.c_str())

--- a/src/job_cache/types.cpp
+++ b/src/job_cache/types.cpp
@@ -301,6 +301,7 @@ AddJobRequest AddJobRequest::from_implicit(const JAST &json) {
   req.command_line = json.get("command_line").value;
   req.envrionment = json.get("envrionment").value;
   req.stdin_str = json.get("stdin").value;
+  req.hash = json.get("hash").value;
   req.stdout_str = json.get("stdout").value;
   req.stderr_str = json.get("stderr").value;
   req.status = std::stoi(json.get("status").value);

--- a/src/job_cache/types.cpp
+++ b/src/job_cache/types.cpp
@@ -572,6 +572,7 @@ FindJobRequest::FindJobRequest(const JAST &find_job_json) {
   envrionment = find_job_json.get("envrionment").value;
   stdin_str = find_job_json.get("stdin").value;
   client_cwd = find_job_json.get("client_cwd").value;
+  hash = find_job_json.get("runner_hash").value;
   if (wcl::is_relative(client_cwd)) {
     wcl::log::error("FindJobRequest::FindJobRequest: client_cwd cannot be relative. found: '%s'",
                     client_cwd.c_str())

--- a/src/job_cache/types.h
+++ b/src/job_cache/types.h
@@ -96,6 +96,7 @@ struct FindJobRequest {
   std::string stdin_str;
   wcl::trie<std::string, std::string> dir_redirects;
   BloomFilter bloom;
+  std::string hash;
   // Using an ordered map is a neat trick here. It
   // gives us repeatable hashes on directories
   // later.

--- a/src/job_cache/types.h
+++ b/src/job_cache/types.h
@@ -187,6 +187,7 @@ struct AddJobRequest {
   std::string envrionment;
   std::string stdin_str;
   BloomFilter bloom;
+  std::string hash;
   std::vector<InputFile> inputs;
   std::vector<InputDir> directories;
   std::vector<OutputFile> outputs;

--- a/src/job_cache/types.h
+++ b/src/job_cache/types.h
@@ -96,7 +96,7 @@ struct FindJobRequest {
   std::string stdin_str;
   wcl::trie<std::string, std::string> dir_redirects;
   BloomFilter bloom;
-  std::string hash;
+  std::string runner_hash;
   // Using an ordered map is a neat trick here. It
   // gives us repeatable hashes on directories
   // later.
@@ -187,7 +187,7 @@ struct AddJobRequest {
   std::string envrionment;
   std::string stdin_str;
   BloomFilter bloom;
-  std::string hash;
+  std::string runner_hash;
   std::vector<InputFile> inputs;
   std::vector<InputDir> directories;
   std::vector<OutputFile> outputs;


### PR DESCRIPTION
This change allows runner authors to add in some kind of hash or other key (I call it a "runner hash" but it is allowed to be any string) to allow runner authors to make the cache aware of differences in jobs that may not be otherwise apparent. This also allows less conservative use of shared caching with the trade off of being more conservative about what is considered to be "matching" and puts this trade off in the runner author's control.