### PR TITLE
Revert documentation wording change to `rmapPass` and `rmapFail`

### DIFF
--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -95,13 +95,13 @@ export def rmap (fn: a => b): Result a fail => Result b fail = match _
     Pass a = Pass (fn a)
     Fail f = Fail f
 
-# rmapPass: apply a Fail-able function to a Pass-ing result
+# rmapPass: apply a fallible function to a Pass-ing result
 # If you find yourself using the function, consider using require instead.
 export def rmapPass (fn: a => Result b fail): Result a fail => Result b fail = match _
     Pass a = fn a
     Fail f = Fail f
 
-# Applies a Fail-able function to Fail value or propogates Pass
+# Applies a fallible function to Fail value or propogates Pass
 # If you find yourself using the function, consider using require instead.
 export def rmapFail (fn: a => Result pass b): Result pass a => Result pass b = match _
     Pass a = Pass a


### PR DESCRIPTION
See https://github.com/sifive/wake/pull/1349