### PR TITLE
Significantly decrease log spam

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -1031,9 +1031,8 @@ void DaemonCache::handle_msg(int client_fd) {
 
   state = it->second.read_messages(msgs);
 
+  wcl::log::info("DaemonCache::handle_msg(): received %zu messages", msgs.size())();
   for (const auto &msg : msgs) {
-    wcl::log::info("msg: %s", msg.c_str())();
-
     JAST json;
     std::stringstream parseErrors;
     if (!JAST::parse(msg, parseErrors, json)) {


### PR DESCRIPTION
The vast majority of the log spam generated by the daemon cache is from logging out the entirety of ever request received. This only logs that a request happened generating significantly less spam