### PR TITLE
Don't force a split inside of interpolated strings

### DIFF
--- a/share/wake/lib/system/plan_scorer.wake
+++ b/share/wake/lib/system/plan_scorer.wake
@@ -66,8 +66,7 @@ export def runJob (p: Plan): Job = match p
                         Accept _ _ = ""
                         Reject why = why
 
-                    makeError "No runner for '{job.getJobDescription}' available, because: {map pretty opts
-                    | catWith ", "}"
+                    makeError "No runner for '{job.getJobDescription}' available, because: {map pretty opts | catWith ", "}"
 
                 # Make sure badlaunch completes before badfinish
                 def _ = wait (\_ badfinish job error) (badlaunch job error)

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1322,6 +1322,6 @@ def y =
     0
 
 def x =
-  def y = "{one | two} thre"
+  def y = "{one | two} three"
   def z = "{one | two | three} four"
   z

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1320,3 +1320,8 @@ def y =
     def x = !a.b,
     def x = !(a+b),
     0
+
+def x =
+  def y = "{one | two} thre"
+  def z = "{one | two | three} four"
+  z

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1592,3 +1592,9 @@ def y =
     def x = !(a + b),
 
     0
+
+def x =
+    def y = "{one | two} thre"
+    def z = "{one | two | three} four"
+
+    z

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1594,7 +1594,7 @@ def y =
     0
 
 def x =
-    def y = "{one | two} thre"
+    def y = "{one | two} three"
     def z = "{one | two | three} four"
 
     z

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1666,7 +1666,7 @@ wcl::doc Emitter::walk_import(ctx_t ctx, CSTElement node) {
 
 wcl::doc Emitter::walk_interpolate(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
-  MEMO_RET(walk_placeholder(ctx, node));
+  MEMO_RET(walk_placeholder(ctx.binop(), node));
 }
 
 wcl::doc Emitter::walk_kind(ctx_t ctx, CSTElement node) {

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1666,6 +1666,7 @@ wcl::doc Emitter::walk_import(ctx_t ctx, CSTElement node) {
 
 wcl::doc Emitter::walk_interpolate(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
+  // TODO: rename/rework binop() to represent 'do not split'
   MEMO_RET(walk_placeholder(ctx.binop(), node));
 }
 


### PR DESCRIPTION
When a `|` was inside a string interpolation is  was being forced into multilining. Don't do that.

Before 

```
"{one | two} three"
```
->
```
"{one 
   | two} three"
```

After:

```
"{one | two} three"
```
->
```
"{one | two} three"
```