### PR TITLE
Switch shared cache comunication over to non-blocking io

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -166,17 +166,6 @@ jobs:
             #   test_cmd: ls # no-op
             #   install_src_glob: build/wake-*/extensions/vscode/wake-*.vsix
 
-            - target: wasm
-              dockerfile: wasm
-              extra_docker_build_args: ''
-              extra_docker_run_args: -u build
-              build_cmd: make -C wake-* wasm
-              test_cmd: ls # no-op
-              # TODO: This doesn't fully capture all the wake contents
-              # but that is okay since wake-wasm in still in its infancy
-              # and is not deployed/depended on
-              install_src_glob: build/wake-*/bin/*.wasm*
-
       steps:
         - name: Create target directories
           run: mkdir dockerfiles && mkdir -p build/tests && mkdir build/debian && chmod ugo+rwx build

--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,6 @@ tarball:	wake.db
 vscode:		wake.db
 	$(WAKE_ENV) ./bin/wake vscode
 
-wasm:		wake.db
-	$(WAKE_ENV) ./bin/wake build wasm
-
 static:	wake.db
 	$(WAKE_ENV) ./bin/wake static
 

--- a/build.wake
+++ b/build.wake
@@ -22,6 +22,7 @@ def toVariant = match _
     "default" = Pass (Pair "native-cpp14-release" "native-c11-release")
     "static" = Pass (Pair "native-cpp14-static" "native-c11-static")
     "debug" = Pass (Pair "native-cpp14-debug" "native-c11-debug")
+    "wasm" = Pass (Pair "wasm-cpp14-release" "wasm-c11-release")
     s = Fail "Unknown build target ({s})".makeError
 
 export def build: List String => Result String Error = match _

--- a/build.wake
+++ b/build.wake
@@ -17,11 +17,6 @@ package build_wake
 
 from wake import _
 
-def testJob Unit =
-    makePlan "echo: test" Nil "echo test"
-    | runJobWith defaultRunner
-    | getJobStdout
-
 # Useful build variants (arguments to all)
 def toVariant = match _
     "default" = Pass (Pair "native-cpp14-release" "native-c11-release")

--- a/build.wake
+++ b/build.wake
@@ -17,6 +17,11 @@ package build_wake
 
 from wake import _
 
+def testJob Unit =
+    makePlan "echo: test" Nil "echo test"
+    | runJobWith defaultRunner
+    | getJobStdout
+
 # Useful build variants (arguments to all)
 def toVariant = match _
     "default" = Pass (Pair "native-cpp14-release" "native-c11-release")

--- a/build.wake
+++ b/build.wake
@@ -22,7 +22,6 @@ def toVariant = match _
     "default" = Pass (Pair "native-cpp14-release" "native-c11-release")
     "static" = Pass (Pair "native-cpp14-static" "native-c11-static")
     "debug" = Pass (Pair "native-cpp14-debug" "native-c11-debug")
-    "wasm" = Pass (Pair "wasm-cpp14-release" "wasm-c11-release")
     s = Fail "Unknown build target ({s})".makeError
 
 export def build: List String => Result String Error = match _

--- a/extensions/vscode/vscode.wake
+++ b/extensions/vscode/vscode.wake
@@ -42,7 +42,7 @@ def createStdlibJSON (stdlibSources: List Path): Result Path Error =
     write "{@here}/stdlib.json" (prettyJSON content)
 
 export def vscode _: Result Path Error =
-    require Pass variant = toVariant "wasm"
+    require Pass variant = Pass (Pair "wasm-cpp14-release" "wasm-c11-release")
     require Pass files = buildLSP variant
 
     require js, Nil = filter (matches `.*\.wasm-.*` _.getPathName) files

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -712,8 +712,9 @@ int DaemonCache::run() {
         handle_write(event.data.fd);
       }
 
-      wcl::log::info("In case I missed this, unrecognized event on %d: events = %d", event.data.fd,
-                     event.events)();
+      if (event.events & (EPOLLIN | EPOLLOUT) == 0) {
+        wcl::log::info("Unrecognized event on %d: events = %d", event.data.fd, event.events)();
+      }
     }
   }
 
@@ -1151,11 +1152,7 @@ void DaemonCache::handle_write(int client_fd) {
   }
 
   MessageSender &sender = *&it->second;
-  wcl::log::info("handle_write(%d): Sending", client_fd)();
-  wcl::log::info("sender.data.size() == %zu", sender.data.size())();
-  wcl::log::info("sender.fd = %d", sender.fd)();
   MessageSenderState state = sender.send();
-  wcl::log::info("handle_write(%d): Sent", client_fd)();
 
   // This client might be deadlocked, do us both
   // a favor and kill this connection

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -683,7 +683,7 @@ int DaemonCache::run() {
 
     if (events.empty()) {
       no_events_sec_counter += wait_until.tv_sec;
-      if (no_events_sec_counter >= 60) {
+      if (no_events_sec_counter >= 10 * 60) {
         wcl::log::info("No events for 10 minutes, exiting.")();
         return 0;
       }
@@ -1252,12 +1252,6 @@ void DaemonCache::handle_read_msg(int client_fd) {
       close_client(client_fd);
     }
   }
-
-  // If the file was closed, remove from epoll and close it.
-  // if (state == MessageParserState::StopSuccess) {
-  //  close_client(client_fd);
-  //  return;
-  //}
 
   // If there's an error just fail.
   if (state == MessageParserState::StopFail) {

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -712,7 +712,7 @@ int DaemonCache::run() {
         handle_write(event.data.fd);
       }
 
-      if (event.events & (EPOLLIN | EPOLLOUT) == 0) {
+      if ((event.events & (EPOLLIN | EPOLLOUT)) == 0) {
         wcl::log::info("Unrecognized event on %d: events = %d", event.data.fd, event.events)();
       }
     }

--- a/src/job_cache/daemon_cache.h
+++ b/src/job_cache/daemon_cache.h
@@ -30,6 +30,8 @@
 
 #include "job_cache.h"
 #include "message_parser.h"
+#include "message_sender.h"
+#include "job_cache_impl_common.h"
 
 namespace job_cache {
 
@@ -46,8 +48,9 @@ class DaemonCache {
   uint64_t low_cache_size;
   std::string key;
   int listen_socket_fd;
-  Poll poll;
+  EPoll poll;
   std::unordered_map<int, MessageParser> message_parsers;
+  std::unordered_map<int, MessageSender> message_senders;
   bool exit_now = false;
 
   void launch_evict_loop();
@@ -59,7 +62,8 @@ class DaemonCache {
   void close_client(int client_fd);
 
   void handle_new_client();
-  void handle_msg(int fd);
+  void handle_read_msg(int fd);
+  void handle_write(int fd);
 
  public:
   ~DaemonCache();

--- a/src/job_cache/daemon_cache.h
+++ b/src/job_cache/daemon_cache.h
@@ -29,9 +29,9 @@
 #include <unordered_map>
 
 #include "job_cache.h"
+#include "job_cache_impl_common.h"
 #include "message_parser.h"
 #include "message_sender.h"
-#include "job_cache_impl_common.h"
 
 namespace job_cache {
 

--- a/src/job_cache/eviction_policy.cpp
+++ b/src/job_cache/eviction_policy.cpp
@@ -243,8 +243,8 @@ static void garbage_collect_job(std::string job_dir) {
     }
 
     // We can keep going even with this failure but we need to at least log it
-    // wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
-    //                job_dir.c_str(), strerror(dir_res.error()))();
+    wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
+                    job_dir.c_str(), strerror(dir_res.error()))();
     return;
   }
 
@@ -275,8 +275,8 @@ static void garbage_collect_group(const std::unordered_set<int64_t> jobs, int64_
   auto dir_res = wcl::directory_range::open(group_dir);
   if (!dir_res) {
     // We can keep going even with this failure but we need to at least log it
-    // wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
-    //                group_dir.c_str(), strerror(dir_res.error()))();
+    wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
+                    group_dir.c_str(), strerror(dir_res.error()))();
     return;
   }
 

--- a/src/job_cache/eviction_policy.cpp
+++ b/src/job_cache/eviction_policy.cpp
@@ -243,8 +243,8 @@ static void garbage_collect_job(std::string job_dir) {
     }
 
     // We can keep going even with this failure but we need to at least log it
-    wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
-                    job_dir.c_str(), strerror(dir_res.error()))();
+    //wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
+    //                job_dir.c_str(), strerror(dir_res.error()))();
     return;
   }
 
@@ -275,8 +275,8 @@ static void garbage_collect_group(const std::unordered_set<int64_t> jobs, int64_
   auto dir_res = wcl::directory_range::open(group_dir);
   if (!dir_res) {
     // We can keep going even with this failure but we need to at least log it
-    wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
-                    group_dir.c_str(), strerror(dir_res.error()))();
+    //wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
+    //                group_dir.c_str(), strerror(dir_res.error()))();
     return;
   }
 
@@ -367,7 +367,8 @@ LRUEvictionPolicy::~LRUEvictionPolicy() {}
 int eviction_loop(const std::string& cache_dir, std::unique_ptr<EvictionPolicy> policy) {
   policy->init(cache_dir);
 
-  MessageParser msg_parser(STDIN_FILENO);
+  // Famous last words "a timeout of a year is plenty"
+  MessageParser msg_parser(STDIN_FILENO, 60 * 60 * 24 * 30 * 12);
   MessageParserState state;
   do {
     std::vector<std::string> msgs;

--- a/src/job_cache/eviction_policy.cpp
+++ b/src/job_cache/eviction_policy.cpp
@@ -243,7 +243,7 @@ static void garbage_collect_job(std::string job_dir) {
     }
 
     // We can keep going even with this failure but we need to at least log it
-    //wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
+    // wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
     //                job_dir.c_str(), strerror(dir_res.error()))();
     return;
   }
@@ -275,7 +275,7 @@ static void garbage_collect_group(const std::unordered_set<int64_t> jobs, int64_
   auto dir_res = wcl::directory_range::open(group_dir);
   if (!dir_res) {
     // We can keep going even with this failure but we need to at least log it
-    //wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
+    // wcl::log::error("garbage collecting orphaned folders: wcl::directory_range::open(%s): %s",
     //                group_dir.c_str(), strerror(dir_res.error()))();
     return;
   }

--- a/src/job_cache/job-cache.wake
+++ b/src/job_cache/job-cache.wake
@@ -16,9 +16,10 @@
 package build_wake
 
 from wake import _
+from gcc_wake import _
 
 target jobCacheLib variant = match variant
-    Pair "wasm-cpp14-release" -> Pass Nil
+    Pair "wasm-cpp14-release" _ -> Pass (SysLib "" Nil Nil Nil Nil)
     _ ->
         require Pass schemaSql = source "src/job_cache/schema.sql"
 

--- a/src/job_cache/job-cache.wake
+++ b/src/job_cache/job-cache.wake
@@ -17,7 +17,9 @@ package build_wake
 
 from wake import _
 
-target jobCacheLib variant =
-    require Pass schemaSql = source "src/job_cache/schema.sql"
+target jobCacheLib variant = match variant
+    Pair "wasm-cpp14-release" -> Pass Nil
+    _ ->
+        require Pass schemaSql = source "src/job_cache/schema.sql"
 
-    src @here variant (json, gopt, blake2, wcl, util,) (sqlite3,) (schemaSql,)
+        src @here variant (json, gopt, blake2, wcl, util,) (sqlite3,) (schemaSql,)

--- a/src/job_cache/job-cache.wake
+++ b/src/job_cache/job-cache.wake
@@ -18,9 +18,7 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-target jobCacheLib variant = match variant
-    Pair "wasm-cpp14-release" _ -> Pass (SysLib "" Nil Nil Nil Nil)
-    _ ->
-        require Pass schemaSql = source "src/job_cache/schema.sql"
+target jobCacheLib variant =
+    require Pass schemaSql = source "src/job_cache/schema.sql"
 
-        src @here variant (json, gopt, blake2, wcl, util,) (sqlite3,) (schemaSql,)
+    src @here variant (json, gopt, blake2, wcl, util,) (sqlite3,) (schemaSql,)

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -281,18 +281,17 @@ wcl::result<FindJobResponse, FindJobError> Cache::read_impl(const FindJobRequest
   std::vector<std::string> messages = std::move(*messages_res);
 
   if (messages.size() == 0) {
-            wcl::log::error("Cache::read(): daemon exited without responding")();
-      return wcl::result_error<FindJobResponse>(FindJobError::NoResponse);
+    wcl::log::error("Cache::read(): daemon exited without responding")();
+    return wcl::result_error<FindJobResponse>(FindJobError::NoResponse);
   }
 
   if (messages.size() > 1) {
-      
-wcl::log::info("message.size() == %lu", messages.size())();
-      for (const auto &message : messages) {
-        wcl::log::info("message.size() = %lu, message = '%s'", message.size(), message.c_str())();
-      }
-      wcl::log::error("Cache::read(): daemon responded with too many results")();
-      return wcl::result_error<FindJobResponse>(FindJobError::TooManyResponses);
+    wcl::log::info("message.size() == %lu", messages.size())();
+    for (const auto &message : messages) {
+      wcl::log::info("message.size() = %lu, message = '%s'", message.size(), message.c_str())();
+    }
+    wcl::log::error("Cache::read(): daemon responded with too many results")();
+    return wcl::result_error<FindJobResponse>(FindJobError::TooManyResponses);
   }
 
   wcl::log::info("Cache::read(): message rx")();
@@ -365,7 +364,7 @@ void Cache::add(const AddJobRequest &add_request) {
   auto socket_fd = backoff_try_connect(10);
   if (!socket_fd) {
     wcl::log::error("Cache::add(): Failed to connect")();
-    return;    
+    return;
   }
   sync_send_json_message(socket_fd->get(), request, 10);
 }

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -136,9 +136,9 @@ static bool daemonize(std::string dir) {
 wcl::optional<wcl::unique_fd> try_connect(std::string dir) {
   wcl::unique_fd socket_fd;
   {
-    int local_socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    int local_socket_fd = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
     if (local_socket_fd == -1) {
-      wcl::log::error("socket(AF_UNIX, SOCK_STREAM, 0): %s\n", strerror(errno)).urgent()();
+      wcl::log::error("socket(AF_UNIX, ..., 0): %s\n", strerror(errno)).urgent()();
       exit(1);
     }
     socket_fd = wcl::unique_fd(local_socket_fd);
@@ -193,14 +193,15 @@ void Cache::launch_daemon() {
 }
 
 // Connect to the job cache daemon with backoff.
-wcl::optional<ConnectError> Cache::backoff_try_connect(int attempts) {
+wcl::result<wcl::unique_fd, ConnectError> Cache::backoff_try_connect(int attempts) {
   wcl::xoshiro_256 rng(wcl::xoshiro_256::get_rng_seed());
   useconds_t backoff = 1000;
+  wcl::unique_fd socket_fd;
   for (int i = 0; i < attempts; i++) {
     // We normally connect in about 3 tries on fresh connect so
     // if we haven't connected at this point its a good spot to start
     // start trying.
-    if (i > 3) {
+    if (i > 4) {
       launch_daemon();
     }
 
@@ -217,10 +218,10 @@ wcl::optional<ConnectError> Cache::backoff_try_connect(int attempts) {
   }
 
   if (!socket_fd.valid()) {
-    return wcl::make_some<ConnectError>(ConnectError::TooManyAttempts);
+    return wcl::make_error<wcl::unique_fd, ConnectError>(ConnectError::TooManyAttempts);
   }
 
-  return {};
+  return wcl::make_result<wcl::unique_fd, ConnectError>(std::move(socket_fd));
 }
 
 template <class Iter>
@@ -241,18 +242,6 @@ Cache::Cache(std::string dir, uint64_t max, uint64_t low, bool miss) {
   mkdir_all(wcl::is_relative(cache_dir) ? "" : "/", fp_range.begin(), fp_range.end());
 
   launch_daemon();
-
-  auto error = backoff_try_connect(14);
-  if (!error) {
-    return;
-  }
-
-  wcl::log::error("could not connect to daemon. dir = %s", cache_dir.c_str()).urgent()();
-  if (miss_on_failure) {
-    return;
-  }
-
-  exit(1);
 }
 
 wcl::result<FindJobResponse, FindJobError> Cache::read_impl(const FindJobRequest &find_request) {
@@ -261,45 +250,50 @@ wcl::result<FindJobResponse, FindJobError> Cache::read_impl(const FindJobRequest
   request.add("params", find_request.to_json());
 
   // serialize the request, send it, deserialize the response, return it
-  auto write_error = send_json_message(socket_fd.get(), request);
+  auto socket_fd = backoff_try_connect(14);
+  if (!socket_fd) {
+    return wcl::result_error<FindJobResponse>(FindJobError::CouldNotConnect);
+  }
+  auto write_error = sync_send_json_message(socket_fd->get(), request, 10);
 
   if (write_error) {
     return wcl::result_error<FindJobResponse>(FindJobError::FailedRequest);
   }
-  MessageParser parser(socket_fd.get());
-  std::vector<std::string> messages;
+  MessageParser parser(socket_fd->get(), 10);
 
-  MessageParserState state = MessageParserState::Continue;
-  do {
-    state = parser.read_messages(messages);
+  // Read the message with a 10 second timeout.
+  auto messages_res = sync_read_message(socket_fd->get(), 10);
 
-    if (state == MessageParserState::StopFail) {
+  if (!messages_res) {
+    if (messages_res.error() == SyncMessageReadError::Fail) {
       wcl::log::error("Cache::read(): failed receiving message")();
       return wcl::result_error<FindJobResponse>(FindJobError::FailedMessageReceive);
     }
 
-    if (state == MessageParserState::StopSuccess && messages.empty()) {
-      wcl::log::error("Cache::read(): daemon exited without responding")();
-      return wcl::result_error<FindJobResponse>(FindJobError::NoResponse);
+    if (messages_res.error() == SyncMessageReadError::Timeout) {
+      wcl::log::error("Cache::read(): timed out reading from the cache daemon")();
+      return wcl::result_error<FindJobResponse>(FindJobError::Timeout);
     }
 
-    if (messages.size() > 1) {
-      wcl::log::info("message.size() == %lu", messages.size())();
+    assert(false);
+  }
+
+  std::vector<std::string> messages = std::move(*messages_res);
+
+  if (messages.size() == 0) {
+            wcl::log::error("Cache::read(): daemon exited without responding")();
+      return wcl::result_error<FindJobResponse>(FindJobError::NoResponse);
+  }
+
+  if (messages.size() > 1) {
+      
+wcl::log::info("message.size() == %lu", messages.size())();
       for (const auto &message : messages) {
         wcl::log::info("message.size() = %lu, message = '%s'", message.size(), message.c_str())();
       }
       wcl::log::error("Cache::read(): daemon responded with too many results")();
       return wcl::result_error<FindJobResponse>(FindJobError::TooManyResponses);
-    }
-
-    // We have a singular valid response
-    if (messages.size() == 1) {
-      break;
-    }
-
-    // MessageParser tries to avoid this but we should defend against
-    // the case where no error has yet occured but messages is still empty.
-  } while (state == MessageParserState::Continue);
+  }
 
   wcl::log::info("Cache::read(): message rx")();
 
@@ -326,7 +320,11 @@ FindJobResponse Cache::read(const FindJobRequest &find_request) {
       return *response;
     }
 
-    if (miss_on_failure && misses_from_failure > 30) {
+    if (response.error() == FindJobError::CouldNotConnect) {
+      failed_on_connect |= true;
+    }
+
+    if (miss_on_failure && misses_from_failure > 300) {
       wcl::log::warning(
           "Cache::read(): reached maximum cache misses for this invocation. Triggering early "
           "miss.")();
@@ -337,12 +335,9 @@ FindJobResponse Cache::read(const FindJobRequest &find_request) {
     usleep(backoff + variance(rng));
     backoff *= 2;
 
-    // Retry
+    // Make sure the daemon is actully launched
+    wcl::log::info("Ensuring daemon is alive by attempting to launch it")();
     launch_daemon();
-
-    wcl::log::info("Reconnecting to daemon.")();
-    auto error = backoff_try_connect(10);
-    failed_on_connect |= (bool)error;
   }
 
   if (failed_on_connect) {
@@ -367,7 +362,12 @@ void Cache::add(const AddJobRequest &add_request) {
 
   // serialize the request and send it, we ignore an error
   // if it occurs here and we keep moving.
-  send_json_message(socket_fd.get(), request);
+  auto socket_fd = backoff_try_connect(10);
+  if (!socket_fd) {
+    wcl::log::error("Cache::add(): Failed to connect")();
+    return;    
+  }
+  sync_send_json_message(socket_fd->get(), request, 10);
 }
 
 }  // namespace job_cache

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -198,9 +198,9 @@ wcl::result<wcl::unique_fd, ConnectError> Cache::backoff_try_connect(int attempt
   useconds_t backoff = 1000;
   wcl::unique_fd socket_fd;
   for (int i = 0; i < attempts; i++) {
-    // We normally connect in about 3 tries on fresh connect so
-    // if we haven't connected at this point its a good spot to start
-    // start trying.
+    // We normally connect in about 3 tries, sometimes 4 on fresh
+    // connect so if we haven't connected at this point its a good
+    // spot to start start trying.
     if (i > 4) {
       launch_daemon();
     }
@@ -319,9 +319,7 @@ FindJobResponse Cache::read(const FindJobRequest &find_request) {
       return *response;
     }
 
-    if (response.error() == FindJobError::CouldNotConnect) {
-      failed_on_connect |= true;
-    }
+    failed_on_connect |= response.error() == FindJobError::CouldNotConnect;
 
     if (miss_on_failure && misses_from_failure > 300) {
       wcl::log::warning(

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -47,11 +47,12 @@ enum class FindJobError {
   NoResponse,
   TooManyResponses,
   FailedParseResponse,
+  Timeout,
+  CouldNotConnect,
 };
 
 class Cache {
  private:
-  wcl::unique_fd socket_fd;
   bool miss_on_failure = false;
 
   // Daemon parameters
@@ -60,7 +61,7 @@ class Cache {
   uint64_t low_threshold;
 
   void launch_daemon();
-  wcl::optional<ConnectError> backoff_try_connect(int attempts);
+  wcl::result<wcl::unique_fd, ConnectError> backoff_try_connect(int attempts);
   wcl::result<FindJobResponse, FindJobError> read_impl(const FindJobRequest &find_request);
 
  public:

--- a/src/job_cache/job_cache_impl_common.cpp
+++ b/src/job_cache/job_cache_impl_common.cpp
@@ -237,7 +237,7 @@ void remove_job_backing_files(const std::string &dir, int64_t job_id) {
   std::string job_dir = wcl::join_paths(dir, wcl::to_hex(&group_id), std::to_string(job_id));
   auto dir_range = wcl::directory_range::open(job_dir);
   if (!dir_range) {
-    // wcl::log::error("opendir(%s): %s", job_dir.c_str(), strerror(dir_range.error())).urgent()();
+    wcl::log::error("opendir(%s): %s", job_dir.c_str(), strerror(dir_range.error())).urgent()();
     exit(1);
   }
 

--- a/src/job_cache/job_cache_impl_common.h
+++ b/src/job_cache/job_cache_impl_common.h
@@ -56,5 +56,19 @@ void symlink_no_fail(const char *target, const char *symlink_path);
 void unlink_no_fail(const char *file);
 void rmdir_no_fail(const char *dir);
 
-// Write the serialized JAST to fd with proper retries on failure
-wcl::optional<wcl::posix_error_t> send_json_message(int fd, const JAST &json);
+namespace job_cache {
+
+enum class SyncMessageReadError {
+  Fail,
+  Timeout,
+};
+
+// Continues reading until fd is closed by the other side, an error occurs, or a timeout occurs.
+// Returns every message read withint that time frame.
+wcl::result<std::vector<std::string>, SyncMessageReadError> sync_read_message(int fd, uint64_t timeout_seconds);
+
+// Write the serialized JAST to fd synchronously, returning an error from write
+// ETIME is returned if a timeout occurs.
+wcl::optional<wcl::posix_error_t> sync_send_json_message(int fd, const JAST &json, uint64_t timeout_seconds);
+
+}

--- a/src/job_cache/job_cache_impl_common.h
+++ b/src/job_cache/job_cache_impl_common.h
@@ -65,10 +65,12 @@ enum class SyncMessageReadError {
 
 // Continues reading until fd is closed by the other side, an error occurs, or a timeout occurs.
 // Returns every message read withint that time frame.
-wcl::result<std::vector<std::string>, SyncMessageReadError> sync_read_message(int fd, uint64_t timeout_seconds);
+wcl::result<std::vector<std::string>, SyncMessageReadError> sync_read_message(
+    int fd, uint64_t timeout_seconds);
 
 // Write the serialized JAST to fd synchronously, returning an error from write
 // ETIME is returned if a timeout occurs.
-wcl::optional<wcl::posix_error_t> sync_send_json_message(int fd, const JAST &json, uint64_t timeout_seconds);
+wcl::optional<wcl::posix_error_t> sync_send_json_message(int fd, const JAST &json,
+                                                         uint64_t timeout_seconds);
 
-}
+}  // namespace job_cache

--- a/src/job_cache/message_sender.h
+++ b/src/job_cache/message_sender.h
@@ -65,7 +65,8 @@ class MessageSender {
     sender.state = MessageSenderState::StopFail;
   }
 
-  MessageSender(std::string data_, int fd, uint64_t timeout_seconds) : data(std::move(data_)), fd(fd) {
+  MessageSender(std::string data_, int fd, uint64_t timeout_seconds)
+      : data(std::move(data_)), fd(fd) {
     start = data.begin();
     deadline = time(nullptr) + timeout_seconds;
     state = MessageSenderState::Continue;
@@ -89,7 +90,7 @@ class MessageSender {
       wcl::log::info("MessageSender::send(): Inside the loop")();
       int res = write(fd, &*start, data.end() - start);
       if (res == -1) {
-        //signal interuptions will be rare and should just be re-tried until
+        // signal interuptions will be rare and should just be re-tried until
         // we get EAGAIN/EWOULDBLOCK
         if (errno == EINTR) {
           continue;
@@ -107,7 +108,8 @@ class MessageSender {
       }
 
       wcl::log::info("MessageSender::send(): Wrote %d bytes", res)();
-      wcl::log::info("MessageSender::send(): Chunk wrote: %s", std::string(start, start + res).c_str())();
+      wcl::log::info("MessageSender::send(): Chunk wrote: %s",
+                     std::string(start, start + res).c_str())();
       start += res;
     }
 
@@ -117,6 +119,5 @@ class MessageSender {
     return state;
   }
 };
-
 
 }  // namespace job_cache

--- a/src/job_cache/message_sender.h
+++ b/src/job_cache/message_sender.h
@@ -87,7 +87,6 @@ class MessageSender {
     }
 
     while (start < data.end()) {
-      wcl::log::info("MessageSender::send(): Inside the loop")();
       int res = write(fd, &*start, data.end() - start);
       if (res == -1) {
         // signal interuptions will be rare and should just be re-tried until
@@ -108,12 +107,9 @@ class MessageSender {
       }
 
       wcl::log::info("MessageSender::send(): Wrote %d bytes", res)();
-      wcl::log::info("MessageSender::send(): Chunk wrote: %s",
                      std::string(start, start + res).c_str())();
-      start += res;
+                     start += res;
     }
-
-    wcl::log::info("MessageSender::send(): Finished writing")();
 
     state = MessageSenderState::StopSuccess;
     return state;

--- a/src/job_cache/message_sender.h
+++ b/src/job_cache/message_sender.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace job_cache {
+
+enum class MessageSenderState {
+  Continue,
+  StopSuccess,
+  StopFail,
+  Timeout,
+};
+
+// Message sender acts sort of like a Rust future, it holds the state needed
+// to keep performing a write even if it would block. This can be thought of as
+// dual to MessageParser. MessageSender will continue writing until it receives
+// EAGAIN/EWOULDBLOCK, or an error occurs. Thus it is a *must* that non-blocking
+// io be used. It is recomended that you use this with edge triggered polling so
+// that you only reattempt the write when you have to. Otherwise you will receive
+// writes that you did not want to receive.
+class MessageSender {
+ public:
+  std::string data;
+  std::string::iterator start;
+  time_t deadline;
+  int fd;
+  MessageSenderState state = MessageSenderState::Continue;
+
+ public:
+  MessageSender() = delete;
+  MessageSender(const MessageSender&) = delete;
+  MessageSender(MessageSender&& sender) {
+    data = std::move(sender.data);
+    start = data.begin();
+    deadline = sender.deadline;
+    fd = sender.fd;
+    state = sender.state;
+
+    sender.start = sender.data.begin();
+    sender.fd = -1;
+    sender.state = MessageSenderState::StopFail;
+  }
+
+  MessageSender(std::string data_, int fd, uint64_t timeout_seconds) : data(std::move(data_)), fd(fd) {
+    start = data.begin();
+    deadline = time(nullptr) + timeout_seconds;
+    state = MessageSenderState::Continue;
+  }
+
+  // errno from the call to `write` remains set if StopFail is returned
+  MessageSenderState send() {
+    wcl::log::info("MessageSender::send(): %d bytes left to send", int(data.end() - start))();
+    if (state != MessageSenderState::Continue) {
+      wcl::log::info("MessageSender::send(): state was already not continue, returning")();
+      return state;
+    }
+
+    if (time(nullptr) > deadline) {
+      wcl::log::info("MessageSender::send(): Timeout")();
+      state = MessageSenderState::Timeout;
+      return state;
+    }
+
+    while (start < data.end()) {
+      wcl::log::info("MessageSender::send(): Inside the loop")();
+      int res = write(fd, &*start, data.end() - start);
+      if (res == -1) {
+        //signal interuptions will be rare and should just be re-tried until
+        // we get EAGAIN/EWOULDBLOCK
+        if (errno == EINTR) {
+          continue;
+        }
+
+        // We still have more work to do but we can't do it right now.
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+          wcl::log::info("MessageSender::send(): Stopping send because it would block")();
+          return MessageSenderState::Continue;
+        }
+
+        wcl::log::info("MessageSender::send(): write(%d): %s", fd, strerror(errno)).urgent()();
+        state = MessageSenderState::StopFail;
+        return state;
+      }
+
+      wcl::log::info("MessageSender::send(): Wrote %d bytes", res)();
+      wcl::log::info("MessageSender::send(): Chunk wrote: %s", std::string(start, start + res).c_str())();
+      start += res;
+    }
+
+    wcl::log::info("MessageSender::send(): Finished writing")();
+
+    state = MessageSenderState::StopSuccess;
+    return state;
+  }
+};
+
+
+}  // namespace job_cache

--- a/src/job_cache/message_sender.h
+++ b/src/job_cache/message_sender.h
@@ -107,8 +107,7 @@ class MessageSender {
       }
 
       wcl::log::info("MessageSender::send(): Wrote %d bytes", res)();
-                     std::string(start, start + res).c_str())();
-                     start += res;
+      start += res;
     }
 
     state = MessageSenderState::StopSuccess;

--- a/src/util/poll.cpp
+++ b/src/util/poll.cpp
@@ -63,9 +63,7 @@ Poll::Poll() : imp(std::make_unique<Poll::detail>()) {
   }
 }
 
-EPoll::~EPoll() {
-  close(epfd);
-}
+EPoll::~EPoll() { close(epfd); }
 
 Poll::~Poll() { close(imp->pfd); }
 
@@ -118,7 +116,6 @@ void Poll::clear() {
     exit(1);
   }
 }
-
 
 std::vector<epoll_event> EPoll::wait(struct timespec *timeout, sigset_t *saved) {
   struct epoll_event events[EVENTS];

--- a/src/util/poll.h
+++ b/src/util/poll.h
@@ -18,8 +18,8 @@
 #ifndef POLL_H
 #define POLL_H
 
-#include <sys/select.h>
 #include <sys/epoll.h>
+#include <sys/select.h>
 
 #include <memory>
 #include <vector>

--- a/src/util/poll.h
+++ b/src/util/poll.h
@@ -19,10 +19,16 @@
 #define POLL_H
 
 #include <sys/select.h>
+#include <sys/epoll.h>
 
 #include <memory>
 #include <vector>
 
+// Poll is an wrapper around epoll on linux but also works on
+// other operating systems. Today we only support linux but
+// in the past we supported other kernels. This is still the
+// the polling struct used throughout wake. It only allows
+// for read level-triggered polling.
 struct Poll {
   struct detail;
   std::unique_ptr<detail> imp;
@@ -37,6 +43,22 @@ struct Poll {
   std::vector<int> wait(struct timespec *timeout, sigset_t *saved);
 
   int max_fds() const;
+};
+
+// EPoll is a more advanced wrapper around the epoll interface.
+// It explicitly uses types from the linux epoll interface.
+// It allows for read and write polling as well as level
+// or edge triggered polling. It's just a nice wrapper around
+// epoll.
+struct EPoll {
+  int epfd;
+
+  EPoll();
+  ~EPoll();
+
+  void add(int fd, uint32_t events);
+  void remove(int fd);
+  std::vector<epoll_event> wait(struct timespec *timeout, sigset_t *saved);
 };
 
 #endif

--- a/src/util/poll.h
+++ b/src/util/poll.h
@@ -63,6 +63,6 @@ struct EPoll {
   std::vector<epoll_event> wait(struct timespec *timeout, sigset_t *saved);
 };
 
-#ifdef
+#endif
 
 #endif

--- a/src/util/poll.h
+++ b/src/util/poll.h
@@ -18,7 +18,6 @@
 #ifndef POLL_H
 #define POLL_H
 
-#include <sys/epoll.h>
 #include <sys/select.h>
 
 #include <memory>
@@ -45,6 +44,9 @@ struct Poll {
   int max_fds() const;
 };
 
+#ifdef __linux__
+
+#include <sys/epoll.h>
 // EPoll is a more advanced wrapper around the epoll interface.
 // It explicitly uses types from the linux epoll interface.
 // It allows for read and write polling as well as level
@@ -60,5 +62,7 @@ struct EPoll {
   void remove(int fd);
   std::vector<epoll_event> wait(struct timespec *timeout, sigset_t *saved);
 };
+
+#ifdef
 
 #endif

--- a/src/util/util.wake
+++ b/src/util/util.wake
@@ -18,4 +18,4 @@ package build_wake
 from wake import _
 
 target util variant =
-    src @here variant (compat, Nil) (whereami, siphash, ncurses, Nil) Nil
+    src @here variant (compat, wcl, Nil) (wcl, whereami, siphash, ncurses, Nil) Nil

--- a/tests/job-cache/basic-fetch/pass.sh
+++ b/tests/job-cache/basic-fetch/pass.sh
@@ -12,11 +12,11 @@ rm wake.db || true
 rm -rf .cache-hit || true
 rm -rf .cache-misses || true
 rm -rf .job-cache || true
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 
 rm wake.db
 rm -rf .cache-misses
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
   exit 1

--- a/tests/job-cache/basic-lru/pass.sh
+++ b/tests/job-cache/basic-lru/pass.sh
@@ -14,18 +14,18 @@ rm one.txt 2> /dev/null || true
 rm two.txt 2> /dev/null || true
 rm three.txt 2> /dev/null || true
 rm four.txt 2> /dev/null || true
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
 rm wake.db
 rm -rf .cache-misses
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test two
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test two
 rm wake.db
 rm -rf .cache-misses
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test three
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test three
 rm wake.db
 rm -rf .cache-misses
 
 # We should still be under the limit here. This is to ensure we mark test one as used
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
 rm wake.db
 rm -rf .cache-misses
 if [ -z "$(ls -A .cache-hit)" ]; then
@@ -34,13 +34,13 @@ if [ -z "$(ls -A .cache-hit)" ]; then
 fi
 
 # Now we're going to go over. Hopefully dropping two and three, but keeping one and four
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test four
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test four
 rm wake.db
 rm -rf .cache-misses
 
 # Now make sure we still get a hit on 1
 rm -rf .cache-hit  2> /dev/null || true
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
 rm wake.db
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
@@ -53,7 +53,7 @@ fi
 
 # And check four as well
 rm -rf .cache-hit
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test four
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test four
 rm wake.db
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
@@ -65,7 +65,7 @@ if [ -d ".cache-misses" ]; then
 fi
 
 # And check that we get misses on four and three
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test two
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test two
 rm wake.db
 if [ -z "$(ls -A .cache-misses)" ]; then
   echo "Expected a chache miss!!"
@@ -74,7 +74,7 @@ fi
 rm -rf .cache-misses
 
 
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test three
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test three
 rm wake.db
 if [ -z "$(ls -A .cache-misses)" ]; then
   echo "Expected a chache miss!!"

--- a/tests/job-cache/dup-output/pass.sh
+++ b/tests/job-cache/dup-output/pass.sh
@@ -10,10 +10,10 @@ rm wake.db || true
 rm -rf .cache-hit || true
 rm -rf .cache-misses || true
 rm -rf .job-cache || true
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 rm wake.db
 rm -rf .cache-misses
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
   exit 1

--- a/tests/job-cache/overwrite-smaller/pass.sh
+++ b/tests/job-cache/overwrite-smaller/pass.sh
@@ -14,18 +14,18 @@ rm -rf .cache-misses || true
 rm -rf .job-cache || true
 
 # Now run again with a small payload, expect a miss
-PAYLOAD=small DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 PAYLOAD=small DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 rm wake.db
 rm -rf .cache-misses
 
 # Run test once with a larger payload, expect a miss
-PAYLOAD=deadbeefdeadbeef DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 PAYLOAD=deadbeefdeadbeef DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 rm wake.db
 rm -rf .cache-misses
 
 # Now run again with a small payload again, this should be a cache hit but it should
 # not overwrite the existing inode, it should create a new one.
-PAYLOAD=small DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 PAYLOAD=small DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
   exit 1

--- a/tests/job-cache/symlink-dir/pass.sh
+++ b/tests/job-cache/symlink-dir/pass.sh
@@ -10,10 +10,10 @@ rm wake.db || true
 rm -rf .cache-hit || true
 rm -rf .cache-misses || true
 rm -rf .job-cache || true
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 rm wake.db
 rm -rf .cache-misses
-DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
   exit 1

--- a/tools/wake-unit/unit.cpp
+++ b/tools/wake-unit/unit.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <set>
 
+#include "json/json5.h"
 #include "util/diagnostic.h"
 #include "util/term.h"
 
@@ -95,6 +96,14 @@ int main(int argc, char** argv) {
     }
   }
   term_init(true, true);
+
+  auto res = JsonSubscriber::fd_t::open("wake.log");
+  if (!res) {
+    std::cerr << "Unable to init logging: wake.log failed to open: " << strerror(res.error())
+              << std::endl;
+  }
+  wcl::log::subscribe(std::make_unique<JsonSubscriber>(std::move(*res)));
+
   TestLogger logger;
   std::set<std::string> failed_tests;
   std::set<std::string> passing_tests;


### PR DESCRIPTION
This is a rather massive change to the shared cache. It doesn't change the protocol, the directory layout, the read or write implementations etc... but it changes the nitty gritty specifics of how messages are sent/received and how blocking is handled. Specifically the following changes have been made It should be impossible for a colleciton of clients and a daemon to deadlock now because neither side ever blocks and there's no shared state between the two sides. Additionally connection closing happens much more aggressively to simplify functionality. This is all in the name of stopping deadlock from occuring.

This change also adds tests that combine large messages with parallelism which is where I think the bug was hiding previously but I've yet to run those tests on a previous commit to see if they triggered deadlock (will do that soon).

1) Unit tests now always output information to wake.log
2) The client now uses non-blocking IO with leveled triggered polling and timeouts in order to ensure that it never blocks for longer than the time
3) The daemon now uses non-blocking IO with *edge* triggered polling and timeouts in order to ensure that it never blocks if there is any other work that it can do instead. Previously each read and each write had to happen synchronously and would potentially block under many circumstances. Now even writes are non-blocking and can happen out of order.
4) If a client times out, the daemon closes the connection
5) Every request is made over 1 domain socket so that there is little to no state shared between the daemon and a client
6) Previously the daemon would close itself after a disconnect form a client if it discovered that it had no further connected clients. Now the daemon exits after 10 minutes of no activity regardless of how many clients are connected. However you can get back the old functionality by using an environment variable to enable fast closing.
7) As part of 3, we have both MessageParser AND MessageSender which is like MessageParser except it allows writes to be chunked and sent out of order as possible just like MessageParser allows the same for reading.
8) There's a new wrapper around epoll because I didn't want to mess with the old Poll wrapper that drives the heart of wake here. This new wrapper is not implementable by non-epoll interfaces and is thus Linux only.

