### PR TITLE
Adding create time for jobs in job cache

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -385,7 +385,8 @@ class JobTable {
 
  public:
   static constexpr const char *insert_query =
-      "insert into jobs (directory, commandline, environment, stdin, bloom_filter, runner_hash, create_time)"
+      "insert into jobs (directory, commandline, environment, stdin, bloom_filter, runner_hash, "
+      "create_time)"
       "values (?, ?, ?, ?, ?, ?, ?)";
 
   static constexpr const char *add_output_info_query =
@@ -1027,7 +1028,8 @@ void DaemonCache::add(const AddJobRequest &add_request) {
   {
     impl->transact.run([this, time, &add_request, &job_id]() {
       job_id = impl->jobs.insert(add_request.cwd, add_request.command_line, add_request.environment,
-                                 add_request.stdin_str, add_request.bloom, add_request.runner_hash, time);
+                                 add_request.stdin_str, add_request.bloom, add_request.runner_hash,
+                                 time);
 
       // Add additional info
       impl->jobs.insert_output_info(job_id, add_request.stdout_str, add_request.stderr_str,

--- a/src/job_cache/schema.sql
+++ b/src/job_cache/schema.sql
@@ -21,7 +21,8 @@ create table if not exists jobs(
   environment  blob    not null,
   stdin        text    not null,
   bloom_filter integer not null,
-  runner_hash  text    not null);
+  runner_hash  text    not null,
+  create_time  integer not null);
 create index if not exists job on jobs(directory, commandline, environment, stdin, runner_hash);
 
 -- This table stores all the details about a job that aren't known until


### PR DESCRIPTION
This change adds a create time for jobs in the job cache which will invalidate the schema. This will be needed both to implement the TTL eviction policy and to implement the needed fixes to the LRU eviction policy so it seems an easy thing to jsut go ahead and add.