### PR TITLE
Fix unused warnings

### DIFF
--- a/src/json/json5.cpp
+++ b/src/json/json5.cpp
@@ -159,7 +159,7 @@ void JsonSubscriber::receive(const wcl::log::Event &e) {
   std::string line = ss.str();
 
   if (line.size() > 4095) {
-    write(to_append.get(), warning_msg.data(), warning_msg.size());
+    (void)write(to_append.get(), warning_msg.data(), warning_msg.size());
   }
-  write(to_append.get(), line.data(), line.size());
+  (void)write(to_append.get(), line.data(), line.size());
 }

--- a/tools/wake-unit/filepath.cpp
+++ b/tools/wake-unit/filepath.cpp
@@ -281,7 +281,7 @@ TEST(filepath_dir_range_basic) {
 
   auto touch_sym = [&](std::string entry) {
     std::string path = "test_dir/" + entry;
-    symlink("touch", path.c_str());
+    (void)symlink("touch", path.c_str());
     expected_type[entry] = wcl::file_type::symlink;
   };
 


### PR DESCRIPTION
I intentionally added un-checked writes to the system. These occur in single threaded instances where we can't block until they succeed, and we don't want to fail the whole system just because they fail, additionally if the log fails we can't log that fact because this *is* the logger and it would create a logger loop if we created an event that we also processed. We could add a tag to it to tell the json subscriber specifically to not process that event but it just gets complicated. So instead we just do the write (which should be a single atomic append) and we move on.