### PR TITLE
cache: Fix bug in runner hash accounting

### DIFF
--- a/src/job_cache/types.cpp
+++ b/src/job_cache/types.cpp
@@ -446,6 +446,7 @@ AddJobRequest::AddJobRequest(const JAST &json) {
   ibytes = std::stoull(json.get("ibytes").value);
   obytes = std::stoull(json.get("obytes").value);
   client_cwd = json.get("client_cwd").value;
+  runner_hash = json.get("runner_hash").value;
   if (wcl::is_relative(client_cwd)) {
     wcl::log::error("AddJobRequest::AddJobRequest: client_cwd cannot be relative. found: '%s'",
                     client_cwd.c_str())
@@ -523,6 +524,7 @@ JAST AddJobRequest::to_json() const {
   json.add("ibytes", int64_t(ibytes));
   json.add("obytes", int64_t(obytes));
   json.add("client_cwd", client_cwd);
+  json.add("runner_hash", runner_hash);
 
   JAST input_files_json(JSON_ARRAY);
   for (const auto &input_file : inputs) {
@@ -641,6 +643,7 @@ JAST FindJobRequest::to_json() const {
   json.add("environment", environment);
   json.add("stdin", stdin_str);
   json.add("client_cwd", client_cwd);
+  json.add("runner_hash", runner_hash);
 
   JAST input_files(JSON_ARRAY);
   for (const auto &input_file : visible) {

--- a/tests/job-cache/basic-lru/pass.sh
+++ b/tests/job-cache/basic-lru/pass.sh
@@ -68,7 +68,7 @@ fi
 WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test two
 rm wake.db
 if [ -z "$(ls -A .cache-misses)" ]; then
-  echo "Expected a chache miss!!"
+  echo "Expected a cache miss!!"
   exit 1
 fi
 rm -rf .cache-misses
@@ -77,7 +77,7 @@ rm -rf .cache-misses
 WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test three
 rm wake.db
 if [ -z "$(ls -A .cache-misses)" ]; then
-  echo "Expected a chache miss!!"
+  echo "Expected a cache miss!!"
   exit 1
 fi
 rm -rf .cache-misses

--- a/tests/job-cache/runner-hash/.wakeroot
+++ b/tests/job-cache/runner-hash/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/job-cache/runner-hash/pass.sh
+++ b/tests/job-cache/runner-hash/pass.sh
@@ -12,11 +12,11 @@ rm wake.db || true
 rm -rf .cache-hit || true
 rm -rf .cache-misses || true
 rm -rf .job-cache || true
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test1
 
 rm wake.db
 rm -rf .cache-misses
-WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test2
 
 
 if [ -z "$(ls -A .cache-misses)" ]; then

--- a/tests/job-cache/runner-hash/pass.sh
+++ b/tests/job-cache/runner-hash/pass.sh
@@ -1,0 +1,40 @@
+#! /bin/sh
+
+if [ $(uname) != Linux ] ; then
+  exit 0
+fi
+
+set -e
+WAKE="${1:+$1/wake}"
+
+rm test.txt || true
+rm wake.db || true
+rm -rf .cache-hit || true
+rm -rf .cache-misses || true
+rm -rf .job-cache || true
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+
+rm wake.db
+rm -rf .cache-misses
+WAKE_SHARED_CACHE_FAST_CLOSE=1 DEBUG_WAKE_SHARED_CACHE=1 WAKE_LOCAL_JOB_CACHE=.job-cache "${WAKE:-wake}" test
+
+
+if [ -z "$(ls -A .cache-misses)" ]; then
+  echo "Expected a cache miss!!"
+  exit 1
+fi
+
+if [ -d ".cache-hit" ]; then
+  echo "Found an unexpected cache hit"
+  exit 1
+fi
+
+# Verify correct bits
+rm test_gold.txt || true
+cat some-input.txt > test_gold.txt && cat some-input.txt >> test_gold.txt
+diff test.txt test_gold.txt >&2
+
+# Cleanup
+echo "fourth round" >&2
+rm test.txt
+rm test_gold.txt

--- a/tests/job-cache/runner-hash/some-input.txt
+++ b/tests/job-cache/runner-hash/some-input.txt
@@ -1,0 +1,1 @@
+this is a test

--- a/tests/job-cache/runner-hash/test.wake
+++ b/tests/job-cache/runner-hash/test.wake
@@ -1,0 +1,29 @@
+from wake import _
+
+publish source = "some-input.txt",
+
+export def test (_: List String): Result (List String) Error =
+    # Read the current time with nanoseconds included
+    # This is intentionally unreproducable to force a
+    # different in the resource string for the test job
+    require Pass stdout =
+        makePlan "runner_hash_test: get nano" Nil "date -Ins"
+        | runJobWith localRunner
+        | getJobStdout
+
+    def hashResource x =
+        require Pass input = x
+
+        Pass (catWith "." input.getRunnerInputResources)
+
+    def runner = mkJobCacheRunner hashResource "/workspace" fuseRunner
+
+    require Pass source = source "some-input.txt"
+    require Pass outputs =
+        makePlan "runner_hash_test" (source,) "cat some-input.txt > test.txt && cat some-input.txt >> test.txt"
+        | setPlanResources (stdout,)
+        # | setPlanPersistence ReRun
+        | runJobWith runner
+        | getJobOutputs
+    Pass (map (_.getPathName) outputs)
+

--- a/tests/job-cache/runner-hash/test.wake
+++ b/tests/job-cache/runner-hash/test.wake
@@ -1,29 +1,39 @@
 from wake import _
 
-publish source = "some-input.txt",
+publish source =
+    "some-input.txt",
 
-export def test (_: List String): Result (List String) Error =
-    # Read the current time with nanoseconds included
-    # This is intentionally unreproducable to force a
-    # different in the resource string for the test job
-    require Pass stdout =
-        makePlan "runner_hash_test: get nano" Nil "date -Ins"
-        | runJobWith localRunner
-        | getJobStdout
+def mkTestPlan (s: String): Result Plan Error =
+    require Pass source = source "some-input.txt"
 
+    makePlan
+    "runner_hash_test"
+    (source,)
+    "cat some-input.txt > test.txt && cat some-input.txt >> test.txt"
+    | setPlanResources (s,)
+    | Pass
+
+def resourceAwareCacheRunner =
     def hashResource x =
         require Pass input = x
 
         Pass (catWith "." input.getRunnerInputResources)
 
-    def runner = mkJobCacheRunner hashResource "/workspace" fuseRunner
+    mkJobCacheRunner hashResource "/workspace" fuseRunner
 
-    require Pass source = source "some-input.txt"
+def runTestJob (s: String) =
+    require Pass plan = mkTestPlan s
+
     require Pass outputs =
-        makePlan "runner_hash_test" (source,) "cat some-input.txt > test.txt && cat some-input.txt >> test.txt"
-        | setPlanResources (stdout,)
-        # | setPlanPersistence ReRun
-        | runJobWith runner
+        plan
+        | runJobWith resourceAwareCacheRunner
         | getJobOutputs
+
     Pass (map (_.getPathName) outputs)
+
+export def test1 (_: List String): Result (List String) Error =
+    runTestJob "test1"
+
+export def test2 (_: List String): Result (List String) Error =
+    runTestJob "test2"
 


### PR DESCRIPTION
The runtime has an accounting bug regarding the wakelang provided `runner_hash`. This lead to situations where wakelang would correctly declare two jobs as different yet the shared cache would still see them as identical.

This bug caused some jobs to resolve with stale/incorrect outputs.

The accounting error has been corrected and a test case was added that ensures a change in the runner hash results in a cache miss.