### PR TITLE
Improve wake-hash errors

### DIFF
--- a/share/wake/lib/core/syntax.wake
+++ b/share/wake/lib/core/syntax.wake
@@ -97,6 +97,12 @@ export def wait (f: a => b) (x: a): b =
 # 200
 # ```
 export def unreachable (reason: String): a =
-    def f x = prim "unreachable"
+    def f x = prim "panic"
 
-    f reason
+    f "REACHED UNREACHABLE CODE: {reason}"
+
+# Like unreachable but with a different error message
+export def panic (reason: String): a =
+   def f x = prim "panic"
+
+   f "PANIC: {reason}"

--- a/share/wake/lib/core/syntax.wake
+++ b/share/wake/lib/core/syntax.wake
@@ -97,12 +97,12 @@ export def wait (f: a => b) (x: a): b =
 # 200
 # ```
 export def unreachable (reason: String): a =
-    def f x = prim "panic"
+    def f x = prim "unreachable"
 
     f "REACHED UNREACHABLE CODE: {reason}"
 
 # Like unreachable but with a different error message
 export def panic (reason: String): a =
-   def f x = prim "panic"
+    def f x = prim "panic"
 
-   f "PANIC: {reason}"
+    f "PANIC: {reason}"

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -636,9 +636,8 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
             if hashcode name ==* hash then
                 Unit
             else if abort # The panic will not be deadcode dropped, because it's an alternative return of the effect-ful notOk
-            # This use of unreachable is not ok!
             then
-                unreachable "The hashcode of output file '{name}' has changed from {hash} (when wake last ran) to {hashcode name} (when inspected this time). Presumably it was hand edited. Please move this file out of the way. Aborting the build to prevent loss of your data."
+                panic "The hashcode of output file '{name}' has changed from {hash} (when wake last ran) to {hashcode name} (when inspected this time). Presumably it was hand edited. Please move this file out of the way. Aborting the build to prevent loss of your data."
             else
                 printlnLevel
                 logError

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -635,8 +635,8 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
         def notOk (Pair name hash) =
             if hashcode name ==* hash then
                 Unit
-            else if abort # The panic will not be deadcode dropped, because it's an alternative return of the effect-ful notOk
-            then
+            # The panic will not be deadcode dropped, because it's an alternative return of the effect-ful notOk
+            else if abort then
                 panic "The hashcode of output file '{name}' has changed from {hash} (when wake last ran) to {hashcode name} (when inspected this time). Presumably it was hand edited. Please move this file out of the way. Aborting the build to prevent loss of your data."
             else
                 printlnLevel

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -196,10 +196,12 @@ def computeHashes (prefix: String) (files: List String): List String =
             | Pass
     else mergeSelect which_files_to_hash (map (add _ "BadHash") to_hash) not_to_hash
 
-    require Pass stdout =
-        plan
-        | runJobWith localRunner
-        | getJobStdout
+    def job = runJobWith localRunner plan
+
+    require Exited 0 = getJobStatus job
+    else mergeSelect which_files_to_hash (map (add _ "BadHash") to_hash) not_to_hash
+
+    require Pass stdout = getJobStdout job
     else mergeSelect which_files_to_hash (map (add _ "BadHash") to_hash) not_to_hash
 
     # We want a better error message if the number of lines do not match
@@ -210,7 +212,7 @@ def computeHashes (prefix: String) (files: List String): List String =
         | filter (_ !=* "")
 
     require True = len hash_lines == to_hash_len
-    else unreachable "wake-hash returned {format hash_lines} lines but we expected {str to_hash_len} lines"
+    else panic "wake-hash returned {format hash_lines} lines but we expected {str to_hash_len} lines"
 
     # Finally actually add all the hashes
     def hashed =

--- a/src/runtime/exception.cpp
+++ b/src/runtime/exception.cpp
@@ -53,16 +53,16 @@ static PRIMFN(prim_stack) {
   RETURN(claim_list(runtime.heap, objs.size(), objs.data()));
 }
 
-static PRIMTYPE(type_unreachable) {
+static PRIMTYPE(type_panic) {
   return args.size() == 1 && args[0]->unify(Data::typeString);
   (void)out;  // leave prim free
 }
 
-static PRIMFN(prim_unreachable) {
+static PRIMFN(prim_panic) {
   EXPECT(1);
   STRING(arg0, 0);
   std::stringstream str;
-  str << "REACHED UNREACHABLE CODE: " << arg0->c_str() << std::endl;
+  str << arg0->c_str() << std::endl;
   status_get_generic_stream(STREAM_ERROR) << str.str() << std::endl;
   require_fail("", 1, runtime, scope);
 }
@@ -85,7 +85,9 @@ static PRIMFN(prim_true) {
 void prim_register_exception(PrimMap &pmap) {
   // These should not be evaluated in const prop, but can be removed
   prim_register(pmap, "stack", prim_stack, type_stack, PRIM_ORDERED);
-  prim_register(pmap, "unreachable", prim_unreachable, type_unreachable, PRIM_ORDERED);
+  prim_register(pmap, "panic", prim_panic, type_panic, PRIM_ORDERED);
+  // We have both panic and unreachable, because "unreachable" is considered to be optimizable away
+  prim_register(pmap, "unreachable", prim_panic, type_panic, PRIM_ORDERED);
   prim_register(pmap, "use", prim_id, type_id, PRIM_IMPURE);
   prim_register(pmap, "true", prim_true, type_true, PRIM_PURE);
 }

--- a/src/runtime/exception.cpp
+++ b/src/runtime/exception.cpp
@@ -85,7 +85,7 @@ static PRIMFN(prim_true) {
 void prim_register_exception(PrimMap &pmap) {
   // These should not be evaluated in const prop, but can be removed
   prim_register(pmap, "stack", prim_stack, type_stack, PRIM_ORDERED);
-  prim_register(pmap, "panic", prim_panic, type_panic, PRIM_ORDERED);
+  prim_register(pmap, "panic", prim_panic, type_panic, PRIM_IMPURE);
   // We have both panic and unreachable, because "unreachable" is considered to be optimizable away
   prim_register(pmap, "unreachable", prim_panic, type_panic, PRIM_ORDERED);
   prim_register(pmap, "use", prim_id, type_id, PRIM_IMPURE);

--- a/tools/wake-hash/main.cpp
+++ b/tools/wake-hash/main.cpp
@@ -165,7 +165,7 @@ static wcl::optional<Hash256> hash_file(const char* file, int fd) {
 
   if (got < 0) {
     std::cerr << "wake-hash read(" << file << "): " << strerror(errno) << std::endl;
-    exit(1);
+    return {};
   }
 
   return wcl::some(Hash256::from_hash(&hash));
@@ -180,13 +180,13 @@ static wcl::optional<Hash256> do_hash(const char* file) {
     if (fd.error() == ELOOP || errno == EMLINK) return hash_link(file);
     if (fd.error() == ENXIO) return hash_exotic();
     std::cerr << "wake-hash open(" << file << "): " << strerror(errno);
-    exit(1);
+    return {};
   }
 
   if (fstat(fd->get(), &stat) != 0) {
     if (errno == EISDIR) return hash_dir();
     std::cerr << "wake-hash fstat(" << file << "): " << strerror(errno);
-    exit(1);
+    return {};
   }
 
   if (S_ISDIR(stat.st_mode)) return hash_dir();

--- a/tools/wake-hash/main.cpp
+++ b/tools/wake-hash/main.cpp
@@ -119,7 +119,7 @@ struct Hash256 {
 };
 
 // If a file handle is not a symlink, directory, or regular file
-// then we consider it "exotic". This includes block devices, 
+// then we consider it "exotic". This includes block devices,
 // character devices, FIFOs, and scokets.
 static wcl::optional<Hash256> hash_exotic() {
   Hash256 out;

--- a/tools/wake-hash/main.cpp
+++ b/tools/wake-hash/main.cpp
@@ -120,7 +120,7 @@ struct Hash256 {
 
 // If a file handle is not a symlink, directory, or regular file
 // then we consider it "exotic". This includes block devices,
-// character devices, FIFOs, and scokets.
+// character devices, FIFOs, and sockets.
 static wcl::optional<Hash256> hash_exotic() {
   Hash256 out;
   out.data[0] = 1;


### PR DESCRIPTION
Recently we've had a lot of issues with people seeing error messages like this:

```
UNREACHABLE: wake hash expected X lines but received Nil
```

This isn't really unreachable if you hit some sort of issue with fnoutputs however but previously this code assumed that no such issues would ever occur (this is manifestly false).

To fix this I do the following

1) If the exit code of wake-hash is non-zero for any reason all hashed files from that job are considered BadHash and will thus later trigger a failure when `getJobOutputs` is called but the error will not point blame at wake-hash and will instead just say that it couldn't hash some random file (which one is chosen is up to which BadHash is checked first)
2) If any specific file cannot be hashed, wake-hash will return BadHash for it and thus that specific file will later give an error with getJobOutputs which should make people's lives easier
3) If for some reason wake still gets this "expected X lines but received Nil" error after those two cases, we now call it at "PANIC" instead of "UNREACHABLE" (I cleaned up one other such unreachable that we commonly see as well)

Additionally it recently came to light that sometimes we wish to have a job "hash" a domain socket similar to how we "hash" directories. So we now consider anything that can be opened as read only that isn't a symlink, directory, or regular file to be "exotic" and to have a hash of 1 (similar to how directories have a hash of 0). This will allow jobs to output exotic "files" if they wish to but this should be avoided by 99% of users.