### PR TITLE
Move the job cache log to a dedicated file for cleanup

### DIFF
--- a/src/job_cache/daemon_cache.h
+++ b/src/job_cache/daemon_cache.h
@@ -23,6 +23,7 @@
 #include <util/poll.h>
 #include <wcl/xoshiro_256.h>
 
+#include <fstream>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -48,6 +49,8 @@ class DaemonCache {
   Poll poll;
   std::unordered_map<int, MessageParser> message_parsers;
   bool exit_now = false;
+
+  std::unique_ptr<std::ofstream> log_file;
 
   void launch_evict_loop();
   void reap_evict_loop();

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -71,6 +71,8 @@ static bool daemonize(std::string dir) {
     return false;
   }
 
+  wcl::log::info("fork1: success")();
+
   {
     // Replace stdin with /dev/null so we can't receive input
     auto null_fd = wcl::unique_fd::open("/dev/null", O_RDONLY);
@@ -104,10 +106,6 @@ static bool daemonize(std::string dir) {
     }
     replace_fd(STDERR_FILENO, err_log_fd->get());
   }
-
-  wcl::log::clear_subscribers();
-  wcl::log::subscribe(std::make_unique<wcl::log::FormatSubscriber>(std::cout.rdbuf()));
-  wcl::log::info("Reinitialized logging for job cache daemon")();
 
   // setsid so we're in our own group
   int sid = setsid();

--- a/tools/job-cache/main.cpp
+++ b/tools/job-cache/main.cpp
@@ -20,7 +20,6 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include <job_cache/daemon_cache.h>
-#include <wcl/defer.h>
 #include <wcl/tracing.h>
 
 // argv[0] = program name

--- a/tools/job-cache/main.cpp
+++ b/tools/job-cache/main.cpp
@@ -20,6 +20,7 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include <job_cache/daemon_cache.h>
+#include <wcl/defer.h>
 #include <wcl/tracing.h>
 
 // argv[0] = program name
@@ -31,9 +32,6 @@ int main(int argc, char **argv) {
     std::cerr << "Usage: job-cache cache/directory 100 5000" << std::endl;
     return 1;
   }
-
-  wcl::log::subscribe(std::make_unique<wcl::log::FormatSubscriber>(std::cout.rdbuf()));
-  wcl::log::info("Initialized logging for job cache daemon")();
 
   std::string cache_dir = std::string(argv[1]);
   uint64_t low_cache_size = std::stoull(argv[2]);


### PR DESCRIPTION
Moves log outputs from `.stdout`/`.stderr` to `.cache.<YYYY-MM-DD>.log`. This was done to make cleaning up old logs easier but also has  the side effect of making our other logging code simplier as we don't have to worry about polluting stdout/stderr

This PR doesn't implement the actual cleanup, that will be a separate PR