### PR TITLE
mkdir_with_parents: skip existing directories

### DIFF
--- a/src/util/mkdir_parents.cpp
+++ b/src/util/mkdir_parents.cpp
@@ -38,6 +38,9 @@ int mkdir_with_parents(const std::string &path, mode_t mode) {
     slash_pos = path.find("/", slash_pos + 1);
     std::string dir = path.substr(0, slash_pos);
 
+    struct stat s;
+    if ((stat(dir.c_str(), &s) != -1) && (S_ISDIR(s.st_mode) != 0)) continue;
+
     if (0 != mkdir(dir.c_str(), mode) && errno != EEXIST) return errno;
   }
   return 0;


### PR DESCRIPTION
Previously we relied on `mkdir` claiming that a (parent) directory already exists.
There are some circumstances where the kernel will report other issues _ahead_ of saying that the directory already exists.
For example, a read-only filesystem error could be reported even when the directory exits.

This PR checks if the directory exists before trying to create it.