### PR TITLE
Make getJobStd{err,out} check job status before returning

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -494,8 +494,8 @@ export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String E
 
                 JArray (map mkVisJson readPaths)
 
-            require Pass stdout = getJobStdout job
-            require Pass stderr = getJobStderr job
+            require Pass stdout = getJobFailedStdout job
+            require Pass stderr = getJobFailedStderr job
 
             def jobCacheAddJson =
                 prettyJSON
@@ -762,9 +762,21 @@ def mapPath = match _
     Pass l = findFailFn treeOk l
 
 export def getJobStdoutRaw (job: Job): Result String Error =
+    require Exited 0 = getJobStatus job
+    else failWithError "job terminated with non-zero exit code"
+
     stdio job 1
 
 export def getJobStderrRaw (job: Job): Result String Error =
+    require Exited 0 = getJobStatus job
+    else failWithError "job terminated with non-zero exit code"
+
+    stdio job 2
+
+export def getJobFailedStdoutRaw (job: Job): Result String Error =
+    stdio job 1
+
+export def getJobFailedStderrRaw (job: Job): Result String Error =
     stdio job 2
 
 export def getJobStdout (job: Job): Result String Error =
@@ -774,6 +786,16 @@ export def getJobStdout (job: Job): Result String Error =
 
 export def getJobStderr (job: Job): Result String Error =
     require Pass stderr = getJobStderrRaw job
+
+    Pass (stderr | filterTerminalCodes)
+
+export def getJobFailedStdout (job: Job): Result String Error =
+    require Pass stdout = getJobFailedStdoutRaw job
+
+    Pass (stdout | filterTerminalCodes)
+
+export def getJobFailedStderr (job: Job): Result String Error =
+    require Pass stderr = getJobFailedStderrRaw job
 
     Pass (stderr | filterTerminalCodes)
 

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -773,27 +773,50 @@ export def getJobStderrRaw (job: Job): Result String Error =
 
     stdio job 2
 
+# Gives the full stdout of a job as a string, without any manipulation.
+# Returns the result successfully as long as the job was successfully launched
+# and closed its stdout handle at some point during its execution. This
+# generally occurs by the process simply terminating. The only case where
+# this would return a failure is if the job did not successfully launch.
 export def getJobFailedStdoutRaw (job: Job): Result String Error =
     stdio job 1
 
+# Gives the full stderr of a job as a string, without any manipulation.
+# Returns the result successfully as long as the job was successfully launched
+# and closed its stderr handle at some point during its execution. This
+# generally occurs by the process simply terminating. The only case
+# in which this would return a failure is if the job did not successfully
+# launch.
 export def getJobFailedStderrRaw (job: Job): Result String Error =
     stdio job 2
 
+# Gives the job's stdout if the job exited with an exit
+# code of zero. The output will be manipulated to not contain
+# ANSI escape codes.
 export def getJobStdout (job: Job): Result String Error =
     require Pass stdout = getJobStdoutRaw job
 
     Pass (stdout | filterTerminalCodes)
 
+# Gives the job's stderr if the job exited with an exit
+# code of zero. The output will be manipulated to not contain
+# ANSI escape codes.
 export def getJobStderr (job: Job): Result String Error =
     require Pass stderr = getJobStderrRaw job
 
     Pass (stderr | filterTerminalCodes)
 
+# Gives the job's stdout if the job was launched successfully
+# and closed its stdout at some point. The output will be
+# manipulated to not contain ANSI escape codes.
 export def getJobFailedStdout (job: Job): Result String Error =
     require Pass stdout = getJobFailedStdoutRaw job
 
     Pass (stdout | filterTerminalCodes)
 
+# Gives the job's stdout if the job was launched successfully
+# and closed its stdout at some point. The output will be
+# manipulated to not contain ANSI escape codes.
 export def getJobFailedStderr (job: Job): Result String Error =
     require Pass stderr = getJobFailedStderrRaw job
 

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -155,11 +155,11 @@ export def runUnitTests _: Result Unit Error =
     def removeCarriageReturns = replace `\r` ""
 
     require Pass jobStdout =
-        testJob.getJobStdout
+        testJob.getJobFailedStdout
         | rmap removeCarriageReturns
 
     require Pass jobStderr =
-        testJob.getJobStderr
+        testJob.getJobFailedStderr
         | rmap removeCarriageReturns
 
     require Pass _ = match testJob.isJobOk
@@ -236,11 +236,11 @@ def runTest (testScript: Path): Result Unit Error =
         | runJobWith localRunner # On OS/X you cannot mount fuse within fuse
 
     require Pass jobStdout =
-        testJob.getJobStdout
+        testJob.getJobFailedStdout
         | rmap (replace `\r` "")
 
     require Pass jobStderr =
-        testJob.getJobStderr
+        testJob.getJobFailedStderr
         | rmap (replace `\r` "")
 
     require Pass _ = match shouldPass testJob.isJobOk


### PR DESCRIPTION
This change makes it so that getJobStdout and getJobStderr first check the job status before returning a Pass, and return a Fail if its non-zero.

To match the old behavoir getJobFailedStdout and getJobFailedStderr were added.