### PR TITLE
Improve logging yet again, focusing on hangs, and distributed case

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -945,8 +945,11 @@ FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {
   std::string msg = cmd.serialize();
   msg += '\0';
 
+  wcl::log::info("Sending Read command to eviction loop")();
   if (write(evict_stdin, msg.data(), msg.size()) == -1) {
     wcl::log::warning("Failed to send eviction update: %s", strerror(errno))();
+  } else {
+    wcl::log::info("Successfully sent eviction the job")();
   }
 
   return FindJobResponse(wcl::make_some<MatchingJob>(std::move(result)));
@@ -1031,8 +1034,11 @@ void DaemonCache::add(const AddJobRequest &add_request) {
   std::string msg = cmd.serialize();
   msg += '\0';
 
+  wcl::log::info("Sending Write command to eviction loop")();
   if (write(evict_stdin, msg.data(), msg.size()) == -1) {
     wcl::log::warning("Failed to send eviction update: %s", strerror(errno))();
+  } else {
+    wcl::log::info("Sucessfully sent eviction add update")();
   }
 }
 

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -308,8 +308,8 @@ wcl::result<FindJobResponse, FindJobError> Cache::read_impl(const FindJobRequest
 }
 
 FindJobResponse Cache::read(const FindJobRequest &find_request) {
-  wcl::log::info("Starting cache read")();
-  auto defer = wcl::make_defer([]() { wcl::log::info("Done with cache read")(); });
+  wcl::log::info("Cache::read enter")();
+  auto defer = wcl::make_defer([]() { wcl::log::info("Cache::read exit")(); });
   static int misses_from_failure = 0;
 
   wcl::xoshiro_256 rng(wcl::xoshiro_256::get_rng_seed());
@@ -356,8 +356,8 @@ FindJobResponse Cache::read(const FindJobRequest &find_request) {
 }
 
 void Cache::add(const AddJobRequest &add_request) {
-  wcl::log::info("About to add a job")();
-  auto defer = wcl::make_defer([]() { wcl::log::info("Done adding the job")(); });
+  wcl::log::info("Cache::add enter")();
+  auto defer = wcl::make_defer([]() { wcl::log::info("Cache::add exit")(); });
   // serialize the request, send it, deserialize the response, return it
   JAST request(JSON_OBJECT);
   request.add("method", "cache/add");

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -25,6 +25,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <util/execpath.h>
+#include <wcl/defer.h>
 #include <wcl/filepath.h>
 #include <wcl/optional.h>
 #include <wcl/tracing.h>
@@ -307,6 +308,8 @@ wcl::result<FindJobResponse, FindJobError> Cache::read_impl(const FindJobRequest
 }
 
 FindJobResponse Cache::read(const FindJobRequest &find_request) {
+  wcl::log::info("Starting cache read")();
+  auto defer = wcl::make_defer([]() { wcl::log::info("Done with cache read")(); });
   static int misses_from_failure = 0;
 
   wcl::xoshiro_256 rng(wcl::xoshiro_256::get_rng_seed());
@@ -316,6 +319,7 @@ FindJobResponse Cache::read(const FindJobRequest &find_request) {
   for (int i = 0; i < 3; i++) {
     auto response = read_impl(find_request);
     if (response) {
+      wcl::log::info("Returning job response: cache_hit = %d", int(bool(response->match)));
       return *response;
     }
 
@@ -352,6 +356,8 @@ FindJobResponse Cache::read(const FindJobRequest &find_request) {
 }
 
 void Cache::add(const AddJobRequest &add_request) {
+  wcl::log::info("About to add a job")();
+  auto defer = wcl::make_defer([]() { wcl::log::info("Done adding the job")(); });
   // serialize the request, send it, deserialize the response, return it
   JAST request(JSON_OBJECT);
   request.add("method", "cache/add");

--- a/src/job_cache/job_cache_impl_common.cpp
+++ b/src/job_cache/job_cache_impl_common.cpp
@@ -376,7 +376,6 @@ wcl::optional<wcl::posix_error_t> sync_send_json_message(int fd, const JAST &jso
       return wcl::make_some<wcl::posix_error_t>(errno);
     }
     if (state == MessageSenderState::StopSuccess) {
-      wcl::log::info("Finished writing: %s", s.str().c_str())();
       return {};
     }
   }

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -651,7 +651,6 @@ JobTable::~JobTable() {
       int status;
       while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
         if (WIFSTOPPED(status)) continue;
-        wcl::log::info("Job with pid = %d completed", pid)();
         imp->pidmap.erase(pid);
       }
     }
@@ -863,7 +862,6 @@ static void launch(JobTable *jobtable) {
     sigprocmask(SIG_UNBLOCK, &set, 0);
     pid_t pid = wake_spawn(cmdline[0], cmdline, environ);
     sigprocmask(SIG_BLOCK, &set, 0);
-    wcl::log::info("Spawned job: label = '%s', pid = %d", job_label_str->c_str(), pid)();
 
     delete[] cmdline;
     delete[] environ;
@@ -1765,8 +1763,8 @@ static PRIMTYPE(type_job_cache_read) {
 }
 
 static PRIMFN(prim_job_cache_read) {
-  wcl::log::info("prim job_cache_read entered")();
-  auto defer = wcl::make_defer([]() { wcl::log::info("prim job_cache_read exiting")(); });
+  wcl::log::info("prim_job_cache_read enter")();
+  auto defer = wcl::make_defer([]() { wcl::log::info("prim_job_cache_read exit")(); });
   EXPECT(1);
   STRING(request_str, 0);
 
@@ -1820,8 +1818,8 @@ static PRIMTYPE(type_job_cache_add) {
 }
 
 static PRIMFN(prim_job_cache_add) {
-  wcl::log::info("prim job_cache_add entered")();
-  auto defer = wcl::make_defer([]() { wcl::log::info("prim job_cache_add exiting")(); });
+  wcl::log::info("prim_job_cache_add enter")();
+  auto defer = wcl::make_defer([]() { wcl::log::info("prim_job_cache_add exit")(); });
   EXPECT(1);
   STRING(request_str, 0);
 
@@ -1856,7 +1854,7 @@ static PRIMFN(prim_job_cache_add) {
   size_t need = String::reserve(result_json_str.size()) + reserve_result();
   runtime.heap.reserve(need);
 
-  wcl::log::info("Cahce::add successfully called")();
+  wcl::log::info("Cache::add successfully called")();
   RETURN(claim_result(runtime.heap, true, String::claim(runtime.heap, result_json_str)));
 }
 

--- a/src/wcl/tracing.cpp
+++ b/src/wcl/tracing.cpp
@@ -85,6 +85,16 @@ Event Event::pid() && {
   return std::move(*this);
 }
 
+Event Event::hostname() && {
+  char buf[512];
+  if (gethostname(buf, sizeof(buf)) == 0) {
+    items[LOG_HOSTNAME] = buf;
+  } else {
+    items[LOG_HOSTNAME] = strerror(errno);
+  }
+  return std::move(*this);
+}
+
 Event Event::level(const char* level) && {
   items[LOG_LEVEL] = level;
   return std::move(*this);
@@ -106,7 +116,7 @@ Event info(const char* fmt, ...) {
   va_start(args, fmt);
   auto defer = make_defer([&]() { va_end(args); });
 
-  return event().level(LOG_LEVEL_INFO).pid().time().message(fmt, args);
+  return event().level(LOG_LEVEL_INFO).pid().time().message(fmt, args).hostname();
 }
 
 Event warning(const char* fmt, ...) {
@@ -114,7 +124,7 @@ Event warning(const char* fmt, ...) {
   va_start(args, fmt);
   auto defer = make_defer([&]() { va_end(args); });
 
-  return event().level(LOG_LEVEL_WARNING).pid().time().message(fmt, args);
+  return event().level(LOG_LEVEL_WARNING).pid().time().message(fmt, args).hostname();
 }
 
 Event error(const char* fmt, ...) {
@@ -122,7 +132,7 @@ Event error(const char* fmt, ...) {
   va_start(args, fmt);
   auto defer = make_defer([&]() { va_end(args); });
 
-  return event().level(LOG_LEVEL_ERROR).pid().time().message(fmt, args);
+  return event().level(LOG_LEVEL_ERROR).pid().time().message(fmt, args).hostname();
 }
 
 void FormatSubscriber::receive(const Event& e) {

--- a/src/wcl/tracing.h
+++ b/src/wcl/tracing.h
@@ -40,6 +40,7 @@ namespace log {
 static constexpr const char* LOG_LEVEL = "level";
 static constexpr const char* LOG_TIME = "time";
 static constexpr const char* LOG_PID = "pid";
+static constexpr const char* LOG_HOSTNAME = "hostname";
 static constexpr const char* LOG_LEVEL_INFO = "info";
 static constexpr const char* LOG_LEVEL_WARNING = "warning";
 static constexpr const char* LOG_LEVEL_ERROR = "error";
@@ -66,6 +67,7 @@ struct Event {
   Event urgent() && __attribute__((warn_unused_result));
   Event time() && __attribute__((warn_unused_result));
   Event pid() && __attribute__((warn_unused_result));
+  Event hostname() && __attribute__((warn_unused_result));
   Event level(const char* level) && __attribute__((warn_unused_result));
 
   void operator()() &&;


### PR DESCRIPTION
This change just tweaks logging in lots of small ways

1) We add a bunch of before/after logging of important events in order to better understand if a hang is occuring and if so to help pin down where
2) I removed a debug line printing out the full message
3) We log before and after comunication with the eviction loop in case that ever hangs
4) We log when a job statrts and when it ends so we can detect job hangs
5) hostnames are always added so that logs can be collated across multiple machines
6) We now print out if a message received was a cache hit or not.