### PR TITLE
Correct minor typo and adjust documentation wording for `rmapPass`

### DIFF
--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -95,13 +95,13 @@ export def rmap (fn: a => b): Result a fail => Result b fail = match _
     Pass a = Pass (fn a)
     Fail f = Fail f
 
-# rmapPass: apply a failible function to a Pass-ing result
+# rmapPass: apply a Fail-able function to a Pass-ing result
 # If you find yourself using the function, consider using require instead.
 export def rmapPass (fn: a => Result b fail): Result a fail => Result b fail = match _
     Pass a = fn a
     Fail f = Fail f
 
-# Applies a failible function to Fail value or propogates Pass
+# Applies a Fail-able function to Fail value or propogates Pass
 # If you find yourself using the function, consider using require instead.
 export def rmapFail (fn: a => Result pass b): Result pass a => Result pass b = match _
     Pass a = Pass a


### PR DESCRIPTION
While reviewing a PR, I noticed the missing "to" in the documentation for `rmapPass`.

I also changed `fallible` to `failable`. Certainly open to just changing it back, but I thought I'd try on the change for size and to just garner feedback. I only changed it at first since I thought it was a typo (yes I know fallible is a word 🙂). It ultimately seems maybe it's debatable whether "failable" is a proper dictionary word or not, but it seems more contextually direct given the function should return a `Pass` or `Fail`. Apache seems to use it: https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/function/Failable.html.

Edit: It would have helped if I actually spelled things correctly in the actual commit, but upon correcting it, I decided to try out `Fail-able` since it sort of matches the existing convention of `Pass-ing` already used in the same documentation.