### PR TITLE
Filter tarball files with globs; filter more files

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -154,11 +154,32 @@ def tarball Unit =
     # Identify those sources files to include in the tarball
     require Pass allSources = sources "." `.*`
 
-    def srcs =
+    def excludeGlobs =
+        "**/.gitignore",
+        ".circleci/**",
+        "debian/**",
+        ".github/**",
+        ".vscode/**",
+        ".clang-format",
+        ".dockerignore",
+        ".git-blame-ignore-revs",
+        ".gitattributes",
+        "wake.spec.in",
+
+    def regexes =
+        excludeGlobs
+        | map globToRegExp
+
+    def Pair rejects srcs =
         allSources
-        | filter (! matches `(debian/|wake.spec).*` _.getPathName) # omit packaging files
-        | filter (! matches `(\.circleci/|\.github/).*|\.dockerignore` _.getPathName) # omit CI files
-        | filter (! matches `(.*/)*\.gitignore` _.getPathName) # omit git files
+        | splitBy (\x matchesAny regexes x.getPathName)
+
+    def _ =
+        def files = (rejects | map (\x (("  ", x.getPathName, Nil) | cat)))
+        def msg = "Files below are excluded from tarball", files
+
+        msg
+        | map (printlnLevel logInfo _)
 
     def Pair testPaths wakePaths = splitBy (matches `tests/.*` _.getPathName) srcs
 

--- a/build.wake
+++ b/build.wake
@@ -166,13 +166,14 @@ def tarball Unit =
         ".gitattributes",
         "wake.spec.in",
 
-    def regexes =
+    def matchesAnyGlob path =
         excludeGlobs
         | map globToRegExp
+        | exists (matches _ path.getPathName)
 
     def Pair rejects srcs =
         allSources
-        | splitBy (\x matchesAny regexes x.getPathName)
+        | splitBy matchesAnyGlob
 
     def _ =
         def files = (rejects | map (\x (("  ", x.getPathName, Nil) | cat)))

--- a/share/wake/lib/core/regexp.wake
+++ b/share/wake/lib/core/regexp.wake
@@ -81,28 +81,6 @@ export def regExpToString (regExp: RegExp): String =
 export def matches (testRegExp: RegExp) (str: String): Boolean =
     (\_ \_ prim "match") testRegExp str
 
-# Test if a String matches all provided regular expressions
-# matchesAll (`a*`, `*b`) "ab" = True
-# matchesAll (`a*`, `*b`) "a" = False
-export def matchesAll (testRegExps: List RegExp) (str: String): Boolean = match testRegExps
-    Nil = True
-    head, tail =
-        if (matches head str) then
-            matchesAll tail str
-        else
-            False
-
-# Test if a String matches any provided regular expressions
-# matchesAny (`a*`, `*b`) "ac" = True
-# matchesAny (`a*`, `*b`) "c" = False
-export def matchesAny (testRegExps: List RegExp) (str: String) = match testRegExps
-    Nil = False
-    head, tail =
-        if (matches head str) then
-            True
-        else
-            matchesAny tail str
-
 # Extract fields out of a String using a parenthetical regular expression.
 # extract `(.*)-(.*)` "hello-world-hello" = ("hello", "world-hello", Nil)
 # extract `(.*)-(.*)` "helloworldhello" = Nil

--- a/share/wake/lib/core/regexp.wake
+++ b/share/wake/lib/core/regexp.wake
@@ -81,6 +81,28 @@ export def regExpToString (regExp: RegExp): String =
 export def matches (testRegExp: RegExp) (str: String): Boolean =
     (\_ \_ prim "match") testRegExp str
 
+# Test if a String matches all provided regular expressions
+# matchesAll (`a*`, `*b`) "ab" = True
+# matchesAll (`a*`, `*b`) "a" = False
+export def matchesAll (testRegExps: List RegExp) (str: String): Boolean = match testRegExps
+    Nil = True
+    head, tail =
+        if (matches head str) then
+            matchesAll tail str
+        else
+            False
+
+# Test if a String matches any provided regular expressions
+# matchesAny (`a*`, `*b`) "ac" = True
+# matchesAny (`a*`, `*b`) "c" = False
+export def matchesAny (testRegExps: List RegExp) (str: String) = match testRegExps
+    Nil = False
+    head, tail =
+        if (matches head str) then
+            True
+        else
+            matchesAny tail str
+
 # Extract fields out of a String using a parenthetical regular expression.
 # extract `(.*)-(.*)` "hello-world-hello" = ("hello", "world-hello", Nil)
 # extract `(.*)-(.*)` "helloworldhello" = Nil


### PR DESCRIPTION
Part two of splitting up https://github.com/sifive/wake/pull/1364

This change 
 - removes more files from the  tarball that have snuck in over time
 - uses globs  for exclusion instead of regexes
 - prints the excluded files to `info`