### PR TITLE
Add bulk logging env var for wake

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -50,7 +50,7 @@ namespace {
 
 using namespace job_cache;
 
-static void initialize_logging() {
+static void initialize_logging(std::string bulk_dir) {
   const char *str_fmt = "%Y-%m-%d";
   const size_t str_fmt_len = 10;         // count("XXXX-XX-XX")
   const size_t filename_prefix_len = 7;  // count (".cache.")
@@ -72,8 +72,7 @@ static void initialize_logging() {
   }
   wcl::log::subscribe(std::make_unique<JsonSubscriber>(std::move(*log_file_res)));
 
-  const char *bulk_dir = getenv("WAKE_BULK_LOGGING_DIR");
-  if (bulk_dir) {
+  if (!bulk_dir.empty()) {
     std::string pid = std::to_string(getpid());
     char buf[512];
     if (gethostname(buf, sizeof(buf)) != 0) {
@@ -664,12 +663,12 @@ struct CacheDbImpl {
         matching_jobs(db) {}
 };
 
-DaemonCache::DaemonCache(std::string dir, uint64_t max, uint64_t low)
+DaemonCache::DaemonCache(std::string dir, std::string bulk_dir, uint64_t max, uint64_t low)
     : rng(wcl::xoshiro_256::get_rng_seed()), max_cache_size(max), low_cache_size(low) {
   mkdir_no_fail(dir.c_str());
   chdir_no_fail(dir.c_str());
 
-  initialize_logging();
+  initialize_logging(bulk_dir);
 
   wcl::log::info("Launching DaemonCache. dir = %s, max = %lu, low = %lu", dir.c_str(),
                  max_cache_size, low_cache_size)();

--- a/src/job_cache/daemon_cache.h
+++ b/src/job_cache/daemon_cache.h
@@ -71,7 +71,7 @@ class DaemonCache {
   DaemonCache() = delete;
   DaemonCache(const DaemonCache &) = delete;
 
-  DaemonCache(std::string dir, uint64_t max, uint64_t low);
+  DaemonCache(std::string dir, std::string bulk_logging_dir, uint64_t max, uint64_t low);
 
   int run();
 };

--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -185,8 +185,8 @@ void Cache::launch_daemon() {
     std::string job_cache = wcl::make_canonical(find_execpath() + "/../bin/job-cache");
     std::string low_str = std::to_string(low_threshold);
     std::string max_str = std::to_string(max_size);
-    execl(job_cache.c_str(), "job-cached", cache_dir.c_str(), low_str.c_str(), max_str.c_str(),
-          nullptr);
+    execl(job_cache.c_str(), "job-cached", cache_dir.c_str(), bulk_logging_dir.c_str(),
+          low_str.c_str(), max_str.c_str(), nullptr);
 
     wcl::log::error("exec(%s): %s", job_cache.c_str(), strerror(errno)).urgent()();
     exit(1);
@@ -233,8 +233,9 @@ static void mkdir_all(std::string acc, Iter begin, Iter end) {
   }
 }
 
-Cache::Cache(std::string dir, uint64_t max, uint64_t low, bool miss) {
+Cache::Cache(std::string dir, std::string bulk_dir, uint64_t max, uint64_t low, bool miss) {
   cache_dir = dir;
+  bulk_logging_dir = bulk_dir;
   max_size = max;
   low_threshold = low;
   miss_on_failure = miss;

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -57,6 +57,7 @@ class Cache {
 
   // Daemon parameters
   std::string cache_dir;
+  std::string bulk_logging_dir;
   uint64_t max_size;
   uint64_t low_threshold;
 
@@ -68,7 +69,7 @@ class Cache {
   Cache() = delete;
   Cache(const Cache &) = delete;
 
-  Cache(std::string dir, uint64_t max, uint64_t low, bool miss);
+  Cache(std::string dir, std::string bulk_logging_dir, uint64_t max, uint64_t low, bool miss);
 
   FindJobResponse read(const FindJobRequest &find_request);
   void add(const AddJobRequest &add_request);

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -216,6 +216,7 @@ POLICY_STATIC_DEFINES(SharedCacheMaxSize)
 POLICY_STATIC_DEFINES(SharedCacheLowSize)
 POLICY_STATIC_DEFINES(SharedCacheMissOnFailure)
 POLICY_STATIC_DEFINES(LogHeaderAlignPolicy)
+POLICY_STATIC_DEFINES(BulkLoggingDirPolicy)
 
 /********************************************************************
  * Non-Trivial Defaults
@@ -280,6 +281,13 @@ void LogHeaderAlignPolicy::set(LogHeaderAlignPolicy& p, const JAST& json) {
   auto json_log_header_align = json.expect_boolean();
   if (json_log_header_align) {
     p.log_header_align = *json_log_header_align;
+  }
+}
+
+void BulkLoggingDirPolicy::set(BulkLoggingDirPolicy& p, const JAST& json) {
+  auto json_bulk_dir = json.expect_string();
+  if (json_bulk_dir) {
+    p.bulk_logging_dir = *json_bulk_dir;
   }
 }
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -253,6 +253,26 @@ struct LogHeaderAlignPolicy {
   static void set_env_var(LogHeaderAlignPolicy& p, const char* env_var) {}
 };
 
+struct BulkLoggingDirPolicy {
+  using type = std::string;
+  using input_type = type;
+  static constexpr const char* key = "bulk_logging_dir";
+  static constexpr bool allowed_in_wakeroot = false;
+  static constexpr bool allowed_in_userconfig = true;
+  type bulk_logging_dir;
+  static constexpr type BulkLoggingDirPolicy::*value = &BulkLoggingDirPolicy::bulk_logging_dir;
+  static constexpr Override<input_type> override_value = nullptr;
+  static constexpr const char* env_var = "WAKE_BULK_LOGGING_DIR";
+
+  BulkLoggingDirPolicy() {}
+  static void set(BulkLoggingDirPolicy& p, const JAST& json);
+  static void set_input(BulkLoggingDirPolicy& p, const input_type& v) { p.*value = v; }
+  static void emit(const BulkLoggingDirPolicy& p, std::ostream& os) { os << p.*value; }
+  static void set_env_var(BulkLoggingDirPolicy& p, const char* env_var) {
+    p.bulk_logging_dir = env_var;
+  }
+};
+
 /********************************************************************
  * Generic WakeConfig implementation
  *********************************************************************/
@@ -398,7 +418,7 @@ struct WakeConfigImpl : public Policies... {
 using WakeConfigImplFull =
     WakeConfigImpl<UserConfigPolicy, VersionPolicy, LogHeaderPolicy, LogHeaderSourceWidthPolicy,
                    LabelFilterPolicy, SharedCacheMaxSize, SharedCacheLowSize,
-                   SharedCacheMissOnFailure, LogHeaderAlignPolicy>;
+                   SharedCacheMissOnFailure, LogHeaderAlignPolicy, BulkLoggingDirPolicy>;
 
 struct WakeConfig final : public WakeConfigImplFull {
   static bool init(const std::string& wakeroot_path, const WakeConfigOverrides& overrides);

--- a/tests/config/empty/stdout
+++ b/tests/config/empty/stdout
@@ -8,3 +8,4 @@ Wake config:
   low_cache_size = '16106127360' (Default)
   cache_miss_on_failure = 'false' (Default)
   log_header_align = 'false' (Default)
+  bulk_logging_dir = '' (Default)

--- a/tests/config/extra_keys/stdout
+++ b/tests/config/extra_keys/stdout
@@ -8,3 +8,4 @@ Wake config:
   low_cache_size = '16106127360' (Default)
   cache_miss_on_failure = 'false' (Default)
   log_header_align = 'false' (Default)
+  bulk_logging_dir = '' (Default)

--- a/tests/config/missing_user_config/stdout
+++ b/tests/config/missing_user_config/stdout
@@ -8,3 +8,4 @@ Wake config:
   low_cache_size = '16106127360' (Default)
   cache_miss_on_failure = 'false' (Default)
   log_header_align = 'false' (Default)
+  bulk_logging_dir = '' (Default)

--- a/tests/config/nominal/stdout
+++ b/tests/config/nominal/stdout
@@ -8,3 +8,4 @@ Wake config:
   low_cache_size = '512' (WakeRoot)
   cache_miss_on_failure = 'true' (WakeRoot)
   log_header_align = 'true' (WakeRoot)
+  bulk_logging_dir = '/tmp/wake_bulk_logs' (UserConfig)

--- a/tests/config/nominal/wake_user.json
+++ b/tests/config/nominal/wake_user.json
@@ -1,2 +1,3 @@
 {
+  "bulk_logging_dir": "/tmp/wake_bulk_logs"
 }

--- a/tools/job-cache/main.cpp
+++ b/tools/job-cache/main.cpp
@@ -25,21 +25,24 @@
 
 // argv[0] = program name
 // argv[1] = cache dir
-// argv[2] = low cache size
-// argv[3] = max cache size
+// argv[2] = bulk cache dir
+// argv[3] = low cache size
+// argv[4] = max cache size
 int main(int argc, char **argv) {
-  if (argc != 4) {
+  if (argc != 5) {
     std::cerr << "Usage: job-cache cache/directory 100 5000" << std::endl;
     return 1;
   }
 
   std::string cache_dir = std::string(argv[1]);
-  uint64_t low_cache_size = std::stoull(argv[2]);
-  uint64_t max_cache_size = std::stoull(argv[3]);
+  std::string bulk_logging_dir = std::string(argv[2]);
+  uint64_t low_cache_size = std::stoull(argv[3]);
+  uint64_t max_cache_size = std::stoull(argv[4]);
 
   int status = 1;
   {
-    job_cache::DaemonCache dcache(std::move(cache_dir), max_cache_size, low_cache_size);
+    job_cache::DaemonCache dcache(std::move(cache_dir), std::move(bulk_logging_dir), max_cache_size,
+                                  low_cache_size);
     status = dcache.run();
   }
 

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -379,7 +379,7 @@ TEST_FUNC(void, fuzz_loop, const FuzzLoopConfig& config, wcl::xoshiro_256 gen) {
 
   mkdir(config.cache_dir.c_str(), 0777);
   mkdir(config.dir.c_str(), 0777);
-  job_cache::Cache cache(config.cache_dir, 1ULL << 24ULL, (1 << 23ULL) + (1 << 22ULL), false);
+  job_cache::Cache cache(config.cache_dir, "", 1ULL << 24ULL, (1 << 23ULL) + (1 << 22ULL), false);
 
   std::string out_dir = wcl::join_paths(config.dir, "outputs");
   for (size_t i = 0; i < config.number_of_steps; ++i) {

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <chrono>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <random>
 #include <set>
@@ -191,6 +192,16 @@ class TerminalReporter : public DiagnosticReporter {
   }
 };
 
+std::string get_date() {
+  auto now = std::chrono::system_clock::now();
+  auto time = std::chrono::system_clock::to_time_t(now);
+  std::stringstream ss;
+
+  ss << std::put_time(std::localtime(&time), "%Y-%m-%d");
+
+  return ss.str();
+}
+
 int main(int argc, char **argv) {
   // Make sure we always get core dumps but don't fail
   // if that fails for some reason.
@@ -332,6 +343,27 @@ int main(int argc, char **argv) {
     return 1;
   }
   wcl::log::subscribe(std::make_unique<JsonSubscriber>(std::move(*res)));
+
+  // Bulk logging
+  const char *bulk_dir = getenv("WAKE_BULK_LOGGING_DIR");
+  if (bulk_dir) {
+    std::string pid = std::to_string(getpid());
+    char buf[512];
+    if (gethostname(buf, sizeof(buf)) != 0) {
+      std::cerr << "Unable to init bulk logging: gethostname(): " << strerror(errno) << std::endl;
+      return 1;
+    }
+    std::string hostname = buf;
+    std::string bulk_log_file_path =
+        wcl::join_paths(bulk_dir, hostname + "-" + pid + "-" + get_date() + "-wake.log");
+    auto bulk_log_file_res = JsonSubscriber::fd_t::open(bulk_log_file_path.c_str());
+    if (!bulk_log_file_res) {
+      std::cerr << "Unable to init bulk logging: " << bulk_log_file_path
+                << " failed to open: " << strerror(bulk_log_file_res.error()) << std::endl;
+      return 1;
+    }
+    wcl::log::subscribe(std::make_unique<JsonSubscriber>(std::move(*bulk_log_file_res)));
+  }
 
   // Log urgent events to cerr
   auto cerr_subscriber = std::make_unique<wcl::log::SimpleFormatSubscriber>(std::cerr.rdbuf());


### PR DESCRIPTION
This change adds the WAKE_BULK_LOGGING_DIR environment variable. If turned on, wake will emit a copy all logs to that directory, with each file having its hostname, pid, the current day as part of the file name. This ensures that even over NFS, logging should stay atomic. NFS has no append atomicity but because wake is single threaded and the pid and hostname are included things should be atomic.

The day in the file name is mostly so that tools and scripts for parsing logs can pre-filter the logs they want to view based on the time frames without parsing all of the logs. In theory if a multi-day process is running on the same host with the same pid, or a pid gets recycled some days later this would also be midly helpful but those are quite rare cases.

Log cleanup can be done by deleting files with an expiered modtime but that system is not implemented in wake itself for bulk logging like it is for cache logging.

