### PR TITLE
Maintain `String` null termination invariant

### DIFF
--- a/src/runtime/string.cpp
+++ b/src/runtime/string.cpp
@@ -210,6 +210,8 @@ static PRIMFN(prim_read) {
       runtime.heap.reserve(need_pass);
 
       String *out = String::claim(runtime.heap, size);
+      out->c_str()[size] = 0;
+
       t.seekg(0, t.beg);
       t.read(out->c_str(), out->size());
       if (t) RETURN(claim_result(runtime.heap, true, out));

--- a/src/runtime/value.cpp
+++ b/src/runtime/value.cpp
@@ -83,7 +83,9 @@ String *String::claim(Heap &h, const std::string &str) {
 }
 
 String *String::claim(Heap &h, const char *str, size_t length) {
-  return new (h.claim(reserve(length))) String(str, length);
+  String* out = new (h.claim(reserve(length))) String(str, length);
+  out->c_str()[length] = 0;
+  return out;
 }
 
 String *String::alloc(Heap &h, size_t length) {
@@ -95,7 +97,9 @@ String *String::alloc(Heap &h, const std::string &str) {
 }
 
 String *String::alloc(Heap &h, const char *str, size_t length) {
-  return new (h.alloc(reserve(length))) String(str, length);
+  String* out = new (h.alloc(reserve(length))) String(str, length);
+  out->c_str()[length] = 0;
+  return out;
 }
 
 String *String::alloc(Heap &h, const char *str) { return alloc(h, str, strlen(str)); }

--- a/src/runtime/value.cpp
+++ b/src/runtime/value.cpp
@@ -83,7 +83,7 @@ String *String::claim(Heap &h, const std::string &str) {
 }
 
 String *String::claim(Heap &h, const char *str, size_t length) {
-  String* out = new (h.claim(reserve(length))) String(str, length);
+  String *out = new (h.claim(reserve(length))) String(str, length);
   out->c_str()[length] = 0;
   return out;
 }
@@ -97,7 +97,7 @@ String *String::alloc(Heap &h, const std::string &str) {
 }
 
 String *String::alloc(Heap &h, const char *str, size_t length) {
-  String* out = new (h.alloc(reserve(length))) String(str, length);
+  String *out = new (h.alloc(reserve(length))) String(str, length);
   out->c_str()[length] = 0;
   return out;
 }

--- a/src/runtime/value.cpp
+++ b/src/runtime/value.cpp
@@ -25,6 +25,7 @@
 #include <re2/re2.h>
 #include <string.h>
 
+#include <algorithm>
 #include <sstream>
 
 #include "optimizer/ssa.h"
@@ -65,25 +66,24 @@ std::string HeapObject::to_str() const {
   return str.str();
 }
 
-String::String(size_t length_) : length(length_) {}
+String::String(size_t length_) : length(length_) {
+  char *str = static_cast<char *>(data());
+  std::fill(str, str + length + 1, 0);
+}
 
 String::String(const String &s) : length(s.length) { memcpy(data(), s.data(), length + 1); }
+String::String(const char *str, size_t length) : length(length) { memcpy(data(), str, length + 1); }
 
 String *String::claim(Heap &h, size_t length) {
   return new (h.claim(reserve(length))) String(length);
 }
 
 String *String::claim(Heap &h, const std::string &str) {
-  String *out = claim(h, str.size());
-  memcpy(out->c_str(), str.c_str(), str.size() + 1);
-  return out;
+  return new (h.claim(reserve(str.length()))) String(str.c_str(), str.length());
 }
 
 String *String::claim(Heap &h, const char *str, size_t length) {
-  auto out = claim(h, length);
-  memcpy(out->c_str(), str, length);
-  out->c_str()[length] = 0;
-  return out;
+  return new (h.claim(reserve(length))) String(str, length);
 }
 
 String *String::alloc(Heap &h, size_t length) {
@@ -91,24 +91,14 @@ String *String::alloc(Heap &h, size_t length) {
 }
 
 String *String::alloc(Heap &h, const std::string &str) {
-  String *out = alloc(h, str.size());
-  memcpy(out->data(), str.c_str(), str.size() + 1);
-  return out;
+  return new (h.alloc(reserve(str.length()))) String(str.c_str(), str.length());
 }
 
 String *String::alloc(Heap &h, const char *str, size_t length) {
-  String *out = alloc(h, length);
-  memcpy(out->c_str(), str, length);
-  out->c_str()[length] = 0;
-  return out;
+  return new (h.alloc(reserve(length))) String(str, length);
 }
 
-String *String::alloc(Heap &h, const char *str) {
-  size_t size = strlen(str);
-  String *out = alloc(h, size);
-  memcpy(out->data(), str, size + 1);
-  return out;
-}
+String *String::alloc(Heap &h, const char *str) { return alloc(h, str, strlen(str)); }
 
 RootPointer<String> String::literal(Heap &h, const std::string &value) {
   h.guarantee(reserve(value.size()));

--- a/src/runtime/value.cpp
+++ b/src/runtime/value.cpp
@@ -79,7 +79,7 @@ String *String::claim(Heap &h, size_t length) {
 }
 
 String *String::claim(Heap &h, const std::string &str) {
-  return new (h.claim(reserve(str.length()))) String(str.c_str(), str.length());
+  return new (h.claim(reserve(str.size()))) String(str.c_str(), str.size());
 }
 
 String *String::claim(Heap &h, const char *str, size_t length) {
@@ -91,7 +91,7 @@ String *String::alloc(Heap &h, size_t length) {
 }
 
 String *String::alloc(Heap &h, const std::string &str) {
-  return new (h.alloc(reserve(str.length()))) String(str.c_str(), str.length());
+  return new (h.alloc(reserve(str.size()))) String(str.c_str(), str.size());
 }
 
 String *String::alloc(Heap &h, const char *str, size_t length) {

--- a/src/runtime/value.h
+++ b/src/runtime/value.h
@@ -76,7 +76,7 @@ struct String final : public GCObject<String, Value> {
 
   size_t length;
 
-  String(size_t length_);
+  String(const char *str, size_t length);
   String(const String &s);
 
   const char *c_str() const { return static_cast<const char *>(data()); }
@@ -134,6 +134,9 @@ struct String final : public GCObject<String, Value> {
 
   // Never call this during runtime! It can invalidate the heap.
   static RootPointer<String> literal(Heap &h, const std::string &value);
+
+ private:
+  String(size_t length_);
 };
 
 // An exception-safe wrapper for mpz_t

--- a/src/runtime/value.h
+++ b/src/runtime/value.h
@@ -136,7 +136,7 @@ struct String final : public GCObject<String, Value> {
   static RootPointer<String> literal(Heap &h, const std::string &value);
 
  private:
-  String(size_t length_);
+  explicit String(size_t length_);
 };
 
 // An exception-safe wrapper for mpz_t


### PR DESCRIPTION
Wake's `String` type internally maintains that its raw string pointer is a null terminated string so that the pointer may be used directly. However in some cases the internal pointer is filled manually outside of the class. In this case the author must remember to manually null  terminate the string or it will be inconsistent to various parts of the runtime. This may manifest itself as a segfault but may alternatively just be a string with a couple extra bytes at the end if a convenient NULL byte is nearby. 

This change fixes a case where the null terminator was forgotten but in the long term we should consider preventing this case all together by making the internal pointer read-only