### PR TITLE
Generate prim.wake representing internal types

### DIFF
--- a/.wakemanifest
+++ b/.wakemanifest
@@ -41,6 +41,7 @@ share/wake/lib/core/result.wake
 share/wake/lib/core/string.wake
 share/wake/lib/core/map.wake
 share/wake/lib/core/syntax.wake
+share/wake/lib/prim/prim.wake
 tools/wake-unit/wake-unit.wake
 tools/fuse-waked/fuse-waked.wake
 tools/lsp-wake/lsp.wake

--- a/scripts/dump_prims.py
+++ b/scripts/dump_prims.py
@@ -1,0 +1,63 @@
+# Copyright 2023 SiFive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You should have received a copy of LICENSE.Apache2 along with
+# this software. If not, you may obtain a copy at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+
+def prim_to_expr(prim_name: str, param_count: int) -> str:
+    expr = '('
+    for _ in range(param_count):
+        expr += '\\_ '
+    expr += 'prim "'
+    expr += prim_name
+    expr += '")'
+    return expr
+
+def determine_expr_type(expr: str) -> str:
+    result = subprocess.run(['./bin/wake', '-q', '--print-expr-type', '-x', expr], stderr=subprocess.DEVNULL, stdout=subprocess.PIPE)
+    return result.stdout.decode('utf-8').splitlines()[0].strip()
+
+def determine_number_of_params(prim_name: str) -> int:
+    for i in range(100):
+        result = subprocess.run(['./bin/wake', '-x', prim_to_expr(prim_name, i)], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+        if result.returncode == 0:
+            return i
+
+    print("Unable to determine number of params under 100 tries, does prim have >100 parameters?")
+    exit(1)
+
+def prim_to_def(name: str, expr: str, type: str) -> str:
+    def_str = "export def prim_" + name + ": " + type + " =" + "\n"
+    def_str += "    " + expr
+    return def_str
+
+
+def main():
+    result = subprocess.run(['./bin/wake', '--list-prims'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+
+    print("package prim_wake")
+    print("")
+
+    for prim in result.stdout.decode('utf-8').splitlines():
+        prim = prim.strip()
+        if prim == "":
+            continue
+        num_params = determine_number_of_params(prim)
+        expr = prim_to_expr(prim, num_params)
+        type = determine_expr_type(expr)
+        print(prim_to_def(prim, expr, type))
+        print("")
+
+if __name__ == "__main__":
+    main()

--- a/share/wake/lib/core/double.wake
+++ b/share/wake/lib/core/double.wake
@@ -15,6 +15,8 @@
 
 package wake
 
+from prim_wake import _
+
 # The Double type is an IEEE 754 64-bit precision number.
 # Any wake literal which include a decimal point or an exponent is parsed into a Double.
 
@@ -22,13 +24,13 @@ package wake
 # dabs (+. 2.5) = 2.5
 # dabs (-. 2.5) = 2.5
 export def dabs (x: Double): Double =
-    (\_ prim "dabs") x
+    prim_dabs x
 
 # Unary negative sign for a Double.
 # -. (-. 2.5) =  2.5
 # -. (+. 2.5) = -2.5
 export def -.(x: Double): Double =
-    (\_ prim "dneg") x
+    prim_dneg x
 
 # Unary positive sign for a Double.
 # +. 2.5 = 2.5
@@ -39,31 +41,31 @@ export def +.(x: Double): Double =
 # 1.1 +. 2.0 = 3.1
 # 0.1 +. 0.5 = 0.6
 export def (x: Double) +. (y: Double): Double =
-    (\_ \_ prim "dadd") x y
+    prim_dadd x y
 
 # Binary subtraction operator for Double values.
 # 4.0 -. 2.2 = 1.8
 # 1.1 -. 2.0 = -. 0.9
 export def (x: Double) -. (y: Double): Double =
-    (\_ \_ prim "dsub") x y
+    prim_dsub x y
 
 # Binary multiplication operator for Double values.
 # 2.0 *. 3.3 = 6.6
 # 2.0 *. 4.1 = 8.2
 export def (x: Double) *. (y: Double): Double =
-    (\_ \_ prim "dmul") x y
+    prim_dmul x y
 
 # Binary division operator for Double valuess.
 # 4.0 /. 2.0 = 2.0
 # 5.0 /. 2.0 = 2.5
 export def (x: Double) /. (y: Double): Double =
-    (\_ \_ prim "ddiv") x y
+    prim_ddiv x y
 
 # Binary exponentiation operator for Double values.
 # 2.0 ^. 3.0 = 8.0
 # 0.5 ^. 2.0 = 0.25
 export def (x: Double) ^. (y: Double): Double =
-    (\_ \_ prim "dpow") x y
+    prim_dpow x y
 
 # Computes x*y + z with rounding only at the end.
 # The fused-multiply-add operation is useful in numeric algorithms.
@@ -71,7 +73,7 @@ export def (x: Double) ^. (y: Double): Double =
 # dfma 2.0 3.0 1.0 = 7.0
 # dfma 1.0 1.0 1.0 = 3.0
 export def dfma (x: Double) (y: Double) (z: Double): Double =
-    (\_ \_ \_ prim "dfma") x y z
+    prim_dfma x y z
 
 # Computes the n-th root.
 # droot 2.0 9.0  = 3.0
@@ -116,9 +118,7 @@ def root4 =
 # 4.5 <=>. 5.0 = Some LT
 # 4.0 <=>. 4.5 = Some GT
 export def dcmp (x: Double) (y: Double): Option Order =
-    def imp x y = prim "dcmp"
-
-    imp x y
+    prim_dcmp x y
     | head
 
 # Comparison of two Doubles.
@@ -258,16 +258,14 @@ export data DoubleFormat =
 #    DoubleScientific  1.000e+03  1.000e+00   # exactly 3 digits after the decimal
 #    DoubleHex         0x1.f40p+9 0x1.000p+0  # exactly 3 digits after the decimal
 #    DoubleDefault     1e+03      1e0         # at 3 digits of precision
-export def dformat (format: DoubleFormat): (digits: Integer) => Double => String =
-    def imp f p x = prim "dstr"
-
-    def f = match format
+export def dformat (format: DoubleFormat): (digits: Integer) => (value: Double) => String =
+    def format_int = match format
         DoubleFixed -> 0
         DoubleScientific -> 1
         DoubleHex -> 2
         DoubleDefault -> 3
 
-    imp f
+    (\d \v prim_dstr format_int d v)
 
 # Convert a String into a Double
 # Can parse any Double formatted by dformat.
@@ -275,7 +273,7 @@ export def dformat (format: DoubleFormat): (digits: Integer) => Double => String
 # double "1.0" = Some 1e0
 # double "xyz" = None
 export def double (doubleInString: String): Option Double =
-    (\_ prim "ddbl") doubleInString
+    prim_ddbl doubleInString
     | head
 
 # Format a Double losslessly in hex
@@ -308,9 +306,7 @@ export data DoubleClass =
 # dclass 1.0 = DoubleNormal
 # dclass 1.0e-322 = DoubleSubNormal
 export def dclass (x: Double): DoubleClass =
-    def imp x = prim "dclass"
-
-    match (imp x)
+    match (prim_dclass x)
         1 -> DoubleInfinite
         2 -> DoubleNaN
         4 -> DoubleSubNormal
@@ -325,7 +321,7 @@ export def dclass (x: Double): DoubleClass =
 # dfrexp 4.0 = Pair 0.5  3
 # dfrexp 3.0 = Pair 0.75 2
 export def dfrexp (x: Double): Pair Double Integer =
-    (\_ prim "dfrexp") x
+   prim_dfrexp x
 
 # Reverse the effects of dfrexp
 #
@@ -334,7 +330,7 @@ export def dfrexp (x: Double): Pair Double Integer =
 # dldexp 0.5  3 = 4.0
 # dldexp 0.75 2 = 3.0
 export def dldexp (fraction: Double) (exponent: Integer): Double =
-    (\_ \_ prim "dldexp") fraction exponent
+    prim_dldexp fraction exponent
 
 # Split 'x' into (Pair int fraction), such that:
 #   x = int + fraction
@@ -345,7 +341,7 @@ export def dldexp (fraction: Double) (exponent: Integer): Double =
 # dmodf 5.1 = Pair 5 0.1
 # dmodf (-.5.1) = Pair -5 -0.1
 export def dmodf (x: Double): Pair Integer Double =
-    (\_ prim "dmodf") x
+    prim_dmodf x
 
 # Handy numerical functions
 
@@ -355,7 +351,7 @@ export def dmodf (x: Double): Pair Integer Double =
 # dcos (pi/.2.0) =   0.0
 # dcos pi        = -.1.0
 export def dcos (radians: Double): Double =
-    (\_ prim "dcos") radians
+    prim_dcos radians
 
 # Calculates the sine of a Double.
 # dsin nan       = nan
@@ -363,14 +359,14 @@ export def dcos (radians: Double): Double =
 # dsin (pi/.2.0) = 1.0
 # dins pi        = 0.0
 export def dsin (radians: Double): Double =
-    (\_ prim "dsin") radians
+    prim_dsin radians
 
 # Calculates the tangent of a Double.
 # dtan (-.pi/.2.0) = -inf
 # dtan 0.0         =  0.0
 # dtan (  pi/.2.0) = +inf
 export def dtan (radians: Double): Double =
-    (\_ prim "dtan") radians
+    prim_dtan radians
 
 # Calculates the inverse cosine of a Double.
 # dacos (-.1.0) = pi
@@ -378,14 +374,14 @@ export def dtan (radians: Double): Double =
 # dacos 1.0     = 0.0
 # dacos 2.0     = nan
 export def dacos (x: Double): Double =
-    (\_ prim "dacos") x
+    prim_dacos x
 
 # Calculates the inverse sine of a Double.
 # dasin (-.1.0) = -.(pi/2.0)
 # dasin 0.0     = 0.0
 # dasin 1.0     = pi/2.0
 export def dasin (x: Double): Double =
-    (\_ prim "dasin") x
+    prim_dasin x
 
 # Calculates the inverse tangent of y/x, giving the angle of the point(x, y) in the coordinate plane.
 # The advantage of 2-argument datan over 1-argument datan is it is defined even where x is 0.
@@ -398,20 +394,20 @@ export def dasin (x: Double): Double =
 # datan     1.0  (-. 1.0) = pi *  0.75
 # datan     0.0  (-. 1.0) = pi *  1.00
 export def datan (x: Double) (y: Double): Double =
-    (\_ \_ prim "datan") x y
+    prim_datan x y
 
 # Calculates e^x.
 # dexp 0.0 = 1.0
 # dexp 1.0 = 2.71828
 # dexp (-.inf) = 0.0
 export def dexp (x: Double): Double =
-    (\_ prim "dexp") x
+    prim_dexp x
 
 # Calculates the natural logarithm of x.
 # dlog (dexp x) = x
 # dlog (-. 1.0) = nan
 export def dlog (x: Double): Double =
-    (\_ prim "dlog") x
+    prim_dlog x
 
 # Calculates e^.x -. 1.0
 # Useful for values of 'x' close to 0.0
@@ -419,7 +415,7 @@ export def dlog (x: Double): Double =
 # dexpm1 0.0     = 0.0
 # dexpm1 0.2     = 0.22
 export def dexpm1 (x: Double): Double =
-    (\_ prim "dexpm1") x
+    prim_dexpm1 x
 
 # Calculates dlog (1.0 +. x)
 # dlog1p (dexpm1 x) = x
@@ -428,29 +424,29 @@ export def dexpm1 (x: Double): Double =
 # dlog1p 0.0     = 0.0
 # dlog1p 0.2     = 0.18
 export def dlog1p (x: Double): Double =
-    (\_ prim "dlog1p") x
+    prim_dlog1p x
 
 # Calculate the 'error function'.
 # 2/sqrt(pi) Integral_{0..x} e^(-t^2) dt
 # This function is handy for statistics
 export def derf (x: Double): Double =
-    (\_ prim "derf") x
+    prim_derf x
 
 # Calculate the complementary 'error function' (1-erf).
 # 2/sqrt(pi) Integral_{0..x} e^(-t^2) dt
 # This function is handy for statistics
 export def derfc (x: Double): Double =
-    (\_ prim "derfc") x
+    prim_derfc x
 
 # Compute the gamma function; Integral_{0..inf} t^{x-1} e^t dt
 # This is an everywhere-defined factorial method; dtgamma (x+1) = x!
 export def dtgamma (x: Double): Double =
-    (\_ prim "dtgamma") x
+    prim_dtgamma x
 
 # Compute the logarithm of the gamma function
 # This is useful to approximate statistics like (n choose m)
 export def dlgamma (x: Double): Double =
-    (\_ prim "dlgamma") x
+    prim_dlgamma x
 
 # Useful constants
 

--- a/share/wake/lib/core/double.wake
+++ b/share/wake/lib/core/double.wake
@@ -305,12 +305,11 @@ export data DoubleClass =
 # dclass nan = DoubleNaN
 # dclass 1.0 = DoubleNormal
 # dclass 1.0e-322 = DoubleSubNormal
-export def dclass (x: Double): DoubleClass =
-    match (prim_dclass x)
-        1 -> DoubleInfinite
-        2 -> DoubleNaN
-        4 -> DoubleSubNormal
-        _ -> DoubleNormal
+export def dclass (x: Double): DoubleClass = match (prim_dclass x)
+    1 -> DoubleInfinite
+    2 -> DoubleNaN
+    4 -> DoubleSubNormal
+    _ -> DoubleNormal
 
 # Split 'x' into (Pair sig exp), such that:
 #   x = sig * 2^exp
@@ -321,7 +320,7 @@ export def dclass (x: Double): DoubleClass =
 # dfrexp 4.0 = Pair 0.5  3
 # dfrexp 3.0 = Pair 0.75 2
 export def dfrexp (x: Double): Pair Double Integer =
-   prim_dfrexp x
+    prim_dfrexp x
 
 # Reverse the effects of dfrexp
 #

--- a/share/wake/lib/core/double.wake
+++ b/share/wake/lib/core/double.wake
@@ -265,7 +265,7 @@ export def dformat (format: DoubleFormat): (digits: Integer) => (value: Double) 
         DoubleHex -> 2
         DoubleDefault -> 3
 
-    (\d \v prim_dstr format_int d v)
+    prim_dstr format_int
 
 # Convert a String into a Double
 # Can parse any Double formatted by dformat.

--- a/share/wake/lib/core/integer.wake
+++ b/share/wake/lib/core/integer.wake
@@ -15,6 +15,8 @@
 
 package wake
 
+from prim_wake import _
+
 # The Integer type has unbounded precision (aka a "big" integer).
 # Any wake literal like 12331_1232 or 0x3123 is an Integer.
 
@@ -26,65 +28,65 @@ export def +(x: Integer): Integer =
 # Unary negative sign operator for Integer values.
 # (-5) = 0-5
 export def -(x: Integer): Integer =
-    (\_ prim "neg") x
+    prim_neg x
 
 # Unary two's complement operator for Integer values.
 # ~0 = -1
 # ~4 = -5
 export def ~(x: Integer): Integer =
-    (\_ prim "com") x
+    prim_com x
 
 # Binary addition operator for Integer values.
 # 1 + 2 = 3
 # 1 + 5 = 6
 export def (x: Integer) + (y: Integer): Integer =
-    (\_ \_ prim "add") x y
+    prim_add x y
 
 # Binary subtraction operator for Integer values.
 # 2 - 1 =  1
 # 3 - 4 = -1
 export def (x: Integer) - (y: Integer): Integer =
-    (\_ \_ prim "sub") x y
+    prim_sub x y
 
 # Binary multiplication operator for Integer values.
 #  3 *   4  = 12
 # -3 * (-4) = 12
 export def (x: Integer) * (y: Integer): Integer =
-    (\_ \_ prim "mul") x y
+    prim_mul x y
 
 # Binary division operator for Integer values.
 # 12 / 3 =  4
 # 13 / 3 =  4
 # -8 / 4 = -2
 export def (x: Integer) / (y: Integer): Integer =
-    (\_ \_ prim "div") x y
+    prim_div x y
 
 # Binary remainder operator for Integer values.
 # 11 % 5 = 1
 #  4 % 5 = 5
 #  7 % 5 = 2
 export def (x: Integer) % (y: Integer): Integer =
-    (\_ \_ prim "mod") x y
+    prim_mod x y
 
 # Binary left shift operator for Integer values.
 # 1 << 10 = 1024
 # 3 <<  8 =  768
 export def (x: Integer) << (y: Integer): Integer =
-    (\_ \_ prim "shl") x y
+    prim_shl x y
 
 # Binary right shift operator for Integer values.
 # 1024 >> 11 = 0
 # 1024 >>  9 = 2
 #  768 >>  8 = 3
 export def (x: Integer) >> (y: Integer): Integer =
-    (\_ \_ prim "shr") x y
+    prim_shr x y
 
 # Binary exponentiation operator for Integer values.
 # 2^8 = 256
 # 3^2 = 9
 # 5^3 = 125
 export def (x: Integer) ^ (y: Integer): Integer =
-    (\_ \_ prim "exp") x y
+    prim_exp x y
 
 # Returns the n-th root of x.
 # root 2  9    = Some 3
@@ -96,7 +98,7 @@ export def root (n: Integer) (x: Integer): Option Integer =
     if and n 1 == 0 && x < 0 then
         None
     else
-        Some ((\_ \_ prim "root") x n)
+        Some (prim_root x n)
 
 # Unary square root operator.
 # sqrt 9    = Some 3
@@ -106,62 +108,62 @@ export def sqrt (x: Integer): Option Integer =
 
 # Unary absolute-value operator.
 export def abs (x: Integer): Integer =
-    (\_ prim "abs") x
+    prim_abs x
 
 # Binary bitwise XOR operator.
 # xor 4 4 = 0
 # xor 4 3 = 7
 # xor (-4) (-3) = 1
 export def xor (x: Integer) (y: Integer): Integer =
-    (\_ \_ prim "xor") x y
+    prim_xor x y
 
 # Binary bitwise AND operator.
 # and 4 4 = 4
 # and 4 3 = 0
 # and (-4) (-3) = -4
 export def and (x: Integer) (y: Integer): Integer =
-    (\_ \_ prim "and") x y
+    prim_and x y
 
 # Binary bitwise OR operator.
 # or 4 4 = 4
 # or 4 3 = 7
 # or (-4) (-3) = -3
 export def or (x: Integer) (y: Integer): Integer =
-    (\_ \_ prim "or") x y
+    prim_or x y
 
 # Greatest Common Divisor.
 # gcd 4 4 = 4
 # gcd 4 3 = 1
 # gcd (-4) (-3) = 1
 export def gcd (x: Integer) (y: Integer): Integer =
-    (\_ \_ prim "gcd") x y
+    prim_gcd x y
 
 # Least Common Multiple.
 # lcm 4 4 = 4
 # lcm 4 3 = 12
 # lcm (-4) (-3) = 12
 export def lcm (x: Integer) (y: Integer): Integer =
-    (\_ \_ prim "lcm") x y
+    prim_lcm x y
 
 # Computes (x^y) % m.
 # powm 2 7 5 = 4
 # powm 3 2 2 = 1
 export def powm (x: Integer) (y: Integer) (m: Integer): Integer =
-    (\_ \_ \_ prim "powm") x y m
+    prim_powm x y m
 
 # Compare two Integers for Order
 # icmp 4 5 = LT
 # icmp 5 5 = EQ
 # icmp 5 4 = GT
 export def icmp (x: Integer) (y: Integer): Order =
-    (\_ \_ prim "icmp") x y
+    prim_icmp x y
 
 # Compare two Integers for Order
 # 4 <=> 5 = LT
 # 5 <=> 5 = EQ
 # 5 <=> 4 = GT
 export def (x: Integer) <=> (y: Integer): Order =
-    (\_ \_ prim "icmp") x y
+    prim_icmp x y
 
 # Binary Less-Than operator for Integers.
 # 4 < 5 = True

--- a/share/wake/lib/core/json.wake
+++ b/share/wake/lib/core/json.wake
@@ -15,6 +15,8 @@
 
 package wake
 
+from prim_wake import _
+
 # The JSON data type
 export data JValue =
     JString String
@@ -56,22 +58,16 @@ export def getJArray: JValue => Option (List JValue) = match _
     JArray x -> Some x
     _ -> None
 
-export def parseJSONBody (body: String): Result JValue Error =
-    def imp b = prim "json_body"
+export def parseJSONBody (body: String): Result JValue Error = match (prim_json_body body)
+    Pass jvalue -> Pass jvalue
+    Fail cause -> Fail (makeError cause)
 
-    match (imp body)
-        Pass jvalue -> Pass jvalue
-        Fail cause -> Fail (makeError cause)
-
-export def parseJSONFile (path: Path): Result JValue Error =
-    def imp f = prim "json_file"
-
-    match (imp path.getPathName)
-        Pass body -> Pass body
-        Fail f -> Fail (makeError f)
+export def parseJSONFile (path: Path): Result JValue Error = match (prim_json_file path.getPathName)
+    Pass body -> Pass body
+    Fail f -> Fail (makeError f)
 
 export def jsonEscape str =
-    prim "json_str"
+    prim_json_str str
 
 tuple JSONFormat =
     export String: String => String

--- a/share/wake/lib/core/print.wake
+++ b/share/wake/lib/core/print.wake
@@ -15,6 +15,8 @@
 
 package wake
 
+from prim_wake import _
+
 # format: render any type into a printable String
 #
 #   format 44        = "44"
@@ -26,9 +28,7 @@ package wake
 #   format True      = "True"
 #   format (_)       = "<source-file.wake:line:column>"
 export def format (anyType: a): String =
-    def p x = prim "format"
-
-    p anyType
+    prim_format anyType
 
 # To construct a LogLevel
 export data LogLevel =
@@ -94,9 +94,7 @@ export def tap (consumerFn: a => b) (value: a): a =
 #   # Produce a yellow hello on stdout unless run with -q
 #   def Unit = printlnLevel logWarning "hello"
 export def printlnLevel (LogLevel name) (message: String): Unit =
-    def p stream outputStr = prim "print"
-
-    p name "{message}\n"
+    prim_print name "{message}\n"
 
 # println: print a colourless String with a newline, visible when run with -v.
 #
@@ -115,7 +113,5 @@ export def println: String => Unit =
 #   # Emit a structured message to 'wake.log'
 #   def _ = breadcrumb "encountered failing event"
 export def breadcrumb (x: String): Unit =
-    def p s = prim "breadcrumb"
-
-    p x
+    prim_breadcrumb x
 

--- a/share/wake/lib/core/regexp.wake
+++ b/share/wake/lib/core/regexp.wake
@@ -15,17 +15,16 @@
 
 package wake
 
+from prim_wake import _
+
 # Regular expressions
 
 # Create RegExp that only matches str, by escaping special characters.
 # quote "a.b" = `a\.b`
 # quote "hello[world]" = `hello\[world\]`
-export def quote (str: String): RegExp =
-    def res str = prim "quote"
-
-    match (res str).stringToRegExp
-        Pass x -> x
-        Fail error -> unreachable "quote primitive bug: {error.getErrorCause}"
+export def quote (str: String): RegExp = match (prim_quote str).stringToRegExp
+    Pass x -> x
+    Fail error -> unreachable "quote primitive bug: {error.getErrorCause}"
 
 # Concatenate a list of regular expressions.
 # The resulting regular expression must match the elements sequentially.
@@ -46,12 +45,9 @@ export def regExpCat (l: List RegExp): RegExp =
 # If the string is an illegal RegExp, returns Fail.
 # stringToRegExp "abc" = Pass `abc`
 # stringToRegExp "a("  = Fail (Error "missing ): a(" _)
-export def stringToRegExp (str: String): Result RegExp Error =
-    def p s = prim "re2"
-
-    match (p str)
-        Pass r -> Pass r
-        Fail e -> failWithError e
+export def stringToRegExp (str: String): Result RegExp Error = match (prim_re2 str)
+    Pass r -> Pass r
+    Fail e -> failWithError e
 
 # Convert a String glob-style expression into a RegExp.
 # A glob expression has:
@@ -61,38 +57,35 @@ export def stringToRegExp (str: String): Result RegExp Error =
 #   **/  matches any path leading up to the /
 #   [ab] matches either a or b
 #   \*   matches a *
-export def globToRegExp (glob: String): RegExp =
-    def glob2regexp glob = prim "glob2regexp"
-
-    match (glob2regexp glob).stringToRegExp
-        Pass x -> x
-        Fail error -> unreachable "glob primitive bug: {error.getErrorCause}"
+export def globToRegExp (glob: String): RegExp = match (prim_glob2regexp glob).stringToRegExp
+    Pass x -> x
+    Fail error -> unreachable "glob primitive bug: {error.getErrorCause}"
 
 # Convert a regular expression into a String.
 # stringToRegExp (regExpToString x) = Pass x
 # regExpToString `abc` = "abc"
 # regExpToString `.*`  = ".*"
 export def regExpToString (regExp: RegExp): String =
-    (\_ prim "re2str") regExp
+    prim_re2str regExp
 
 # Test if a regular expression matches an entire String.
 # matches `a*` "ba" = False
 # matches `a*` "aa" = True
 export def matches (testRegExp: RegExp) (str: String): Boolean =
-    (\_ \_ prim "match") testRegExp str
+    prim_match testRegExp str
 
 # Extract fields out of a String using a parenthetical regular expression.
 # extract `(.*)-(.*)` "hello-world-hello" = ("hello", "world-hello", Nil)
 # extract `(.*)-(.*)` "helloworldhello" = Nil
 export def extract (parensRegexp: RegExp) (str: String): List String =
-    (\_ \_ prim "extract") parensRegexp str
+    prim_extract parensRegexp str
 
 # Replace all occurances of locatorRegExp in str with replacement.
 # replace `:` " " "a:b:c" = "a b c"
 export def replace (locatorRegExp: RegExp) (replacement: String) (str: String): String =
-    (\_ \_ \_ prim "replace") locatorRegExp replacement str
+    prim_replace locatorRegExp replacement str
 
 # Remove all occurances of seperatorRegExp from str, creating a List of String fragments.
 # tokenize `:` "hello:there:friend" = ("hello", "there", "friend", Nil)
 export def tokenize (seperatorRegExp: RegExp) (str: String): List String =
-    (\_ \_ prim "tokenize") seperatorRegExp str
+    prim_tokenize seperatorRegExp str

--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -15,6 +15,8 @@
 
 package wake
 
+from prim_wake import _
+
 # Functions which may fail should return the `Result a Error` type.
 # This allows the caller to distinguish between Pass and Fail.
 # Appropriate use of the `require` keyword can chain Results together.
@@ -200,9 +202,7 @@ export def findPassFn (fn: a => Result pass b): List a => Result pass (List b) =
 # stack: dump a stack trace from the call site
 # This function currently only works with debug mode enabled.
 export def stack Unit: List String =
-    def f x = prim "stack"
-
-    f Unit
+    prim_stack Unit
 
 # An Error has a cause and a stack trace
 # Result types should generally use an Error for their Fail case.

--- a/share/wake/lib/core/string.wake
+++ b/share/wake/lib/core/string.wake
@@ -15,6 +15,8 @@
 
 package wake
 
+from prim_wake import _
+
 # String methods
 
 # strlen: report the number of bytes a String consumes in UTF-8 representation.
@@ -22,9 +24,7 @@ package wake
 # This information can be relevant when reading / writing Strings to disk.
 # To manipulate Strings, such as extract-ing a substring, use regular expressions.
 export def strlen (string: String): Integer =
-    def p s = prim "strlen"
-
-    p string
+    prim_strlen string
 
 # cat: concatenate a List of Strings into a String.
 # If you have a finite list of terms, consider using String interpolation.
@@ -32,9 +32,7 @@ export def strlen (string: String): Integer =
 #   cat ("hello", " ", "world", Nil) = "hello world"
 #   cat (x, ":", y, ":", z, Nil) = "{x}:{y}:{z}"
 export def cat (strings: List String): String =
-    def p l = prim "lcat"
-
-    p strings
+    prim_lcat strings
 
 # catWith: concatenate a List of Strings with a separator.
 #
@@ -55,9 +53,7 @@ export def catWith (separator: String) (strings: List String): String =
 #   explode "hello" = "h", "e", "l", "l", "o", Nil
 #   explode "süß"   = "s", "ü", "ß", Nil
 export def explode (string: String): List String =
-    def p s = prim "explode"
-
-    p string
+    prim_explode string
 
 # strbase: convert an Integer into a String using a given base.
 #
@@ -78,9 +74,7 @@ export def strbase (base: Integer): Option (Integer => String) =
     def ok = (2 <= base && base <= 62) || (-36 <= base && base <= -2)
 
     if ok then
-        def p n integerToFormat = prim "str"
-
-        Some (p base)
+        Some (prim_str base)
     else
         None
 
@@ -96,9 +90,7 @@ export def strbase (base: Integer): Option (Integer => String) =
 #
 # For any other base (or an illegal input String), None is returned.
 export def intbase (base: Integer) (stringToParse: String): Option Integer =
-    def p b s = prim "int"
-
-    p base stringToParse
+    prim_int base stringToParse
     | head
 
 # str: format an Integer to a String in decimal notation.
@@ -106,32 +98,24 @@ export def intbase (base: Integer) (stringToParse: String): Option Integer =
 #   str 10   =  "10"
 #   str 0xff = "256"
 export def str: Integer => String =
-    def p n integerToFormat = prim "str"
-
-    p 10
+    prim_str 10
 
 # strHex: format an Integer to a String in hexadecimal notation.
 #
 #   strHex 10   =  "a"
 #   strHex 0xff = "ff"
 export def strHex: Integer => String =
-    def p n integerToFormat = prim "str"
-
-    p 16
+    prim_str 16
 
 # strOctal: format an Integer to a String in octal notation.
 #
 #   strOctal 10   =  "12"
 #   strOctal 0xff = "377"
 export def strOctal: Integer => String =
-    def p n integerToFormat = prim "str"
-
-    p 8
+    prim_str 8
 
 export def filterTerminalCodes (str: String): String =
-    def p s = prim "filter_term_codes"
-
-    p str
+    prim_filter_term_codes str
 
 # int: convert a String into an Integer with the usual prefixes.
 #
@@ -160,9 +144,7 @@ export def int (stringToParse: String): Option Integer =
 #   integerToUnicode 0x1f600 = "😀"
 #   integerToUnicode 0 = "\x00"
 export def integerToUnicode (codepoint: Integer): String =
-    def p x = prim "code2str"
-
-    p codepoint
+    prim_code2str codepoint
 
 # unicodeToInteger: convert the first codepoint in a String to an Integer.
 #
@@ -173,9 +155,7 @@ export def integerToUnicode (codepoint: Integer): String =
 #   unicodeToInteger "" = 0
 #   unicodeToInteger "\0a" = 0
 export def unicodeToInteger (firstCharacterToConvert: String): Integer =
-    def p x = prim "str2code"
-
-    p firstCharacterToConvert
+    prim_str2code firstCharacterToConvert
 
 # integerToByte: convert an Integer into a String using raw binary.
 # WARNING: For 128 <= byte <= 255, this function creates invalid UTF-8 / Unicode.
@@ -191,9 +171,7 @@ export def unicodeToInteger (firstCharacterToConvert: String): Integer =
 # It is possible to create legal UTF-8 from illegal String fragments; eg:
 #   "{integerToByte 0xc3}{integerToByte 0xa7}" = "ç"
 export def integerToByte (byte: Integer): String =
-    def p b = prim "bin2str"
-
-    p byte
+    prim_bin2str byte
 
 # byteToInteger: convert the first byte of a UTF-8-encoded String into an Integer.
 # Instead of calling this function, you probably meant to call unicodeToInteger.
@@ -203,31 +181,23 @@ export def integerToByte (byte: Integer): String =
 #   byteToInteger "A" = 65
 #   byteToInteger (integerToByte 231) = 231
 export def byteToInteger (firstByteToConvert: String): Integer =
-    def p s = prim "str2bin"
-
-    p firstByteToConvert
+    prim_str2bin firstByteToConvert
 
 # Version of wake
 export def version: String =
-    prim "version"
+    prim_version
 
 # unicodeCanonical: eliminate combining characters; C+◌̧ => Ç
 export def unicodeCanonical (str: String): String =
-    def p s = prim "sNFC"
-
-    p str
+    prim_sNFC str
 
 # unicodeIdentifier: eliminate rendering distinctions; ¼i⁹ => 1/4i9
 export def unicodeIdentifier (str: String): String =
-    def p s = prim "sNFKC"
-
-    p str
+    prim_sNFKC str
 
 # unicodeLowercase: eliminate case distinctions; C => c
 export def unicodeLowercase (str: String): String =
-    def p s = prim "scaseNFKC"
-
-    p str
+    prim_scaseNFKC str
 
 # sortStrings: sort a list of strings as a human would judge them.
 export def sortStrings (list: List String): List String =
@@ -247,9 +217,7 @@ export def scmpLowercase (x: String) (y: String): Order =
 
 # Raw binary string comparison; no normalization performed
 export def scmp (x: String) (y: String): Order =
-    def p x y = prim "scmp"
-
-    p x y
+    prim_scmp x y
 
 # NFKC order (fancy format removed) -- secure default
 # This is the string order you should use to compare human inputs
@@ -338,6 +306,4 @@ export def (x: String) !=* (y: String): Boolean =
     isNE (x <=>* y)
 
 export def hashString (x: String): String =
-    def hashStr x = prim "hash_str"
-
-    hashStr x
+    prim_hash_str x

--- a/share/wake/lib/prim/prim.wake
+++ b/share/wake/lib/prim/prim.wake
@@ -1,0 +1,401 @@
+package prim_wake
+
+export def prim_abs: Integer => Integer =
+    (\_ prim "abs")
+
+export def prim_access: String => Integer => Boolean =
+    (\_ \_ prim "access")
+
+export def prim_add: Integer => Integer => Integer =
+    (\_ \_ prim "add")
+
+export def prim_add_hash: String => String => String =
+    (\_ \_ prim "add_hash")
+
+export def prim_add_sources: String => Boolean =
+    (\_ prim "add_sources")
+
+export def prim_and: Integer => Integer => Integer =
+    (\_ \_ prim "and")
+
+export def prim_bin2str: Integer => String =
+    (\_ prim "bin2str")
+
+export def prim_breadcrumb: String => Unit =
+    (\_ prim "breadcrumb")
+
+export def prim_cmdline: List String =
+    (prim "cmdline")
+
+export def prim_code2str: Integer => String =
+    (\_ prim "code2str")
+
+export def prim_com: Integer => Integer =
+    (\_ prim "com")
+
+export def prim_cwd: String =
+    (prim "cwd")
+
+export def prim_dabs: Double => Double =
+    (\_ prim "dabs")
+
+export def prim_dacos: Double => Double =
+    (\_ prim "dacos")
+
+export def prim_dadd: Double => Double => Double =
+    (\_ \_ prim "dadd")
+
+export def prim_dasin: Double => Double =
+    (\_ prim "dasin")
+
+export def prim_datan: Double => Double => Double =
+    (\_ \_ prim "datan")
+
+export def prim_dclass: Double => Integer =
+    (\_ prim "dclass")
+
+export def prim_dcmp: Double => Double => List Order =
+    (\_ \_ prim "dcmp")
+
+export def prim_dcmp_nan_lt: Double => Double => Order =
+    (\_ \_ prim "dcmp_nan_lt")
+
+export def prim_dcos: Double => Double =
+    (\_ prim "dcos")
+
+export def prim_ddbl: String => List Double =
+    (\_ prim "ddbl")
+
+export def prim_ddiv: Double => Double => Double =
+    (\_ \_ prim "ddiv")
+
+export def prim_derf: Double => Double =
+    (\_ prim "derf")
+
+export def prim_derfc: Double => Double =
+    (\_ prim "derfc")
+
+export def prim_dexp: Double => Double =
+    (\_ prim "dexp")
+
+export def prim_dexpm1: Double => Double =
+    (\_ prim "dexpm1")
+
+export def prim_dfma: Double => Double => Double => Double =
+    (\_ \_ \_ prim "dfma")
+
+export def prim_dfrexp: Double => Pair Double Integer =
+    (\_ prim "dfrexp")
+
+export def prim_div: Integer => Integer => Integer =
+    (\_ \_ prim "div")
+
+export def prim_dldexp: Double => Integer => Double =
+    (\_ \_ prim "dldexp")
+
+export def prim_dlgamma: Double => Double =
+    (\_ prim "dlgamma")
+
+export def prim_dlog: Double => Double =
+    (\_ prim "dlog")
+
+export def prim_dlog1p: Double => Double =
+    (\_ prim "dlog1p")
+
+export def prim_dmodf: Double => Pair Integer Double =
+    (\_ prim "dmodf")
+
+export def prim_dmul: Double => Double => Double =
+    (\_ \_ prim "dmul")
+
+export def prim_dneg: Double => Double =
+    (\_ prim "dneg")
+
+export def prim_dpow: Double => Double => Double =
+    (\_ \_ prim "dpow")
+
+export def prim_dsin: Double => Double =
+    (\_ prim "dsin")
+
+export def prim_dstr: Integer => Integer => Double => String =
+    (\_ \_ \_ prim "dstr")
+
+export def prim_dsub: Double => Double => Double =
+    (\_ \_ prim "dsub")
+
+export def prim_dtan: Double => Double =
+    (\_ prim "dtan")
+
+export def prim_dtgamma: Double => Double =
+    (\_ prim "dtgamma")
+
+export def prim_execpath: String =
+    (prim "execpath")
+
+export def prim_exp: Integer => Integer => Integer =
+    (\_ \_ prim "exp")
+
+export def prim_explode: String => List String =
+    (\_ prim "explode")
+
+export def prim_extract: RegExp => String => List String =
+    (\_ \_ prim "extract")
+
+export def prim_files: String => RegExp => List String =
+    (\_ \_ prim "files")
+
+export def prim_filter_term_codes: String => String =
+    (\_ prim "filter_term_codes")
+
+export def prim_format: a => String =
+    (\_ prim "format")
+
+export def prim_gcd: Integer => Integer => Integer =
+    (\_ \_ prim "gcd")
+
+export def prim_get_hash: String => String =
+    (\_ prim "get_hash")
+
+export def prim_get_modtime: String => Integer =
+    (\_ prim "get_modtime")
+
+export def prim_getenv: String => List String =
+    (\_ prim "getenv")
+
+export def prim_glob2regexp: String => String =
+    (\_ prim "glob2regexp")
+
+export def prim_hash: Integer =
+    (prim "hash")
+
+export def prim_hash_str: String => String =
+    (\_ prim "hash_str")
+
+export def prim_icmp: Integer => Integer => Order =
+    (\_ \_ prim "icmp")
+
+export def prim_int: Integer => String => List Integer =
+    (\_ \_ prim "int")
+
+export def prim_job_cache: String => String => String => String => Integer => String => Integer => Pair (List Job) (List (Pair String String)) =
+    (\_ \_ \_ \_ \_ \_ \_ prim "job_cache")
+
+export def prim_job_cache_add: String => Result String String =
+    (\_ prim "job_cache_add")
+
+export def prim_job_cache_read: String => Result String String =
+    (\_ prim "job_cache_read")
+
+export def prim_job_create: String => String => String => String => String => Integer => String => Integer => String => String => String => Integer => Job =
+    (\_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ prim "job_create")
+
+export def prim_job_desc: Job => String =
+    (\_ prim "job_desc")
+
+export def prim_job_fail_finish: Job => Error => Unit =
+    (\_ \_ prim "job_fail_finish")
+
+export def prim_job_fail_launch: Job => Error => Unit =
+    (\_ \_ prim "job_fail_launch")
+
+export def prim_job_finish: Job => String => String => String => Integer => Double => Double => Integer => Integer => Integer => Unit =
+    (\_ \_ \_ \_ \_ \_ \_ \_ \_ \_ prim "job_finish")
+
+export def prim_job_id: Job => Integer =
+    (\_ prim "job_id")
+
+export def prim_job_launch: Job => String => String => String => String => Integer => Double => Double => Integer => Integer => Integer => Integer => Unit =
+    (\_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ prim "job_launch")
+
+export def prim_job_output: Job => Integer => Result String Error =
+    (\_ \_ prim "job_output")
+
+export def prim_job_reality: Job => Result (Pair (Pair Integer Double) (Pair (Pair Double Integer) (Pair Integer Integer))) Error =
+    (\_ prim "job_reality")
+
+export def prim_job_record: Job => List (Pair (Pair Integer Double) (Pair (Pair Double Integer) (Pair Integer Integer))) =
+    (\_ prim "job_record")
+
+export def prim_job_report: Job => Result (Pair (Pair Integer Double) (Pair (Pair Double Integer) (Pair Integer Integer))) Error =
+    (\_ prim "job_report")
+
+export def prim_job_tag: Job => String => String => Unit =
+    (\_ \_ \_ prim "job_tag")
+
+export def prim_job_tree: Job => Integer => Result (List (Pair String String)) Error =
+    (\_ \_ prim "job_tree")
+
+export def prim_job_virtual: Job => String => String => Integer => Double => Double => Integer => Integer => Integer => Unit =
+    (\_ \_ \_ \_ \_ \_ \_ \_ \_ prim "job_virtual")
+
+export def prim_json_body: String => Result JValue String =
+    (\_ prim "json_body")
+
+export def prim_json_file: String => Result JValue String =
+    (\_ prim "json_file")
+
+export def prim_json_str: String => String =
+    (\_ prim "json_str")
+
+export def prim_lcat: List String => String =
+    (\_ prim "lcat")
+
+export def prim_lcm: Integer => Integer => Integer =
+    (\_ \_ prim "lcm")
+
+export def prim_level: Integer =
+    (prim "level")
+
+export def prim_match: RegExp => String => Boolean =
+    (\_ \_ prim "match")
+
+export def prim_mkdir: Integer => String => Result String String =
+    (\_ \_ prim "mkdir")
+
+export def prim_mod: Integer => Integer => Integer =
+    (\_ \_ prim "mod")
+
+export def prim_mul: Integer => Integer => Integer =
+    (\_ \_ prim "mul")
+
+export def prim_neg: Integer => Integer =
+    (\_ prim "neg")
+
+export def prim_or: Integer => Integer => Integer =
+    (\_ \_ prim "or")
+
+export def prim_panic: String => a =
+    (\_ prim "panic")
+
+export def prim_pid: Integer =
+    (prim "pid")
+
+export def prim_powm: Integer => Integer => Integer => Integer =
+    (\_ \_ \_ prim "powm")
+
+export def prim_print: String => String => Unit =
+    (\_ \_ prim "print")
+
+export def prim_quote: String => String =
+    (\_ prim "quote")
+
+export def prim_rcat: RegExp =
+    (prim "rcat")
+
+export def prim_rcmp: RegExp => RegExp => Order =
+    (\_ \_ prim "rcmp")
+
+export def prim_re2: String => Result RegExp String =
+    (\_ prim "re2")
+
+export def prim_re2str: RegExp => String =
+    (\_ prim "re2str")
+
+export def prim_read: String => Result String String =
+    (\_ prim "read")
+
+export def prim_relative: String => String => String =
+    (\_ \_ prim "relative")
+
+export def prim_replace: RegExp => String => String => String =
+    (\_ \_ \_ prim "replace")
+
+export def prim_root: Integer => Integer => Integer =
+    (\_ \_ prim "root")
+
+export def prim_sNFC: String => String =
+    (\_ prim "sNFC")
+
+export def prim_sNFKC: String => String =
+    (\_ prim "sNFKC")
+
+export def prim_scaseNFKC: String => String =
+    (\_ prim "scaseNFKC")
+
+export def prim_scmp: String => String => Order =
+    (\_ \_ prim "scmp")
+
+export def prim_search_path: String => String => String =
+    (\_ \_ prim "search_path")
+
+export def prim_shell_str: String => String =
+    (\_ prim "shell_str")
+
+export def prim_shl: Integer => Integer => Integer =
+    (\_ \_ prim "shl")
+
+export def prim_shr: Integer => Integer => Integer =
+    (\_ \_ prim "shr")
+
+export def prim_simplify: String => String =
+    (\_ prim "simplify")
+
+export def prim_sources: String => RegExp => List String =
+    (\_ \_ prim "sources")
+
+export def prim_stack: Unit => List String =
+    (\_ prim "stack")
+
+export def prim_str: Integer => Integer => String =
+    (\_ \_ prim "str")
+
+export def prim_str2bin: String => Integer =
+    (\_ prim "str2bin")
+
+export def prim_str2code: String => Integer =
+    (\_ prim "str2code")
+
+export def prim_strlen: String => Integer =
+    (\_ prim "strlen")
+
+export def prim_sub: Integer => Integer => Integer =
+    (\_ \_ prim "sub")
+
+# export def prim_tget: Target => (Target => a) => a =
+#     (\_ \_ prim "tget")
+
+# export def prim_tnew: String => Integer => Target =
+#     (\_ \_ prim "tnew")
+
+export def prim_tokenize: RegExp => String => List String =
+    (\_ \_ prim "tokenize")
+
+export def prim_true: a => Boolean =
+    (\_ prim "true")
+
+export def prim_uname: Pair String String =
+    (prim "uname")
+
+export def prim_unlink: String => Unit =
+    (\_ prim "unlink")
+
+export def prim_unreachable: String => a =
+    (\_ prim "unreachable")
+
+export def prim_use: a => a =
+    (\_ prim "use")
+
+export def prim_vcat: String =
+    (prim "vcat")
+
+export def prim_version: String =
+    (prim "version")
+
+# export def prim_vget: Array a => Integer => a =
+#     (\_ \_ prim "vget")
+
+# export def prim_vnew: Integer => Array a =
+#     (\_ prim "vnew")
+
+# export def prim_vset: Array a => Integer => a => Unit =
+#     (\_ \_ \_ prim "vset")
+
+export def prim_workspace: String =
+    (prim "workspace")
+
+export def prim_write: Integer => String => String => Result String String =
+    (\_ \_ \_ prim "write")
+
+export def prim_xor: Integer => Integer => Integer =
+    (\_ \_ prim "xor")
+

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -56,6 +56,8 @@ struct CommandLineOptions {
   bool timeline;
   bool clean;
   bool list_outputs;
+  bool list_prims;
+  bool print_expr_type;
   wcl::optional<bool> log_header_align;
   wcl::optional<bool> cache_miss_on_failure;
 
@@ -146,6 +148,8 @@ struct CommandLineOptions {
       {0, "stderr", GOPT_ARGUMENT_REQUIRED},
       {0, "clean", GOPT_ARGUMENT_FORBIDDEN },
       {0, "list-outputs", GOPT_ARGUMENT_FORBIDDEN },
+      {0, "list-prims", GOPT_ARGUMENT_FORBIDDEN },
+      {0, "print-expr-type", GOPT_ARGUMENT_FORBIDDEN },
       {0, "fd:3", GOPT_ARGUMENT_REQUIRED},
       {0, "fd:4", GOPT_ARGUMENT_REQUIRED},
       {0, "fd:5", GOPT_ARGUMENT_REQUIRED},
@@ -194,6 +198,8 @@ struct CommandLineOptions {
     timeline = arg(options, "timeline")->count;
     clean = arg(options, "clean")->count;
     list_outputs = arg(options, "list-outputs")->count;
+    list_prims = arg(options, "list-prims")->count;
+    print_expr_type = arg(options, "print-expr-type")->count;
 
     percent_str = arg(options, "percent")->argument;
     jobs_str = arg(options, "jobs")->argument;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -848,6 +848,13 @@ int main(int argc, char **argv) {
                   cmdline);
   PrimMap pmap = prim_register_all(&info, &jobtable);
 
+  if (clo.list_prims) {
+    for (auto kvp : pmap) {
+      std::cout << kvp.first << std::endl;
+    }
+    return 0;
+  }
+
   bool isTreeBuilt = true;
   std::unique_ptr<Expr> root = bind_refs(std::move(top), pmap, isTreeBuilt);
   if (!isTreeBuilt) ok = false;
@@ -987,6 +994,10 @@ int main(int argc, char **argv) {
     }
     if (!clo.quiet || !pass) {
       HeapObject::format(os, v, clo.debug, clo.verbose ? 0 : -1);
+      os << std::endl;
+    }
+    if (clo.print_expr_type) {
+      type.format(os, type);
       os << std::endl;
     }
   }


### PR DESCRIPTION
This is a somewhat hacky (and quite slow) script that I've been wanting for a long time. 

Basically the script asks `wake` a bunch of questions about the installed `prim`s then outputs typed `def`s representing them. 

This should alleviate some of the "string typing" that the prims have in wake source.

run with `python3 scripts/dump_prims.py > share/wake/lib/prim/prim.wake`

Once this goes it, it would be official policy that `prim "name"` not be allowed in wake source outside of the stdlibs `prim.wake`