### PR TITLE
Fix some oversights in statusbuf code

### DIFF
--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -318,10 +318,27 @@ struct JobTable::detail {
   bool batch;
   struct timespec wall;
   RUsage childrenUsage;
+
   std::unordered_map<int, std::unique_ptr<std::streambuf>> fd_bufs;
   std::unordered_map<int, std::unique_ptr<TermInfoBuf>> term_bufs;
 
   detail() {}
+
+  ~detail() {
+    // We need a very specific release order on these so we do it manually
+    for (auto &entry : pidmap) {
+      entry.second.reset();
+    }
+    for (auto &entry : pipes) {
+      entry.second.reset();
+    }
+    for (auto &entry : fd_bufs) {
+      entry.second.release();
+    }
+    for (auto &entry : term_bufs) {
+      entry.second.release();
+    }
+  }
 
   CriticalJob critJob(double nexttime) const;
 };

--- a/src/runtime/status.cpp
+++ b/src/runtime/status.cpp
@@ -74,6 +74,14 @@ static void write_all(int fd, const char *data, size_t len) {
   }
 }
 
+static void status_clear_state() {
+  if (!term_tty()) {
+    return;
+  }
+  std::string nrm = term_normal();
+  write_all(1, nrm.c_str(), nrm.size());
+}
+
 static void status_clear() {
   if (term_tty() && used) {
     std::stringstream os;
@@ -232,6 +240,7 @@ int StatusBuf::overflow(int c) {
     status_clear();
     emit_header();
     buf.sputn(line_buf.data(), line_buf.size());
+    status_clear_state();
     line_buf = "";
   }
 
@@ -252,6 +261,7 @@ StatusBuf::~StatusBuf() {
     line_buf += '\n';
     emit_header();
     buf.sputn(line_buf.data(), line_buf.size());
+    status_clear_state();
   }
   sync();
 }
@@ -552,6 +562,7 @@ void status_refresh(bool idle) {
 void status_finish() {
   status_clear();
   if (term_tty()) {
+    status_clear_state();
     struct itimerval timer;
     memset(&timer, 0, sizeof(timer));
     setitimer(ITIMER_REAL, &timer, 0);


### PR DESCRIPTION
This fixes two issues

1) If a job is not hygenic about its color output, wake was not cleaning up after it. This change fixes that and does an extra defensive cleanup at the end

2) There was as segfault that was occurring when SIGTERM was sent in the middle of a run. I finally figured out that this was because the StreamBuf destuctor was trying to write to an invalid TermBufInfo and that was happening because the TermInfoBuf that it was referring to was not being deleted in the correct order. That order is affected by the order of the fields but its better to just manually write code that releases the data in the correct order in the JobTable::detail destructor.