### PR TITLE
Add read only mode for shared caching

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -517,6 +517,11 @@ export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String E
                 require True = status == 0
                 else Pass ""
 
+                # Sometimes we want a read-only cache. For instance read-only pre-merge
+                # with read-write post-merge.
+                require Some _ = getenv "WAKE_EXPERIMENTAL_JOB_CACHE_READ_ONLY"
+                else Pass ""
+
                 job_cache_add jobCacheAddJson
 
             Pass (RunnerOutput (map getPathName vis) outputs useage)

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -519,7 +519,7 @@ export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String E
 
                 # Sometimes we want a read-only cache. For instance read-only pre-merge
                 # with read-write post-merge.
-                require Some _ = getenv "WAKE_EXPERIMENTAL_JOB_CACHE_READ_ONLY"
+                require None = getenv "WAKE_EXPERIMENTAL_JOB_CACHE_READ_ONLY"
                 else Pass ""
 
                 job_cache_add jobCacheAddJson


### PR DESCRIPTION
Sometimes you might want the benefit of cache hits but not trust the source to write to the cache (for instance in pre-merge CI perhaps). This PR adds that ability which can be set by setting `WAKE_EXPERIMENTAL_JOB_CACHE_READ_ONLY=1`