### PR TITLE
Cleanup what runOnce considers as required for re-run

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -656,7 +656,7 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
                 Pair Nil last = confirm False last (build Unit)
 
 # Only run if the first four arguments differ
-target runOnce cmd env dir stdin \ res usage finputs foutputs vis keep run echo stdout stderr label isatty =
+target runOnce cmd env dir stdin vis isatty run \ res usage finputs foutputs keep echo stdout stderr label =
     runAlways cmd env dir stdin res usage finputs foutputs vis keep run echo stdout stderr label isatty
 
 export def runJobImp label cmd env dir stdin res usage finputs foutputs vis pers run (LogLevel echo) (LogLevel stdout) (LogLevel stderr) isatty =
@@ -666,18 +666,18 @@ export def runJobImp label cmd env dir stdin res usage finputs foutputs vis pers
         env
         dir
         stdin
+        vis
+        isatty
+        run
         res
         usage
         finputs
         foutputs
-        vis
         (isKeep pers)
-        run
         echo
         stdout
         stderr
         label
-        isatty
     else
         runAlways
         cmd


### PR DESCRIPTION
We agreed on the following changes for runOnce

1) The visible list should cause a re-run. This will what is today a warning into an error that says that two different jobs had the same output rather than saying that the same job was requested with different auxiliary params
2) Likewise, isatty was always supposed to be part of the primary key and is considered as such in the database already
3) If a different runner is used, the behavoir of the program will change accordingly so this is now part of the primary key of runOnce.