### PR TITLE
Remove support for wake wasm target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -166,17 +166,6 @@ jobs:
             #   test_cmd: ls # no-op
             #   install_src_glob: build/wake-*/extensions/vscode/wake-*.vsix
 
-            - target: wasm
-              dockerfile: wasm
-              extra_docker_build_args: ''
-              extra_docker_run_args: -u build
-              build_cmd: make -C wake-* wasm
-              test_cmd: ls # no-op
-              # TODO: This doesn't fully capture all the wake contents
-              # but that is okay since wake-wasm in still in its infancy
-              # and is not deployed/depended on
-              install_src_glob: build/wake-*/bin/*.wasm*
-
       steps:
         - name: Create target directories
           run: mkdir dockerfiles && mkdir -p build/tests && mkdir build/debian && chmod ugo+rwx build

--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,6 @@ tarball:	wake.db
 vscode:		wake.db
 	$(WAKE_ENV) ./bin/wake vscode
 
-wasm:		wake.db
-	$(WAKE_ENV) ./bin/wake build wasm
-
 static:	wake.db
 	$(WAKE_ENV) ./bin/wake static
 

--- a/src/runtime/gc.h
+++ b/src/runtime/gc.h
@@ -321,12 +321,7 @@ struct alignas(PadObject) GCObject : public B {
   template <typename... ARGS>
   GCObject(ARGS &&...args) : B(std::forward<ARGS>(args)...) {
     static_assert(sizeof(MovedObject) <= sizeof(T), "HeapObject is too small");
-// TODO: on wasm pointer types are 4 bytes while doubles are 8 and that is
-// causing this assert to fail. Doubles won't be properly aligned in wasm
-// which may prove troublesome.
-#ifndef __EMSCRIPTEN__
     static_assert(sizeof(PadObject) == alignof(T), "HeapObject alignment wrong");
-#endif
   }
 
   T *self() { return static_cast<T *>(this); }

--- a/src/runtime/status.cpp
+++ b/src/runtime/status.cpp
@@ -21,8 +21,6 @@
 
 #include "status.h"
 
-#ifndef __EMSCRIPTEN__
-
 #include <assert.h>
 #include <curses.h>
 #include <fcntl.h>
@@ -568,42 +566,3 @@ void status_finish() {
     setitimer(ITIMER_REAL, &timer, 0);
   }
 }
-
-#else
-#include <emscripten/emscripten.h>
-
-StatusState status_state;
-
-void status_init() {}
-
-// TODO: I need to make a stream buf specifically for emscripten
-void status_write(const char *name, const char *data, int len) {
-  // clang-format off
-  EM_ASM_INT({
-    console.log('[' + UTF8ToString($0) + '] ' + UTF8ToString($1));
-    return 0;
-  }, name, data);
-  // clang-format on
-}
-
-void status_refresh(bool idle) {}
-void status_finish() {}
-
-void status_set_colour(const char *name, int colour) {}
-void status_set_fd(const char *name, int fd) {}
-void status_set_bulk_fd(int fd, const char *streams) {}
-
-int status_get_colour(const char *name) { return 0; }
-
-int status_get_fd(const char *name) { return -1; }
-
-std::ostream &status_get_generic_stream(const char *name) { return std::cout; }
-
-void StatusBuf::emit_header() {}
-int StatusBuf::overflow(int c) { return 0; }
-StatusBuf::StatusBuf(std::string name, wcl::optional<std::string> extra, int color,
-                     TermInfoBuf &buf)
-    : buf(buf) {}
-StatusBuf::~StatusBuf() {}
-
-#endif

--- a/src/util/poll.cpp
+++ b/src/util/poll.cpp
@@ -31,8 +31,6 @@
 #define USE_EPOLL 1
 #elif defined(__APPLE__)
 #define USE_PSELECT 1
-#elif defined(__EMSCRIPTEN__)
-#define USE_PSELECT
 #else
 #define USE_PPOLL 1
 #endif

--- a/tools/fuse-waked/fuse-waked.wake
+++ b/tools/fuse-waked/fuse-waked.wake
@@ -19,6 +19,4 @@ from wake import _
 from gcc_wake import _
 
 target buildFuseDaemon variant: Result (List Path) Error = match variant
-    # Fuse doesn't, and likely won't ever, support building for wasm
-    Pair "wasm-cpp14-release" _ = Pass Nil
     _ = tool @here Nil variant "lib/wake/fuse-waked" (json, fuse, util, Nil) Nil Nil

--- a/vendor/gmp.wake
+++ b/vendor/gmp.wake
@@ -16,41 +16,6 @@
 package build_wake
 
 from wake import _
-from gcc_wake import _
 
-def gmp = match _
-    Pair "wasm-cpp14-release" _ = buildGmpWASM Unit
-    _ = Pass (pkg "gmp")
-
-def buildGmpWASM _ =
-    require Some emmake = emmake
-    else failWithError "emmake is not available"
-
-    def emsdk = replace `/[^/]*$` "" emmake
-    def version = "6.2.1"
-
-    require Pass buildDir = vendorBuildDir Unit
-
-    def job =
-        """
-        cd .build
-        wget https://ftp.gnu.org/gnu/gmp/gmp-%{version}.tar.xz
-        tar xmf gmp-%{version}.tar.xz
-        cd gmp-%{version}
-        emconfigure ./configure --disable-assembly --host none --enable-cxx
-        emmake make -j4 MAKEINFO=true
-        """
-        | makePlan "compiling gmp" (buildDir, Nil)
-        | editPlanEnvironment (addEnvironmentPath emsdk)
-        | setPlanDirectory @here
-        | setPlanShare False
-        | runJobWith defaultRunner
-
-    require Pass outputs = job.getJobOutputs
-
-    def headers = filter (matches `.*\.h` _.getPathName) outputs
-    def objects = filter (matches `.*\.a` _.getPathName) outputs
-    def cflags = "-I{@here}/.build/gmp-{version}", Nil
-    def lflags = Nil
-
-    Pass (SysLib version headers objects cflags lflags)
+def gmp _ =
+    Pass (pkg "gmp")

--- a/vendor/ncurses.wake
+++ b/vendor/ncurses.wake
@@ -18,8 +18,10 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-def ncurses _ =
-    pkgConfig "ncurses tinfo"
-    | getOrElseFn (\Unit pkg "ncurses")
-    | editSysLibCFlags (filter (matches `-I.*` _)) # remove feature test manipulation
-    | Pass
+def ncurses = match _
+    Pair "wasm-cpp14-release" _ = Pass (makeSysLib "ncurses")
+    _ =
+        pkgConfig "ncurses tinfo"
+        | getOrElseFn (\Unit pkg "ncurses")
+        | editSysLibCFlags (filter (matches `-I.*` _)) # remove feature test manipulation
+        | Pass

--- a/vendor/ncurses.wake
+++ b/vendor/ncurses.wake
@@ -18,10 +18,8 @@ package build_wake
 from wake import _
 from gcc_wake import _
 
-def ncurses = match _
-    Pair "wasm-cpp14-release" _ = Pass (makeSysLib "ncurses")
-    _ =
-        pkgConfig "ncurses tinfo"
-        | getOrElseFn (\Unit pkg "ncurses")
-        | editSysLibCFlags (filter (matches `-I.*` _)) # remove feature test manipulation
-        | Pass
+def ncurses _ =
+    pkgConfig "ncurses tinfo"
+    | getOrElseFn (\Unit pkg "ncurses")
+    | editSysLibCFlags (filter (matches `-I.*` _)) # remove feature test manipulation
+    | Pass

--- a/vendor/sqlite3.wake
+++ b/vendor/sqlite3.wake
@@ -16,40 +16,6 @@
 package build_wake
 
 from wake import _
-from gcc_wake import _
 
-def sqlite3 = match _
-    Pair "wasm-cpp14-release" _ = buildSqlite3WASM Unit
-    _ = Pass (pkg "sqlite3")
-
-def buildSqlite3WASM _ =
-    require Some emmake = emmake
-    else failWithError "emmake is not available"
-
-    def emsdk = replace `/[^/]*$` "" emmake
-    def version = "0.0.0"
-
-    require Pass buildDir = vendorBuildDir Unit
-
-    def job =
-        """
-        cd .build
-        wget https://sqlite.org/2022/sqlite-amalgamation-3390200.zip
-        unzip sqlite-amalgamation-3390200
-        cd sqlite-amalgamation-3390200
-        emcc -c sqlite3.c
-        """
-        | makePlan "compiling sqlite3" (buildDir, Nil)
-        | editPlanEnvironment (addEnvironmentPath emsdk)
-        | setPlanDirectory @here
-        | setPlanShare False
-        | runJobWith defaultRunner
-
-    require Pass outputs = job.getJobOutputs
-
-    def headers = filter (matches `.*\.h` _.getPathName) outputs
-    def objects = filter (matches `.*\.o` _.getPathName) outputs
-    def cflags = "-I{@here}/.build/sqlite-amalgamation-3390200", Nil
-    def lflags = Nil
-
-    Pass (SysLib version headers objects cflags lflags)
+def sqlite3 _ =
+    Pass (pkg "sqlite3")


### PR DESCRIPTION
The wake-wasm target was never actually used and now it is blocking shared caching in a non-trivial wake. Because of this, remove it.