### PR TITLE
lemon: Emit cpp files from lemon

### DIFF
--- a/vendor/lemon/lemon.c
+++ b/vendor/lemon/lemon.c
@@ -4311,7 +4311,7 @@ void ReportTable(
 
   in = tplt_open(lemp);
   if( in==0 ) return;
-  out = file_open(lemp,".c","wb");
+  out = file_open(lemp,".cpp","wb");
   if( out==0 ){
     fclose(in);
     return;

--- a/vendor/lemon/lemon.wake
+++ b/vendor/lemon/lemon.wake
@@ -60,13 +60,11 @@ def lemon variant (file: Path): Result (Pair Path Path) Error =
         | runJobWith defaultRunner
         | getJobOutputs
 
-    require Some (Pair cfile _) = find (matches `.*\.c` _.getPathName) result
+    require Some (Pair cppfile _) = find (matches `.*\.cpp` _.getPathName) result
     else failWithError "lemon produced no C file"
 
     require Some (Pair hfile _) = find (matches `.*\.h` _.getPathName) result
     else failWithError "lemon produced no H file"
-
-    require Pass cppfile = installAs (replace `\.c$` ".cpp" cfile.getPathName) cfile
 
     require Some "1" = getenv "UPGRADE_GENERATED"
     else Pass (Pair cppfile hfile)


### PR DESCRIPTION
The template we pass to lemon is only compatible with C++ not C. 

Right now when we build, lemon emits an invalid `.c` which we rename to `.cpp`. This leaves the invalid `.c` file on disk.

On certain targets (fedora) the `.c` file maybe be used to generate the `.o` file instead of the `.cpp` file which causes an expected error in the C compiler.

This change makes it so the `.c` file is never emitted thus can't be erroneously used.