### PR TITLE
Don't exit LSP when manifest error occurs

### DIFF
--- a/src/parser/wakefiles.cpp
+++ b/src/parser/wakefiles.cpp
@@ -488,7 +488,8 @@ std::vector<std::string> find_workspace_wakefiles_via_search(bool &ok, bool verb
 }
 
 std::vector<std::string> find_workspace_wakefiles_via_manifest(const std::string &manifest_path,
-                                                               const std::string &workdir) {
+                                                               const std::string &workdir,
+                                                               bool strict) {
   std::vector<std::string> workfiles;
   std::vector<std::string> unreadable_files;
   DiagnosticIgnorer ignorer;
@@ -527,7 +528,7 @@ std::vector<std::string> find_workspace_wakefiles_via_manifest(const std::string
         .urgent()();
   }
 
-  if (!unreadable_files.empty()) {
+  if (strict && !unreadable_files.empty()) {
     exit(1);
   }
 
@@ -535,7 +536,7 @@ std::vector<std::string> find_workspace_wakefiles_via_manifest(const std::string
 }
 std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbose,
                                             const std::string &libdir, const std::string &workdir,
-                                            FILE *user_warning_dest) {
+                                            FILE *user_warning_dest, bool strict) {
   ok = true;
   RE2::Options options;
   options.set_log_errors(false);
@@ -556,7 +557,7 @@ std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbo
 
   std::string manifest_path = workdir + "/.wakemanifest";
   if (is_readable(manifest_path.c_str())) {
-    workfiles = find_workspace_wakefiles_via_manifest(manifest_path, workdir);
+    workfiles = find_workspace_wakefiles_via_manifest(manifest_path, workdir, strict);
   } else {
     workfiles = find_workspace_wakefiles_via_search(ok, verbose, workdir, user_warning_dest, exp);
   }

--- a/src/parser/wakefiles.h
+++ b/src/parser/wakefiles.h
@@ -30,6 +30,6 @@ bool push_files(std::vector<std::string> &out, const std::string &path, const re
 std::string glob2regexp(const std::string &glob);
 std::vector<std::string> find_all_wakefiles(bool &ok, bool workspace, bool verbose,
                                             const std::string &libdir, const std::string &workdir,
-                                            FILE *user_warning_dest);
+                                            FILE *user_warning_dest, bool strict = true);
 
 #endif

--- a/tools/lsp-wake/astree.cpp
+++ b/tools/lsp-wake/astree.cpp
@@ -62,7 +62,7 @@ void ASTree::diagnoseProject(const std::function<void(FileDiagnostics &)> &proce
   comments.clear();
 
   bool enumok = true;
-  auto allFiles = find_all_wakefiles(enumok, true, false, absLibDir, absWorkDir, stdout);
+  auto allFiles = find_all_wakefiles(enumok, true, false, absLibDir, absWorkDir, stdout, false);
 
   std::map<std::string, std::vector<Diagnostic>> diagnostics;
   LSPReporter lspReporter(diagnostics, allFiles);


### PR DESCRIPTION
When editing wake code with a running LSP an author may end up in a position where a file exists in the editor but not on disk. (rename or unsaved new file) that they then (correctly) add to the `.wakemanifest` file. This creates an issue where to the user the file exists but to wake source discovery it doesn't. When source discovery sees a file listed that doesn't exist it will exit with an error which is correct for wake, but not the LSP. 

This change adds a strict flag to source discovery that the LSP can set to false. This allows the LSP to keep going even if the manifest doesn't fully agree.

In the long term, we should do a better job of managing the source lifetime within the LSP and we should report the missing file as an LSP notification but that change will be difficult without a significant refactor 