### PR TITLE
db: Emit # before tags in script

### DIFF
--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -200,7 +200,7 @@ static void describe_shell(const std::vector<JobReflection> &jobs, bool debug, b
     if (!job.tags.empty()) {
       out << "# Tags:" << std::endl;
       for (auto &x : job.tags) {
-        out << "   " << x.uri << ": ";
+        out << "#   " << x.uri << ": ";
         indent(out, "#     ", x.content);
       }
     }


### PR DESCRIPTION
Fixes #1371 

When dumping a script with  `wake -o blah.txt -s`  tags are not commented out. This change fixes that


```
$ wake-o out.txt -s
#! /bin/sh -ex

# Wake job 2354 (potato):
cd a/path/here
env -i \
        PATH=/usr/bin:/bin \
        TERM=xterm-256color \
/usr/bin/dash \
        -c \
        'echo '\''a b c'\'' > out.txt' \
        < /dev/null

# When wake ran this command:
#   Built:     2023-08-02 10:55:31.604541531
#   Runtime:   0.000753
#   CPUtime:   0.001199
#   Mem bytes: 4198400
#   In  bytes: 0
#   Out bytes: 6
#   Status:    0
#  Wake run:  2023-08-02 10:55:31.586483871 (./bin/wake --in foo foo a b c)
# Visible:
# Inputs:
# Outputs:
#  d4b66093f2ec5ec5cbc8147d279e6839e6866516ea62ceb1f801402878c9651d out.txt
# Stack:
# Tags:
#   foo: bar
```