### PR TITLE
Add chaos monkey style testing for shared caching

### DIFF
--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -7,7 +7,6 @@ PASSED:
   diff_empty
   diff_fuzz1
   diff_fuzz2
-  diff_fuzz2_large
   diff_fuzz3
   diff_id
   diff_permute

--- a/tests/wake-unit/unit-test.sh
+++ b/tests/wake-unit/unit-test.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-TERM=xterm-256color script --return --quiet -c "$1 --no-color" /dev/null
+TERM=xterm-256color script --return --quiet -c "$1 --no-color --tag threaded" /dev/null
 
 # We run the tests *twice* so that shared caching can run without a clean slate
-TERM=xterm-256color script --return --quiet -c "$1 --no-color" /dev/null > /dev/null
+TERM=xterm-256color script --return --quiet -c "$1 --no-color --tag threaded" /dev/null > /dev/null
 
 rm -rf job_cache_test
 rm -rf .job_cache_test

--- a/tools/wake-unit/diff.cpp
+++ b/tools/wake-unit/diff.cpp
@@ -213,7 +213,7 @@ TEST(diff_fuzz2) {
 // also increases the probability of finding a snag.
 // This also doubles as a santity check to ensure that
 // we aren't doing too bad on performance.
-TEST(diff_fuzz2_large) {
+TEST(diff_fuzz2_large, "large") {
   // seed the rng for fuzzing
   uint64_t seedV = 0xdeadbeefdeadbeef;
   std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> seed = {seedV, seedV, seedV, seedV};

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -316,14 +316,14 @@ bool run_as_init_proc(F f) {
       wcl::log::error("run_as_init_proc: waitpid(): %s", strerror(errno))();
       return false;
     }
-  
+
     // Relay errors up to the top
     if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
       return true;
     }
     return false;
   }
-  
+
   // Now that we're in an isolated child, we unshare our namespaces
   if (unshare(CLONE_NEWUSER | CLONE_NEWPID) != 0) {
     wcl::log::error("unshare(CLONE_NEW_USER | CLONE_NEWPID): %s", strerror(errno))();


### PR DESCRIPTION
This change adds a new kind of shared cache fuzz testing where the test harness will actively kill or briefly pause processes to test fault tolerance.

Additionally this change adds some long needed features to the unit testing framework to allow filtering of the tests that are run. You can now filter by test name prefix, or you can filter by tags. Any tests which matches any prefix will be considered for running and if no prefix is specified its as if the empty prefix was used so all tests are considered. Among considered tests only those tests who's tags are a subset of the ones the user specified will run. I've found these two controls to allow me to get almost any subset of tests I want to run to run.

@mmjconolly Your expertise is needed in reviewing the code for pid namespaces, forking, traversal of /proc, etc...

@V-FEXrt if you could review what remains or any parts you understand that should cover the rest