### PR TITLE
Rewrite match `=` as `->` inside of `match`

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -19,30 +19,30 @@ from wake import _
 
 # Useful build variants (arguments to all)
 def toVariant = match _
-    "default" = Pass (Pair "native-cpp14-release" "native-c11-release")
-    "static" = Pass (Pair "native-cpp14-static" "native-c11-static")
-    "debug" = Pass (Pair "native-cpp14-debug" "native-c11-debug")
-    s = Fail "Unknown build target ({s})".makeError
+    "default" -> Pass (Pair "native-cpp14-release" "native-c11-release")
+    "static" -> Pass (Pair "native-cpp14-static" "native-c11-static")
+    "debug" -> Pass (Pair "native-cpp14-debug" "native-c11-debug")
+    s -> Fail "Unknown build target ({s})".makeError
 
 export def build: List String => Result String Error = match _
-    "tarball", Nil =
+    "tarball", Nil ->
         tarball Unit
         | rmap (\_ "TARBALL")
-    kind, Nil =
+    kind, Nil ->
         require Pass variant = toVariant kind
 
         all variant
         | rmap (\_ "BUILD")
-    _ = Fail "no target specified (try: build default/debug/tarball)".makeError
+    _ -> Fail "no target specified (try: build default/debug/tarball)".makeError
 
 export def install: List String => Result String Error = match _
-    dest, kind, Nil =
+    dest, kind, Nil ->
         doInstall (in cwd dest) kind
         | rmap (\_ "INSTALL")
-    dest, Nil =
+    dest, Nil ->
         doInstall (in cwd dest) "default"
         | rmap (\_ "INSTALL")
-    _ = Fail "no directory specified (try: install /opt/local)".makeError
+    _ -> Fail "no directory specified (try: install /opt/local)".makeError
 
 def bootstrapTarget targetFn variant =
     require Pass paths = targetFn variant
@@ -75,8 +75,8 @@ def bootstrapTarget targetFn variant =
             | getJobOutputs
 
         match installed
-            Pass (first, Nil) = Pass first
-            _ = Fail "Unexpected arity in  bootstrap install".makeError
+            Pass (first, Nil) -> Pass first
+            _ -> Fail "Unexpected arity in  bootstrap install".makeError
 
     paths
     | map doInstall

--- a/share/wake/lib/core/double.wake
+++ b/share/wake/lib/core/double.wake
@@ -134,8 +134,8 @@ export def (x: Double) <=>. (y: Double): Option Order =
 
 # IEEE 754 requires comparisons with NaN to return False (except for !=)
 def dhelper x y fn = match (x <=>. y)
-    Some x = fn x
-    None = False
+    Some x -> fn x
+    None -> False
 
 # Binary Less-Than Operator.
 # IEEE 754 requires comparison with NaN to return False
@@ -211,9 +211,9 @@ export def (x: Double) !=. (y: Double): Boolean =
 # dmin 1.0 3.0 = 1.0
 # dmin 3.0 1.0 = 1.0
 export def dmin (x: Double) (y: Double): Double = match (x <=>. y)
-    None = nan
-    Some LT = x
-    _ = y
+    None -> nan
+    Some LT -> x
+    _ -> y
 
 # Computes the maximum of two Doubles.
 # If either is nan, the result is nan
@@ -223,9 +223,9 @@ export def dmin (x: Double) (y: Double): Double = match (x <=>. y)
 # dmax 1.0 3.0 = 3.0
 # dmax 3.0 1.0 = 3.0
 export def dmax (x: Double) (y: Double): Double = match (x <=>. y)
-    None = nan
-    Some LT = y
-    _ = x
+    None -> nan
+    Some LT -> y
+    _ -> x
 
 # Product of a List of Doubles.
 # dprod (3.0, 3.0, 1.0, Nil) = 9.0
@@ -262,10 +262,10 @@ export def dformat (format: DoubleFormat): (digits: Integer) => Double => String
     def imp f p x = prim "dstr"
 
     def f = match format
-        DoubleFixed = 0
-        DoubleScientific = 1
-        DoubleHex = 2
-        DoubleDefault = 3
+        DoubleFixed -> 0
+        DoubleScientific -> 1
+        DoubleHex -> 2
+        DoubleDefault -> 3
 
     imp f
 
@@ -292,8 +292,8 @@ export def dstr: Double => String =
 # dint 55 = 55e0
 # dint (1 << 2000) = inf
 export def dint (x: Integer): Double = match (double (str x))
-    Some x = x
-    None = unreachable "parsing a large integer should return +/- inf"
+    Some x -> x
+    None -> unreachable "parsing a large integer should return +/- inf"
 
 # Conversion methods
 export data DoubleClass =
@@ -311,10 +311,10 @@ export def dclass (x: Double): DoubleClass =
     def imp x = prim "dclass"
 
     match (imp x)
-        1 = DoubleInfinite
-        2 = DoubleNaN
-        4 = DoubleSubNormal
-        _ = DoubleNormal
+        1 -> DoubleInfinite
+        2 -> DoubleNaN
+        4 -> DoubleSubNormal
+        _ -> DoubleNormal
 
 # Split 'x' into (Pair sig exp), such that:
 #   x = sig * 2^exp

--- a/share/wake/lib/core/json.wake
+++ b/share/wake/lib/core/json.wake
@@ -26,49 +26,49 @@ export data JValue =
     JArray (List JValue)
 
 export def getJString: JValue => Option String = match _
-    JString x = Some x
-    JArray (JString x, Nil) = Some x
-    _ = None
+    JString x -> Some x
+    JArray (JString x, Nil) -> Some x
+    _ -> None
 
 export def getJInteger: JValue => Option Integer = match _
-    JInteger x = Some x
-    JArray (JInteger x, Nil) = Some x
-    _ = None
+    JInteger x -> Some x
+    JArray (JInteger x, Nil) -> Some x
+    _ -> None
 
 export def getJDouble: JValue => Option Double = match _
-    JDouble x = Some x
-    JInteger x = Some (dint x)
-    JArray (JDouble x, Nil) = Some x
-    JArray (JInteger x, Nil) = Some (dint x)
-    _ = None
+    JDouble x -> Some x
+    JInteger x -> Some (dint x)
+    JArray (JDouble x, Nil) -> Some x
+    JArray (JInteger x, Nil) -> Some (dint x)
+    _ -> None
 
 export def getJBoolean: JValue => Option Boolean = match _
-    JBoolean x = Some x
-    JArray (JBoolean x, Nil) = Some x
-    _ = None
+    JBoolean x -> Some x
+    JArray (JBoolean x, Nil) -> Some x
+    _ -> None
 
 export def getJObject: JValue => Option (List (Pair String JValue)) = match _
-    JObject x = Some x
-    JArray (JObject x, Nil) = Some x
-    _ = None
+    JObject x -> Some x
+    JArray (JObject x, Nil) -> Some x
+    _ -> None
 
 export def getJArray: JValue => Option (List JValue) = match _
-    JArray x = Some x
-    _ = None
+    JArray x -> Some x
+    _ -> None
 
 export def parseJSONBody (body: String): Result JValue Error =
     def imp b = prim "json_body"
 
     match (imp body)
-        Pass jvalue = Pass jvalue
-        Fail cause = Fail (makeError cause)
+        Pass jvalue -> Pass jvalue
+        Fail cause -> Fail (makeError cause)
 
 export def parseJSONFile (path: Path): Result JValue Error =
     def imp f = prim "json_file"
 
     match (imp path.getPathName)
-        Pass body = Pass body
-        Fail f = Fail (makeError f)
+        Pass body -> Pass body
+        Fail f -> Fail (makeError f)
 
 export def jsonEscape str =
     prim "json_str"
@@ -99,20 +99,20 @@ def doFormat (fmt: JSONFormat) (lhs: JValue): List String =
             | getOrElse ""
 
         match lhs
-            JString s = '"', fmt.getJSONFormatString s, '"', rhs
-            JInteger i = fmt.getJSONFormatInteger i, rhs
-            JDouble d = fmt.getJSONFormatDouble d, rhs
-            JBoolean True = "true", rhs
-            JBoolean False = "false", rhs
-            JNull = "null", rhs
-            JArray list =
+            JString s -> '"', fmt.getJSONFormatString s, '"', rhs
+            JInteger i -> fmt.getJSONFormatInteger i, rhs
+            JDouble d -> fmt.getJSONFormatDouble d, rhs
+            JBoolean True -> "true", rhs
+            JBoolean False -> "false", rhs
+            JNull -> "null", rhs
+            JArray list ->
                 def helper value acc = ",{tabbeder}", rec acc deeper value
 
                 if list.empty then
                     '[]', rhs
                 else
                     "[{tabbeder}", foldr helper ("{tabbed}]", rhs) list | tail
-            JObject list =
+            JObject list ->
                 def helper (Pair key value) acc =
                     ",{tabbeder}", '"', jsonEscape key, ("\":{space}", rec acc deeper value)
 
@@ -125,10 +125,10 @@ def doFormat (fmt: JSONFormat) (lhs: JValue): List String =
 
 export def defaultJSONFormat: JSONFormat =
     def formatDouble d = match (dclass d)
-        DoubleInfinite if d <. 0e0 = "-Infinity"
-        DoubleInfinite = "Infinity"
-        DoubleNaN = "NaN"
-        _ = dstr d
+        DoubleInfinite if d <. 0e0 -> "-Infinity"
+        DoubleInfinite -> "Infinity"
+        DoubleNaN -> "NaN"
+        _ -> dstr d
 
     JSONFormat jsonEscape str formatDouble 0
 
@@ -150,8 +150,8 @@ export def root /| filterFn =
     jfilter filterFn root
 
 export def jfilter filterFn root = match root
-    JArray l = JArray (filter filterFn l)
-    _ =
+    JArray l -> JArray (filter filterFn l)
+    _ ->
         if filterFn root then
             JArray (root, Nil)
         else
@@ -162,21 +162,21 @@ export def root /../ filterFn =
 
 export def jfind filterFn root =
     def helper node acc = match node
-        JArray l =
+        JArray l ->
             def tail = foldr helper acc l
 
             if filterFn node then
                 node, tail
             else
                 tail
-        JObject l =
+        JObject l ->
             def tail = foldr (helper _.getPairSecond _) acc l
 
             if filterFn node then
                 node, tail
             else
                 tail
-        _ =
+        _ ->
             if filterFn node then
                 node, acc
             else
@@ -189,23 +189,23 @@ export def jempty root =
     empty (jlist root)
 
 export def jlist root = match root
-    JArray x = x
-    _ = root, Nil
+    JArray x -> x
+    _ -> root, Nil
 
 export def x // y =
     def helper tail = match _
-        JString _ = tail
-        JInteger _ = tail
-        JDouble _ = tail
-        JBoolean _ = tail
-        JNull = tail
-        JObject l =
+        JString _ -> tail
+        JInteger _ -> tail
+        JDouble _ -> tail
+        JBoolean _ -> tail
+        JNull -> tail
+        JObject l ->
             def flatten v tail = match v.getPairSecond
-                JArray l = l ++ tail
-                w = w, tail
+                JArray l -> l ++ tail
+                w -> w, tail
 
             foldr flatten tail (filter (matches y _.getPairFirst) l)
-        JArray l =
+        JArray l ->
             def flatten v tail = helper tail v
 
             foldr flatten tail l
@@ -213,12 +213,12 @@ export def x // y =
     JArray (helper Nil x)
 
 export def x ==/ y = match x y
-    (JString a) (JString b) = a ==~ b
-    (JInteger a) (JInteger b) = a == b
-    (JDouble a) (JDouble b) = a ==. b
-    (JBoolean a) (JBoolean b) = if a then b else !b
-    JNull JNull = True
-    (JObject a) (JObject b) =
+    (JString a) (JString b) -> a ==~ b
+    (JInteger a) (JInteger b) -> a == b
+    (JDouble a) (JDouble b) -> a ==. b
+    (JBoolean a) (JBoolean b) -> if a then b else !b
+    JNull JNull -> True
+    (JObject a) (JObject b) ->
         def helper (Pair (Pair k c) (Pair l d)) = k ==~ l && c ==/ d
 
         if a.len != b.len then
@@ -226,7 +226,7 @@ export def x ==/ y = match x y
         else
             zip a b
             | forall helper
-    (JArray a) (JArray b) =
+    (JArray a) (JArray b) ->
         def helper (Pair c d) = c ==/ d
 
         if a.len != b.len then
@@ -234,9 +234,9 @@ export def x ==/ y = match x y
         else
             zip a b
             | forall helper
-    (JArray a) _ = exists (_ ==/ y) a
-    _ (JArray b) = exists (_ ==/ x) b
-    _ _ = False
+    (JArray a) _ -> exists (_ ==/ y) a
+    _ (JArray b) -> exists (_ ==/ x) b
+    _ _ -> False
 
 # Simplify a JSON structure for broad compatibility as defined by the specs.
 # While doing so is unnecessary where Wake is always used to consume any
@@ -263,27 +263,27 @@ export def normalizeJSON: (json: JValue) => Result JValue Error =
 # if the specific branch causing the failure would later have been pruned.
 export def normalizeJSONWith (fmt: JSONNormalize) (json: JValue): Result JValue Error =
     def normalized = match json
-        JString a =
+        JString a ->
             getJSONNormalizeString fmt a
             | rmap JString
-        JInteger a =
+        JInteger a ->
             getJSONNormalizeInteger fmt a
             | rmap JInteger
-        JDouble a =
+        JDouble a ->
             getJSONNormalizeDouble fmt a
             | rmap JDouble
-        JBoolean a =
+        JBoolean a ->
             getJSONNormalizeBoolean fmt a
             | rmap JBoolean
-        JNull = Pass JNull
-        JObject a =
+        JNull -> Pass JNull
+        JObject a ->
             def normalizeJObjectValue entry =
                 def Pair key value = entry
                 def normalized = normalizeJSONWith fmt value
 
                 match normalized
-                    (Pass norm) = Pass (Pair key norm)
-                    (Fail error) = addJSONErrorPath key error
+                    (Pass norm) -> Pass (Pair key norm)
+                    (Fail error) -> addJSONErrorPath key error
 
             def normalizedList = map normalizeJObjectValue a
 
@@ -292,7 +292,7 @@ export def normalizeJSONWith (fmt: JSONNormalize) (json: JValue): Result JValue 
             children
             | getJSONNormalizeObject fmt
             | rmap JObject
-        JArray a =
+        JArray a ->
             def recurseArray (Pair i x) =
                 normalizeJSONWith fmt x
                 | rmapFail (addJSONErrorPath "[{str i}]")
@@ -431,9 +431,9 @@ export def normalizeJSONCompat: JSONNormalize =
 # Published JSON specifications describe their double values as allowing decimal
 # or exponential forms, but don't implement the full IEEE standard.
 def filterNonDigitJDouble (n: Double): Result Double Error = match n.dclass
-    DoubleInfinite = failWithError "For compatibility, JSON doubles should not be infinite."
-    DoubleNaN = failWithError "For compatibility, JSON doubles should not be NaN values."
-    _ = Pass n
+    DoubleInfinite -> failWithError "For compatibility, JSON doubles should not be infinite."
+    DoubleNaN -> failWithError "For compatibility, JSON doubles should not be NaN values."
+    _ -> Pass n
 
 # Attempt to simplify any `JObject`s which contain multiple instances of a key.
 # While the published specifications explicitly allow such duplicate keys, none
@@ -459,22 +459,22 @@ def deduplicateJObjectKeys (simplifyValueList: List JValue => Result JValue Erro
 
     def simplifyKeyGroup (pairs: List (Pair String JValue)): Result (Pair String JValue) Error =
         match pairs
-            Nil =
+            Nil ->
                 # `simplifyKeyGroups` is only ever mapped over the output of
                 # `groupBy`, which is always a list of *non-empty* lists.
                 unreachable "groupBy invariant reached in deduplicateJObjectKeys"
-            (Pair key value), ps =
+            (Pair key value), ps ->
                 def simplified =
                     (value, map getPairSecond ps: List JValue)
                     | simplifyValues
 
                 match simplified
-                    (Pass value) = Pass (Pair key value)
-                    (Fail error) = addJSONErrorPath key error
+                    (Pass value) -> Pass (Pair key value)
+                    (Fail error) -> addJSONErrorPath key error
 
     def simplifyValues (values: List JValue): Result JValue Error = match values
-        v, Nil = Pass v
-        _ = simplifyValueList values
+        v, Nil -> Pass v
+        _ -> simplifyValueList values
 
     groupBy cmpKeysOnly dict
     | findFailFn simplifyKeyGroup
@@ -505,11 +505,11 @@ def mergeValueList (describeCompat: Boolean) (values: List JValue): Result JValu
                 | failWithError
 
         match values
-            v1, v2, vs =
+            v1, v2, vs ->
                 rfoldl eqOrFail v1 (v2, vs)
                 | rmap wrapFn
-            v, Nil = Pass (wrapFn v)
-            _ = unreachable "groupBy invariant reached in mergeValueList"
+            v, Nil -> Pass (wrapFn v)
+            _ -> unreachable "groupBy invariant reached in mergeValueList"
 
     def formatExamples examples =
         map formatJSON examples
@@ -520,8 +520,8 @@ def mergeValueList (describeCompat: Boolean) (values: List JValue): Result JValu
         # We filter out `JNull` values for most types as being a "wildcard"
         # value, but if *everything* is a `JNull` we do want to return that.
         def isNull = match _
-            JNull = True
-            _ = False
+            JNull -> True
+            _ -> False
 
         def allNull = forall isNull values
         def nonNullValues = filter (!_.isNull) values
@@ -531,17 +531,17 @@ def mergeValueList (describeCompat: Boolean) (values: List JValue): Result JValu
         def anyArray = exists (_.getJArray | isSome) values
 
         match allNull anyArray
-            True _ = Some values; None; None; None; None; None; None
-            _ True =
+            True _ -> Some values; None; None; None; None; None; None
+            _ True ->
                 def arrays =
                     def getJArrayOrNull = match _
-                        JNull = Some (JNull, Nil)
-                        json = getJArray json
+                        JNull -> Some (JNull, Nil)
+                        json -> getJArray json
 
                     findNoneFn getJArrayOrNull values
 
                 None; None; None; None; None; None; arrays
-            _ _ =
+            _ _ ->
                 # If *all* values are of the same type, get those values.
                 def strings = findNoneFn getJString nonNullValues
                 def ints = findNoneFn getJInteger nonNullValues
@@ -549,8 +549,8 @@ def mergeValueList (describeCompat: Boolean) (values: List JValue): Result JValu
                 def doubles =
                     # `getJDouble` will convert any `JInteger` values.
                     def isDouble = match _
-                        JDouble _ = True
-                        _ = False
+                        JDouble _ -> True
+                        _ -> False
 
                     if forall isDouble nonNullValues then
                         findNoneFn getJDouble nonNullValues
@@ -563,12 +563,12 @@ def mergeValueList (describeCompat: Boolean) (values: List JValue): Result JValu
                 None; strings; ints; doubles; bools; objects; None
 
     match nullTest stringTest intTest doubleTest boolTest objectTest arrayTest
-        (Some _) None None None None None None = Pass JNull
-        _ (Some strings) None None None None None = requireEqual (_ ==* _) JString strings
-        _ None (Some ints) None None None None = requireEqual (_ == _) JInteger ints
-        _ None None (Some doubles) None None None = requireEqual (_ ==. _) JDouble doubles
-        _ None None None (Some bools) None None = requireEqual enor JBoolean bools
-        _ None None None None (Some objects) None =
+        (Some _) None None None None None None -> Pass JNull
+        _ (Some strings) None None None None None -> requireEqual (_ ==* _) JString strings
+        _ None (Some ints) None None None None -> requireEqual (_ == _) JInteger ints
+        _ None None (Some doubles) None None None -> requireEqual (_ ==. _) JDouble doubles
+        _ None None None (Some bools) None None -> requireEqual enor JBoolean bools
+        _ None None None None (Some objects) None ->
             # If multiple keys all point to a `JObject`, there's a chance
             # keys are shared between those objects (even if not within the
             # objects individually) and so they need to be deduplicated
@@ -579,11 +579,11 @@ def mergeValueList (describeCompat: Boolean) (values: List JValue): Result JValu
             flatten objects
             | deduplicateJObjectKeys (mergeValueList describeCompat)
             | rmap JObject
-        _ None None None None None (Some arrays) =
+        _ None None None None None (Some arrays) ->
             flatten arrays
             | JArray
             | Pass
-        _ _ _ _ _ _ _ =
+        _ _ _ _ _ _ _ ->
             # wake-format off
             compatibilityMessage "V" "v" "alues of different types may not be combined. The incompatible values are: {formatExamples values}"
             | failWithError
@@ -598,16 +598,16 @@ export def lastValueInList (values: List JValue): Result JValue Error =
     def revValues = reverse values
 
     def isNotObject = match _
-        JObject _ = False
-        _ = True
+        JObject _ -> False
+        _ -> True
 
     match (takeUntil isNotObject revValues)
-        Nil =
+        Nil ->
             revValues
             | head
             | getOrElse JNull
             | Pass
-        objs =
+        objs ->
             # Return to original order after taking from `revValues`.
             reverse objs
             | mapPartial getJObject

--- a/share/wake/lib/core/list.wake
+++ b/share/wake/lib/core/list.wake
@@ -74,8 +74,8 @@ export def element, =
 #   empty (seq 9)  = False
 # ```
 export def empty: List a => Boolean = match _
-    Nil = True
-    _ = False
+    Nil -> True
+    _ -> False
 
 # Retrieve the first element of the list, else None.
 # If you find yourself using the function, consider using match instead.
@@ -87,8 +87,8 @@ export def empty: List a => Boolean = match _
 #   head (seq 10) = Some 0
 # ```
 export def head: List a => Option a = match _
-    Nil = None
-    h, _ = Some h
+    Nil -> None
+    h, _ -> Some h
 
 # Remove the first element from the List
 # If you find yourself using the function, consider using match instead.
@@ -101,8 +101,8 @@ export def head: List a => Option a = match _
 #   tail (pi, 1.0, Nil) = 1.0, Nil
 # ```
 export def tail: List a => List a = match _
-    Nil = Nil
-    _, t = t
+    Nil -> Nil
+    _, t -> t
 
 # Create a new List by applying the function `mapFn` to each element of `list`.
 # The `map` function (along with `foldl`) is generally how one implements loops in wake.
@@ -122,8 +122,8 @@ export def tail: List a => List a = match _
 # ```
 export def map (mapFn: a => b): (list: List a) => List b =
     def loop list = match list
-        Nil = Nil
-        h, t = mapFn h, loop t
+        Nil -> Nil
+        h, t -> mapFn h, loop t
 
     loop
 
@@ -141,8 +141,8 @@ export def map (mapFn: a => b): (list: List a) => List b =
 # ```
 export def mapFlat (mapFn: a => List b): (list: List a) => List b =
     def loop = match _
-        Nil = Nil
-        h, t = mapFn h ++ loop t
+        Nil -> Nil
+        h, t -> mapFn h ++ loop t
 
     loop
 
@@ -162,14 +162,14 @@ export def mapFlat (mapFn: a => List b): (list: List a) => List b =
 # ```
 export def mapPartial (f: a => Option b): (list: List a) => List b =
     def loop = match _
-        Nil = Nil
-        h, t =
+        Nil -> Nil
+        h, t ->
             # don't wait on f to process tail:
             def sub = loop t
 
             match (f h)
-                Some x = x, sub
-                None = sub
+                Some x -> x, sub
+                None -> sub
 
     loop
 
@@ -198,8 +198,8 @@ export def mapPartial (f: a => Option b): (list: List a) => List b =
 # ```
 export def foldl (combiningFn: accumulator => element => accumulator): accumulator => List element => accumulator =
     def loop accumulator = match _
-        Nil = accumulator
-        element, rest = loop (combiningFn accumulator element) rest
+        Nil -> accumulator
+        element, rest -> loop (combiningFn accumulator element) rest
 
     loop
 
@@ -228,8 +228,8 @@ export def foldl (combiningFn: accumulator => element => accumulator): accumulat
 #  ```
 export def scanl (combiningFn: accumulator => element => accumulator): accumulator => List element => List accumulator =
     def loop accumulator = match _
-        Nil = accumulator, Nil
-        element, rest = accumulator, loop (combiningFn accumulator element) rest
+        Nil -> accumulator, Nil
+        element, rest -> accumulator, loop (combiningFn accumulator element) rest
 
     loop
 
@@ -249,8 +249,8 @@ export def scanl (combiningFn: accumulator => element => accumulator): accumulat
 # ```
 export def foldr (combiningFn: element => accumulator => accumulator): accumulator => List element => accumulator =
     def loop accumulator = match _
-        Nil = accumulator
-        element, rest = combiningFn element (loop accumulator rest)
+        Nil -> accumulator
+        element, rest -> combiningFn element (loop accumulator rest)
 
     loop
 
@@ -279,8 +279,8 @@ export def foldr (combiningFn: element => accumulator => accumulator): accumulat
 #  ```
 export def scanr (combiningFn: element => accumulator => accumulator): accumulator => List element => List accumulator =
     def loop accumulator = match _
-        Nil = accumulator, Nil
-        element, rest =
+        Nil -> accumulator, Nil
+        element, rest ->
             def tail = loop accumulator rest
 
             require acc, _ = tail
@@ -395,8 +395,8 @@ export def splitAt (index: Integer) (listToDivide: List a): Pair (List a) (List 
     if index <= 0 then
         Pair Nil listToDivide
     else match listToDivide
-        Nil = Pair Nil Nil
-        h, t =
+        Nil -> Pair Nil Nil
+        h, t ->
             def Pair u v = splitAt (index - 1) t
 
             Pair (h, u) v
@@ -414,8 +414,8 @@ export def take (length: Integer) (l: List a): List a =
     if length <= 0 then
         Nil
     else match l
-        Nil = Nil
-        h, t = h, take (length - 1) t
+        Nil -> Nil
+        h, t -> h, take (length - 1) t
 
 # Discard the first `num` elements
 #
@@ -430,8 +430,8 @@ export def drop (num: Integer) (l: List a): List a =
     if num <= 0 then
         l
     else match l
-        Nil = Nil
-        _, t = drop (num - 1) t
+        Nil -> Nil
+        _, t -> drop (num - 1) t
 
 # Extract the i-th element if it exists or else None
 #
@@ -460,8 +460,8 @@ export def at (i: Integer) (l: List a): Option a =
 # ```
 export def splitUntil (stopFn: a => Boolean): List a => Pair (List a) (List a) =
     def loop l = match l
-        Nil = Pair Nil Nil
-        h, t =
+        Nil -> Pair Nil Nil
+        h, t ->
             if stopFn h then
                 Pair Nil l
             else
@@ -484,9 +484,9 @@ export def splitUntil (stopFn: a => Boolean): List a => Pair (List a) (List a) =
 # ```
 export def takeUntil (f: a => Boolean): List a => List a =
     def loop = match _
-        Nil = Nil
-        h, _ if f h = Nil
-        h, t = h, loop t
+        Nil -> Nil
+        h, _ if f h -> Nil
+        h, t -> h, loop t
 
     loop
 
@@ -503,9 +503,9 @@ export def takeUntil (f: a => Boolean): List a => List a =
 # ```
 export def dropUntil (f: a => Boolean): List a => List a =
     def loop l = match l
-        Nil = Nil
-        h, _ if f h = l
-        _, t = loop t
+        Nil -> Nil
+        h, _ if f h -> l
+        _, t -> loop t
 
     loop
 
@@ -524,9 +524,9 @@ export def dropUntil (f: a => Boolean): List a => List a =
 # ```
 export def find (f: a => Boolean): List a => Option (Pair a Integer) =
     def loop i = match _
-        Nil = None
-        h, _ if f h = Some (Pair h i)
-        _, t = loop (i + 1) t
+        Nil -> None
+        h, _ if f h -> Some (Pair h i)
+        _, t -> loop (i + 1) t
 
     loop 0
 
@@ -588,8 +588,8 @@ export def forall (f: a => Boolean): List a => Boolean =
 # ```
 export def splitBy (acceptFn: a => Boolean): (list: List a) => Pair (true: List a) (false: List a) =
     def loop list = match list
-        Nil = Pair Nil Nil
-        h, t =
+        Nil -> Pair Nil Nil
+        h, t ->
             # don't wait on f to process tail:
             def Pair u v = loop t
 
@@ -613,8 +613,8 @@ export def splitBy (acceptFn: a => Boolean): (list: List a) => Pair (true: List 
 # ```
 export def filter (f: a => Boolean): List a => List a =
     def loop = match _
-        Nil = Nil
-        h, t =
+        Nil -> Nil
+        h, t ->
             def sub = loop t
 
             if f h then
@@ -642,9 +642,9 @@ export def transpose: List (List a) => List (List a) =
     def innerHead = mapPartial head
 
     def innerTail = match _
-        Nil = Nil
-        Nil, t = innerTail t
-        (_, b), t = b, innerTail t
+        Nil -> Nil
+        Nil, t -> innerTail t
+        (_, b), t -> b, innerTail t
 
     def outer l =
         def heads = innerHead l
@@ -698,8 +698,8 @@ export def sortBy (cmpFn: a => a => Order): (list: List a) => List a =
 # ```
 export def distinctBy (cmpFn: a => a => Order): List a => List a =
     def loop tree = match _
-        Nil = Nil
-        x, tail =
+        Nil -> Nil
+        x, tail ->
             def sub = loop (tinsert x tree) tail
 
             if x ∈ tree then
@@ -750,10 +750,10 @@ export def distinctRunBy (eqFn: a => a => Boolean): List a => List a =
 # ```
 export def cmp (cmpFn: a => b => Order): (l: List a) => (r: List b) => Order =
     def loop = match _ _
-        Nil Nil = EQ
-        Nil _ = LT
-        _ Nil = GT
-        (lh, lt) (rh, rt) =
+        Nil Nil -> EQ
+        Nil _ -> LT
+        _ Nil -> GT
+        (lh, lt) (rh, rt) ->
             require EQ = cmpFn lh rh
 
             loop lt rt
@@ -801,9 +801,9 @@ export def seq: Integer => List Integer =
 #   zip x Nil = Nil
 # ```
 export def zip (a: List a) (b: List b): List (Pair a b) = match a b
-    Nil _ = Nil
-    _ Nil = Nil
-    (lh, lt) (rh, rt) = Pair lh rh, zip lt rt
+    Nil _ -> Nil
+    _ Nil -> Nil
+    (lh, lt) (rh, rt) -> Pair lh rh, zip lt rt
 
 # Turn a List of Pairs into a Pair of Lists
 #
@@ -818,8 +818,8 @@ export def zip (a: List a) (b: List b): List (Pair a b) = match a b
 #   unzip Nil = Pair Nil Nil
 # ```
 export def unzip (list: List (Pair a b)): Pair (List a) (List b) = match list
-    Nil = Pair Nil Nil
-    Pair a b, t =
+    Nil -> Pair Nil Nil
+    Pair a b, t ->
         def Pair u v = unzip t
 
         Pair (a, u) (b, v)
@@ -845,7 +845,7 @@ export def groupBy (cmpFn: a => a => Order) (list: List a): List (List a) =
     def sorted = sortBy cmpFn list
 
     def combo elem acc = match acc
-        (head, rest), tail if !(cmpFn elem head | isLT) = (elem, head, rest), tail
-        _ = (elem, Nil), acc
+        (head, rest), tail if !(cmpFn elem head | isLT) -> (elem, head, rest), tail
+        _ -> (elem, Nil), acc
 
     foldr combo Nil sorted

--- a/share/wake/lib/core/map.wake
+++ b/share/wake/lib/core/map.wake
@@ -252,9 +252,9 @@ export def mmap (fn: k => v => w) (map: Map k v): Map k w =
         def Tree _ root = tree
 
         def helper = match _
-            Tip = Tip
+            Tip -> Tip
             # join3 and similar aren't required since the keys haven't changed.
-            Bin i l (Pair x y) r = Bin i (helper l) (Pair x (fn x y)) (helper r)
+            Bin i l (Pair x y) r -> Bin i (helper l) (Pair x (fn x y)) (helper r)
 
         helper root
         | Tree (makeCmpPair map.getMapComparison)
@@ -271,8 +271,8 @@ export def mmapPass (fn: k => v => Result w e) (map: Map k v): Result (Map k w) 
     def Tree _ root = map.getMapData
 
     def helper = match _
-        Tip = Pass Tip
-        Bin i l (Pair x y) r =
+        Tip -> Pass Tip
+        Bin i l (Pair x y) r ->
             def lResult = helper l
             def wResult = fn x y
             def rResult = helper r
@@ -392,10 +392,10 @@ export def mupperLE (key: k) (map: Map k v): Option (Pair k v) =
 #   listToMap scmp ("a" → 1, "b" → 2, Nil) | mdelete "b" | mlookup "b" = None
 #   ```
 export def mlookup (key: k) (map: Map k v): Option v = match (mupperLE key map)
-    None = None
-    (Some (Pair l v)) = match (map.getMapComparison l key)
-        EQ = Some v
-        _ = None
+    None -> None
+    (Some (Pair l v)) -> match (map.getMapComparison l key)
+        EQ -> Some v
+        _ -> None
 
 # Check whether some key is associated with any value in the map.
 #

--- a/share/wake/lib/core/option.wake
+++ b/share/wake/lib/core/option.wake
@@ -27,8 +27,8 @@ export data Option a =
 #   isSome (Some "x") = True
 #   isSome None       = False
 export def isSome: Option a => Boolean = match _
-    Some _ = True
-    None = False
+    Some _ -> True
+    None -> False
 
 # isNone: Report if an Option has no value.
 # If you find yourself using the function, consider using a match instead.
@@ -37,8 +37,8 @@ export def isSome: Option a => Boolean = match _
 #   isNone (Some "x") = False
 #   isNone None       = True
 export def isNone: Option a => Boolean = match _
-    Some _ = False
-    None = True
+    Some _ -> False
+    None -> True
 
 # getOrElse: extract the value from an Option, with a supplied default if None.
 # The default value expression is evaluated whether or not the Option is None.
@@ -48,8 +48,8 @@ export def isNone: Option a => Boolean = match _
 #   ---
 #   5
 export def getOrElse (default: a): Option a => a = match _
-    Some x = x
-    None = default
+    Some x -> x
+    None -> default
 
 # getOrElse: extract the value from an Option, with a supplied default function if None.
 # The default value function is evaluated only when the Option is None.
@@ -59,8 +59,8 @@ export def getOrElse (default: a): Option a => a = match _
 #   ---
 #   567
 export def getOrElseFn (fn: Unit => a): Option a => a = match _
-    Some a = a
-    None = fn Unit
+    Some a -> a
+    None -> fn Unit
 
 # orElse: combine two Options, using the first value found, if any.
 #
@@ -70,8 +70,8 @@ export def getOrElseFn (fn: Unit => a): Option a => a = match _
 #   ---
 #   Some 343
 export def orElse (alternate: Option a): Option a => Option a = match _
-    Some a = Some a
-    None = alternate
+    Some a -> Some a
+    None -> alternate
 
 # omap: apply function `f` to the optional contents
 # If you find yourself using the function with getOrElse, consider using a match instead.
@@ -79,8 +79,8 @@ export def orElse (alternate: Option a): Option a => Option a = match _
 #   omap (_+1) (Some 4) = Some 5
 #   omap (_+1) None     = None
 export def omap (f: a => b): Option a => Option b = match _
-    Some a = Some (f a)
-    None = None
+    Some a -> Some (f a)
+    None -> None
 
 # omapPartial: apply partial function 'f' to the optional contents
 # A partial function returns Option; only Some cases result in a value.
@@ -95,8 +95,8 @@ export def omap (f: a => b): Option a => Option b = match _
 #   omapPartial divideEven (Some 8) = Some 4
 #   omapPartial divideEven (Some 7) = None
 export def omapPartial (f: a => Option b): Option a => Option b = match _
-    Some a = f a
-    None = None
+    Some a -> f a
+    None -> None
 
 # ofilter: remove the contents of an option when `f` returns False.
 #
@@ -106,8 +106,8 @@ export def omapPartial (f: a => Option b): Option a => Option b = match _
 #   ofilter isEven (Some 7) = None
 #   ofilter isEven (Some 8) = Some 8
 export def ofilter (f: a => Boolean): Option a => Option a = match _
-    Some a if f a = Some a
-    _ = None
+    Some a if f a -> Some a
+    _ -> None
 
 # findSome: return the first Some in a List or else None
 #
@@ -125,8 +125,8 @@ export def findSome: List (Option a) => Option a =
 #   findSomeFn int ("abc", "_56", "zz", "_23", Nil) = None
 export def findSomeFn (fn: a => Option b): List a => Option b =
     def loop = match _
-        Nil = None
-        h, t =
+        Nil -> None
+        h, t ->
             require None = fn h
 
             loop t
@@ -149,8 +149,8 @@ export def findNone: List (Option a) => Option (List a) =
 #   findNoneFn int ("_56", "123", Nil) = None
 export def findNoneFn (fn: a => Option b): List a => Option (List b) =
     def loop = match _
-        Nil = Some Nil
-        h, t =
+        Nil -> Some Nil
+        h, t ->
             require Some x = fn h
             require Some t = loop t
 
@@ -188,8 +188,8 @@ export def getOrFail (failVal: fail): Option pass => Result pass fail =
 #   ---
 #   Pass 81234
 export def getOrFailFn (failFn: Unit => fail): Option pass => Result pass fail = match _
-    Some a = Pass a
-    None = Fail (failFn Unit)
+    Some a -> Pass a
+    None -> Fail (failFn Unit)
 
 # getOrPass: Convert Some to Fail and None to a Pass with the supplied value.
 # The fail expression is evaluated even when the Option is None.
@@ -219,5 +219,5 @@ export def getOrPass (passVal: pass): Option fail => Result pass fail =
 #   ---
 #   Fail 81234
 export def getOrPassFn (passFn: Unit => pass): Option fail => Result pass fail = match _
-    None = Pass (passFn Unit)
-    Some f = Fail f
+    None -> Pass (passFn Unit)
+    Some f -> Fail f

--- a/share/wake/lib/core/order.wake
+++ b/share/wake/lib/core/order.wake
@@ -31,8 +31,8 @@ export data Order =
 # isLT EQ = False
 # isLT GT = False
 export def isLT: Order => Boolean = match _
-    LT = True
-    _ = False
+    LT -> True
+    _ -> False
 
 # Is equal: convert Order Boolean
 # def a == b = a <=> b | isEQ
@@ -40,8 +40,8 @@ export def isLT: Order => Boolean = match _
 # isEQ EQ = True
 # isEQ GT = False
 export def isEQ: Order => Boolean = match _
-    EQ = True
-    _ = False
+    EQ -> True
+    _ -> False
 
 # Is greater-than: convert Order to Boolean
 # def a > b = a <=> b | isGT
@@ -49,8 +49,8 @@ export def isEQ: Order => Boolean = match _
 # isGT EQ = False
 # isGT GT = True
 export def isGT: Order => Boolean = match _
-    GT = True
-    _ = False
+    GT -> True
+    _ -> False
 
 # Is less-than-or-equal: convert Order to Boolean
 # def a <= b = a <=> b | isLE
@@ -58,8 +58,8 @@ export def isGT: Order => Boolean = match _
 # isLE EQ = True
 # isLE GT = False
 export def isLE: Order => Boolean = match _
-    GT = False
-    _ = True
+    GT -> False
+    _ -> True
 
 # Is not-equal: convert Order to Boolean
 # def a != b = a <=> b | isNE
@@ -67,8 +67,8 @@ export def isLE: Order => Boolean = match _
 # isEQ EQ = False
 # isEQ GT = True
 export def isNE: Order => Boolean = match _
-    EQ = False
-    _ = True
+    EQ -> False
+    _ -> True
 
 # Is greater-than-or-equal: convert Order to Boolean
 # def a >= b = a <=> b | isGE
@@ -76,5 +76,5 @@ export def isNE: Order => Boolean = match _
 # isGE EQ = True
 # isGE GT = True
 export def isGE: Order => Boolean = match _
-    LT = False
-    _ = True
+    LT -> False
+    _ -> True

--- a/share/wake/lib/core/regexp.wake
+++ b/share/wake/lib/core/regexp.wake
@@ -24,8 +24,8 @@ export def quote (str: String): RegExp =
     def res str = prim "quote"
 
     match (res str).stringToRegExp
-        Pass x = x
-        Fail error = unreachable "quote primitive bug: {error.getErrorCause}"
+        Pass x -> x
+        Fail error -> unreachable "quote primitive bug: {error.getErrorCause}"
 
 # Concatenate a list of regular expressions.
 # The resulting regular expression must match the elements sequentially.
@@ -39,8 +39,8 @@ export def regExpCat (l: List RegExp): RegExp =
         | stringToRegExp
 
     match res
-        Pass regex = regex
-        Fail error = unreachable "regexp parser bug post concatenation: {error.getErrorCause}"
+        Pass regex -> regex
+        Fail error -> unreachable "regexp parser bug post concatenation: {error.getErrorCause}"
 
 # Convert a String into a Regular expression.
 # If the string is an illegal RegExp, returns Fail.
@@ -50,8 +50,8 @@ export def stringToRegExp (str: String): Result RegExp Error =
     def p s = prim "re2"
 
     match (p str)
-        Pass r = Pass r
-        Fail e = failWithError e
+        Pass r -> Pass r
+        Fail e -> failWithError e
 
 # Convert a String glob-style expression into a RegExp.
 # A glob expression has:
@@ -65,8 +65,8 @@ export def globToRegExp (glob: String): RegExp =
     def glob2regexp glob = prim "glob2regexp"
 
     match (glob2regexp glob).stringToRegExp
-        Pass x = x
-        Fail error = unreachable "glob primitive bug: {error.getErrorCause}"
+        Pass x -> x
+        Fail error -> unreachable "glob primitive bug: {error.getErrorCause}"
 
 # Convert a regular expression into a String.
 # stringToRegExp (regExpToString x) = Pass x

--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -43,48 +43,48 @@ export data Result pass fail =
 #   isPass (Pass 123) = True
 #   isPass (Fail 123) = False
 export def isPass: Result a b => Boolean = match _
-    Pass _ = True
-    Fail _ = False
+    Pass _ -> True
+    Fail _ -> False
 
 # isFail: report if the Result was a Fail
 #
 #   isFail (Pass 123) = False
 #   isFail (Fail 123) = True
 export def isFail: Result a b => Boolean = match _
-    Pass _ = False
-    Fail _ = True
+    Pass _ -> False
+    Fail _ -> True
 
 # getPass: retrieve the Pass value else None
 #
 #   getPass (Pass 123) = Some 123
 #   getPass (Fail 123) = None
 export def getPass: Result a b => Option a = match _
-    Pass x = Some x
-    Fail _ = None
+    Pass x -> Some x
+    Fail _ -> None
 
 # getFail: retrieve the Fail value else None
 #
 #   getFail (Pass 123) = None
 #   getFail (Fail 123) = Some 123
 export def getFail: Result a b => Option b = match _
-    Pass _ = None
-    Fail x = Some x
+    Pass _ -> None
+    Fail x -> Some x
 
 # getWhenFail: retrieve the Pass value, using a default value for Fail
 #
 #   getWhenFail 42 (Pass 123) = 123
 #   getWhenFail 42 (Pass 123) = 42
 export def getWhenFail (default: pass): Result pass fail => pass = match _
-    Pass a = a
-    Fail _ = default
+    Pass a -> a
+    Fail _ -> default
 
 # getWhenPass: retrieve the Fail value, using a default value for Pass
 #
 #   getWhenPass 42 (Pass 123) = 42
 #   getWhenPass 42 (Pass 123) = 123
 export def getWhenPass (default: fail): Result pass fail => fail = match _
-    Pass _ = default
-    Fail f = f
+    Pass _ -> default
+    Fail f -> f
 
 # rmap: apply a function to a Pass-ing result
 # If you find yourself using the function, consider using require instead.
@@ -92,20 +92,20 @@ export def getWhenPass (default: fail): Result pass fail => fail = match _
 #   rmap (_+1) (Pass 123) = Pass 124
 #   rmap (_+1) (Fail 123) = Fail 123
 export def rmap (fn: a => b): Result a fail => Result b fail = match _
-    Pass a = Pass (fn a)
-    Fail f = Fail f
+    Pass a -> Pass (fn a)
+    Fail f -> Fail f
 
 # rmapPass: apply a Fail-able function to a Pass-ing result
 # If you find yourself using the function, consider using require instead.
 export def rmapPass (fn: a => Result b fail): Result a fail => Result b fail = match _
-    Pass a = fn a
-    Fail f = Fail f
+    Pass a -> fn a
+    Fail f -> Fail f
 
 # Applies a Fail-able function to Fail value or propogates Pass
 # If you find yourself using the function, consider using require instead.
 export def rmapFail (fn: a => Result pass b): Result pass a => Result pass b = match _
-    Pass a = Pass a
-    Fail f = fn f
+    Pass a -> Pass a
+    Fail f -> fn f
 
 # Try to combine the elements of a `List` front-to-back, where each step might fail.
 # If any update step fails, the error value of the first such failure is
@@ -118,8 +118,8 @@ export def rmapFail (fn: a => Result pass b): Result pass a => Result pass b = m
 #  - `list`: The elements which should be combined.
 export def rfoldl (combiningFn: accumulator => element => Result accumulator error): (acc: accumulator) => (list: List element) => Result accumulator error =
     def loop acc = match _
-        Nil = Pass acc
-        element, rest =
+        Nil -> Pass acc
+        element, rest ->
             require Pass result = combiningFn acc element
 
             loop result rest
@@ -137,8 +137,8 @@ export def rfoldl (combiningFn: accumulator => element => Result accumulator err
 #  - `list`: The elements which should be combined.
 export def rfoldr (combiningFn: element => accumulator => Result accumulator error): (acc: accumulator) => (list: List element) => Result accumulator error =
     def loop acc = match _
-        Nil = Pass acc
-        element, rest =
+        Nil -> Pass acc
+        element, rest ->
             require Pass result = loop acc rest
 
             combiningFn element result
@@ -162,8 +162,8 @@ export def findFail: List (Result a b) => Result (List a) b =
 #   findFailFn toInt ("_56", "123", Nil) = Fail "not an Integer (_56)"
 export def findFailFn (fn: a => Result b fail): List a => Result (List b) fail =
     def helper = match _
-        Nil = Pass Nil
-        h, t =
+        Nil -> Pass Nil
+        h, t ->
             require Pass x = fn h
             require Pass tt = helper t
 
@@ -188,8 +188,8 @@ export def findPass: List (Result a b) => Result a (List b) =
 #   findPassFn toInt ("_56", "_23", "_77", Nil) = Fail ("bad: _56", "bad: _23", "bad: _77", Nil)
 export def findPassFn (fn: a => Result pass b): List a => Result pass (List b) =
     def helper = match _
-        Nil = Fail Nil
-        h, t =
+        Nil -> Fail Nil
+        h, t ->
             require Fail x = fn h
             require Fail tt = helper t
 
@@ -223,8 +223,8 @@ export def makeError (cause: String): Error =
 #     read file
 #     | addErrorContext "opening {file.getPathName}"
 export def addErrorContext (prefix: String): Result a Error => Result a Error = match _
-    Pass x = Pass x
-    Fail (Error cause stack) = Fail (Error "{prefix}: {cause}" stack)
+    Pass x -> Pass x
+    Fail (Error cause stack) -> Fail (Error "{prefix}: {cause}" stack)
 
 # failWithError: produce a Fail for us in error conditions
 #

--- a/share/wake/lib/core/syntax.wake
+++ b/share/wake/lib/core/syntax.wake
@@ -54,8 +54,8 @@ export def wait (f: a => b) (x: a): b =
     def imp x = prim "true"
 
     match (imp x)
-        True = f x
-        False = unreachable "true returned false"
+        True -> f x
+        False -> unreachable "true returned false"
 
 # Tell the wake interpreter that it is impossible to reach this expression.
 # The behaviour of an execution which DOES reach `unreachable` is undefined.

--- a/share/wake/lib/core/tree.wake
+++ b/share/wake/lib/core/tree.wake
@@ -57,9 +57,9 @@ export def vectorToTree cmp v =
     Tree cmp (build (vdistinctRunBy (cmp _ _ | isEQ) (vsortBy cmp v)))
 
 def build v = match (vlen v)
-    0 = Tip
-    1 = Bin 1 Tip (vat_ 0 v) Tip
-    len =
+    0 -> Tip
+    1 -> Bin 1 Tip (vat_ 0 v) Tip
+    len ->
         def mid = len >> 1
         def l = vtake mid v
         def r = vdrop (mid + 1) v
@@ -71,22 +71,22 @@ export def tlen (Tree _ root: Tree a): Integer =
     size root
 
 def size = match _
-    Tip = 0
-    Bin s _ _ _ = s
+    Tip -> 0
+    Bin s _ _ _ -> s
 
 # Returns True if the Tree is empty, False otherwise.
 export def tempty (Tree _ root: Tree a): Boolean = match root
-    Tip = True
-    _ = False
+    Tip -> True
+    _ -> False
 
 # Insert y into the tree only if no other keys == y
 export def tinsert (y: a) (Tree cmp root: Tree a): Tree a =
     def helper t = match t
-        Tip = Bin 1 Tip y Tip
-        Bin _ l x r = match (cmp x y)
-            GT = balanceL (helper l) x r
-            EQ = t
-            LT = balanceR l x (helper r)
+        Tip -> Bin 1 Tip y Tip
+        Bin _ l x r -> match (cmp x y)
+            GT -> balanceL (helper l) x r
+            EQ -> t
+            LT -> balanceR l x (helper r)
 
     Tree cmp (helper root)
 
@@ -95,21 +95,21 @@ export def tinsertReplace (y: a) (tree: Tree a): Tree a =
     def Tree cmp root = tree
 
     def helper t = match t
-        Tip = Bin 1 Tip y Tip
-        Bin _ l x r = match (cmp x y)
-            GT = join3 (helper l) x r
-            EQ = join3 (delete cmp y l) y (delete cmp y r)
-            LT = join3 l x (helper r)
+        Tip -> Bin 1 Tip y Tip
+        Bin _ l x r -> match (cmp x y)
+            GT -> join3 (helper l) x r
+            EQ -> join3 (delete cmp y l) y (delete cmp y r)
+            LT -> join3 l x (helper r)
 
     Tree cmp (helper root)
 
 # Insert y into the tree at the lowest rank of keys = y
 export def tinsertMulti (y: a) (Tree cmp root: Tree a): Tree a =
     def helper = match _
-        Tip = Bin 1 Tip y Tip
-        Bin _ l x r = match (cmp x y)
-            GT = balanceL (helper l) x r
-            _ = balanceR l x (helper r)
+        Tip -> Bin 1 Tip y Tip
+        Bin _ l x r -> match (cmp x y)
+            GT -> balanceL (helper l) x r
+            _ -> balanceR l x (helper r)
 
     Tree cmp (helper root)
 
@@ -119,11 +119,11 @@ export def tinsertWith (fn: (incoming: a) => (existing: a) => a) (y: a) (tree: T
     def Tree cmp root = tree
 
     def helper = match _
-        Tip = Bin 1 Tip y Tip
-        Bin _ l x r = match (cmp x y)
-            GT = join3 (helper l) x r
-            LT = join3 l x (helper r)
-            EQ =
+        Tip -> Bin 1 Tip y Tip
+        Bin _ l x r -> match (cmp x y)
+            GT -> join3 (helper l) x r
+            LT -> join3 l x (helper r)
+            EQ ->
                 # Get all other values equal to y, while maintaining the order
                 # in which they occur.
                 def Triple lm le lg = split y cmp l
@@ -195,9 +195,9 @@ export def tsubset (a: Tree x) (b: Tree x): Boolean =
 # syntax is introduced to ensure that that behaviour is at least consistent.
 def tsubsetCmp (aroot: TreeNode x) (broot: TreeNode x) (cmp: x => x => Order): Boolean =
     def helper a b = match a b
-        Tip _ = True
-        _ Tip = False
-        _ (Bin _ bl bx br) =
+        Tip _ -> True
+        _ Tip -> False
+        _ (Bin _ bl bx br) ->
             def Triple al _ ag = split bx cmp a
 
             helper al bl && helper ag br
@@ -210,27 +210,27 @@ export def tdelete (y: a) (Tree cmp root: Tree a): Tree a =
 
 def delete cmp y t =
     def helper = match _
-        Tip = Tip
-        Bin _ l x r = match (cmp x y)
-            GT = join3 (helper l) x r
-            EQ = join2 (helper l) (helper r)
-            LT = join3 l x (helper r)
+        Tip -> Tip
+        Bin _ l x r -> match (cmp x y)
+            GT -> join3 (helper l) x r
+            EQ -> join2 (helper l) (helper r)
+            LT -> join3 l x (helper r)
 
     helper t
 
 # Folds from left to right.
 export def tfoldl f a (Tree _ root) =
     def helper a = match _
-        Tip = a
-        Bin _ l x r = helper (f (helper a l) x) r
+        Tip -> a
+        Bin _ l x r -> helper (f (helper a l) x) r
 
     helper a root
 
 # Folds from right to left.
 export def tfoldr f a (Tree _ root) =
     def helper a = match _
-        Tip = a
-        Bin _ l x r = helper (f x (helper a r)) l
+        Tip -> a
+        Bin _ l x r -> helper (f x (helper a r)) l
 
     helper a root
 
@@ -248,8 +248,8 @@ export def tfoldmap (combineFn: b => b => b) (base: b) (transformFn: a => b) (tr
     def Tree _ root = tree
 
     def helper a = match _
-        Tip = a
-        Bin _ l x r = combineFn (helper a l) (helper (transformFn x) r)
+        Tip -> a
+        Bin _ l x r -> combineFn (helper a l) (helper (transformFn x) r)
 
     helper base root
 
@@ -262,8 +262,8 @@ export def treeToList =
 
 export def tappi f (Tree _ root) =
     def helper i = match _
-        Tip = Unit
-        Bin _ l x r =
+        Tip -> Unit
+        Bin _ l x r ->
             def ix = i + size l
             def _ = helper i l
             def _ = helper (ix + 1) r
@@ -276,32 +276,32 @@ export def tappi f (Tree _ root) =
 # Extract the i-th ranked element
 export def tat (i: Integer) (Tree _ root: Tree a): Option a =
     def helper i = match _
-        Tip = None
-        Bin _ l x r =
+        Tip -> None
+        Bin _ l x r ->
             def sizeL = size l
 
             match (icmp i sizeL)
-                LT = helper i l
-                EQ = Some x
-                GT = helper (i - sizeL - 1) r
+                LT -> helper i l
+                EQ -> Some x
+                GT -> helper (i - sizeL - 1) r
 
     helper i root
 
 # Split elements ranked [0,i) and [i,inf) into two trees
 export def tsplitAt (i: Integer) (Tree cmp root: Tree a): Pair (Tree a) (Tree a) =
     def helper i = match _
-        Tip = Pair Tip Tip
-        Bin _ l x r =
+        Tip -> Pair Tip Tip
+        Bin _ l x r ->
             def sizeL = size l
 
             if i > sizeL then
                 match (helper (i - sizeL - 1) r)
-                    Pair rl rr = Pair (join3 l x rl) rr
+                    Pair rl rr -> Pair (join3 l x rl) rr
             else match (helper i l)
-                Pair ll lr = Pair ll (join3 lr x r)
+                Pair ll lr -> Pair ll (join3 lr x r)
 
     match (helper i root)
-        Pair l r = Pair (Tree cmp l) (Tree cmp r)
+        Pair l r -> Pair (Tree cmp l) (Tree cmp r)
 
 export def ttake i t =
     tsplitAt i t
@@ -314,19 +314,19 @@ export def tdrop i t =
 # Lowest rank element where f x = True  => Option (Pair x rank)
 export def tfind f (Tree _ root) =
     def helper = match _
-        Tip = None
-        Bin s l x r = match (helper l) (f x) (helper r)
-            (Some p) _ _ = Some p
-            _ True _ = Some (Pair x (s - size r - 1))
-            _ _ (Some (Pair x i)) = Some (Pair x (i + size l + 1))
-            _ _ _ = None
+        Tip -> None
+        Bin s l x r -> match (helper l) (f x) (helper r)
+            (Some p) _ _ -> Some p
+            _ True _ -> Some (Pair x (s - size r - 1))
+            _ _ (Some (Pair x i)) -> Some (Pair x (i + size l + 1))
+            _ _ _ -> None
 
     helper root
 
 export def tsplitUntil f t = match (tfind f t)
-    None = match t
-        (Tree cmp _) = Pair t (Tree cmp Tip)
-    Some (Pair _ i) = tsplitAt i t
+    None -> match t
+        (Tree cmp _) -> Pair t (Tree cmp Tip)
+    Some (Pair _ i) -> tsplitAt i t
 
 export def ttakeUntil f t =
     tsplitUntil f t
@@ -338,64 +338,64 @@ export def tdropUntil f t =
 
 # Returns True if there exists an x in t where f x = True
 export def texists f t = match (tfind f t)
-    Some _ = True
-    None = False
+    Some _ -> True
+    None -> False
 
 export def tforall f t =
     ! texists (! f _) t
 
 # Split tree into those elements <, =, and > y
 export def tsplit y (Tree cmp root) = match (split y cmp root)
-    Triple l e g = Triple (Tree cmp l) (Tree cmp e) (Tree cmp g)
+    Triple l e g -> Triple (Tree cmp l) (Tree cmp e) (Tree cmp g)
 
 def split y cmp root =
     def helper = match _
-        Tip = Triple Tip Tip Tip
-        Bin _ l x r = match (cmp x y)
-            LT = match (helper r)
-                Triple rl re rg = Triple (join3 l x rl) re rg
-            GT = match (helper l)
-                Triple ll le lg = Triple ll le (join3 lg x r)
-            EQ = match (splitlt l) (splitgt r)
-                (Pair ll le) (Pair re rg) = Triple ll (join3 le x re) rg
+        Tip -> Triple Tip Tip Tip
+        Bin _ l x r -> match (cmp x y)
+            LT -> match (helper r)
+                Triple rl re rg -> Triple (join3 l x rl) re rg
+            GT -> match (helper l)
+                Triple ll le lg -> Triple ll le (join3 lg x r)
+            EQ -> match (splitlt l) (splitgt r)
+                (Pair ll le) (Pair re rg) -> Triple ll (join3 le x re) rg
 
     def splitlt = match _
-        Tip = Pair Tip Tip
-        Bin _ l x r = match (cmp x y)
-            LT = match (splitlt r)
-                Pair rl re = Pair (join3 l x rl) re
-            _ = match (splitlt l)
-                Pair ll le = Pair ll (join3 le x r)
+        Tip -> Pair Tip Tip
+        Bin _ l x r -> match (cmp x y)
+            LT -> match (splitlt r)
+                Pair rl re -> Pair (join3 l x rl) re
+            _ -> match (splitlt l)
+                Pair ll le -> Pair ll (join3 le x r)
 
     def splitgt = match _
-        Tip = Pair Tip Tip
-        Bin _ l x r = match (cmp x y)
-            GT = match (splitgt l)
-                Pair le lg = Pair le (join3 lg x r)
-            _ = match (splitgt r)
-                Pair re rg = Pair (join3 l x re) rg
+        Tip -> Pair Tip Tip
+        Bin _ l x r -> match (cmp x y)
+            GT -> match (splitgt l)
+                Pair le lg -> Pair le (join3 lg x r)
+            _ -> match (splitgt r)
+                Pair re rg -> Pair (join3 l x re) rg
 
     helper root
 
 # Split tree into those elements where f x = True and those where f x = False
 export def tsplitBy (f: a => Boolean) (Tree cmp root: Tree a): Pair (Tree a) (Tree a) =
     def helper t = match t
-        Tip = Pair Tip Tip
-        Bin _ l x r = match (helper l) (helper r)
-            (Pair tl fl) (Pair tr fr) =
+        Tip -> Pair Tip Tip
+        Bin _ l x r -> match (helper l) (helper r)
+            (Pair tl fl) (Pair tr fr) ->
                 if f x then
                     Pair (join3 tl x tr) (join2 fl fr)
                 else
                     Pair (join2 tl tr) (join3 fl x fr)
 
     match (helper root)
-        Pair t f = Pair (Tree cmp t) (Tree cmp f)
+        Pair t f -> Pair (Tree cmp t) (Tree cmp f)
 
 # Remove all elements x such that f x = False.
 export def tfilter (f: a => Boolean) (Tree cmp root: Tree a): Tree a =
     def helper t = match t
-        Tip = Tip
-        Bin _ l x r =
+        Tip -> Tip
+        Bin _ l x r ->
             def l_ = helper l
             def r_ = helper r
 
@@ -412,12 +412,12 @@ export def tmin (Tree _ root: Tree a): Option a =
 
 def min_ root =
     def none = match _
-        Tip = None
-        Bin _ l x _ = some x l
+        Tip -> None
+        Bin _ l x _ -> some x l
 
     def some x = match _
-        Tip = Some x
-        Bin _ l y _ = some y l
+        Tip -> Some x
+        Bin _ l y _ -> some y l
 
     none root
 
@@ -427,52 +427,52 @@ export def tmax (Tree _ root: Tree a): Option a =
 
 def max_ root =
     def none = match _
-        Tip = None
-        Bin _ _ x r = some x r
+        Tip -> None
+        Bin _ _ x r -> some x r
 
     def some x = match _
-        Tip = Some x
-        Bin _ _ y r = some y r
+        Tip -> Some x
+        Bin _ _ y r -> some y r
 
     none root
 
 # Lowest rank element with x >= y, along with that rank.
 export def tlowerGE (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
     def f x = match (cmp x y)
-        LT = False
-        _ = True
+        LT -> False
+        _ -> True
 
     lower f root
 
 # Lowest rank element with x > y, along with that rank.
 export def tlowerGT (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
     def f x = match (cmp x y)
-        GT = True
-        _ = False
+        GT -> True
+        _ -> False
 
     lower f root
 
 # Lowest rank element f x = True   => Option (Pair x rank)
 def lower f root =
     def none = match _
-        Tip = None
-        Bin s l x r =
+        Tip -> None
+        Bin s l x r ->
             if f x then
                 someL x (size root - s) l
             else
                 none r
 
     def someR z i = match _ # i = size including self
-        Tip = Some (Pair z i)
-        Bin s l x r =
+        Tip -> Some (Pair z i)
+        Bin s l x r ->
             if f x then
                 someL x (i - s) l
             else
                 someR z i r
 
     def someL z i = match _ # i = size left of self
-        Tip = Some (Pair z i)
-        Bin s l x r =
+        Tip -> Some (Pair z i)
+        Bin s l x r ->
             if f x then
                 someL x i l
             else
@@ -483,40 +483,40 @@ def lower f root =
 # Highest rank element with x < y, along with that rank.
 export def tupperLT (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
     def f x = match (cmp x y)
-        LT = False
-        _ = True
+        LT -> False
+        _ -> True
 
     upper f root
 
 # Highest rank element with x <= y, along with that rank.
 export def tupperLE (y: a) (Tree cmp root: Tree a): Option (Pair a Integer) =
     def f x = match (cmp x y)
-        GT = True
-        _ = False
+        GT -> True
+        _ -> False
 
     upper f root
 
 # Highest rank element with f x = False  => Option (Pair x rank)
 def upper f root =
     def none = match _
-        Tip = None
-        Bin s l x r =
+        Tip -> None
+        Bin s l x r ->
             if f x then
                 none l
             else
                 someR x s r
 
     def someR z i = match _ # i = size including self
-        Tip = Some (Pair z (i - 1))
-        Bin s l x r =
+        Tip -> Some (Pair z (i - 1))
+        Bin s l x r ->
             if f x then
                 someL z (i - s) l
             else
                 someR x i r
 
     def someL z i = match _ # i = size left of self
-        Tip = Some (Pair z (i - 1))
-        Bin s l x r =
+        Tip -> Some (Pair z (i - 1))
+        Bin s l x r ->
             if f x then
                 someL z i l
             else
@@ -528,18 +528,18 @@ def upper f root =
 # => Pair (matches: List x) (rank: Integer)
 export def tequal y (Tree cmp root) =
     def helperR i out = match _ # i = size including self
-        Tip = Pair out i
-        Bin s l x r = match (cmp x y)
-            LT = helperR i out r
-            GT = helperL (i - s) out l
-            EQ = helperL (i - s) (x, helperR i out r | getPairFirst) l
+        Tip -> Pair out i
+        Bin s l x r -> match (cmp x y)
+            LT -> helperR i out r
+            GT -> helperL (i - s) out l
+            EQ -> helperL (i - s) (x, helperR i out r | getPairFirst) l
 
     def helperL i out = match _ # i = size left of self
-        Tip = Pair out i
-        Bin s l x r = match (cmp x y)
-            LT = helperR (i + s) out r
-            GT = helperL i out l
-            EQ = helperL i (x, helperR (i + s) out r | getPairFirst) l
+        Tip -> Pair out i
+        Bin s l x r -> match (cmp x y)
+            LT -> helperR (i + s) out r
+            GT -> helperL i out l
+            EQ -> helperL i (x, helperR (i + s) out r | getPairFirst) l
 
     helperL 0 Nil root
 
@@ -560,18 +560,18 @@ export def x ∌ y =
     y ∉ x
 
 export def tcontains (y: a) (t: Tree a): Boolean = match t (tupperLE y t)
-    (Tree _ _) None = False
-    (Tree cmp _) (Some (Pair x _)) = match (cmp x y)
-        EQ = True
-        _ = False
+    (Tree _ _) None -> False
+    (Tree cmp _) (Some (Pair x _)) -> match (cmp x y)
+        EQ -> True
+        _ -> False
 
 # Eliminate duplicates, as identified by cmp
 export def tdistinctBy (cmp: a => a => Order) (t: Tree a): Tree a = match t
-    Tree tcmp _ = listToTree tcmp (distinctBy cmp (treeToList t))
+    Tree tcmp _ -> listToTree tcmp (distinctBy cmp (treeToList t))
 
 # Eliminate duplicates, as identified by f
 export def tdistinctRunBy (f: a => a => Boolean) (t: Tree a): Tree a = match t
-    Tree cmp _ = Tree cmp (build (vdistinctRunBy f (treeToVector t)))
+    Tree cmp _ -> Tree cmp (build (vdistinctRunBy f (treeToVector t)))
 
 # Returns the union of trees a and b, keeps only values from a if they are equal to values in b.
 export def a ∪ b =
@@ -583,10 +583,10 @@ export def tunion (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
 
 def union cmp aroot broot =
     def helper a b = match a b
-        Tip _ = b
-        _ Tip = a
-        (Bin _ al ax ar) _ = match (split ax cmp b)
-            Triple bl _ bg = join3 (helper al bl) ax (helper ar bg)
+        Tip _ -> b
+        _ Tip -> a
+        (Bin _ al ax ar) _ -> match (split ax cmp b)
+            Triple bl _ bg -> join3 (helper al bl) ax (helper ar bg)
 
     helper aroot broot
 
@@ -595,9 +595,9 @@ export def tunionWith (fn: a => a => a) (left: Tree a) (right: Tree a): Tree a =
     def Tree cmp rightRoot = right
 
     def unionWith a b = match a b
-        Tip _ = b
-        _ Tip = a
-        (Bin _ al ax ar) _ =
+        Tip _ -> b
+        _ Tip -> a
+        (Bin _ al ax ar) _ ->
             # Get all other values equal to ax (according to the right cmp
             # function), while maintaining the order in which they occur.
             def Triple all ale alg = split ax cmp al
@@ -628,10 +628,10 @@ export def tunionMulti (Tree _ aroot) (Tree cmp broot) =
 
 def unionMulti cmp aroot broot =
     def helper a b = match a b
-        Tip _ = b
-        _ Tip = a
-        (Bin _ _ ax _) _ = match (split ax cmp a) (split ax cmp b)
-            (Triple al ae ag) (Triple bl be bg) =
+        Tip _ -> b
+        _ Tip -> a
+        (Bin _ _ ax _) _ -> match (split ax cmp a) (split ax cmp b)
+            (Triple al ae ag) (Triple bl be bg) ->
                 def l = helper al bl
                 def r = helper ag bg
 
@@ -648,10 +648,10 @@ def unionMulti cmp aroot broot =
 # Returns the set difference of A and B, that is, a tree containing all elements of A which are not in B.
 export def tsubtract (Tree _ aroot: Tree a) (Tree cmp broot: Tree a): Tree a =
     def helper a b = match a b
-        Tip _ = Tip
-        _ Tip = a
-        _ (Bin _ bl bx br) = match (split bx cmp a)
-            Triple al _ ag = join2 (helper al bl) (helper ag br)
+        Tip _ -> Tip
+        _ Tip -> a
+        _ (Bin _ bl bx br) -> match (split bx cmp a)
+            Triple al _ ag -> join2 (helper al bl) (helper ag br)
 
     Tree cmp (helper aroot broot)
 
@@ -661,16 +661,16 @@ export def a ∩ b =
 
 export def tintersect (Tree _ aroot) (Tree cmp broot) =
     def helper a b = match a b
-        Tip _ = Tip
-        _ Tip = Tip
-        _ (Bin _ bl bx br) = match (split bx cmp a)
-            Triple al ae ag =
+        Tip _ -> Tip
+        _ Tip -> Tip
+        _ (Bin _ bl bx br) -> match (split bx cmp a)
+            Triple al ae ag ->
                 def l = helper al bl
                 def r = helper ag br
 
                 match ae
-                    Tip = join2 l r
-                    Bin aes _ aex _ =
+                    Tip -> join2 l r
+                    Bin aes _ aex _ ->
                         if aes == 1 then
                             join3 l aex r
                         else
@@ -683,9 +683,9 @@ export def tintersectWith (fn: a => a => a) (left: Tree a) (right: Tree a): Tree
     def Tree cmp rightRoot = right
 
     def intersectWith a b = match a b
-        Tip _ = Tip
-        _ Tip = Tip
-        _ (Bin _ bl bx br) =
+        Tip _ -> Tip
+        _ Tip -> Tip
+        _ (Bin _ bl bx br) ->
             # Get all other values equal to ax (according to the right cmp
             # function), while maintaining the order in which they occur.
             def Triple al ae ag = split bx cmp a
@@ -705,8 +705,8 @@ export def tintersectWith (fn: a => a => a) (left: Tree a) (right: Tree a): Tree
 
             match ae
                 # If nothing in a == bx, then cx was constructed only from b.
-                Tip = join2 l g
-                Bin _ _ _ _ = join3 l cx g
+                Tip -> join2 l g
+                Bin _ _ _ _ -> join3 l cx g
 
     Tree cmp (intersectWith leftRoot rightRoot)
 
@@ -723,9 +723,9 @@ export def tintersectWith (fn: a => a => a) (left: Tree a) (right: Tree a): Tree
 
 # Create a balanced tree with with order: l:Tree x:Element r:Tree
 def join3 l x r = match l r
-    Tip _ = insertMin x r
-    _ Tip = insertMax x l
-    (Bin ls ll lx lr) (Bin rs rl rx rr) =
+    Tip _ -> insertMin x r
+    _ Tip -> insertMax x l
+    (Bin ls ll lx lr) (Bin rs rl rx rr) ->
         if deltaQ * ls < deltaD * rs then
             balanceL (join3 l x rl) rx rr
         else if deltaQ * rs < deltaD * ls then
@@ -735,60 +735,60 @@ def join3 l x r = match l r
 
 # Create a balanced tree with with order: l:Tree r:Tree
 def join2 l r = match l
-    Tip = r
-    Bin _ ll lx lr = match (splitLast ll lx lr)
-        Pair l_ x_ = join3 l_ x_ r
+    Tip -> r
+    Bin _ ll lx lr -> match (splitLast ll lx lr)
+        Pair l_ x_ -> join3 l_ x_ r
 
 def splitLast l x r = match r
-    Tip = Pair l x
-    Bin _ rl rx rr = match (splitLast rl rx rr)
-        Pair l_ x_ = Pair (join3 l x l_) x_
+    Tip -> Pair l x
+    Bin _ rl rx rr -> match (splitLast rl rx rr)
+        Pair l_ x_ -> Pair (join3 l x l_) x_
 
 def insertMax x = match _
-    Tip = Bin 1 Tip x Tip
-    Bin _ l y r = balanceR l y (insertMax x r)
+    Tip -> Bin 1 Tip x Tip
+    Bin _ l y r -> balanceR l y (insertMax x r)
 
 def insertMin x = match _
-    Tip = Bin 1 Tip x Tip
-    Bin _ l y r = balanceL (insertMin x l) y r
+    Tip -> Bin 1 Tip x Tip
+    Bin _ l y r -> balanceL (insertMin x l) y r
 
 # Written while reading the Haskell Set implementation 
 def balanceL l x r = match l r
-    Tip Tip = Bin 1 Tip x Tip
-    (Bin ls ll lx lr) Tip = match ll lr
-        Tip Tip = Bin 2 l x Tip
-        ll Tip = Bin 3 ll lx (Bin 1 Tip x Tip)
-        Tip (Bin _ _ lrx _) = Bin 3 (Bin 1 Tip lx Tip) lrx (Bin 1 Tip x Tip)
-        (Bin lls _ _ _) (Bin lrs lrl lrx lrr) = match (ratioD * lrs < ratioQ * lls)
-            True = Bin (1 + ls) ll lx (Bin (1 + lrs) lr x Tip)
-            False =
+    Tip Tip -> Bin 1 Tip x Tip
+    (Bin ls ll lx lr) Tip -> match ll lr
+        Tip Tip -> Bin 2 l x Tip
+        ll Tip -> Bin 3 ll lx (Bin 1 Tip x Tip)
+        Tip (Bin _ _ lrx _) -> Bin 3 (Bin 1 Tip lx Tip) lrx (Bin 1 Tip x Tip)
+        (Bin lls _ _ _) (Bin lrs lrl lrx lrr) -> match (ratioD * lrs < ratioQ * lls)
+            True -> Bin (1 + ls) ll lx (Bin (1 + lrs) lr x Tip)
+            False ->
                 Bin (1 + ls) (Bin (1 + lls + size lrl) ll lx lrl) lrx (Bin (1 + size lrr) lrr x Tip)
-    Tip (Bin rs _ _ _) = Bin (1 + rs) Tip x r
-    (Bin ls ll lx lr) (Bin rs _ _ _) = match (ls * deltaD > deltaQ * rs)
-        True = match ll lr
-            (Bin lls _ _ _) (Bin lrs lrl lrx lrr) = match (ratioD * lrs < ratioQ * lls)
-                True = Bin (1 + ls + rs) ll lx (Bin (1 + rs + lrs) lr x r)
-                False =
+    Tip (Bin rs _ _ _) -> Bin (1 + rs) Tip x r
+    (Bin ls ll lx lr) (Bin rs _ _ _) -> match (ls * deltaD > deltaQ * rs)
+        True -> match ll lr
+            (Bin lls _ _ _) (Bin lrs lrl lrx lrr) -> match (ratioD * lrs < ratioQ * lls)
+                True -> Bin (1 + ls + rs) ll lx (Bin (1 + rs + lrs) lr x r)
+                False ->
                     Bin (1 + ls + rs) (Bin (1 + lls + size lrl) ll lx lrl) lrx (Bin (1 + rs + size lrr) lrr x r)
-            _ _ = unreachable "tree balance invariant violated in Tree.balanceL"
-        False = Bin (1 + ls + rs) l x r
+            _ _ -> unreachable "tree balance invariant violated in Tree.balanceL"
+        False -> Bin (1 + ls + rs) l x r
 
 def balanceR l x r = match l r
-    Tip Tip = Bin 1 Tip x Tip
-    Tip (Bin rs rl rx rr) = match rl rr
-        Tip Tip = Bin 2 Tip x r
-        Tip _ = Bin 3 (Bin 1 Tip x Tip) rx rr
-        (Bin _ _ rlx _) Tip = Bin 3 (Bin 1 Tip x Tip) rlx (Bin 1 Tip rx Tip)
-        (Bin rls rll rlx rlr) (Bin rrs _ _ _) = match (ratioD * rls < ratioQ * rrs)
-            True = Bin (1 + rs) (Bin (1 + rls) Tip x rl) rx rr
-            False =
+    Tip Tip -> Bin 1 Tip x Tip
+    Tip (Bin rs rl rx rr) -> match rl rr
+        Tip Tip -> Bin 2 Tip x r
+        Tip _ -> Bin 3 (Bin 1 Tip x Tip) rx rr
+        (Bin _ _ rlx _) Tip -> Bin 3 (Bin 1 Tip x Tip) rlx (Bin 1 Tip rx Tip)
+        (Bin rls rll rlx rlr) (Bin rrs _ _ _) -> match (ratioD * rls < ratioQ * rrs)
+            True -> Bin (1 + rs) (Bin (1 + rls) Tip x rl) rx rr
+            False ->
                 Bin (1 + rs) (Bin (1 + size rll) Tip x rll) rlx (Bin (1 + rrs + size rlr) rlr rx rr)
-    (Bin ls _ _ _) Tip = Bin (1 + ls) l x Tip
-    (Bin ls _ _ _) (Bin rs rl rx rr) = match (deltaD * rs > deltaQ * ls)
-        True = match rl rr
-            (Bin rls rll rlx rlr) (Bin rrs _ _ _) = match (ratioD * rls < ratioQ * rrs)
-                True = Bin (1 + ls + rs) (Bin (1 + ls + rls) l x rl) rx rr
-                False =
+    (Bin ls _ _ _) Tip -> Bin (1 + ls) l x Tip
+    (Bin ls _ _ _) (Bin rs rl rx rr) -> match (deltaD * rs > deltaQ * ls)
+        True -> match rl rr
+            (Bin rls rll rlx rlr) (Bin rrs _ _ _) -> match (ratioD * rls < ratioQ * rrs)
+                True -> Bin (1 + ls + rs) (Bin (1 + ls + rls) l x rl) rx rr
+                False ->
                     Bin (1 + ls + rs) (Bin (1 + ls + size rll) l x rll) rlx (Bin (1 + rrs + size rlr) rlr rx rr)
-            _ _ = unreachable "tree balance invariant violated in Tree.balanceR"
-        False = Bin (1 + ls + rs) l x r
+            _ _ -> unreachable "tree balance invariant violated in Tree.balanceR"
+        False -> Bin (1 + ls + rs) l x r

--- a/share/wake/lib/core/vector.wake
+++ b/share/wake/lib/core/vector.wake
@@ -605,12 +605,12 @@ export def vsortBy (cmpFn: a => a => Order): Vector a => Vector a =
         def doit x a b = Pair (Pair (ai + a) (bi + b)) x
 
         match (vat ai a) (vat bi b)
-            None None = unreachable "merged beyond vector limits"
-            (Some x) None = doit x 1 0
-            None (Some y) = doit y 0 1
-            (Some x) (Some y) = match (cmpFn x y)
-                GT = doit y 0 1
-                _ =
+            None None -> unreachable "merged beyond vector limits"
+            (Some x) None -> doit x 1 0
+            None (Some y) -> doit y 0 1
+            (Some x) (Some y) -> match (cmpFn x y)
+                GT -> doit y 0 1
+                _ ->
                     doit x 1 0 # x <= y prefers x for stable sort
 
     def mergeLoop = vunfoldl2 mergeStep
@@ -805,15 +805,15 @@ def vmapPartialTop =
 #   vmapPartial2 int ["3", "x", "44"] = [3, 44]
 export def vmapPartial2 (f: a => Option b): Vector a => Vector b =
     def intSome x = match (f x)
-        Some _ = 1
-        None = 0
+        Some _ -> 1
+        None -> 0
 
     #def destFn = vmapScan intSome (_+_) 0
     def destFn = vscanl (_ + intSome _) 0
 
     def step (Triple v dest out) i = match (f (vat_ i v))
-        Some x = vset out (vat_ i dest) x
-        None = Unit
+        Some x -> vset out (vat_ i dest) x
+        None -> Unit
 
     def loop = vappi2 step
 

--- a/share/wake/lib/gcc_wake/gcc.wake
+++ b/share/wake/lib/gcc_wake/gcc.wake
@@ -155,8 +155,8 @@ publish linkO =
     makeLinkO "native-cpp14-static" (which "c++") (cpp14Flags ++ staticLFlags)
 
 def pickVariant variant variants = match (find (variant ==* _.getPairFirst) variants)
-    Some (Pair x _) = Pass x.getPairSecond
-    None =
+    Some (Pair x _) -> Pass x.getPairSecond
+    None ->
         def ok = catWith " " (map getPairFirst variants)
 
         failWithError "No variant matches {variant}; options: {ok}"

--- a/share/wake/lib/gcc_wake/pkgconfig.wake
+++ b/share/wake/lib/gcc_wake/pkgconfig.wake
@@ -48,8 +48,8 @@ target pkgConfigImp flags pkgs =
     def cmdline = pkgConfig, flags ++ pkgs
 
     def addenv list = match (getenv "PKG_CONFIG_PATH")
-        Some p = "PKG_CONFIG_PATH={p}", list
-        None = list
+        Some p -> "PKG_CONFIG_PATH={p}", list
+        None -> list
 
     def result =
         makeExecPlan cmdline Nil

--- a/share/wake/lib/system/environment.wake
+++ b/share/wake/lib/system/environment.wake
@@ -46,8 +46,8 @@ publish environment =
 # Inject command-line specified path entries
 # Note: changing this value will likely cause a total workspace rebuild
 publish path = match (getenv "WAKE_PATH")
-    Some x = tokenize `:` x
-    None = Nil
+    Some x -> tokenize `:` x
+    None -> Nil
 
 # Setup a default path
 publish path =
@@ -58,9 +58,9 @@ publish path =
 
 # On MacOS and FreeBSD, many important system binaries are not in /usr/bin
 publish path = match sysname
-    "Darwin" = "/opt/local/bin", "/usr/local/bin", Nil
-    "FreeBSD" = "/usr/local/bin", Nil
-    _ = Nil
+    "Darwin" -> "/opt/local/bin", "/usr/local/bin", Nil
+    "FreeBSD" -> "/usr/local/bin", Nil
+    _ -> Nil
 
 # A topic used to globally add variables to the default environment of Plans
 export topic environment: String
@@ -112,8 +112,8 @@ export def editEnvironment (key: String) (fn: Option String => Option String) (e
     def Pair eq rest = splitBy (test key) environment
 
     match (head eq | omap value | fn)
-        Some v = "{key}={v}", rest
-        None = rest
+        Some v -> "{key}={v}", rest
+        None -> rest
 
 # Add a component to the PATH in a KEY=VALUE environment
 #
@@ -122,13 +122,13 @@ export def editEnvironment (key: String) (fn: Option String => Option String) (e
 #    | ...
 export def addEnvironmentPath (path: String) (environment: List String): List String =
     def mod = match _
-        None = Some path
-        Some x = Some "{path}:{x}"
+        None -> Some path
+        Some x -> Some "{path}:{x}"
 
     editEnvironment "PATH" mod environment
 
 # Optionally add a component to the PATH in a KEY=VALUE environment
 export def addEnvironmentPathOpt (pathopt: Option String) (environment: List String): List String =
     match pathopt
-        None = environment
-        Some x = addEnvironmentPath x environment
+        None -> environment
+        Some x -> addEnvironmentPath x environment

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -20,8 +20,8 @@ export def read (path: Path): Result String Error =
     def imp p = prim "read"
 
     match (imp path.getPathName)
-        Pass body = Pass body
-        Fail f = Fail (makeError f)
+        Pass body -> Pass body
+        Fail f -> Fail (makeError f)
 
 target writeImp inputs mode path content =
     def writeRunner =
@@ -29,13 +29,13 @@ target writeImp inputs mode path content =
         def pre input = Pair input Unit
 
         def post = match _
-            Pair (Fail f) _ = Fail f
-            Pair (Pass output) Unit =
+            Pair (Fail f) _ -> Fail f
+            Pair (Pass output) Unit ->
                 if mode < 0 || mode > 0x1ff then
                     Fail (makeError "write {path}: Invalid mode ({strOctal mode})")
                 else match (imp mode path content)
-                    Fail f = Fail (makeError f)
-                    Pass path = Pass (editRunnerOutputOutputs (path, _) output)
+                    Fail f -> Fail (makeError f)
+                    Pass path -> Pass (editRunnerOutputOutputs (path, _) output)
 
         makeRunner "write" (\_ Pass 0.0) pre post virtualRunner
 
@@ -106,14 +106,14 @@ def mkdirRunner: Runner =
     def imp m p = prim "mkdir"
 
     def pre = match _
-        Fail f = Pair (Fail f) (Pair "" "")
-        Pass input = match input.getRunnerInputCommand
-            _, _, mode, dir, Nil = Pair (Pass input) (Pair mode dir)
-            _ = unreachable "mkdirImp violated command-line contract"
+        Fail f -> Pair (Fail f) (Pair "" "")
+        Pass input -> match input.getRunnerInputCommand
+            _, _, mode, dir, Nil -> Pair (Pass input) (Pair mode dir)
+            _ -> unreachable "mkdirImp violated command-line contract"
 
     def post = match _
-        Pair (Fail f) _ = Fail f
-        Pair (Pass output) (Pair smode dir) =
+        Pair (Fail f) _ -> Fail f
+        Pair (Pass output) (Pair smode dir) ->
             def mode =
                 int smode
                 | getOrElse 0x200
@@ -121,8 +121,8 @@ def mkdirRunner: Runner =
             if mode < 0 || mode > 0x1ff then
                 Fail (makeError "mkdir {dir}: Invalid mode ({smode})")
             else match (imp mode dir)
-                Fail f = Fail (makeError f)
-                Pass path = Pass (editRunnerOutputOutputs (path, _) output)
+                Fail f -> Fail (makeError f)
+                Pass path -> Pass (editRunnerOutputOutputs (path, _) output)
 
     makeRunner "mkdir" (\_ Pass 0.0) pre post virtualRunner
 
@@ -141,9 +141,9 @@ export def mkdirIn (parent: Path) (mode: Integer) (name: String): Result Path Er
 # Make all every element in the directory path with mode 0755
 export def mkdir (path: String): Result Path Error =
     def root = match _
-        "", x, t = Pair (mkdirImp Nil 0755 "/{x}") t
-        x, t = Pair (mkdirImp Nil 0755 x) t
-        Nil = unreachable "tokenize never returns an empty list"
+        "", x, t -> Pair (mkdirImp Nil 0755 "/{x}") t
+        x, t -> Pair (mkdirImp Nil 0755 x) t
+        Nil -> unreachable "tokenize never returns an empty list"
 
     def mkdirRecursive (Pair rootResult pathTail) =
         require Pass root = rootResult

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -69,7 +69,7 @@ export tuple Runner =
 
 export def makeRunner name score pre post (Runner _ _ run) =
     def doit job preInput = match (pre preInput)
-        Pair runInput state =
+        Pair runInput state ->
             def runOutput = run job runInput
             def final _ = post (Pair runOutput state)
 
@@ -133,17 +133,17 @@ export tuple Plan =
     export IsAtty: Boolean
 
 def isOnce: Persistence => Boolean = match _
-    ReRun = False
-    _ = True
+    ReRun -> False
+    _ -> True
 
 def isKeep: Persistence => Boolean = match _
-    ReRun = False
-    Once = False
-    _ = True
+    ReRun -> False
+    Once -> False
+    _ -> True
 
 def isShare: Persistence => Boolean = match _
-    Share = True
-    _ = False
+    Share -> True
+    _ -> False
 
 # Convenience accessor methods
 
@@ -197,31 +197,31 @@ export def setPlanEnvVar (name: String) (value: String) (plan: Plan): Plan =
 # encountered once in any wake execution anyway.
 export def editPlanOnce (f: Boolean => Boolean): Plan => Plan =
     def helper = match _
-        ReRun if f False = Once
-        Once if ! f True = ReRun
-        Keep if ! f True = ReRun
-        Share if ! f True = ReRun
-        x = x
+        ReRun if f False -> Once
+        Once if ! f True -> ReRun
+        Keep if ! f True -> ReRun
+        Share if ! f True -> ReRun
+        x -> x
 
     editPlanPersistence helper
 
 export def editPlanKeep (f: Boolean => Boolean): Plan => Plan =
     def helper = match _
-        ReRun if f False = Keep
-        Once if f False = Keep
-        Keep if ! f True = Once
-        Share if ! f True = Once
-        x = x
+        ReRun if f False -> Keep
+        Once if f False -> Keep
+        Keep if ! f True -> Once
+        Share if ! f True -> Once
+        x -> x
 
     editPlanPersistence helper
 
 export def editPlanShare (f: Boolean => Boolean): Plan => Plan =
     def helper = match _
-        ReRun if f False = Share
-        Once if f False = Share
-        Keep if f False = Share
-        Share if ! f True = Keep
-        x = x
+        ReRun if f False -> Share
+        Once if f False -> Share
+        Keep if f False -> Share
+        Share if ! f True -> Keep
+        x -> x
 
     editPlanPersistence helper
 
@@ -292,19 +292,19 @@ export def localRunner: Runner =
     def badlaunch job error = prim "job_fail_launch"
 
     def doit job = match _
-        Fail e =
+        Fail e ->
             def _ = badlaunch job e
 
             Fail e
-        Pass (RunnerInput _ cmd vis env dir stdin _ _ predict isatty) =
+        Pass (RunnerInput _ cmd vis env dir stdin _ _ predict isatty) ->
             def Usage status runtime cputime mem in out = predict
 
             def _ =
                 launch job dir stdin env.implode cmd.implode status runtime cputime mem in out (bToInt isatty)
 
             match (getJobReality job)
-                Pass reality = Pass (RunnerOutput (map getPathName vis) Nil reality)
-                Fail f = Fail f
+                Pass reality -> Pass (RunnerOutput (map getPathName vis) Nil reality)
+                Fail f -> Fail f
 
     def score _ = Pass 1.0
 
@@ -321,26 +321,26 @@ def jField (jvalue: JValue) (key: String) =
     Pass value
 
 def jInteger = match _
-    Pass (JInteger x) = Pass x
-    Fail err = Fail err
-    _ = failWithError "not an integer"
+    Pass (JInteger x) -> Pass x
+    Fail err -> Fail err
+    _ -> failWithError "not an integer"
 
 def jString = match _
-    Pass (JString x) = Pass x
-    Fail err = Fail err
-    _ = failWithError "not a string"
+    Pass (JString x) -> Pass x
+    Fail err -> Fail err
+    _ -> failWithError "not a string"
 
 def jDouble = match _
-    Pass (JDouble x) = Pass x
-    Fail err = Fail err
-    _ = failWithError "not a number"
+    Pass (JDouble x) -> Pass x
+    Fail err -> Fail err
+    _ -> failWithError "not a number"
 
 def jArray (fn: Result JValue Error => Result a Error) = match _
-    Pass (JArray arr) =
+    Pass (JArray arr) ->
         map (fn _.Pass) arr
         | findFail
-    Fail err = Fail err
-    _ = failWithError "not an array"
+    Fail err -> Fail err
+    _ -> failWithError "not an array"
 
 def getPath input =
     require Pass elem = input
@@ -357,11 +357,11 @@ export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String E
     def job_cache_add str = prim "job_cache_add"
 
     def doit job runnerInput = match runnerInput
-        Fail e =
+        Fail e ->
             def _ = badlaunch job e
 
             Fail e
-        Pass (RunnerInput label cmd vis env dir stdin _ prefix _ _) =
+        Pass (RunnerInput label cmd vis env dir stdin _ prefix _ _) ->
             def mkVisJson (Path path hash) =
                 JObject (
                     "path" :-> JString path,
@@ -552,19 +552,19 @@ export def virtualRunner: Runner =
     def badlaunch job error = prim "job_fail_launch"
 
     def doit job = match _
-        Fail e =
+        Fail e ->
             def _ = badlaunch job e
 
             Fail e
-        Pass (RunnerInput _ _ vis _ _ _ _ _ predict _) =
+        Pass (RunnerInput _ _ vis _ _ _ _ _ predict _) ->
             def Usage status runtime cputime mem in out = predict
 
             def _ =
                 virtual job "" "" status runtime cputime mem in out # sets predict+reality
 
             match (getJobReality job)
-                Pass reality = Pass (RunnerOutput (map getPathName vis) Nil reality)
-                Fail f = Fail f
+                Pass reality -> Pass (RunnerOutput (map getPathName vis) Nil reality)
+                Fail f -> Fail f
 
     Runner "virtual" (\_ Pass 0.0) doit
 
@@ -611,8 +611,8 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
             run job (Pass (RunnerInput label cmd vis env dir stdin res prefix usage isatty))
 
         def final _ = match output
-            Fail e = badfinish job e
-            Pass (RunnerOutput inputs outputs (Usage status runtime cputime mem in out)) =
+            Fail e -> badfinish job e
+            Pass (RunnerOutput inputs outputs (Usage status runtime cputime mem in out)) ->
                 def input =
                     finputs inputs
                     | map simplify
@@ -648,11 +648,11 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
         job
 
     match keep
-        False = build Unit
-        True =
+        False -> build Unit
+        True ->
             match (cache dir stdin env.implode cmd.implode hash (map getPathName vis).implode (bToInt isatty))
-                Pair (job, _) last = confirm True last job
-                Pair Nil last = confirm False last (build Unit)
+                Pair (job, _) last -> confirm True last job
+                Pair Nil last -> confirm False last (build Unit)
 
 # Only run if the first four arguments differ
 target runOnce cmd env dir stdin vis isatty run \ res usage finputs foutputs keep echo stdout stderr label =
@@ -747,19 +747,19 @@ def treeOk file =
     def Pair f h = file
 
     match h
-        "BadHash" = failWithError "Could not hash {f}"
-        _ = Pass (Path f h)
+        "BadHash" -> failWithError "Could not hash {f}"
+        _ -> Pass (Path f h)
 
 def guardPath job = match _
-    Fail e = Fail e
-    Pass l if job.isJobOk = findFailFn treeOk l
-    _ =
+    Fail e -> Fail e
+    Pass l if job.isJobOk -> findFailFn treeOk l
+    _ ->
         failWithError
         "Non-zero exit status ({format job.getJobStatus}) for job {str job.getJobId}: '{job.getJobDescription}'"
 
 def mapPath = match _
-    Fail e = Fail e
-    Pass l = findFailFn treeOk l
+    Fail e -> Fail e
+    Pass l -> findFailFn treeOk l
 
 export def getJobStdoutRaw (job: Job): Result String Error =
     require Exited 0 = getJobStatus job
@@ -848,15 +848,15 @@ export def getJobOutput (job: Job): Result Path Error =
     require Pass outputs = getJobOutputs job
 
     match outputs
-        Nil =
+        Nil ->
             failWithError "No outputs available from job {str job.getJobId}: '{job.getJobDescription}'"
-        (singleOutput, Nil) = Pass singleOutput
-        _ =
+        (singleOutput, Nil) -> Pass singleOutput
+        _ ->
             failWithError "More than one output found from job {str job.getJobId}: '{job.getJobDescription}'"
 
 export def isJobOk (job: Job): Boolean = match (getJobReport job)
-    Fail _ = False
-    Pass u = u.getUsageStatus == 0
+    Fail _ -> False
+    Pass u -> u.getUsageStatus == 0
 
 export data Status =
     Exited Integer
@@ -864,8 +864,8 @@ export data Status =
     Aborted Error
 
 export def getJobStatus (job: Job): Status = match (getJobReport job)
-    Fail f = Aborted f
-    Pass u =
+    Fail f -> Aborted f
+    Pass u ->
         def status = u.getUsageStatus
 
         if status >= 0 then
@@ -942,9 +942,9 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
     def ok = access script xOK
 
     def pre = match _
-        Fail f = Pair (Fail f) ""
-        _ if !ok = Pair (Fail (makeError "Runner {script} is not executable")) ""
-        Pass (RunnerInput label command visible environment directory stdin res prefix record isatty) =
+        Fail f -> Pair (Fail f) ""
+        _ if !ok -> Pair (Fail (makeError "Runner {script} is not executable")) ""
+        Pass (RunnerInput label command visible environment directory stdin res prefix record isatty) ->
             def Usage status runtime cputime membytes inbytes outbytes = record
 
             def json =
@@ -995,23 +995,23 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
     def resultPath specPath = replace `spec-` "result-" specPath
 
     def post = match _
-        Pair (Fail f) _ = Fail f
-        Pair (Pass (RunnerOutput _ _ (Usage x _ _ _ _ _))) inFile if x != 0 =
+        Pair (Fail f) _ -> Fail f
+        Pair (Pass (RunnerOutput _ _ (Usage x _ _ _ _ _))) inFile if x != 0 ->
             Fail (makeError "Non-zero exit status ({str x}) for JSON runner {script} on {inFile}")
-        Pair (Pass _) inFile =
+        Pair (Pass _) inFile ->
             def outFile = resultPath inFile
             def json = parseJSONFile (Path outFile "BadHash")
 
             match json
-                Fail f = Fail f
-                Pass content =
+                Fail f -> Fail f
+                Pass content ->
                     def _ = markFileCleanable outFile
 
                     def field name = match _ _
-                        _ (Fail f) = Fail f
-                        None (Pass fn) =
+                        _ (Fail f) -> Fail f
+                        None (Pass fn) ->
                             Fail "{script} produced {outFile}, which is missing usage/{name}"
-                        (Some x) (Pass fn) = Pass (fn x)
+                        (Some x) (Pass fn) -> Pass (fn x)
 
                     def usage = content // `usage`
 
@@ -1031,7 +1031,7 @@ export def makeJSONRunner (plan: JSONRunnerPlan): Runner =
                         | mapPartial getJString
 
                     match usageResult
-                        Fail f = Fail (makeError f)
-                        Pass usage = Pass (RunnerOutput (getK `inputs`) (getK `outputs`) usage)
+                        Fail f -> Fail (makeError f)
+                        Pass usage -> Pass (RunnerOutput (getK `inputs`) (getK `outputs`) usage)
 
     makeRunner "json-{script}" score pre post localRunner

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -253,8 +253,8 @@ target hashcode (f: String): String =
             | extract `(.{64}).*`
 
         match job.isJobOk hash
-            True (x, Nil) = x
-            _ _ = "BadHash"
+            True (x, Nil) -> x
+            _ _ -> "BadHash"
 
 # Allow an untracked file to be removed via `wake --clean`
 export target markFileCleanable (filepath: String): Result Unit Error =

--- a/share/wake/lib/system/plan_scorer.wake
+++ b/share/wake/lib/system/plan_scorer.wake
@@ -25,33 +25,33 @@ publish runner =
 
 # Run a job, via a Runner chosen based on 'score' functions.
 export def runJob (p: Plan): Job = match p
-    Plan label cmd vis env dir stdin stdout stderr echo pers res usage finputs foutputs isatty =
+    Plan label cmd vis env dir stdin stdout stderr echo pers res usage finputs foutputs isatty ->
         def implode l = cat (foldr (_, "\0", _) Nil l)
         def bToInt b = if b then 1 else 0
 
         # Transform the 'List Runner' into 'List RunnerOption'
         def qualify runner = match runner
-            Runner name scorefn fn = match (scorefn p)
-                Pass x if x <=. 0.0 = Reject "{name}: non-positive score"
-                Pass x = Accept x fn
-                Fail x = Reject "{name} {x}"
+            Runner name scorefn fn -> match (scorefn p)
+                Pass x if x <=. 0.0 -> Reject "{name}: non-positive score"
+                Pass x -> Accept x fn
+                Fail x -> Reject "{name} {x}"
 
         def opts =
             subscribe runner
             | map qualify
 
         def best acc = match _ acc
-            (Reject _) _ = acc
-            (Accept score fn) (Pair bests _bestr) =
+            (Reject _) _ -> acc
+            (Accept score fn) (Pair bests _bestr) ->
                 if score >. bests then
                     Pair score (Some fn)
                 else
                     acc
 
         match (opts | foldl best (Pair 0.0 None) | getPairSecond)
-            Some r =
+            Some r ->
                 runJobImp label cmd env dir stdin res usage finputs foutputs vis pers r echo stdout stderr isatty
-            None =
+            None ->
                 def create label dir stdin env cmd signature visible keep echo stdout stderr isatty =
                     prim "job_create"
 
@@ -63,8 +63,8 @@ export def runJob (p: Plan): Job = match p
 
                 def error =
                     def pretty = match _
-                        Accept _ _ = ""
-                        Reject why = why
+                        Accept _ _ -> ""
+                        Reject why -> why
 
                     makeError "No runner for '{job.getJobDescription}' available, because: {map pretty opts | catWith ", "}"
 

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -61,9 +61,9 @@ export def source (file: String): Result Path Error =
     require Pass allSources = sources dir base.quote
 
     match allSources
-        Nil = failWithError "{file}: not a source file"
-        x, Nil = Pass x
-        _ = unreachable "a quoted RegExp can never match more than one distinct String"
+        Nil -> failWithError "{file}: not a source file"
+        x, Nil -> Pass x
+        _ -> unreachable "a quoted RegExp can never match more than one distinct String"
 
 # Allows claiming of a file so long as the file is within
 # wake's workspace. Keep in mind that if another job
@@ -140,10 +140,10 @@ export def sources (dir: String) (filterRegexp: RegExp): Result (List Path) Erro
     def scan dir regexp = prim "sources"
 
     match got_sources
-        True =
+        True ->
             scan dir filterRegexp
             | findFailFn raw_source
-        False = unreachable "add_sources always returns True"
+        False -> unreachable "add_sources always returns True"
 
 # This API makes it possible to include a non-source file into a wake build.
 # Generally, one should obtain Paths from sources or as the output of Jobs.

--- a/tests/tests.wake
+++ b/tests/tests.wake
@@ -37,12 +37,12 @@ export topic wakeTestBinary: Unit => Result (Pair String (List Path)) Error
 export topic wakeUnitTestBinary: (variant: Pair String String) => Result (List Path) Error
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
-    buildTestWake, Nil =
+    buildTestWake, Nil ->
         require Pass (Pair path visible) = buildTestWake Unit
 
         Pass (Pair (simplify "{path}/..") visible)
-    Nil = Pass (Pair "{wakePath}" Nil)
-    _ = Fail (makeError "Two wake binaries declared for testing!")
+    Nil -> Pass (Pair "{wakePath}" Nil)
+    _ -> Fail (makeError "Two wake binaries declared for testing!")
 
 def wakeUnitToTest Unit =
     require buildWakeUnit, Nil = subscribe wakeUnitTestBinary
@@ -57,9 +57,9 @@ def wakeUnitToTest Unit =
 
 export def runTests (cmdline: List String): Result String Error =
     require Pass filter = match cmdline
-        Nil = Pass `.*`
-        arg, Nil = stringToRegExp arg
-        _ = Fail (makeError "Too many arguments to runTests")
+        Nil -> Pass `.*`
+        arg, Nil -> stringToRegExp arg
+        _ -> Fail (makeError "Too many arguments to runTests")
 
     require Pass (Pair wakeDir _) = wakeToTestDir Unit
     require Pass tests = sources @here `${filter}/(pass|fail)\.sh`
@@ -83,8 +83,8 @@ export def runTests (cmdline: List String): Result String Error =
         else "impossible"
 
         def reportFailed = match _
-            Triple _ name (Fail (Error cause _)) = Some "    - {name}: {cause}"
-            _ = None
+            Triple _ name (Fail (Error cause _)) -> Some "    - {name}: {cause}"
+            _ -> None
 
         def failures = mapPartial reportFailed list
 
@@ -119,11 +119,11 @@ export def runUnitTests _: Result Unit Error =
         | replace `^${quote @here}/` ""
 
     def readFile list = match list
-        Some file =
+        Some file ->
             require Pass content = read file
 
             Pass (Some content)
-        None = Pass None
+        None -> Pass None
 
     require Pass expectedStdout =
         source "{testDirectory}/stdout"
@@ -163,24 +163,24 @@ export def runUnitTests _: Result Unit Error =
         | rmap removeCarriageReturns
 
     require Pass _ = match testJob.isJobOk
-        True = Pass Unit
-        False =
+        True -> Pass Unit
+        False ->
             def _ = println jobStderr
 
             Fail (makeError "Test failed ({format testJob.getJobStatus}). See above for details")
 
     require Pass _ = match expectedStderr
-        Some x if x ==* jobStderr = Pass Unit
-        None = Pass Unit
-        Some _ =
+        Some x if x ==* jobStderr -> Pass Unit
+        None -> Pass Unit
+        Some _ ->
             def _ = println jobStderr
 
             Fail (makeError "Unexpected standard error. See above for details")
 
     match expectedStdout
-        Some x if x ==* jobStdout = Pass Unit
-        None = Pass Unit
-        _ =
+        Some x if x ==* jobStdout -> Pass Unit
+        None -> Pass Unit
+        _ ->
             def _ = println jobStdout
 
             Fail (makeError "Unexpected standard output. See above for details")
@@ -201,11 +201,11 @@ def runTest (testScript: Path): Result Unit Error =
         | replace `^${quote @here}/` ""
 
     def readFile list = match list
-        Some file =
+        Some file ->
             require Pass content = read file
 
             Pass (Some content)
-        None = Pass None
+        None -> Pass None
 
     require Pass expectedStdout =
         source "{testDirectory}/stdout"
@@ -244,17 +244,17 @@ def runTest (testScript: Path): Result Unit Error =
         | rmap (replace `\r` "")
 
     require Pass _ = match shouldPass testJob.isJobOk
-        True True = Pass Unit
-        False False = Pass Unit
-        True False =
+        True True -> Pass Unit
+        False False -> Pass Unit
+        True False ->
             Fail (makeError "Test failed ({format testJob.getJobStatus}) with '{replace `\n.*` "" jobStderr}'")
-        False True =
+        False True ->
             Fail (makeError "Test should not have passed with '{replace `\n.*` "" jobStderr}'")
 
     require Pass _ = match expectedStderr
-        Some x if x ==* jobStderr = Pass Unit
-        None = Pass Unit
-        Some _ =
+        Some x if x ==* jobStderr -> Pass Unit
+        None -> Pass Unit
+        Some _ ->
             # TODO: use diff prim to compare jobStderr with expectedStderr
             def _ =
                 (testName, "\n", jobStderr, Nil)
@@ -264,9 +264,9 @@ def runTest (testScript: Path): Result Unit Error =
             Fail (makeError "Unexpected standard error. See above for details")
 
     match expectedStdout
-        Some x if x ==* jobStdout = Pass Unit
-        None = Pass Unit
-        _ =
+        Some x if x ==* jobStdout -> Pass Unit
+        None -> Pass Unit
+        _ ->
             # TODO: use diff prim to compare jobStdout with expectedStdout
             def _ =
                 (testName, "\n", jobStdout, Nil)

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -137,8 +137,8 @@ def name Unit =
     another
 
 def t1 = match _
-    0 = 0
-    n = 2 + t (n - 1)
+    0 -> 0
+    n -> 2 + t (n - 1)
 
 # wake-format off
 def t1 =match _
@@ -148,10 +148,10 @@ def t1 =match _
 def t1 = match _
     # wake-format off
     0=0
-    n = 2 + t (n - 1)
+    n -> 2 + t (n - 1)
 
 def t1 = match _
-    0 = 0
+    0 -> 0
     # wake-format off
     n = 2+t(n-1)
 
@@ -169,7 +169,7 @@ def t1 = match _
     # many
     # more
     # comments
-    n = 2 + t (n - 1)
+    n -> 2 + t (n - 1)
 
 def t2 =
     ((x + 7) * 3)
@@ -410,12 +410,12 @@ def ff =
     hhhhhhhhhhh
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
-    buildTestWake, Nil =
+    buildTestWake, Nil ->
         require Pass (Pair path visible) = buildTestWake Unit
 
         Pass (Pair (simplify "{path}/..") visible)
-    Nil = Pass (Pair "{wakePath}" Nil)
-    _ = Fail (makeError "Two wake binaries declared for testing!")
+    Nil -> Pass (Pair "{wakePath}" Nil)
+    _ -> Fail (makeError "Two wake binaries declared for testing!")
 
 def x (var: String): Value =
     x
@@ -441,7 +441,7 @@ target someLongTargetName (variable1: Pair (Option String) Path) (variable2: Str
     Pass Nil
 
 def wakeToTestDir Unit = match (subscribe wakeTestBinary)
-    buildTestWake, Nil =
+    buildTestWake, Nil ->
         require (
             Pass
             # comment
@@ -449,8 +449,8 @@ def wakeToTestDir Unit = match (subscribe wakeTestBinary)
         ) = buildTestWake Unit
 
         Pass (Pair (simplify "{path}/..") visible)
-    Nil = Pass (Pair "{wakePath}" Nil)
-    _ = Fail (makeError "Two wake binaries declared for testing!")
+    Nil -> Pass (Pair "{wakePath}" Nil)
+    _ -> Fail (makeError "Two wake binaries declared for testing!")
 
 package test_wake
 
@@ -535,19 +535,19 @@ def app =
     hhhhhhhhhhhhhh
 
 def t1 = match _
-    0 = 0
+    0 -> 0
     n # comment
-    = 2 + t (n - 1)
+    -> 2 + t (n - 1)
 
 def t1 = match _
     # comment
-    0 = 0
-    n = 2 + t (n - 1)
+    0 -> 0
+    n -> 2 + t (n - 1)
 
 def t1 = match _
-    0 = 0
+    0 -> 0
     # comment
-    n = 2 + t (n - 1)
+    n -> 2 + t (n - 1)
 
 publish wakeTestBinary =
     defaultWake, Nil
@@ -562,13 +562,13 @@ publish compileC =
     makeCompileC "native-c11-debug" (which "cc") (c11Flags ++ debugCFlags)
 
 publish path = match (getenv "WAKE_PATH")
-    Some x = tokenize `:` x
-    None = Nil
+    Some x -> tokenize `:` x
+    None -> Nil
 
 publish path = match sysname
-    "Darwin" = "/opt/local/bin", "/usr/local/bin", Nil
-    "FreeBSD" = "/usr/local/bin", Nil
-    _ = Nil
+    "Darwin" -> "/opt/local/bin", "/usr/local/bin", Nil
+    "FreeBSD" -> "/usr/local/bin", Nil
+    _ -> Nil
 
 publish compileC =
     emccFn (makeCompileC "wasm-c11-release" _ ("-std=gnu11", emscriptenCFlags))
@@ -602,9 +602,9 @@ target runOnce cmd env dir stdin \ res usage finputs foutputs vis keep run echo 
     runAlways cmd env dir stdin res usage finputs foutputs vis keep run echo stdout stderr label
 
 global export target fib n = match n
-    0 = 1
-    1 = 1
-    _ = fib (n - 1) + fib (n - 2)
+    0 -> 1
+    1 -> 1
+    _ -> fib (n - 1) + fib (n - 2)
 
 def buildRE2WASM Unit =
     def version = "2021-08-01"
@@ -646,31 +646,31 @@ def t5 =
     a.b.c
 
 def toVariant = match _
-    "default" = Pass (Pair "native-cpp14-release" "native-c11-release")
-    "static" = Pass (Pair "native-cpp14-static" "native-c11-static")
-    "debug" = Pass (Pair "native-cpp14-debug" "native-c11-debug")
-    "wasm" = Pass (Pair "wasm-cpp14-release" "wasm-c11-release")
-    s = Fail "Unknown build target ({s})".makeError
+    "default" -> Pass (Pair "native-cpp14-release" "native-c11-release")
+    "static" -> Pass (Pair "native-cpp14-static" "native-c11-static")
+    "debug" -> Pass (Pair "native-cpp14-debug" "native-c11-debug")
+    "wasm" -> Pass (Pair "wasm-cpp14-release" "wasm-c11-release")
+    s -> Fail "Unknown build target ({s})".makeError
 
 export def build: List String => Result String Error = match _
-    "tarball", Nil =
+    "tarball", Nil ->
         tarball Unit
         | rmap (\_ "TARBALL")
-    kind, Nil =
+    kind, Nil ->
         require Pass variant = toVariant kind
 
         all variant
         | rmap (\_ "BUILD")
-    _ = Fail "no target specified (try: build default/debug/tarball)".makeError
+    _ -> Fail "no target specified (try: build default/debug/tarball)".makeError
 
 export def install: List String => Result String Error = match _
-    dest, kind, Nil =
+    dest, kind, Nil ->
         doInstall (in cwd dest) kind
         | rmap (\_ "INSTALL")
-    dest, Nil =
+    dest, Nil ->
         doInstall (in cwd dest) "default"
         | rmap (\_ "INSTALL")
-    _ = Fail "no directory specified (try: install /opt/local)".makeError
+    _ -> Fail "no directory specified (try: install /opt/local)".makeError
 
 # Build all wake targets
 def targets =
@@ -899,17 +899,17 @@ def Pair _ _: Pair Integer String =
     Pair 44 "as"
 
 def f0 = match _ _
-    (x: Integer) (True: Boolean) = x + 1
-    (x: Integer) (False: Boolean) = x + 0
+    (x: Integer) (True: Boolean) -> x + 1
+    (x: Integer) (False: Boolean) -> x + 0
 
 def f0 =
     match aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
             x + 1
-        x b = x + 0
+        x b -> x + 0
 
 def x = match p
-    Something aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aa bb cc dd =
+    Something aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aa bb cc dd ->
         0
 
 export def vfoldl (combiningFn: accum => element => accum): accum => Vector element => accum =
@@ -1098,8 +1098,8 @@ def a name =
     # comment
     # comment
     match (a thing)
-        x, _ = x, Nil
-        Nil = Nil
+        x, _ -> x, Nil
+        Nil -> Nil
 
 def x =
     map (\(Pair a b) c a b)
@@ -1127,38 +1127,38 @@ def d =
 
 export def defaultJSONFormat: JSONFormat =
     def formatDouble d = match (dclass d)
-        DoubleInfinite if d <. 0e0 = "-Infinity"
-        DoubleInfinite = "Infinity"
-        DoubleNaN = "NaN"
-        _ = dstr d
+        DoubleInfinite if d <. 0e0 -> "-Infinity"
+        DoubleInfinite -> "Infinity"
+        DoubleNaN -> "NaN"
+        _ -> dstr d
 
     JSONFormat jsonEscape str formatDouble 0
 
 def longFunc param: Result (List Path) Error = match _
-    Nil = Nil,
-    a, b =
+    Nil -> Nil,
+    a, b ->
         def f = funcB b
 
         match f
-            Some x = x
-            None = x
-    c, e = match f0
-        Some x = x
-        None = x
+            Some x -> x
+            None -> x
+    c, e -> match f0
+        Some x -> x
+        None -> x
 
 export def !(x: Boolean): Boolean =
     if x then False else True
 
 export def mapPartial (f: a => Option b): (list: List a) => List b =
     def loop = match _
-        Nil = Nil
-        h, t =
+        Nil -> Nil
+        h, t ->
             # don't wait on f to process tail:
             def sub = loop t
 
             match (f h)
-                Some x = x, sub
-                None = sub
+                Some x -> x, sub
+                None -> sub
 
     loop
 
@@ -1168,13 +1168,13 @@ target writeImp inputs mode path content =
         def pre input = Pair input Unit
 
         def post = match _
-            Pair (Fail f) _ = Fail f
-            Pair (Pass output) Unit =
+            Pair (Fail f) _ -> Fail f
+            Pair (Pass output) Unit ->
                 if mode < 0 || mode > 0x1ff then
                     Fail (makeError "write {path}: Invalid mode ({strOctal mode})")
                 else match (imp mode path content)
-                    Fail f = Fail (makeError f)
-                    Pass path = Pass (editRunnerOutputOutputs (path, _) output)
+                    Fail f -> Fail (makeError f)
+                    Pass path -> Pass (editRunnerOutputOutputs (path, _) output)
 
         makeRunner "write" (\_ Pass 0.0) pre post virtualRunner
 

--- a/tools/fuse-waked/fuse-waked.wake
+++ b/tools/fuse-waked/fuse-waked.wake
@@ -19,4 +19,4 @@ from wake import _
 from gcc_wake import _
 
 target buildFuseDaemon variant: Result (List Path) Error = match variant
-    _ = tool @here Nil variant "lib/wake/fuse-waked" (json, fuse, util, Nil) Nil Nil
+    _ -> tool @here Nil variant "lib/wake/fuse-waked" (json, fuse, util, Nil) Nil Nil

--- a/tools/lsp-wake/lsp.wake
+++ b/tools/lsp-wake/lsp.wake
@@ -18,7 +18,7 @@ package build_wake
 from wake import _
 
 target buildLSP variant: Result (List Path) Error = match variant
-    Pair "wasm-cpp14-release" _ =
+    Pair "wasm-cpp14-release" _ ->
         require Pass postJS = source "extensions/vscode/lsp-server/wasm/lsp-wake.post.js"
         require Pass preJS = source "extensions/vscode/lsp-server/wasm/lsp-wake.pre.js"
 
@@ -31,4 +31,4 @@ target buildLSP variant: Result (List Path) Error = match variant
             "--pre-js", preJS.getPathName,
 
         tool @here Nil variant "lib/wake/lsp-wake" (dst, util, wcl, Nil) (postJS, preJS, Nil) extraLFlags
-    _ = tool @here Nil variant "lib/wake/lsp-wake" (dst, util, wcl, Nil) Nil Nil
+    _ -> tool @here Nil variant "lib/wake/lsp-wake" (dst, util, wcl, Nil) Nil Nil

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -1591,15 +1591,13 @@ wcl::doc Emitter::walk_flag_global(ctx_t ctx, CSTElement node) {
 
 wcl::doc Emitter::walk_guard(ctx_t ctx, CSTElement node) {
   MEMO(ctx, node);
-  MEMO_RET(walk_placeholder(ctx, node));
 
-  // TODO: uncomment this after rolling out MVP
-  // MEMO_RET(fmt()
-  //              .fmt_if(TOKEN_KW_IF,
-  //                      fmt().token(TOKEN_KW_IF).ws().prevent_explode(fmt().walk(WALK_NODE)).ws())
-  //              .fmt_if(TOKEN_P_ARROW, fmt().token(TOKEN_P_ARROW))
-  //              .fmt_if(TOKEN_P_EQUALS, fmt().token(TOKEN_P_EQUALS, symbolExample(TOKEN_P_ARROW)))
-  //              .format(ctx, node.firstChildElement(), token_traits));
+  MEMO_RET(fmt()
+               .fmt_if(TOKEN_KW_IF,
+                       fmt().token(TOKEN_KW_IF).ws().prevent_explode(fmt().walk(WALK_NODE)).ws())
+               .fmt_if(TOKEN_P_ARROW, fmt().token(TOKEN_P_ARROW))
+               .fmt_if(TOKEN_P_EQUALS, fmt().token(TOKEN_P_EQUALS, symbolExample(TOKEN_P_ARROW)))
+               .format(ctx, node.firstChildElement(), token_traits));
 }
 
 wcl::doc Emitter::walk_hole(ctx_t ctx, CSTElement node) {

--- a/vendor/emscripten.wake
+++ b/vendor/emscripten.wake
@@ -19,12 +19,12 @@ from wake import _
 from gcc_wake import _
 
 def emccFn fn = match (whichInEnvPath "emcc")
-    None = Nil
-    Some x = fn x
+    None -> Nil
+    Some x -> fn x
 
 def emppFn fn = match (whichInEnvPath "em++")
-    None = Nil
-    Some x = fn x
+    None -> Nil
+    Some x -> fn x
 
 def emmake =
     whichInEnvPath "emmake"

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -20,8 +20,8 @@ from wake import _
 topic releaseAs: String
 
 def buildAs Unit = match (subscribe releaseAs)
-    version, Nil = Pass version
-    _ =
+    version, Nil -> Pass version
+    _ ->
         def cmdline = which "git", "describe", "--tags", "--dirty", Nil
 
         require Pass stdout =
@@ -46,8 +46,8 @@ def buildAs Unit = match (subscribe releaseAs)
 topic releaseOn: String
 
 def buildOn Unit = match (subscribe releaseOn)
-    date, Nil = Pass date
-    _ =
+    date, Nil -> Pass date
+    _ ->
         def cmdline = which "git", "show", "-s", "--format=%ci", "HEAD", Nil
 
         require Pass stdout =
@@ -82,7 +82,7 @@ def mk_node_semver_safe v =
     else v
 
     match (extract unsafe_version_regex v)
-        version, commit, rest, Nil =
+        version, commit, rest, Nil ->
             (version, "-plus-", commit, "-", rest, Nil)
             | cat
-        _ = v
+        _ -> v

--- a/vendor/lemon/lemon.wake
+++ b/vendor/lemon/lemon.wake
@@ -38,9 +38,9 @@ def m4 (file: Path): Result Path Error =
     require Pass stdout = run.getJobStdout
 
     match run.getJobStatus
-        Exited 0 = write output stdout
-        Aborted e = Fail e
-        z =
+        Exited 0 -> write output stdout
+        Aborted e -> Fail e
+        z ->
             failWithError
             "Non-zero exit status ({format z}) for job {str run.getJobId}: '{run.getJobDescription}'"
 
@@ -77,8 +77,8 @@ def lemon variant (file: Path): Result (Pair Path Path) Error =
         | runJobWith defaultRunner
 
     match zip.getJobStatus
-        Exited 0 = Pass (Pair cppfile hfile)
-        Aborted e = Fail e
-        z =
+        Exited 0 -> Pass (Pair cppfile hfile)
+        Aborted e -> Fail e
+        z ->
             failWithError
             "Non-zero exit status ({format z}) for job {str zip.getJobId}: '{zip.getJobDescription}'"

--- a/vendor/ncurses.wake
+++ b/vendor/ncurses.wake
@@ -19,8 +19,8 @@ from wake import _
 from gcc_wake import _
 
 def ncurses = match _
-    Pair "wasm-cpp14-release" _ = Pass (makeSysLib "ncurses")
-    _ =
+    Pair "wasm-cpp14-release" _ -> Pass (makeSysLib "ncurses")
+    _ ->
         pkgConfig "ncurses tinfo"
         | getOrElseFn (\Unit pkg "ncurses")
         | editSysLibCFlags (filter (matches `-I.*` _)) # remove feature test manipulation

--- a/vendor/re2.wake
+++ b/vendor/re2.wake
@@ -19,8 +19,8 @@ from wake import _
 from gcc_wake import _
 
 def re2 = match _
-    Pair "wasm-cpp14-release" _ = buildRE2WASM Unit
-    _ =
+    Pair "wasm-cpp14-release" _ -> buildRE2WASM Unit
+    _ ->
         pkgConfig "re2"
         | getOrElseFn (\Unit pkg "re2")
         | editSysLibCFlags (filter (\x !(matches `-std=.*` x))) # remove feature test manipulation

--- a/vendor/re2c.wake
+++ b/vendor/re2c.wake
@@ -64,9 +64,9 @@ def re2cReal re2c file =
         | runJobWith defaultRunner
 
     match zip.getJobStatus
-        Exited 0 = Pass result
-        Aborted e = Fail e
-        z = failWithError "Non-zero exit status ({format z}) for '{zip.getJobDescription}'"
+        Exited 0 -> Pass result
+        Aborted e -> Fail e
+        z -> failWithError "Non-zero exit status ({format z}) for '{zip.getJobDescription}'"
 
 def re2cFake file =
     def cpp = replace `\.re$` ".cpp" file.getPathName
@@ -91,8 +91,8 @@ def gunzip zip =
     | getJobOutput
 
 def re2c (file: Path): Result Path Error = match (re2cOk Unit)
-    Pass re2c = re2cReal re2c file
-    Fail err =
+    Pass re2c -> re2cReal re2c file
+    Fail err ->
         def _ =
             if (getenv "UPGRADE_GENERATED" | getOrElse "0") ==* "1" then
                 println "[WARN] Requested re2c which is unsatisfiable. Using fake\n  why: {err.getErrorCause}"

--- a/vendor/utf8proc/utf8proc.wake
+++ b/vendor/utf8proc/utf8proc.wake
@@ -20,5 +20,5 @@ from gcc_wake import _
 
 # Prefer to use system utf8proc if available
 def utf8proc variant = match (pkgConfig "utf8proc")
-    Some x = Pass x
-    None = vendor @here variant "2.2.0" `.*\.h|utf8proc_data\.c` `utf8proc\.c`
+    Some x -> Pass x
+    None -> vendor @here variant "2.2.0" `.*\.h|utf8proc_data\.c` `utf8proc\.c`

--- a/vendor/vendor.wake
+++ b/vendor/vendor.wake
@@ -39,7 +39,7 @@ def vendor (dir: String) (variant: Pair String String) (version: String) (header
     Pass (SysLib version headerPaths objects.flatten Nil Nil)
 
 def pkg name = match (pkgConfig name)
-    Some x = x
-    None =
+    Some x -> x
+    None ->
         makeSysLib ""
         | editSysLibLFlags ("-l{name}", _)


### PR DESCRIPTION
Updates `wake-format` rule to always emit `->` as the match case separator which shows the correct data flow direction.