### PR TITLE
wake-format: Fix format off failure in certain cases

### DIFF
--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -1481,3 +1481,15 @@ def x =
         z
     ) = b
     z
+
+def a =
+    # wake-format off
+    def b =
+        1+2
+
+    # wake-format off
+    def c =
+        3+5
+
+    5
+

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -1770,3 +1770,15 @@ def x =
     ) = b
 
     z
+
+def a =
+    # wake-format off
+    def b =
+        1+2
+
+    # wake-format off
+    def c =
+        3+5
+
+    5
+

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -960,6 +960,13 @@ void Emitter::mark_no_format_nodes(CSTElement node) {
         FMT_ASSERT(!child.empty(), child, "Expected non-empty child");
 
         node_traits[block_item].turn_format_off();
+
+        // The CST_BLOCK may have other format off comments.
+        // It needs to be processed here so it isn't skipped.
+        // We don't need to skip the first non-token child since
+        //   1) its impossible to put a comment after a CST_BLOCK but before anything else
+        //   2) even if it was, there is no harm in turning off formatting twice
+        mark_no_format_nodes(child);
         continue;
       }
 


### PR DESCRIPTION
When `# wake-format off` turns off formatting for a CST_BLOCK it would ignore any further `# wake-format off`s in the same CST_BLOCK. Update it so it works correctly.

Given

```
def a =
    # wake-format off
    def b =
        1+2

    # wake-format off
    def c =
        3+5

    5
```


Old
```
def a =
    # wake-format off
    def b =
        1+2

    # wake-format off
    def c = 3 + 5

    5
```
    
New

```
def a =
    # wake-format off
    def b =
        1+2

    # wake-format off
    def c =
        3+5

    5
```  