### PR TITLE
Fix `in` documentation

### DIFF
--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -27,10 +27,10 @@ export def sortPaths (paths: List Path): List Path =
     sortBy fn paths
 
 # Concatenate two paths
-#  join "foo"  "bar"    => "foo/bar"
-#  join "foo"  "/bar "  => "/bar"
-#  join "/foo" "bar"    => "/foo/bar"
-#  join "foo"  "../bar" => "bar"
+#  in "foo"  "bar"    => "foo/bar"
+#  in "foo"  "/bar "  => "/bar"
+#  in "/foo" "bar"    => "/foo/bar"
+#  in "foo"  "../bar" => "bar"
 export def in (dir: String) (path: String): String =
     if matches `/.*` path then
         path


### PR DESCRIPTION
The documentation mentioned `join` and not `in`, so the documentation has been corrected. `join` is the more common name here, so I'd be amenable to that change. But this PR just makes a start at addressing this by correcting the documentation to the currently defined name. It appears that `in` is intended to be used in a pipeline, as in `<path> | in <directory>`, which is why the name is slightly off for normal use of joining two paths.