### PR TITLE
Always coredump on crash if we're allowed to

### DIFF
--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -21,6 +21,7 @@
 
 #include <inttypes.h>
 #include <stdlib.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <wcl/defer.h>
@@ -190,6 +191,14 @@ class TerminalReporter : public DiagnosticReporter {
 };
 
 int main(int argc, char **argv) {
+  // Make sure we always get core dumps but don't fail
+  // if that fails for some reason.
+  struct rlimit core_lim;
+  getrlimit(RLIMIT_CORE, &core_lim);
+  core_lim.rlim_cur = core_lim.rlim_max;
+  setrlimit(RLIMIT_CORE, &core_lim);
+
+  // Geth the start time for wake
   auto start = std::chrono::steady_clock::now();
 
   TerminalReporter terminalReporter;


### PR DESCRIPTION
This change should just set the limit on the core size to what ever the maximum allowed is. When the size is 0 (often the default on various systems) no core dump will be produced.