### PR TITLE
Delete spaces trailing after a comment

### DIFF
--- a/share/wake/lib/core/double.wake
+++ b/share/wake/lib/core/double.wake
@@ -387,7 +387,7 @@ export def dacos (x: Double): Double =
 export def dasin (x: Double): Double =
     (\_ prim "dasin") x
 
-# Calculates the inverse tangent of y/x, giving the angle of the point(x, y) in the coordinate plane. 
+# Calculates the inverse tangent of y/x, giving the angle of the point(x, y) in the coordinate plane.
 # The advantage of 2-argument datan over 1-argument datan is it is defined even where x is 0.
 # datan (-. 1.0) (-. 1.0) = pi * -0.75
 # datan (-. 1.0)     0.0  = pi * -0.50

--- a/share/wake/lib/core/order.wake
+++ b/share/wake/lib/core/order.wake
@@ -15,7 +15,7 @@
 
 package wake
 
-# Used for comparing quantities.  
+# Used for comparing quantities.
 # Can hold the following values:
 # ``LT`` = Less Than
 # ``EQ`` = Equal

--- a/share/wake/lib/core/tree.wake
+++ b/share/wake/lib/core/tree.wake
@@ -752,7 +752,7 @@ def insertMin x = match _
     Tip -> Bin 1 Tip x Tip
     Bin _ l y r -> balanceL (insertMin x l) y r
 
-# Written while reading the Haskell Set implementation 
+# Written while reading the Haskell Set implementation
 def balanceL l x r = match l r
     Tip Tip -> Bin 1 Tip x Tip
     (Bin ls ll lx lr) Tip -> match ll lr

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -22,7 +22,7 @@ def name Unit =
 def name Unit =
   def other = here
 
-  # not floating with trailing        
+  # not floating with trailing        	
 
   def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   another

--- a/tests/wake-format/basic/basic.wake
+++ b/tests/wake-format/basic/basic.wake
@@ -7,6 +7,7 @@
 def five = 5
 
 # ordinary comment
+# comment with trailing spaces      
 
 def name Unit =
   def other = here
@@ -21,7 +22,7 @@ def name Unit =
 def name Unit =
   def other = here
 
-  # not floating
+  # not floating with trailing        
 
   def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   another

--- a/tests/wake-format/basic/stdout
+++ b/tests/wake-format/basic/stdout
@@ -8,6 +8,7 @@ def five =
     5
 
 # ordinary comment
+# comment with trailing spaces
 
 def name Unit =
     def other = @here
@@ -26,7 +27,7 @@ def name Unit =
 def name Unit =
     def other = @here
 
-    # not floating
+    # not floating with trailing
 
     def other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 

--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -28,7 +28,7 @@
 
 static inline wcl::doc rtrim_comment(const CSTElement& node) {
   std::string comment = node.fragment().segment().str();
-  comment.erase(comment.find_last_not_of(" ") + 1);
+  comment.erase(comment.find_last_not_of(" \t") + 1);
   return wcl::doc::lit(comment);
 }
 

--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -101,7 +101,10 @@ struct TokenReplaceAction {
         if (n.id() == TOKEN_COMMENT) {
           // Realign indent before writing the comment
           freshline(builder, ctx);
-          builder.append(n.fragment().segment().str());
+
+          std::string comment = n.fragment().segment().str();
+          comment.erase(comment.find_last_not_of(" ") + 1);
+          builder.append(wcl::doc::lit(comment));
           builder.append(wcl::doc::lit("\n"));
           continue;
         }

--- a/tools/wake-format/actions.h
+++ b/tools/wake-format/actions.h
@@ -26,11 +26,10 @@
 #include "predicates.h"
 #include "types.h"
 
-
-static inline wcl::doc rtrim_comment(const CSTElement& node) { 
-    std::string comment = node.fragment().segment().str();
-    comment.erase(comment.find_last_not_of(" ") + 1);
-    return wcl::doc::lit(comment);
+static inline wcl::doc rtrim_comment(const CSTElement& node) {
+  std::string comment = node.fragment().segment().str();
+  comment.erase(comment.find_last_not_of(" ") + 1);
+  return wcl::doc::lit(comment);
 }
 
 // This does nothing, good for kicking off a chain of formatters
@@ -145,9 +144,9 @@ struct TokenReplaceAction {
       for (auto n : it->second.after_bound) {
         space(builder, 1);
         if (n.id() == TOKEN_COMMENT) {
-            builder.append(rtrim_comment(n));
+          builder.append(rtrim_comment(n));
         } else {
-            builder.append(n.fragment().segment().str());
+          builder.append(n.fragment().segment().str());
         }
         newline(builder, 0);
       }

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -580,7 +580,7 @@ wcl::doc Emitter::walk(ctx_t ctx, CSTElement node) {
       is_floating_comment,
       fmt()
           .fmt_while(TOKEN_COMMENT,
-                     fmt().token(TOKEN_COMMENT).freshline().fmt_if(TOKEN_NL, fmt().next()))
+                     fmt().walk(WALK_TOKEN).freshline().fmt_if(TOKEN_NL, fmt().next()))
           .freshline()
           .newline()
           .join(consume_wsnl),
@@ -995,7 +995,12 @@ wcl::doc Emitter::walk_token(ctx_t ctx, CSTElement node) {
     case TOKEN_WS:
       builder.append(wcl::doc::lit(" "));
       break;
-    case TOKEN_COMMENT:
+    case TOKEN_COMMENT: {
+      std::string comment = node.fragment().segment().str();
+      comment.erase(comment.find_last_not_of(" ") + 1);
+      builder.append(wcl::doc::lit(comment));
+      break;
+    }
     case TOKEN_P_BOPEN:
     case TOKEN_P_BCLOSE:
     case TOKEN_P_SOPEN:

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -580,7 +580,7 @@ wcl::doc Emitter::walk(ctx_t ctx, CSTElement node) {
       is_floating_comment,
       fmt()
           .fmt_while(TOKEN_COMMENT,
-                     fmt().walk(WALK_TOKEN).freshline().fmt_if(TOKEN_NL, fmt().next()))
+                     fmt().token(TOKEN_COMMENT).freshline().fmt_if(TOKEN_NL, fmt().next()))
           .freshline()
           .newline()
           .join(consume_wsnl),
@@ -995,12 +995,7 @@ wcl::doc Emitter::walk_token(ctx_t ctx, CSTElement node) {
     case TOKEN_WS:
       builder.append(wcl::doc::lit(" "));
       break;
-    case TOKEN_COMMENT: {
-      std::string comment = node.fragment().segment().str();
-      comment.erase(comment.find_last_not_of(" ") + 1);
-      builder.append(wcl::doc::lit(comment));
-      break;
-    }
+    case TOKEN_COMMENT:
     case TOKEN_P_BOPEN:
     case TOKEN_P_BCLOSE:
     case TOKEN_P_SOPEN:

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -68,7 +68,7 @@ def buildOn Unit = match (subscribe releaseOn)
 #       ^^^
 # which breaks node's version requiement and is considered invalid
 #
-# Capture the parts and insert '-plus-' between the version and the commit. 
+# Capture the parts and insert '-plus-' between the version and the commit.
 # Do nothing if the version is already safe.
 def mk_node_semver_safe v =
     #                            | Matches the version tag, which should be 3 numbers separated by '.' with an optional leading 'v'


### PR DESCRIPTION
When parsing a TOKEN_COMMENT node everything until a newline (including trailing whitespace) gets slurped into the 'contents' of the comment. We don't want to re-emit this whitespace so it has to be manually removed when emitted comments.

An alternative implementation would be to manually edit the CST after parsing to remove trailing whitespace from any TOKEN_COMMENT node but editing the CST seems ill advised if its even possible.