### PR TITLE
Add opt in logging for lsp-wake

### DIFF
--- a/tools/lsp-wake/lsp.wake
+++ b/tools/lsp-wake/lsp.wake
@@ -30,5 +30,5 @@ target buildLSP variant: Result (List Path) Error = match variant
             "--post-js", postJS.getPathName,
             "--pre-js", preJS.getPathName,
 
-        tool @here Nil variant "lib/wake/lsp-wake" (dst, util,) (postJS, preJS,) extraLFlags
-    _ = tool @here Nil variant "lib/wake/lsp-wake" (dst, util,) Nil Nil
+        tool @here Nil variant "lib/wake/lsp-wake" (dst, util, wcl,) (postJS, preJS,) extraLFlags
+    _ = tool @here Nil variant "lib/wake/lsp-wake" (dst, util, wcl,) Nil Nil


### PR DESCRIPTION
Adds an env var `WAKE_LSP_LOG_PATH` which when set will write lsp logs out to the provided filepath.

Useful for debugging unexpected lsp reactions.

the header `rpc` can be grepped to extract just the messages exchanged between client and server

`cat file.log | grep 'rpc='` -> all messages
`cat file.log | grep 'rpc=tx'` -> all messages from server to client
`cat file.log | grep 'rpc=rx'` -> all messages from client to server