### PR TITLE
Shared cache env-var tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ Below is a full example
 }
 ```
 
+While there are many sources that a config option might come from, the following priority is always observed from lowest
+to highest:
+1) .wakeroot
+2) user config
+3) environment variables
+4) command line options
+
+So a command line option overides anything, an environment variable overrides user config and wakeroot, user config
+overrides wakeroot, and wakeroot overrides nothing
+
 # Documentation
 
 Documentation for wake can be found in [share/doc/wake](share/doc/wake).

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -538,7 +538,7 @@ export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String E
 
                 # Sometimes we want a read-only cache. For instance read-only pre-merge
                 # with read-write post-merge.
-                require None = getenv "WAKE_EXPERIMENTAL_JOB_CACHE_READ_ONLY"
+                require None = getenv "WAKE_LOCAL_JOB_CACHE_READ_ONLY"
                 else Pass ""
 
                 job_cache_add jobCacheAddJson
@@ -855,7 +855,7 @@ export def access (file: String) (mode: Integer): Boolean =
     (\f \m prim "access") file mode
 
 export def defaultRunner: Runner =
-    require Some _ = getenv "WAKE_EXPERIMENTAL_JOB_CACHE"
+    require Some _ = getenv "WAKE_LOCAL_JOB_CACHE"
     else fuseRunner
 
     # The fuseRunner does not actully mount over / and instead uses the

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -319,7 +319,7 @@ FindJobResponse Cache::read(const FindJobRequest &find_request) {
   for (int i = 0; i < 3; i++) {
     auto response = read_impl(find_request);
     if (response) {
-      wcl::log::info("Returning job response: cache_hit = %d", int(bool(response->match)));
+      wcl::log::info("Returning job response: cache_hit = %d", int(bool(response->match)))();
       return *response;
     }
 

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -338,6 +338,13 @@ bool WakeConfig::init(const std::string& wakeroot_path, const WakeConfigOverride
   // Parse values from .wakeroot
   _config->set_all<WakeConfigProvenance::WakeRoot>(wakeroot_json);
 
+  // Sometimes we need to the user_config with an env-var so we check env-vars first here
+  _config->set_all_env_var();
+
+  // Further more users may choose to override the user config at the command line level so
+  // we run that too only to run it again later
+  _config->override_all(overrides);
+
   // Parse user config
   auto user_config_res = read_json_file(_config->user_config);
   if (!user_config_res) {
@@ -371,7 +378,10 @@ bool WakeConfig::init(const std::string& wakeroot_path, const WakeConfigOverride
   // Parse values from the user config
   _config->set_all<WakeConfigProvenance::UserConfig>(user_config_json);
 
-  // Finally apply command line overrides
+  // Set all env-vars again as they should override user configs
+  _config->set_all_env_var();
+
+  // Finally apply command line overrides as they override everything
   _config->override_all(overrides);
 
   return true;

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -1771,7 +1771,7 @@ static PRIMFN(prim_job_cache_read) {
   // First, the user may have not turned on the job cache
   if (!internal_job_cache) {
     std::string s =
-        "A job cache has not been specified. Please use WAKE_JOB_CACHE=<path> to turn on job "
+        "A job cache has not been specified. Please use WAKE_LOCAL_JOB_CACHE=<path> to turn on job "
         "caching";
     size_t need = String::reserve(s.size()) + reserve_result();
     runtime.heap.reserve(need);
@@ -1826,7 +1826,7 @@ static PRIMFN(prim_job_cache_add) {
   // First, the user may have not turned on the job cache
   if (!internal_job_cache) {
     std::string s =
-        "A job cache has not been specified. Please use WAKE_JOB_CACHE=<path> to turn on job "
+        "A job cache has not been specified. Please use WAKE_LOCAL_JOB_CACHE=<path> to turn on job "
         "caching";
     size_t need = String::reserve(s.size()) + reserve_result();
     runtime.heap.reserve(need);

--- a/tests/config/nominal/pass.sh
+++ b/tests/config/nominal/pass.sh
@@ -6,4 +6,4 @@ if [ $(uname) != Linux ] ; then
 fi
 
 WAKE="${1:+$1/wake}"
-"${WAKE:-wake}" --config
+WAKE_SHARED_CACHE_MAX_SIZE=1024 "${WAKE:-wake}" --config

--- a/tests/config/nominal/stdout
+++ b/tests/config/nominal/stdout
@@ -4,7 +4,7 @@ Wake config:
   log_header = 'foobar $source: ' (WakeRoot)
   log_header_source_width = '13' (WakeRoot)
   label_filter = '.*' (Default)
-  max_cache_size = '1024' (WakeRoot)
+  max_cache_size = '1024' (EnvVar)
   low_cache_size = '512' (WakeRoot)
   cache_miss_on_failure = 'true' (WakeRoot)
   log_header_align = 'true' (WakeRoot)

--- a/tests/job-cache/basic-fetch/pass.sh
+++ b/tests/job-cache/basic-fetch/pass.sh
@@ -12,11 +12,11 @@ rm wake.db || true
 rm -rf .cache-hit || true
 rm -rf .cache-misses || true
 rm -rf .job-cache || true
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 
 rm wake.db
 rm -rf .cache-misses
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
   exit 1

--- a/tests/job-cache/basic-lru/pass.sh
+++ b/tests/job-cache/basic-lru/pass.sh
@@ -14,18 +14,18 @@ rm one.txt 2> /dev/null || true
 rm two.txt 2> /dev/null || true
 rm three.txt 2> /dev/null || true
 rm four.txt 2> /dev/null || true
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
 rm wake.db
 rm -rf .cache-misses
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test two
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test two
 rm wake.db
 rm -rf .cache-misses
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test three
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test three
 rm wake.db
 rm -rf .cache-misses
 
 # We should still be under the limit here. This is to ensure we mark test one as used
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
 rm wake.db
 rm -rf .cache-misses
 if [ -z "$(ls -A .cache-hit)" ]; then
@@ -34,13 +34,13 @@ if [ -z "$(ls -A .cache-hit)" ]; then
 fi
 
 # Now we're going to go over. Hopefully dropping two and three, but keeping one and four
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test four
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test four
 rm wake.db
 rm -rf .cache-misses
 
 # Now make sure we still get a hit on 1
 rm -rf .cache-hit  2> /dev/null || true
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test one
 rm wake.db
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
@@ -53,7 +53,7 @@ fi
 
 # And check four as well
 rm -rf .cache-hit
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test four
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test four
 rm wake.db
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
@@ -65,7 +65,7 @@ if [ -d ".cache-misses" ]; then
 fi
 
 # And check that we get misses on four and three
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test two
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test two
 rm wake.db
 if [ -z "$(ls -A .cache-misses)" ]; then
   echo "Expected a chache miss!!"
@@ -74,7 +74,7 @@ fi
 rm -rf .cache-misses
 
 
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test three
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test three
 rm wake.db
 if [ -z "$(ls -A .cache-misses)" ]; then
   echo "Expected a chache miss!!"

--- a/tests/job-cache/dup-output/pass.sh
+++ b/tests/job-cache/dup-output/pass.sh
@@ -10,10 +10,10 @@ rm wake.db || true
 rm -rf .cache-hit || true
 rm -rf .cache-misses || true
 rm -rf .job-cache || true
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 rm wake.db
 rm -rf .cache-misses
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
   exit 1

--- a/tests/job-cache/overwrite-smaller/pass.sh
+++ b/tests/job-cache/overwrite-smaller/pass.sh
@@ -14,18 +14,18 @@ rm -rf .cache-misses || true
 rm -rf .job-cache || true
 
 # Now run again with a small payload, expect a miss
-WAKE_SHARED_CACHE_FAST_CLOSE=1 PAYLOAD=small DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 PAYLOAD=small DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 rm wake.db
 rm -rf .cache-misses
 
 # Run test once with a larger payload, expect a miss
-WAKE_SHARED_CACHE_FAST_CLOSE=1 PAYLOAD=deadbeefdeadbeef DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 PAYLOAD=deadbeefdeadbeef DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 rm wake.db
 rm -rf .cache-misses
 
 # Now run again with a small payload again, this should be a cache hit but it should
 # not overwrite the existing inode, it should create a new one.
-WAKE_SHARED_CACHE_FAST_CLOSE=1 PAYLOAD=small DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 PAYLOAD=small DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
   exit 1

--- a/tests/job-cache/symlink-dir/pass.sh
+++ b/tests/job-cache/symlink-dir/pass.sh
@@ -10,10 +10,10 @@ rm wake.db || true
 rm -rf .cache-hit || true
 rm -rf .cache-misses || true
 rm -rf .job-cache || true
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 rm wake.db
 rm -rf .cache-misses
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_EXPERIMENTAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
 if [ -z "$(ls -A .cache-hit)" ]; then
   echo "No cache hit found"
   exit 1

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -81,6 +81,7 @@ struct CommandLineOptions {
   const char *fd5;
   const char *label_filter;  // TODO: Allow unions of multiple filters
   const char *log_header;
+  const char *user_config;
 
   wcl::optional<int64_t> log_header_source_width;
 
@@ -155,6 +156,7 @@ struct CommandLineOptions {
       {0, "no-log-header-align", GOPT_ARGUMENT_FORBIDDEN},
       {0, "cache-miss-on-failure", GOPT_ARGUMENT_FORBIDDEN},
       {0, "no-cache-miss-on-failure", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "user-config", GOPT_ARGUMENT_REQUIRED},
       {':', "shebang", GOPT_ARGUMENT_REQUIRED},
       {0, 0, GOPT_LAST}
     };
@@ -215,6 +217,7 @@ struct CommandLineOptions {
     fd5 = arg(options, "fd:5")->argument;
     label_filter = arg(options, "label-filter")->argument;
     log_header = arg(options, "log-header")->argument;
+    user_config = arg(options, "user-config")->argument;
 
     if (arg(options, "log-header-align")->count) {
       log_header_align = wcl::some(true);

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -349,6 +349,9 @@ int main(int argc, char **argv) {
   if (clo.log_header) {
     config_override.log_header = wcl::make_some<std::string>(clo.log_header);
   }
+  if (clo.user_config) {
+    config_override.user_config = wcl::make_some<std::string>(clo.user_config);
+  }
   config_override.log_header_source_width = clo.log_header_source_width;
   config_override.log_header_align = clo.log_header_align;
   config_override.cache_miss_on_failure = clo.cache_miss_on_failure;
@@ -381,7 +384,7 @@ int main(int argc, char **argv) {
 
   // Open the job-cache if it exists
   std::unique_ptr<job_cache::Cache> cache;
-  const char *job_cache_dir = getenv("WAKE_EXPERIMENTAL_JOB_CACHE");
+  const char *job_cache_dir = getenv("WAKE_LOCAL_JOB_CACHE");
   if (job_cache_dir != nullptr) {
     cache = std::make_unique<job_cache::Cache>(job_cache_dir, WakeConfig::get()->max_cache_size,
                                                WakeConfig::get()->low_cache_size,


### PR DESCRIPTION
This change does the following

1) Declares the wake shared cache no longer experimental and changes the env-var used for it to be WAKE_LOCAL_JOB_CACHE
2) Adds the ability to configure some config options via environment variables. In particular the user config can now be specified via an env-var which allows for greatly increased flexibility. I did however additionally allow env-vars for cache miss on failure, and cache size manipulation in case that's helpful but we anticipate only
3) I went ahead and added a command line override for user-config so that you can locally fix what might become a shell-global override of .wakeroot