### PR TITLE
Fake syntax highlighting by lying to GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.wake linguist-language=python
+*.wake linguist-language=ruby

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.wake linguist-language=ruby
+*.wake linguist-language=scala

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.wake linguist-language=ruby

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.wake linguist-language=scala
+*.wake linguist-language=python

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.wake linguist-language=ruby
+*.wake linguist-language=python


### PR DESCRIPTION
This PR tells GitHub that the `*.wake` files in this repo should be highlighted as `python` files. We have enough overlap with python keywords and `# comments` that it is better than no highlighting while still being far from perfect.

You can view an example of this here: https://github.com/sifive/wake/blob/23238a0304e57804d6d8b8d0cf9bb949d288be5c/build.wake

It is still unclear if this makes it easier or harder to follow so we are going to trial run it in the wake repo