### PR TITLE
lsp: Result should be null instead of empty object

### DIFF
--- a/tools/lsp-wake/json_converter.cpp
+++ b/tools/lsp-wake/json_converter.cpp
@@ -307,7 +307,6 @@ JAST highlightsToJSON(JAST receivedMessage, const std::vector<Location> &occurre
 
 JAST hoverInfoToJSON(JAST receivedMessage, const std::vector<SymbolDefinition> &hoverInfoPieces) {
   JAST message = createResponseMessage(std::move(receivedMessage));
-  JAST &result = message.add("result", JSON_OBJECT);
 
   std::string value;
   for (const SymbolDefinition &def : hoverInfoPieces) {
@@ -321,11 +320,16 @@ JAST hoverInfoToJSON(JAST receivedMessage, const std::vector<SymbolDefinition> &
     }
     value += def.outerDocumentation + "\n\n";
   }
-  if (!value.empty()) {
-    JAST &contents = result.add("contents", JSON_OBJECT);
-    contents.add("kind", "markdown");
-    contents.add("value", value.c_str());
+
+  if (value.empty()) {
+    message.add("result", JSON_NULLVAL);
+    return message;
   }
+
+  JAST &result = message.add("result", JSON_OBJECT);
+  JAST &contents = result.add("contents", JSON_OBJECT);
+  contents.add("kind", "markdown");
+  contents.add("value", value.c_str());
   return message;
 }
 


### PR DESCRIPTION
There are likely several instance of these, but just throwing this up as a quick fix.

Per the spec here https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#responseMessage
> The result property of the ResponseMessage should be set to null in this case to signal a successful request.

We were previously sending `{}` instead of `null` which less forgiving languages are not happy with.