### PR TITLE
Remove clients that have timed out

### DIFF
--- a/src/job_cache/message_parser.h
+++ b/src/job_cache/message_parser.h
@@ -44,6 +44,8 @@ struct MessageParser {
   MessageParser() = delete;
   MessageParser(int fd, uint64_t timeout) : fd(fd), deadline(time(nullptr) + timeout) {}
 
+  bool has_timed_out() const { return time(nullptr) > deadline; }
+
   MessageParserState read_messages(std::vector<std::string>& messages) {
     messages = {};
 

--- a/src/job_cache/message_sender.h
+++ b/src/job_cache/message_sender.h
@@ -72,6 +72,8 @@ class MessageSender {
     state = MessageSenderState::Continue;
   }
 
+  bool has_timed_out() const { return time(nullptr) > deadline; }
+
   // errno from the call to `write` remains set if StopFail is returned
   MessageSenderState send() {
     wcl::log::info("MessageSender::send(): %d bytes left to send", int(data.end() - start))();


### PR DESCRIPTION
In the previous non-blocking io change I forgot to evict clients that had timed out. This wound up not mattering much but I think its a good feature to keep in mind. All tests still pass.