### PR TITLE
Use a Label before the cmdline for describing Jobs

### DIFF
--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -1535,7 +1535,9 @@ static PRIMTYPE(type_job_desc) {
 static PRIMFN(prim_job_desc) {
   EXPECT(1);
   JOB(arg0, 0);
-  RETURN(String::alloc(runtime.heap, pretty_cmd(arg0->cmdline->as_str())));
+  std::string desc =
+      arg0->label->empty() ? pretty_cmd(arg0->cmdline->as_str()) : arg0->label->as_str();
+  RETURN(String::alloc(runtime.heap, desc));
 }
 
 static PRIMTYPE(type_job_finish) {


### PR DESCRIPTION
Some compilation commands with a lot of library references, etc., can get untenably long and severely reduce the user experience of debugging failed jobs.  This replaces the unconditional command line printing in `getJobDescription` and thus in a number of error messages (`Non-zero exit status (Exited 1) for job 1855: '/usr/lib64/ccache/c++ -o bin/wake.native-cpp14-release src/compat/aligned_alloc.native-c11-release.o src/compat/mtime.native-c11-release.o [...] tools/wake/timeline.native-cpp14-release.o -std=c++14 -lpthread -Wl,--build-id -lncurses -ltinfo -lgmp -lsqlite3 -pthread -lre2 -lncurses -ltinfo -lsqlite3'`) with printing the label instead (`Non-zero exit status (Exited 1) for job 1855: 'link: c++ bin/wake'`); if no label has been set for a job (or if the label is `""`), it still falls back on the command line as is printed currently.

I don't know how the C++ memory management would interact here; does this need any move/clone annotations or something?