### PR TITLE
lsp: Fix VSCode wrapper hack around lsp server

### DIFF
--- a/extensions/vscode/lsp-server/src/common.ts
+++ b/extensions/vscode/lsp-server/src/common.ts
@@ -188,12 +188,7 @@ export function prepareConnection(connection: Connection, isWeb: Boolean) {
     });
 
     connection.onHover(async (params: HoverParams): Promise<Hover | null | ResponseError<void>> => {
-        let result: Hover | ResponseError<void> = await getResponse(createLspJson('textDocument/hover', params));
-        if (result.hasOwnProperty("contents")) {
-            return result;
-        } else {
-            return null;
-        }
+        return await getResponse(createLspJson('textDocument/hover', params));
     });
 
     connection.onDocumentSymbol(async (params: DocumentSymbolParams): Promise<SymbolInformation[] | ResponseError<void>> => {


### PR DESCRIPTION
In https://github.com/sifive/wake/pull/1328, I fixed an out of spec response. This caused an issue in the VSCode wrapper for the lsp as we detected the out-of-spec response and rewrote it to be in-spec.

Now that we are in-spec this hack is no longer needed and should be deleted