### PR TITLE
Fix tokenize segfault when too many tokens are output

### DIFF
--- a/src/runtime/regexp.cpp
+++ b/src/runtime/regexp.cpp
@@ -215,13 +215,13 @@ static PRIMFN(prim_tokenize) {
   // NOTE: if there is not enough space, this routine will be re-entered.
   // This means tokens is recomputed with fresh/correct heap locations.
 
-  Value *out[tokens.size()];
+  std::vector<Value*> out;
   for (size_t i = 0; i < tokens.size(); ++i) {
     re2::StringPiece &p = tokens[i];
-    out[i] = String::claim(runtime.heap, p.data(), p.size());
+    out.emplace_back(String::claim(runtime.heap, p.data(), p.size()));
   }
 
-  RETURN(claim_list(runtime.heap, tokens.size(), out));
+  RETURN(claim_list(runtime.heap, tokens.size(), out.data()));
 }
 
 static PRIMTYPE(type_rcat) {

--- a/src/runtime/regexp.cpp
+++ b/src/runtime/regexp.cpp
@@ -215,7 +215,7 @@ static PRIMFN(prim_tokenize) {
   // NOTE: if there is not enough space, this routine will be re-entered.
   // This means tokens is recomputed with fresh/correct heap locations.
 
-  std::vector<Value*> out;
+  std::vector<Value *> out;
   for (size_t i = 0; i < tokens.size(); ++i) {
     re2::StringPiece &p = tokens[i];
     out.emplace_back(String::claim(runtime.heap, p.data(), p.size()));


### PR DESCRIPTION
The output array from which we construct the token list in prim tokenize was incorrectly allocated. This switches it to use a vector instead. This issue was never seen before because no one tried to do a split this big until now apparently. A user encountered this issue in the wild and I'm still not 100% sure that this will resolve their issues but I'm going to try that next.