### PR TITLE
Fix race between previous daemon close, and next daemon create

### DIFF
--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -200,7 +200,7 @@ wcl::optional<ConnectError> Cache::backoff_try_connect(int attempts) {
     // We normally connect in about 3 tries on fresh connect so
     // if we haven't connected at this point its a good spot to start
     // start trying.
-    if (attempts > 3) {
+    if (i > 3) {
       launch_daemon();
     }
 


### PR DESCRIPTION
There is a race that can happen if you run a wake process directly after another wake process that looks like this:

1. A wake process runs and successfully creates and connects to a shared cache daemon
2. That wake process exits
3. That shared cache daemon sees that it has no more connections which sends it into a shutdown sequence but the shutdown sequence doesn't complete before...
4. A new wake process starts up, trys to create a daemon, that daemon sees that the cache lock is still locked so it exits
5. The shutdown sequence from step 3 finishes and releases the lock
6. The process from step 4 keeps trying to connect but there is no shared cache to connect to

Aside from that race being an issue, there are all sorts of reasons why a shared cache daemon might fail while we're trying to connect so this is a good change to make regardless.