### PR TITLE
Require explode when a binop ends with a unary comma

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -51,12 +51,18 @@ def bootstrapTarget targetFn variant =
     else Pass paths
 
     def cppSuffixRegex =
-        (".", variant.getPairFirst,)
+        (
+            ".",
+            variant.getPairFirst,
+        )
         | cat
         | quote
 
     def cSuffixRegex =
-        (".", variant.getPairSecond,)
+        (
+            ".",
+            variant.getPairSecond,
+        )
         | cat
         | quote
 

--- a/build.wake
+++ b/build.wake
@@ -51,18 +51,12 @@ def bootstrapTarget targetFn variant =
     else Pass paths
 
     def cppSuffixRegex =
-        (
-            ".",
-            variant.getPairFirst,
-        )
+        (".", variant.getPairFirst, Nil)
         | cat
         | quote
 
     def cSuffixRegex =
-        (
-            ".",
-            variant.getPairSecond,
-        )
+        (".", variant.getPairSecond, Nil)
         | cat
         | quote
 

--- a/rust/log_viewer/build.wake
+++ b/rust/log_viewer/build.wake
@@ -21,7 +21,15 @@ from rust import _
 def buildWakeLogViewer Unit =
     require Pass cargoToml = source "rust/log_viewer/Cargo.toml"
     require Pass main = source "rust/log_viewer/src/main.rs"
-    require Pass outputs = cargoBuild (cargoToml, main,) "rust/log_viewer" ("log_viewer",)
+
+    require Pass outputs =
+        cargoBuild
+        (
+            cargoToml,
+            main,
+        )
+        "rust/log_viewer"
+        ("log_viewer",)
 
     require (logViewer, Nil) = outputs
     else failWithError "More than one output returned when building log_viewer"

--- a/rust/log_viewer/build.wake
+++ b/rust/log_viewer/build.wake
@@ -21,15 +21,7 @@ from rust import _
 def buildWakeLogViewer Unit =
     require Pass cargoToml = source "rust/log_viewer/Cargo.toml"
     require Pass main = source "rust/log_viewer/src/main.rs"
-
-    require Pass outputs =
-        cargoBuild
-        (
-            cargoToml,
-            main,
-        )
-        "rust/log_viewer"
-        ("log_viewer",)
+    require Pass outputs = cargoBuild (cargoToml, main, Nil) "rust/log_viewer" ("log_viewer", Nil)
 
     require (logViewer, Nil) = outputs
     else failWithError "More than one output returned when building log_viewer"

--- a/share/wake/lib/gcc_wake/pkgconfig.wake
+++ b/share/wake/lib/gcc_wake/pkgconfig.wake
@@ -76,11 +76,30 @@ target pkgConfigImp flags pkgs =
 export def pkgConfig (pkg: String): Option SysLib =
     def pkgs = tokenize ` ` pkg
 
-    require Some (version, _) = pkgConfigImp ("--short-errors", "--modversion",) pkgs
+    require Some (version, _) =
+        pkgConfigImp
+        (
+            "--short-errors",
+            "--modversion",
+        )
+        pkgs
     else None
 
-    def cflags = pkgConfigImp ("--silence-errors", "--cflags",) pkgs
-    def lflags = pkgConfigImp ("--silence-errors", "--libs",) pkgs
+    def cflags =
+        pkgConfigImp
+        (
+            "--silence-errors",
+            "--cflags",
+        )
+        pkgs
+
+    def lflags =
+        pkgConfigImp
+        (
+            "--silence-errors",
+            "--libs",
+        )
+        pkgs
 
     require Some cflags = cflags
     require Some lflags = lflags

--- a/share/wake/lib/gcc_wake/pkgconfig.wake
+++ b/share/wake/lib/gcc_wake/pkgconfig.wake
@@ -76,30 +76,11 @@ target pkgConfigImp flags pkgs =
 export def pkgConfig (pkg: String): Option SysLib =
     def pkgs = tokenize ` ` pkg
 
-    require Some (version, _) =
-        pkgConfigImp
-        (
-            "--short-errors",
-            "--modversion",
-        )
-        pkgs
+    require Some (version, _) = pkgConfigImp ("--short-errors", "--modversion", Nil) pkgs
     else None
 
-    def cflags =
-        pkgConfigImp
-        (
-            "--silence-errors",
-            "--cflags",
-        )
-        pkgs
-
-    def lflags =
-        pkgConfigImp
-        (
-            "--silence-errors",
-            "--libs",
-        )
-        pkgs
+    def cflags = pkgConfigImp ("--silence-errors", "--cflags", Nil) pkgs
+    def lflags = pkgConfigImp ("--silence-errors", "--libs", Nil) pkgs
 
     require Some cflags = cflags
     require Some lflags = lflags

--- a/share/wake/lib/rust_wake/cargo.wake
+++ b/share/wake/lib/rust_wake/cargo.wake
@@ -34,13 +34,7 @@ export def cargoBuild (sources: List Path) (pathToCrate: String) (outputs: List 
     require Pass cargoPath = findCargoPath Unit
 
     require Pass outputs =
-        makeExecPlan
-        (
-            cargoPath,
-            "build",
-            "--release",
-        )
-        sources
+        makeExecPlan (cargoPath, "build", "--release", Nil) sources
         | setPlanLabel "cargo: {pathToCrate}"
         | setPlanDirectory pathToCrate
         | setPlanFnOutputs (\_ map ("{pathToCrate}/target/release/{_}") outputs)

--- a/share/wake/lib/rust_wake/cargo.wake
+++ b/share/wake/lib/rust_wake/cargo.wake
@@ -34,7 +34,13 @@ export def cargoBuild (sources: List Path) (pathToCrate: String) (outputs: List 
     require Pass cargoPath = findCargoPath Unit
 
     require Pass outputs =
-        makeExecPlan (cargoPath, "build", "--release",) sources
+        makeExecPlan
+        (
+            cargoPath,
+            "build",
+            "--release",
+        )
+        sources
         | setPlanLabel "cargo: {pathToCrate}"
         | setPlanDirectory pathToCrate
         | setPlanFnOutputs (\_ map ("{pathToCrate}/target/release/{_}") outputs)

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -231,7 +231,7 @@ export def getPlanHash (plan: Plan): Integer =
     def isAttyStr = if isAtty then "true" else "false"
 
     def sig =
-        cat (
+        (
             isAttyStr,
             "\0\0",
             implode cmd,
@@ -242,6 +242,7 @@ export def getPlanHash (plan: Plan): Integer =
             "\0\0",
             stdin,
         )
+        | cat
 
     require Some out = intbase 16 (hashString sig)
     else unreachable "hash_str returned a non-hex string!!!"

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -229,7 +229,19 @@ export def editPlanShare (f: Boolean => Boolean): Plan => Plan =
 export def getPlanHash (plan: Plan): Integer =
     def Plan _ cmd _ env dir stdin _ _ _ _ _ _ _ _ isAtty = plan
     def isAttyStr = if isAtty then "true" else "false"
-    def sig = cat (isAttyStr, "\0\0", implode cmd, "\0\0", implode env, "\0\0", dir, "\0\0", stdin,)
+
+    def sig =
+        cat (
+            isAttyStr,
+            "\0\0",
+            implode cmd,
+            "\0\0",
+            implode env,
+            "\0\0",
+            dir,
+            "\0\0",
+            stdin,
+        )
 
     require Some out = intbase 16 (hashString sig)
     else unreachable "hash_str returned a non-hex string!!!"
@@ -350,7 +362,10 @@ export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String E
             Fail e
         Pass (RunnerInput label cmd vis env dir stdin _ prefix _ _) =
             def mkVisJson (Path path hash) =
-                JObject ("path" :-> JString path, "hash" :-> JString hash,)
+                JObject (
+                    "path" :-> JString path,
+                    "hash" :-> JString hash,
+                )
 
             def jobCacheVisible = JArray (map mkVisJson vis)
 
@@ -466,7 +481,10 @@ export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String E
             def inputsTree = listToTree scmpCanonical inputs
 
             def mkOutputFileJson src =
-                JObject ("src" :-> JString src, "path" :-> JString "{wakeroot}/{src}",)
+                JObject (
+                    "src" :-> JString src,
+                    "path" :-> JString "{wakeroot}/{src}",
+                )
 
             def jobCacheOutputFiles = JArray (map mkOutputFileJson outputs)
 

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -188,7 +188,12 @@ def computeHashes (prefix: String) (files: List String): List String =
         True ->
             require Pass stdin_file = write stdin_file_path (catWith "\n" to_hash)
 
-            hashPlan ("{wakePath}/../lib/wake/wake-hash", "@",) (stdin_file,)
+            hashPlan
+            (
+                "{wakePath}/../lib/wake/wake-hash",
+                "@",
+            )
+            (stdin_file,)
             | setPlanStdin stdin_file.getPathName
             | Pass
         False ->

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -188,12 +188,7 @@ def computeHashes (prefix: String) (files: List String): List String =
         True ->
             require Pass stdin_file = write stdin_file_path (catWith "\n" to_hash)
 
-            hashPlan
-            (
-                "{wakePath}/../lib/wake/wake-hash",
-                "@",
-            )
-            (stdin_file,)
+            hashPlan ("{wakePath}/../lib/wake/wake-hash", "@", Nil) (stdin_file,)
             | setPlanStdin stdin_file.getPathName
             | Pass
         False ->

--- a/src/job_cache/job-cache.wake
+++ b/src/job_cache/job-cache.wake
@@ -21,15 +21,4 @@ from gcc_wake import _
 target jobCacheLib variant =
     require Pass schemaSql = source "src/job_cache/schema.sql"
 
-    src
-    @here
-    variant
-    (
-        json,
-        gopt,
-        blake2,
-        wcl,
-        util,
-    )
-    (sqlite3,)
-    (schemaSql,)
+    src @here variant (json, gopt, blake2, wcl, util, Nil) (sqlite3,) (schemaSql,)

--- a/src/job_cache/job-cache.wake
+++ b/src/job_cache/job-cache.wake
@@ -21,4 +21,15 @@ from gcc_wake import _
 target jobCacheLib variant =
     require Pass schemaSql = source "src/job_cache/schema.sql"
 
-    src @here variant (json, gopt, blake2, wcl, util,) (sqlite3,) (schemaSql,)
+    src
+    @here
+    variant
+    (
+        json,
+        gopt,
+        blake2,
+        wcl,
+        util,
+    )
+    (sqlite3,)
+    (schemaSql,)

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -257,11 +257,8 @@ def runTest (testScript: Path): Result Unit Error =
         Some _ =
             # TODO: use diff prim to compare jobStderr with expectedStderr
             def _ =
-                cat (
-                    testName,
-                    "\n",
-                    jobStderr,
-                )
+                (testName, "\n", jobStderr, Nil)
+                | cat
                 | println
 
             Fail (makeError "Unexpected standard error. See above for details")
@@ -272,11 +269,8 @@ def runTest (testScript: Path): Result Unit Error =
         _ =
             # TODO: use diff prim to compare jobStdout with expectedStdout
             def _ =
-                cat (
-                    testName,
-                    "\n",
-                    jobStdout,
-                )
+                (testName, "\n", jobStdout, Nil)
+                | cat
                 | println
 
             Fail (makeError "Unexpected standard output. See above for details")

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -257,7 +257,11 @@ def runTest (testScript: Path): Result Unit Error =
         Some _ =
             # TODO: use diff prim to compare jobStderr with expectedStderr
             def _ =
-                cat (testName, "\n", jobStderr,)
+                cat (
+                    testName,
+                    "\n",
+                    jobStderr,
+                )
                 | println
 
             Fail (makeError "Unexpected standard error. See above for details")
@@ -268,7 +272,11 @@ def runTest (testScript: Path): Result Unit Error =
         _ =
             # TODO: use diff prim to compare jobStdout with expectedStdout
             def _ =
-                cat (testName, "\n", jobStdout,)
+                cat (
+                    testName,
+                    "\n",
+                    jobStdout,
+                )
                 | println
 
             Fail (makeError "Unexpected standard output. See above for details")

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1584,8 +1584,17 @@ def y =
     def x = -(1 + 2),
     def x = -a.b,
     def x = -(a b c),
-    def xs = (2, fib 3,)
-    def x = x, y, 3 + 2,
+
+    def xs = (
+        2,
+        fib 3,
+    )
+
+    def x =
+        x,
+        y,
+        3 + 2,
+
     def x = -a + b,
     def x = ! a + b,
     def x = !a.b,
@@ -1740,7 +1749,11 @@ def x _ =
     a
 
 def x =
-    def (x, a, z,) = b
+    def (
+        x,
+        a,
+        z,
+    ) = b
 
     z
 

--- a/tools/lsp-wake/lsp.wake
+++ b/tools/lsp-wake/lsp.wake
@@ -30,5 +30,31 @@ target buildLSP variant: Result (List Path) Error = match variant
             "--post-js", postJS.getPathName,
             "--pre-js", preJS.getPathName,
 
-        tool @here Nil variant "lib/wake/lsp-wake" (dst, util, wcl,) (postJS, preJS,) extraLFlags
-    _ = tool @here Nil variant "lib/wake/lsp-wake" (dst, util, wcl,) Nil Nil
+        tool
+        @here
+        Nil
+        variant
+        "lib/wake/lsp-wake"
+        (
+            dst,
+            util,
+            wcl,
+        )
+        (
+            postJS,
+            preJS,
+        )
+        extraLFlags
+    _ =
+        tool
+        @here
+        Nil
+        variant
+        "lib/wake/lsp-wake"
+        (
+            dst,
+            util,
+            wcl,
+        )
+        Nil
+        Nil

--- a/tools/lsp-wake/lsp.wake
+++ b/tools/lsp-wake/lsp.wake
@@ -30,31 +30,5 @@ target buildLSP variant: Result (List Path) Error = match variant
             "--post-js", postJS.getPathName,
             "--pre-js", preJS.getPathName,
 
-        tool
-        @here
-        Nil
-        variant
-        "lib/wake/lsp-wake"
-        (
-            dst,
-            util,
-            wcl,
-        )
-        (
-            postJS,
-            preJS,
-        )
-        extraLFlags
-    _ =
-        tool
-        @here
-        Nil
-        variant
-        "lib/wake/lsp-wake"
-        (
-            dst,
-            util,
-            wcl,
-        )
-        Nil
-        Nil
+        tool @here Nil variant "lib/wake/lsp-wake" (dst, util, wcl, Nil) (postJS, preJS, Nil) extraLFlags
+    _ = tool @here Nil variant "lib/wake/lsp-wake" (dst, util, wcl, Nil) Nil Nil

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1365,6 +1365,22 @@ wcl::doc Emitter::walk_binary(ctx_t ctx, CSTElement node) {
     MEMO_RET(*doc);
   }
 
+  // Lists with trailing unary commas should always exlode
+  // Ex:
+  //   a, b, c, => explode
+  //   a, b, c  => prefer flat when possible
+  if (parts.back().id() == CST_UNARY) {
+    auto op = parts.back().firstChildNode();
+    op.nextSiblingNode();
+    if (op.id() == CST_OP && op.firstChildElement().id() == TOKEN_OP_COMMA) {
+      auto doc = combine_explode_all(ctx.binop(), parts);
+      if (!doc) {
+        FMT_ASSERT(false, op_token, "Failed to expload format binop");
+      }
+      MEMO_RET(*doc);
+    }
+  }
+
   if (!ctx.nested_binop && (is_binop_matching_str(op_token, TOKEN_OP_DOLLAR, "$") ||
                             is_binop_matching_str(op_token, TOKEN_OP_OR, "|"))) {
     MEMO_RET(select_best_choice({

--- a/tools/wake-format/wake-format.wake
+++ b/tools/wake-format/wake-format.wake
@@ -18,17 +18,4 @@ package build_wake
 from wake import _
 
 target buildWakeFormat variant =
-    tool
-    @here
-    Nil
-    variant
-    "bin/wake-format"
-    (
-        parser,
-        gopt,
-        wcl,
-        util,
-        dst,
-    )
-    Nil
-    Nil
+    tool @here Nil variant "bin/wake-format" (parser, gopt, wcl, util, dst, Nil) Nil Nil

--- a/tools/wake-format/wake-format.wake
+++ b/tools/wake-format/wake-format.wake
@@ -18,4 +18,17 @@ package build_wake
 from wake import _
 
 target buildWakeFormat variant =
-    tool @here Nil variant "bin/wake-format" (parser, gopt, wcl, util, dst,) Nil Nil
+    tool
+    @here
+    Nil
+    variant
+    "bin/wake-format"
+    (
+        parser,
+        gopt,
+        wcl,
+        util,
+        dst,
+    )
+    Nil
+    Nil

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -83,12 +83,6 @@ def mk_node_semver_safe v =
 
     match (extract unsafe_version_regex v)
         version, commit, rest, Nil =
-            (
-                version,
-                "-plus-",
-                commit,
-                "-",
-                rest,
-            )
+            (version, "-plus-", commit, "-", rest, Nil)
             | cat
         _ = v

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -83,6 +83,12 @@ def mk_node_semver_safe v =
 
     match (extract unsafe_version_regex v)
         version, commit, rest, Nil =
-            (version, "-plus-", commit, "-", rest,)
+            (
+                version,
+                "-plus-",
+                commit,
+                "-",
+                rest,
+            )
             | cat
         _ = v


### PR DESCRIPTION
Trailing unary comma now tells the formatter to newline a list. 

Ex:

```
def x = a, b, c,
```
becomes 
```
def x = 
    a,
    b,
    c,
```

instead of being flat.

This is something that @ag-eitilt and @bmitc have been asking for for awhile and I think its a good tradeoff now that I've seen a bunch of use cases in internal repos that would either use this or `# wake-format off`