### PR TITLE
Profile wake startup times

### DIFF
--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -599,9 +599,8 @@ int main(int argc, char **argv) {
     auto start = std::chrono::steady_clock::now();
     wakefilenames = find_all_wakefiles(enumok, clo.workspace, clo.verbose, libdir, ".", user_warn);
     auto stop = std::chrono::steady_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start).count();
-    wcl::log::info("Find all wakefiles took %f seconds",
-                   static_cast<double>(duration) / 1000000.0)();
+    auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(stop - start).count();
+    wcl::log::info("Find all wakefiles took %f seconds", duration)();
   }
 
   if (!enumok) {
@@ -617,8 +616,8 @@ int main(int argc, char **argv) {
     auto start = std::chrono::steady_clock::now();
     sources = find_all_sources(runtime, clo.workspace);
     auto stop = std::chrono::steady_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start).count();
-    wcl::log::info("Find all sources took %f seconds", static_cast<double>(duration) / 1000000.0)();
+    auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(stop - start).count();
+    wcl::log::info("Find all sources took %f seconds", duration)();
   }
 
   if (!sources) {
@@ -690,9 +689,8 @@ int main(int argc, char **argv) {
     }
 
     auto stop = std::chrono::steady_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start).count();
-    wcl::log::info("Scanning wake files took %f seconds",
-                   static_cast<double>(duration) / 1000000.0)();
+    auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(stop - start).count();
+    wcl::log::info("Scanning wake files took %f seconds", duration)();
 
     if (!clo.quiet && alerted_slow_cache && is_stdout_tty) {
       std::cout << "Scanning " << wakefilenames.size() << "/" << wakefilenames.size()
@@ -716,7 +714,7 @@ int main(int argc, char **argv) {
 
   if (!flatten_exports(*top)) ok = false;
 
-  std::vector<std::pair<std::string, std::string> > defs;
+  std::vector<std::pair<std::string, std::string>> defs;
   std::set<std::string> types;
 
   if (targets) {


### PR DESCRIPTION
This is the first PR of several being split out from  https://github.com/sifive/wake/pull/1364

This change profiles wake startup time and dumps it into `wake.log` so that optimizations can be verified.

In the long term, it would be interesting to build out some kind of macro or C++ template for a `ProfiledStep` that accepts a low cost function and wraps in it profiling but I don't think that is needed just yet