### PR TITLE
Fix wake-format find_all_files flake 

### DIFF
--- a/src/parser/wakefiles.cpp
+++ b/src/parser/wakefiles.cpp
@@ -536,6 +536,7 @@ std::vector<std::string> find_workspace_wakefiles_via_manifest(const std::string
 std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbose,
                                             const std::string &libdir, const std::string &workdir,
                                             FILE *user_warning_dest) {
+  ok = true;
   RE2::Options options;
   options.set_log_errors(false);
   options.set_one_line(true);

--- a/tools/wake-format/main.cpp
+++ b/tools/wake-format/main.cpp
@@ -198,7 +198,7 @@ int main(int argc, char **argv) {
   FILE *user_warn = stdout;
   user_warn = fopen("/dev/null", "w");
   if (auto_find_files) {
-    bool ok;
+    bool ok = true;
     wakefiles = find_all_wakefiles(ok, true, false, ".", ".", user_warn);
     if (!ok) {
       std::cerr << "Failed to automatically discover wake files" << std::endl;


### PR DESCRIPTION
Previously `ok` is uninitialized and never set to true on success.  If the underlying memory happened to be set to `0` then it would incorrectly report a failure even though none had occurred. Set the default to true to avoid that case