### PR TITLE
Add primitive for stat to avoid a job or string parsing

### DIFF
--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -95,13 +95,12 @@ export def rmap (fn: a => b): Result a fail => Result b fail = match _
     Pass a -> Pass (fn a)
     Fail f -> Fail f
 
-# rmapError: apply a function to a Failing-ing result
+# rmapError: apply a function to a Fail-ing result
 #
 #   rmapError (_+1) (Pass 123) = Pass 123
 #   rmapError (_+1) (Fail 123) = Fail 124
-export def rmapError (fn: a => b): Result c a => Result c b = match _
-    Pass a -> Pass a
-    Fail f -> Fail (fn f)
+export def rmapError (fn: a => b): Result c a => Result c b =
+    rmapFail (fn _ | Fail)
 
 # rmapPass: apply a Fail-able function to a Pass-ing result
 # If you find yourself using the function, consider using require instead.

--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -100,8 +100,8 @@ export def rmap (fn: a => b): Result a fail => Result b fail = match _
 #   rmapError (_+1) (Pass 123) = Pass 123
 #   rmapError (_+1) (Fail 123) = Fail 124
 export def rmapError (fn: a => b): Result c a => Result c b = match _
-    Pass a = Pass a
-    Fail f = Fail (fn f)
+    Pass a -> Pass a
+    Fail f -> Fail (fn f)
 
 # rmapPass: apply a Fail-able function to a Pass-ing result
 # If you find yourself using the function, consider using require instead.

--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -95,6 +95,14 @@ export def rmap (fn: a => b): Result a fail => Result b fail = match _
     Pass a -> Pass (fn a)
     Fail f -> Fail f
 
+# rmapError: apply a function to a Failing-ing result
+#
+#   rmapError (_+1) (Pass 123) = Pass 123
+#   rmapError (_+1) (Fail 123) = Fail 124
+export def rmapError (fn: a => b): Result c a => Result c b = match _
+    Pass a = Pass a
+    Fail f = Fail (fn f)
+
 # rmapPass: apply a Fail-able function to a Pass-ing result
 # If you find yourself using the function, consider using require instead.
 export def rmapPass (fn: a => Result b fail): Result a fail => Result b fail = match _

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -30,9 +30,23 @@ export tuple Permission =
     Execute: Boolean
 
 export def perm2bits (perm: Permission) =
-    def b3 = if getPermissionRead perm then 4 else 0
-    def b2 = if getPermissionWrite perm then 2 else 0
-    def b1 = if getPermissionExecute perm then 1 else 0
+    def b3 =
+        if getPermissionRead perm then
+            4
+        else
+            0
+
+    def b2 =
+        if getPermissionWrite perm then
+            2
+        else
+            0
+
+    def b1 =
+        if getPermissionExecute perm then
+            1
+        else
+            0
 
     b1 + b2 + b3
 
@@ -41,26 +55,26 @@ export def bits2perm (bits: Integer) =
     def b2 = 2 == and bits 2
     def b1 = 1 == and bits 1
 
-    Permission b3 b2 b1 
+    Permission b3 b2 b1
 
-export tuple Mode = 
+export tuple Mode =
     User: Permission
     Group: Permission
     Other: Permission
 
 export def bits2mode (bits: Integer) =
-   def otherBits = and bits 7
-   def groupBits = and (bits >> 3) 7
-   def userBits = and (bits >> 6) 7
+    def otherBits = and bits 7
+    def groupBits = and (bits >> 3) 7
+    def userBits = and (bits >> 6) 7
 
-   Mode (bits2perm userBits) (bits2perm groupBits) (bits2perm otherBits)
+    Mode (bits2perm userBits) (bits2perm groupBits) (bits2perm otherBits)
 
 export def mode2bits (mode: Mode) =
-   def otherBits = perm2bits mode.getModeOther
-   def groupBits = perm2bits mode.getModeGroup << 3
-   def userBits = perm2bits mode.getModeUser << 6
+    def otherBits = perm2bits mode.getModeOther
+    def groupBits = perm2bits mode.getModeGroup << 3
+    def userBits = perm2bits mode.getModeUser << 6
 
-   otherBits + groupBits + userBits
+    otherBits + groupBits + userBits
 
 export tuple Stat =
     Type: PathType

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -15,6 +15,40 @@
 
 package wake
 
+export data PathType =
+    PathTypeRegularFile
+    PathTypeDirectory
+    PathTypeCharacterDevice
+    PathTypeBlockDevice
+    PathTypeFifo
+    PathTypeSymlink
+    PathTypeSocket
+
+export tuple Stat =
+    Type: PathType
+    Mode: Integer
+    Size: Integer
+
+def statTypeNumberToPathType (inodeType: Integer): PathType = match inodeType
+    0 -> PathTypeRegularFile
+    1 -> PathTypeDirectory
+    2 -> PathTypeCharacterDevice
+    3 -> PathTypeBlockDevice
+    4 -> PathTypeFifo
+    5 -> PathTypeSymlink
+    6 -> PathTypeSocket
+    _ -> unreachable "stat returned invalid file type"
+
+export def stat (path: Path): Result Stat Error =
+    def imp p = prim "stat"
+
+    require Pass (Pair size (Pair inodeType mode)) =
+        imp path.getPathName
+        | rmapError makeError
+
+    Stat (statTypeNumberToPathType inodeType) mode size
+    | Pass
+
 # Read the file contents of a Path
 export def read (path: Path): Result String Error =
     def imp p = prim "read"

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -24,10 +24,48 @@ export data PathType =
     PathTypeSymlink
     PathTypeSocket
 
+export tuple Permission =
+    Read: Boolean
+    Write: Boolean
+    Execute: Boolean
+
+export def perm2bits (perm: Permission) =
+    def b3 = if getPermissionRead perm then 4 else 0
+    def b2 = if getPermissionWrite perm then 2 else 0
+    def b1 = if getPermissionExecute then 1 else 0
+
+    b1 + b2 + b3
+
+export def bits2perm (bits: Integer) =
+    def b3 = 4 == and bits 4
+    def b2 = 2 == and bits 2
+    def b1 = 1 == and bits 1
+
+    Permission b3 b2 b1 
+
+export def Mode = 
+    User: Permission
+    Group: Permission
+    Other: Permission
+
+export def bits2mode (bits: Integer) =
+   def otherBits = and bits 7
+   def groupBits = and bits (7 << 3)
+   def userBits = and bits (7 << 6)
+
+   Mode (bits2perm userBits) (bits2perm groupBits) (bits2perm otherBits)
+
+export def mode2bits (mode: Mode) =
+   def otherBits = perm2bits mode.getModeOther
+   def groupBits = perm2bits mode.getModeGroup << 3
+   def userBits = perm2bits mode.getModeUser << 6
+
+   otherBits + groupBits + userBits
+
 export tuple Stat =
     Type: PathType
-    Mode: Integer
-    Size: Integer
+    Mode: Mode
+    SizeBytes: Integer
 
 def statTypeNumberToPathType (inodeType: Integer): PathType = match inodeType
     0 -> PathTypeRegularFile
@@ -39,14 +77,14 @@ def statTypeNumberToPathType (inodeType: Integer): PathType = match inodeType
     6 -> PathTypeSocket
     _ -> unreachable "stat returned invalid file type"
 
-export def stat (path: Path): Result Stat Error =
+export target stat (path: Path): Result Stat Error =
     def imp p = prim "stat"
 
     require Pass (Pair size (Pair inodeType mode)) =
         imp path.getPathName
         | rmapError makeError
 
-    Stat (statTypeNumberToPathType inodeType) mode size
+    Stat (statTypeNumberToPathType inodeType) (bits2mode mode) size
     | Pass
 
 # Read the file contents of a Path

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -32,7 +32,7 @@ export tuple Permission =
 export def perm2bits (perm: Permission) =
     def b3 = if getPermissionRead perm then 4 else 0
     def b2 = if getPermissionWrite perm then 2 else 0
-    def b1 = if getPermissionExecute then 1 else 0
+    def b1 = if getPermissionExecute perm then 1 else 0
 
     b1 + b2 + b3
 
@@ -43,15 +43,15 @@ export def bits2perm (bits: Integer) =
 
     Permission b3 b2 b1 
 
-export def Mode = 
+export tuple Mode = 
     User: Permission
     Group: Permission
     Other: Permission
 
 export def bits2mode (bits: Integer) =
    def otherBits = and bits 7
-   def groupBits = and bits (7 << 3)
-   def userBits = and bits (7 << 6)
+   def groupBits = and (bits >> 3) 7
+   def userBits = and (bits >> 6) 7
 
    Mode (bits2perm userBits) (bits2perm groupBits) (bits2perm otherBits)
 

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -15,6 +15,10 @@
 
 package wake
 
+# The file type a path known to wake.
+#
+# Most Paths will be regular files, sylinks, or directories. Paths to other types are generally
+# not well supported by wake.
 export data PathType =
     PathTypeRegularFile
     PathTypeDirectory
@@ -24,32 +28,30 @@ export data PathType =
     PathTypeSymlink
     PathTypeSocket
 
+# The various flags of a given file permission.
 export tuple Permission =
+    # The actor may read the file.
     Read: Boolean
+    # The actor may write to the file.
     Write: Boolean
+    # The actor may execute the file.
     Execute: Boolean
 
+# Converts a Permission tuple to a masked Linux permission bit field.
+#
+# perm2bits (Permission False True True) -> 3
+# perm2bits (Permission True True False) -> 6
 export def perm2bits (perm: Permission) =
-    def b3 =
-        if getPermissionRead perm then
-            4
-        else
-            0
-
-    def b2 =
-        if getPermissionWrite perm then
-            2
-        else
-            0
-
-    def b1 =
-        if getPermissionExecute perm then
-            1
-        else
-            0
+    def b3 = if perm.getPermissionRead then 4 else 0
+    def b2 = if perm.getPermissionWrite then 2 else 0
+    def b1 = if perm.getPermissionExecute then 1 else 0
 
     b1 + b2 + b3
 
+# Converts a masked Linux permission bit field to a Permission tuple
+#
+# bits2perm 3 -> (Permission False True True)
+# bits2perm 6 -> (Permission True True False)
 export def bits2perm (bits: Integer) =
     def b3 = 4 == and bits 4
     def b2 = 2 == and bits 2
@@ -57,11 +59,15 @@ export def bits2perm (bits: Integer) =
 
     Permission b3 b2 b1
 
+# The full permission set of a given Path
 export tuple Mode =
     User: Permission
     Group: Permission
     Other: Permission
 
+# Converts an unmasked permission bit field into a Mode tuple
+#
+# bits2mode 365 -> Mode (Permission True False True) (Permission True False True) (Permission True False True)
 export def bits2mode (bits: Integer) =
     def otherBits = and bits 7
     def groupBits = and (bits >> 3) 7
@@ -69,6 +75,9 @@ export def bits2mode (bits: Integer) =
 
     Mode (bits2perm userBits) (bits2perm groupBits) (bits2perm otherBits)
 
+#  Converts Mode tuple into an unmasked permission bit field
+#
+# mode2bits Mode (Permission True False True) (Permission True False True) (Permission True False True) -> 365
 export def mode2bits (mode: Mode) =
     def otherBits = perm2bits mode.getModeOther
     def groupBits = perm2bits mode.getModeGroup << 3
@@ -76,9 +85,13 @@ export def mode2bits (mode: Mode) =
 
     otherBits + groupBits + userBits
 
+# The system Stat of a given Path
 export tuple Stat =
+    # The Path's file type
     Type: PathType
+    # The Path's complete permissions
     Mode: Mode
+    # The size in bytes of the Path's content
     SizeBytes: Integer
 
 def statTypeNumberToPathType (inodeType: Integer): PathType = match inodeType
@@ -91,6 +104,7 @@ def statTypeNumberToPathType (inodeType: Integer): PathType = match inodeType
     6 -> PathTypeSocket
     _ -> unreachable "stat returned invalid file type"
 
+# Returns the system Stat for a given path
 export target stat (path: Path): Result Stat Error =
     def imp p = prim "stat"
 


### PR DESCRIPTION
This change adds a fast way to get the following information for a file that's already been hashed

1) inode permissions (e.g.
2) inode type (e.g. regular file, symlink, directory, or something more exotic like a pipe or socket)
3) file size

This is exposed via a new function in the standard library called "stat" that returns a `Result Stat Error` which in turn (if its a Pass) contains that information.

Other information contained in the posix stat struct is volatile and inconsistent across machines so I did not add it but these should be relatively stable.