### PR TITLE
Increase local shared cache robustness to daemon being killed

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -216,7 +216,7 @@ int create_cache_socket(const std::string &dir, const std::string &key) {
   // While this successfully stops multiple daemons from running,
   // it has another issue in that just because the lock is aquired,
   // doesn't mean that the service has started. I don't see a strong
-  // way around this however so I think the clients will just have
+  // way around this however so I think the client will just have
   // keep retrying the connection. Worse yet the old key may
   // still exist so users will have to keep re-*reading* the key
   // while retrying with expoential backoff.

--- a/src/job_cache/daemon_cache.h
+++ b/src/job_cache/daemon_cache.h
@@ -58,6 +58,7 @@ class DaemonCache {
   FindJobResponse read(const FindJobRequest &find_request);
   void add(const AddJobRequest &add_request);
   void remove_corrupt_job(int64_t job_id);
+  void close_client(int client_fd);
 
   void handle_new_client();
   void handle_msg(int fd);

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -16,6 +16,7 @@
  */
 
 // Open Group Base Specifications Issue 7
+#include "types.h"
 #define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 200809L
 
@@ -260,7 +261,11 @@ wcl::result<FindJobResponse, FindJobError> Cache::read_impl(const FindJobRequest
   request.add("params", find_request.to_json());
 
   // serialize the request, send it, deserialize the response, return it
-  send_json_message(socket_fd.get(), request);
+  wcl::errno_t write_error = send_json_message(socket_fd.get(), request);
+
+  if (write_error != 0) {
+    return wcl::result_error<FindJobResponse>(FindJobError::FailedRequest);    
+  }
   MessageParser parser(socket_fd.get());
   std::vector<std::string> messages;
 
@@ -360,7 +365,8 @@ void Cache::add(const AddJobRequest &add_request) {
   request.add("method", "cache/add");
   request.add("params", add_request.to_json());
 
-  // serialize the request and send it
+  // serialize the request and send it, we ignore an error
+  // if it occurs here and we keep moving.
   send_json_message(socket_fd.get(), request);
 }
 

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -20,8 +20,6 @@
 #define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 200809L
 
-#include "job_cache.h"
-
 #include <json/json5.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -39,6 +37,7 @@
 #include <vector>
 
 #include "daemon_cache.h"
+#include "job_cache.h"
 #include "job_cache_impl_common.h"
 #include "message_parser.h"
 
@@ -261,10 +260,10 @@ wcl::result<FindJobResponse, FindJobError> Cache::read_impl(const FindJobRequest
   request.add("params", find_request.to_json());
 
   // serialize the request, send it, deserialize the response, return it
-  wcl::errno_t write_error = send_json_message(socket_fd.get(), request);
+  auto write_error = send_json_message(socket_fd.get(), request);
 
-  if (write_error != 0) {
-    return wcl::result_error<FindJobResponse>(FindJobError::FailedRequest);    
+  if (write_error) {
+    return wcl::result_error<FindJobResponse>(FindJobError::FailedRequest);
   }
   MessageParser parser(socket_fd.get());
   std::vector<std::string> messages;

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -16,9 +16,10 @@
  */
 
 // Open Group Base Specifications Issue 7
-#include "types.h"
 #define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 200809L
+
+#include "job_cache.h"
 
 #include <json/json5.h>
 #include <sys/socket.h>
@@ -37,9 +38,9 @@
 #include <vector>
 
 #include "daemon_cache.h"
-#include "job_cache.h"
 #include "job_cache_impl_common.h"
 #include "message_parser.h"
+#include "types.h"
 
 namespace job_cache {
 

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -42,6 +42,7 @@ enum class ConnectError {
 };
 
 enum class FindJobError {
+  FailedRequest,
   FailedMessageReceive,
   NoResponse,
   TooManyResponses,

--- a/src/job_cache/job_cache_impl_common.cpp
+++ b/src/job_cache/job_cache_impl_common.cpp
@@ -296,7 +296,7 @@ void remove_backing_files(std::string dir,
   }
 }
 
-wcl::errno_t send_json_message(int fd, const JAST &json) {
+wcl::optional<wcl::posix_error_t> send_json_message(int fd, const JAST &json) {
   std::stringstream s;
   s << json;
   std::string json_str = s.str();
@@ -313,9 +313,11 @@ wcl::errno_t send_json_message(int fd, const JAST &json) {
         continue;
       }
       wcl::log::error("send_json_message: write(%d): %s", fd, strerror(errno)).urgent()();
-      return errno;
+      return wcl::make_some<wcl::posix_error_t>(errno);
     }
 
     start += res;
   }
+
+  return {};
 }

--- a/src/job_cache/job_cache_impl_common.cpp
+++ b/src/job_cache/job_cache_impl_common.cpp
@@ -296,7 +296,7 @@ void remove_backing_files(std::string dir,
   }
 }
 
-void send_json_message(int fd, const JAST &json) {
+wcl::errno_t send_json_message(int fd, const JAST &json) {
   std::stringstream s;
   s << json;
   std::string json_str = s.str();
@@ -312,8 +312,8 @@ void send_json_message(int fd, const JAST &json) {
       if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
         continue;
       }
-      wcl::log::error("write(%d): %s", fd, strerror(errno)).urgent()();
-      exit(1);
+      wcl::log::error("send_json_message: write(%d): %s", fd, strerror(errno)).urgent()();
+      return errno;
     }
 
     start += res;

--- a/src/job_cache/job_cache_impl_common.h
+++ b/src/job_cache/job_cache_impl_common.h
@@ -25,6 +25,8 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+
+#include "wcl/optional.h"
 #include "wcl/result.h"
 
 using group_id_t = uint8_t;
@@ -55,4 +57,4 @@ void unlink_no_fail(const char *file);
 void rmdir_no_fail(const char *dir);
 
 // Write the serialized JAST to fd with proper retries on failure
-wcl::errno_t send_json_message(int fd, const JAST &json);
+wcl::optional<wcl::posix_error_t> send_json_message(int fd, const JAST &json);

--- a/src/job_cache/job_cache_impl_common.h
+++ b/src/job_cache/job_cache_impl_common.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include "wcl/result.h"
 
 using group_id_t = uint8_t;
 
@@ -54,4 +55,4 @@ void unlink_no_fail(const char *file);
 void rmdir_no_fail(const char *dir);
 
 // Write the serialized JAST to fd with proper retries on failure
-void send_json_message(int fd, const JAST &json);
+wcl::errno_t send_json_message(int fd, const JAST &json);

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -388,12 +388,6 @@ TEST(job_cache_basic_par_fuzz) {
       TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
     }));
   }
-  for (int i = 0; i < 100; ++i) {
-    // 1) randomly select one of these options: suspend, or kill
-    // 2) randomly select a thread to apply this to
-    // 3) on kill we just kill and then move on to the next thread
-    // 4) on suspend we sleep for a bit, and then wake the thread.
-  }
   for (auto& fut : futs) {
     if (fut.valid()) fut.wait();
   }

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -388,6 +388,12 @@ TEST(job_cache_basic_par_fuzz) {
       TEST_FUNC_CALL(fuzz_loop, config, std::move(gen));
     }));
   }
+  for (int i = 0; i < 100; ++i) {
+    // 1) randomly select one of these options: suspend, or kill
+    // 2) randomly select a thread to apply this to
+    // 3) on kill we just kill and then move on to the next thread
+    // 4) on suspend we sleep for a bit, and then wake the thread.
+  }
   for (auto& fut : futs) {
     if (fut.valid()) fut.wait();
   }


### PR DESCRIPTION
This change is meant to do the following

1) If a write to a client fails, the daemon keeps running and just closes its connection to that client.
2) If a write to the daemon fails, the client treats that as it would read failures and the client should restart

I don't have a good way to do auto-mated testing of this yet but I manually killed the job-cache many times and everything continued to work perfectly. I don't consider this change complete without automated testing but its hard and I wanted to get these fixes out there first so we can do another release with them in it. All existing tests pass, and manually killing the daemon repeatedly causes no issues that I can observe yet