### PR TITLE
Make JsonSubscriber more atomic

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -59,14 +59,15 @@ static void initialize_logging() {
   strftime(time_buffer, sizeof(time_buffer), str_fmt, &tm);
   std::string log_path = ".cache." + std::string(time_buffer) + ".log";
 
-  auto sub_res = JsonSubscriber::create(log_path.c_str());
-  if (!sub_res) {
-    std::cerr << "urgent warning: Could not init logging: " << strerror(sub_res.error())
-              << std::endl;
+  auto log_file_res = JsonSubscriber::fd_t::open(log_path.c_str());
+
+  if (!log_file_res) {
+    std::cerr << "urgent warning: Could not init logging: " << log_path
+              << " failed to open: " << strerror(log_file_res.error()) << std::endl;
     std::cerr << "urgent warning: Continuing without logging." << std::endl;
     return;
   }
-  wcl::log::subscribe(std::make_unique<JsonSubscriber>(std::move(*sub_res)));
+  wcl::log::subscribe(std::make_unique<JsonSubscriber>(std::move(*log_file_res)));
 
   wcl::log::info("Initialized logging for job cache daemon")();
 

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -47,7 +47,7 @@ namespace {
 
 using namespace job_cache;
 
-static std::unique_ptr<std::ofstream> initialize_logging() {
+static void initialize_logging() {
   const char *str_fmt = "%Y-%m-%d";
   const size_t str_fmt_len = 10;         // count("XXXX-XX-XX")
   const size_t filename_prefix_len = 7;  // count (".cache.")
@@ -59,16 +59,21 @@ static std::unique_ptr<std::ofstream> initialize_logging() {
   strftime(time_buffer, sizeof(time_buffer), str_fmt, &tm);
   std::string log_path = ".cache." + std::string(time_buffer) + ".log";
 
-  std::unique_ptr<std::ofstream> log_file =
-      std::make_unique<std::ofstream>(log_path, std::ios::app);
-  wcl::log::subscribe(std::make_unique<JsonSubscriber>(log_file->rdbuf()));
+  auto sub_res = JsonSubscriber::create(log_path.c_str());
+  if (!sub_res) {
+    std::cerr << "urgent warning: Could not init logging: " << strerror(sub_res.error())
+              << std::endl;
+    std::cerr << "urgent warning: Continuing without logging." << std::endl;
+    return;
+  }
+  wcl::log::subscribe(std::make_unique<JsonSubscriber>(std::move(*sub_res)));
 
   wcl::log::info("Initialized logging for job cache daemon")();
 
   auto res = wcl::directory_range::open(".");
   if (!res) {
     wcl::log::warning("Failed to open cwd to cleanup log files")();
-    return log_file;
+    return;
   }
 
   std::vector<std::string> to_delete;
@@ -108,7 +113,7 @@ static std::unique_ptr<std::ofstream> initialize_logging() {
     unlink(file.c_str());
   }
 
-  return log_file;
+  return;
 }
 
 // Helper that only returns successful file opens.
@@ -637,7 +642,7 @@ DaemonCache::DaemonCache(std::string dir, uint64_t max, uint64_t low)
   mkdir_no_fail(dir.c_str());
   chdir_no_fail(dir.c_str());
 
-  log_file = initialize_logging();
+  initialize_logging();
 
   wcl::log::info("Launching DaemonCache. dir = %s, max = %lu, low = %lu", dir.c_str(),
                  max_cache_size, low_cache_size)();

--- a/src/job_cache/daemon_cache.h
+++ b/src/job_cache/daemon_cache.h
@@ -50,8 +50,6 @@ class DaemonCache {
   std::unordered_map<int, MessageParser> message_parsers;
   bool exit_now = false;
 
-  std::unique_ptr<std::ofstream> log_file;
-
   void launch_evict_loop();
   void reap_evict_loop();
 

--- a/src/job_cache/eviction_policy.cpp
+++ b/src/job_cache/eviction_policy.cpp
@@ -237,10 +237,12 @@ static void garbage_collect_job(std::string job_dir) {
   wcl::log::info("found orphaned job folder: %s", job_dir.c_str())();
   auto dir_res = wcl::directory_range::open(job_dir);
   if (!dir_res) {
-    // We can keep going even with this failure but we need to at least log it
+    // It's not an error if this directory doesn't exist
     if (dir_res.error() == ENOENT) {
       return;
     }
+
+    // We can keep going even with this failure but we need to at least log it
     wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
                     job_dir.c_str(), strerror(dir_res.error()))();
     return;

--- a/src/job_cache/eviction_policy.cpp
+++ b/src/job_cache/eviction_policy.cpp
@@ -238,6 +238,9 @@ static void garbage_collect_job(std::string job_dir) {
   auto dir_res = wcl::directory_range::open(job_dir);
   if (!dir_res) {
     // We can keep going even with this failure but we need to at least log it
+    if (dir_res.error() == ENOENT) {
+      return;
+    }
     wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
                     job_dir.c_str(), strerror(dir_res.error()))();
     return;

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -301,7 +301,7 @@ wcl::result<FindJobResponse, FindJobError> Cache::read_impl(const FindJobRequest
     // the case where no error has yet occured but messages is still empty.
   } while (state == MessageParserState::Continue);
 
-  wcl::log::info("Cache::read(): message rx: %s", messages[0].c_str())();
+  wcl::log::info("Cache::read(): message rx")();
 
   JAST json;
   std::stringstream parseErrors;

--- a/src/json/json5.cpp
+++ b/src/json/json5.cpp
@@ -156,7 +156,7 @@ wcl::result<JsonSubscriber, wcl::posix_error_t> JsonSubscriber::create(const cha
 }
 
 void JsonSubscriber::receive(const wcl::log::Event &e) {
-  std::string warning_msg = "{\"message\": \"warning: The next line may be split\"}\n";
+  std::string warning_msg = "{\"message\": \"warning: The next line may be corrupted\"}\n";
   JAST out(JSON_OBJECT);
   for (const auto &item : e.items) {
     out.add(item.first, item.second);

--- a/src/json/json5.cpp
+++ b/src/json/json5.cpp
@@ -21,6 +21,9 @@
 
 #include "json5.h"
 
+#include <memory>
+#include <sstream>
+
 #include "wcl/optional.h"
 #include "wcl/tracing.h"
 
@@ -144,11 +147,27 @@ std::ostream &operator<<(std::ostream &os, const JAST &jast) {
   }
 }
 
+wcl::result<JsonSubscriber, wcl::posix_error_t> JsonSubscriber::create(const char *log_path) {
+  auto res = wcl::unique_fd::open(log_path, O_APPEND | O_CREAT | O_WRONLY, 0644);
+  if (!res) {
+    return wcl::make_error<JsonSubscriber, wcl::posix_error_t>(res.error());
+  }
+  return wcl::make_result<JsonSubscriber, wcl::posix_error_t>(JsonSubscriber(std::move(*res)));
+}
+
 void JsonSubscriber::receive(const wcl::log::Event &e) {
+  std::string warning_msg = "{\"message\": \"warning: The next line may be split\"}\n";
   JAST out(JSON_OBJECT);
   for (const auto &item : e.items) {
     out.add(item.first, item.second);
   }
 
-  s << out << std::endl;
+  std::stringstream ss;
+  ss << out << std::endl;
+  std::string line = ss.str();
+
+  if (line.size() > 4095) {
+    write(to_append.get(), warning_msg.data(), warning_msg.size());
+  }
+  write(to_append.get(), line.data(), line.size());
 }

--- a/src/json/json5.cpp
+++ b/src/json/json5.cpp
@@ -147,14 +147,6 @@ std::ostream &operator<<(std::ostream &os, const JAST &jast) {
   }
 }
 
-wcl::result<JsonSubscriber, wcl::posix_error_t> JsonSubscriber::create(const char *log_path) {
-  auto res = wcl::unique_fd::open(log_path, O_APPEND | O_CREAT | O_WRONLY, 0644);
-  if (!res) {
-    return wcl::make_error<JsonSubscriber, wcl::posix_error_t>(res.error());
-  }
-  return wcl::make_result<JsonSubscriber, wcl::posix_error_t>(JsonSubscriber(std::move(*res)));
-}
-
 void JsonSubscriber::receive(const wcl::log::Event &e) {
   std::string warning_msg = "{\"message\": \"warning: The next line may be corrupted\"}\n";
   JAST out(JSON_OBJECT);

--- a/src/json/json5.h
+++ b/src/json/json5.h
@@ -26,13 +26,20 @@
 #include "util/location.h"
 #include "wcl/optional.h"
 #include "wcl/tracing.h"
+#include "wcl/unique_fd.h"
 
 class JsonSubscriber : public wcl::log::Subscriber {
  private:
-  std::ostream s;
+  wcl::unique_fd to_append;
+
+  explicit JsonSubscriber(wcl::unique_fd &&f) : to_append(std::move(f)) {}
 
  public:
-  JsonSubscriber(std::streambuf *rdbuf) : s(rdbuf) {}
+  JsonSubscriber(const JsonSubscriber &) = delete;
+  JsonSubscriber(JsonSubscriber &&) = default;
+  JsonSubscriber() = delete;
+  static wcl::result<JsonSubscriber, wcl::posix_error_t> create(const char *log_path);
+
   void receive(const wcl::log::Event &e) override;
   ~JsonSubscriber() override{};
 };

--- a/src/json/json5.h
+++ b/src/json/json5.h
@@ -29,16 +29,17 @@
 #include "wcl/unique_fd.h"
 
 class JsonSubscriber : public wcl::log::Subscriber {
- private:
-  wcl::unique_fd to_append;
+ public:
+  using fd_t = wcl::precise_unique_fd<O_APPEND | O_CREAT | O_WRONLY, 0644>;
 
-  explicit JsonSubscriber(wcl::unique_fd &&f) : to_append(std::move(f)) {}
+ private:
+  fd_t to_append;
 
  public:
+  explicit JsonSubscriber(fd_t f) : to_append(std::move(f)) {}
   JsonSubscriber(const JsonSubscriber &) = delete;
   JsonSubscriber(JsonSubscriber &&) = default;
   JsonSubscriber() = delete;
-  static wcl::result<JsonSubscriber, wcl::posix_error_t> create(const char *log_path);
 
   void receive(const wcl::log::Event &e) override;
   ~JsonSubscriber() override{};

--- a/src/wcl/unique_fd.h
+++ b/src/wcl/unique_fd.h
@@ -86,4 +86,29 @@ class unique_fd {
   }
 };
 
+template <int flags, mode_t mode>
+class precise_unique_fd {
+ private:
+  unique_fd fd;
+
+  precise_unique_fd(unique_fd&& fd) : fd(std::move(fd)) {}
+
+ public:
+  precise_unique_fd(precise_unique_fd&&) = default;
+  precise_unique_fd(const precise_unique_fd&) = delete;
+  precise_unique_fd() = delete;
+
+  static result<precise_unique_fd, posix_error_t> open(const char* str) {
+    auto fd = unique_fd::open(str, flags, mode);
+    if (!fd) {
+      return make_error<precise_unique_fd, posix_error_t>(fd.error());
+    }
+    return make_result<precise_unique_fd, posix_error_t>(precise_unique_fd(std::move(*fd)));
+  }
+
+  int get() const { return fd.get(); }
+
+  bool valid() const { return fd.valid(); }
+};
+
 }  // namespace wcl

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -325,9 +325,10 @@ int main(int argc, char **argv) {
   // Initialize Wake logging subsystem
 
   // Log all events to wake.log
-  auto res = JsonSubscriber::create("wake.log");
+  auto res = JsonSubscriber::fd_t::open("wake.log");
   if (!res) {
-    std::cerr << "Unable to init logging: " << strerror(res.error()) << std::endl;
+    std::cerr << "Unable to init logging: wake.log failed to open: " << strerror(res.error())
+              << std::endl;
     return 1;
   }
   wcl::log::subscribe(std::make_unique<JsonSubscriber>(std::move(*res)));

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -325,9 +325,12 @@ int main(int argc, char **argv) {
   // Initialize Wake logging subsystem
 
   // Log all events to wake.log
-  std::ofstream log_file("wake.log", std::ios::app);
-  auto log_file_defer = wcl::make_defer([&log_file]() { log_file.close(); });
-  wcl::log::subscribe(std::make_unique<JsonSubscriber>(log_file.rdbuf()));
+  auto res = JsonSubscriber::create("wake.log");
+  if (!res) {
+    std::cerr << "Unable to init logging: " << strerror(res.error()) << std::endl;
+    return 1;
+  }
+  wcl::log::subscribe(std::make_unique<JsonSubscriber>(std::move(*res)));
 
   // Log urgent events to cerr
   auto cerr_subscriber = std::make_unique<wcl::log::SimpleFormatSubscriber>(std::cerr.rdbuf());


### PR DESCRIPTION
This change is an attempt to make log corruption due to concurrent writers less likely but it doesn't fully solve the problem. It does two things

1) It removes the biggest offender for large log lines
2) It makes sure that we write log lines in a single call to write (ignoring errors)

This should hopefully eliminate all of our log parsing errors...I should probably also make the log viewer handle corrupted lines better than by just failing on them but this PR doesn't do that yet.