### PR TITLE
wakebox: signal when parent exits

### DIFF
--- a/src/wakefs/fuse.cpp
+++ b/src/wakefs/fuse.cpp
@@ -148,6 +148,12 @@ bool run_in_fuse(fuse_args &args, int &status, std::string &result_json) {
     std::vector<std::string> command = args.command;
     std::vector<std::string> envs_from_mounts;
 #ifdef __linux__
+    // This process should terminate if the parent process exits.
+    if (prctl(PR_SET_PDEATHSIG, SIGKILL) == -1) {
+      std::cerr << "run_in_fuse prctl: " << strerror(errno) << std::endl;
+      exit(1);
+    }
+
     if (!setup_user_namespaces(args.userid, args.groupid, args.isolate_network, args.hostname,
                                args.domainname))
       exit(1);

--- a/src/wakefs/namespace.cpp
+++ b/src/wakefs/namespace.cpp
@@ -478,6 +478,11 @@ bool setup_user_namespaces(int id_user, int id_group, bool isolate_network,
 [[noreturn]] int pidns_init(void *arg) {
   // We should be in a new PID namespace now, label the process in 'ps'.
   prctl(PR_SET_NAME, "wb-pid-ns", 0, 0, 0);
+  // This process should terminate if the parent process exits.
+  if (prctl(PR_SET_PDEATHSIG, SIGKILL) == -1) {
+    std::cerr << "pidns_init prctl: " << strerror(errno) << std::endl;
+    exit(1);
+  }
 
   // A fresh mount of procfs over the previous namespace's /proc.
   // which we can only do as we're already in a mount namespace.


### PR DESCRIPTION
In this PR:
* If the `wakebox` process exits, the `wb-mount-ns` process will be sent `SIGTERM`.
* If the `wb-mount-ns` process exits, the `wb-pid-ns` process will be sent `SIGTERM`.

In an earlier PR:
* When the `wb-pid-ns` process terminates, the whole pid namespace collapses and all its children terminate.

So, if you have a process tree that looks like:
```
$ pstree -p 2815889
bash(2815889)─┬─fuse-waked(2826391)
              └─wakebox(2826388)───wb-mount-ns(2826394)───wb-pid-ns(2826395)───mypayload(2826396)
```
Then if you send a signal to _any_ of `wakebox`/`wb-mount-ns`/`wb-pid-ns`/`mypayload`, then everything except the root `bash` process will exit.