### PR TITLE
Fix case where certain defs matched zero rules

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1425,10 +1425,59 @@ def _ =
         fi
     """
 
+target do (a: String) (
+  Type
+  b    # comment about 'b'.
+  c
+) = ""
+
+target (
+  Type
+  b    # comment about 'b'.
+  c
+) = ""
+
 def x _ =
     def (
         A # test
-        b  
-    ) = c
-
+        b
+    ) =
+       c 
     b
+
+def x _ = 
+    require Pass (
+        Type 
+        x # test
+        z
+    ) = b
+    a
+
+def x _ = 
+    require (
+        Type 
+        x # test
+        z
+    ) = b
+    a
+
+def x = 
+    def (
+        x,
+        a,
+        z,
+    ) = b
+    z
+
+def x = 
+    def (
+        x,
+        (
+            Type 
+            y # comment
+            a
+        ),
+        a,
+        z
+    ) = b
+    z

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1424,3 +1424,11 @@ def _ =
             %{x}
         fi
     """
+
+def x _ =
+    def (
+        A # test
+        b  
+    ) = c
+
+    b

--- a/tests/wake-format/basic/simple.wake
+++ b/tests/wake-format/basic/simple.wake
@@ -1,8 +1,0 @@
-
-def _ =
-    # wake-format off
-    """
-        if %{x}; then
-            %{x}
-        fi
-    """

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1698,3 +1698,11 @@ def _ =
         %{x}
     fi
     """
+
+def x _ =
+    def (
+        A # test
+        b
+    ) = c
+
+    b

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1699,6 +1699,20 @@ def _ =
     fi
     """
 
+target do (a: String) (
+    Type
+    b # comment about 'b'.
+    c
+) =
+    ""
+
+target (
+    Type
+    b # comment about 'b'.
+    c
+) =
+    ""
+
 def x _ =
     def (
         A # test
@@ -1706,3 +1720,40 @@ def x _ =
     ) = c
 
     b
+
+def x _ =
+    require Pass (
+        Type
+        x # test
+        z
+    ) = b
+
+    a
+
+def x _ =
+    require (
+        Type
+        x # test
+        z
+    ) = b
+
+    a
+
+def x =
+    def (x, a, z,) = b
+
+    z
+
+def x =
+    def (
+        x,
+        (
+            Type
+            y # comment
+            a
+        ),
+        a,
+        z
+    ) = b
+
+    z

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1131,7 +1131,7 @@ wcl::optional<wcl::doc> Emitter::combine_apply_constructor(ctx_t ctx,
     return {};
   }
 
-  // If the LHS has a trailing comment then we must respect the regualr format
+  // If the LHS has a trailing comment then we must respect the regular format
   // Json # comment
   // ( ... )
   //
@@ -1517,7 +1517,8 @@ wcl::doc Emitter::walk_def(ctx_t ctx, CSTElement node) {
                .fmt_if(CST_FLAG_EXPORT, fmt().walk(WALK_NODE).ws())
                .token(TOKEN_KW_DEF)
                .ws()
-               .prevent_explode(fmt().walk(is_expression, WALK_NODE))
+               .fmt_if_else(CST_PAREN, fmt().walk(is_expression, WALK_NODE),
+                            fmt().prevent_explode(fmt().walk(is_expression, WALK_NODE)))
                .consume_wsnlc()
                .space()
                .token(TOKEN_P_EQUALS)

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1164,6 +1164,20 @@ wcl::optional<wcl::doc> Emitter::combine_apply_explode_all(ctx_t ctx,
   return {wcl::in_place_t{}, std::move(builder).build()};
 }
 
+wcl::optional<wcl::doc> Emitter::combine_apply_pattern(ctx_t ctx,
+                                                       const std::vector<CSTElement>& parts) {
+  ctx = ctx.allow_explode();
+  wcl::doc_builder builder;
+  for (size_t i = 0; i < parts.size() - 1; i++) {
+    CSTElement part = parts[i];
+    builder.append(fmt().walk(WALK_NODE).space().compose(ctx.sub(builder), part, token_traits));
+  }
+
+  builder.append(walk_node(ctx.sub(builder), parts.back()));
+
+  return {wcl::in_place_t{}, std::move(builder).build()};
+}
+
 wcl::doc Emitter::walk_apply(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
   FMT_ASSERT(node.id() == CST_APP, node, "Expected CST_APP");
@@ -1177,6 +1191,15 @@ wcl::doc Emitter::walk_apply(ctx_t ctx, CSTElement node) {
 
   if (ctx.explode_option != ExplodeOption::Prevent) {
     choices.push_back(combine_apply_explode_all(ctx, parts));
+  }
+
+  bool has_choice = false;
+  for (const auto& c : choices) {
+    if (c) has_choice |= true;
+  }
+
+  if (!has_choice) {
+    choices.push_back(combine_apply_pattern(ctx, parts));
   }
 
   MEMO_RET(select_best_choice(choices));
@@ -2035,7 +2058,8 @@ wcl::doc Emitter::walk_target(ctx_t ctx, CSTElement node) {
                .fmt_if(CST_FLAG_EXPORT, fmt().walk(WALK_NODE).ws())
                .token(TOKEN_KW_TARGET)
                .ws()
-               .prevent_explode(fmt().walk(is_expression, WALK_NODE))
+               .fmt_if_else(CST_PAREN, fmt().walk(is_expression, WALK_NODE),
+                            fmt().prevent_explode(fmt().walk(is_expression, WALK_NODE)))
                .consume_wsnlc()
                .space()
                .fmt_if(TOKEN_P_BSLASH,

--- a/tools/wake-format/emitter.h
+++ b/tools/wake-format/emitter.h
@@ -139,6 +139,7 @@ class Emitter {
                                                     const std::vector<CSTElement>& parts);
   wcl::optional<wcl::doc> combine_apply_explode_all(ctx_t ctx,
                                                     const std::vector<CSTElement>& parts);
+  wcl::optional<wcl::doc> combine_apply_pattern(ctx_t ctx, const std::vector<CSTElement>& parts);
 
   // Returns a formatter that inserts the next node
   // on the current line if it fits, or on a new nested line


### PR DESCRIPTION
When a comment is inside a paren which is inside a def (see below) there are zero matching rules. 

```
def x _ =
    def (
        A # test
        b
    ) =
       c 
    b
```

because the comment requires exploding but `CST_DEF` disallows it. This change make it so `CST_DEF` allows explode only for `CST_PAREN`