### PR TITLE
db: Switch verbose and debug priority

### DIFF
--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -497,12 +497,12 @@ int main(int argc, char **argv) {
     policy = DescribePolicy::metadata();
   }
 
-  if (clo.debug) {
-    policy = DescribePolicy::debug();
-  }
-
   if (clo.verbose) {
     policy = DescribePolicy::verbose();
+  }
+
+  if (clo.debug) {
+    policy = DescribePolicy::debug();
   }
 
   std::unordered_map<long, JobReflection> captured_jobs = {};


### PR DESCRIPTION
Fixes #1314 

Move verbose before debug in priority list since verbose has less information.