### PR TITLE
Support globbing for all param based inspection

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -386,14 +386,14 @@ std::string Database::open(bool wait, bool memory, bool tty) {
       "j.starttime, j.endtime, j.stale, r.time, r.cmdline, s.status, s.runtime, s.cputime, "
       "s.membytes, s.ibytes, s.obytes"
       " from  jobs j left join stats s on j.stat_id=s.stat_id join runs r on j.run_id=r.run_id"
-      " where j.job_id=?";
+      " where cast(j.job_id as TEXT) like ? order by j.job_id";
   const char *sql_find_owner =
       "select j.job_id, j.label, j.directory, j.commandline, j.environment, j.stack, j.stdin, "
       "j.starttime, j.endtime, j.stale, r.time, r.cmdline, s.status, s.runtime, s.cputime, "
       "s.membytes, s.ibytes, s.obytes"
       " from files f, filetree t, jobs j left join stats s on j.stat_id=s.stat_id join runs r on "
       "j.run_id=r.run_id"
-      " where f.path=? and t.file_id=f.file_id and t.access=? and j.job_id=t.job_id order by "
+      " where f.path like ? and t.file_id=f.file_id and t.access=? and j.job_id=t.job_id order by "
       "j.job_id";
   const char *sql_find_last_exe =
       "select j.job_id, j.label, j.directory, j.commandline, j.environment, j.stack, j.stdin, "
@@ -1295,15 +1295,15 @@ std::vector<JobReflection> Database::labels_matching(const std::string glob) {
   return find_all(this, imp->find_label);
 }
 
-std::vector<JobReflection> Database::explain(long job) {
+std::vector<JobReflection> Database::job_ids_matching(const std::string glob) {
   const char *why = "Could not bind args";
-  bind_integer(why, imp->find_job, 1, job);
+  bind_string(why, imp->find_job, 1, glob);
   return find_all(this, imp->find_job);
 }
 
-std::vector<JobReflection> Database::explain(const std::string &file, int use) {
+std::vector<JobReflection> Database::files_matching(const std::string &glob, int use) {
   const char *why = "Could not bind args";
-  bind_string(why, imp->find_owner, 1, file);
+  bind_string(why, imp->find_owner, 1, glob);
   bind_integer(why, imp->find_owner, 2, use);
   return find_all(this, imp->find_owner);
 }

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -151,12 +151,17 @@ struct Database {
 
   std::string get_hash(const std::string &file, long modified);
 
-  std::vector<JobReflection> explain(long job);
-
-  std::vector<JobReflection> explain(const std::string &file, int use);
-
   std::vector<JobReflection> failed();
+
+  std::vector<JobReflection> job_ids_matching(const std::string glob);
   std::vector<JobReflection> labels_matching(const std::string glob);
+  std::vector<JobReflection> files_matching(const std::string &glob, int use);
+  std::vector<JobReflection> input_files_matching(const std::string &glob) {
+    return files_matching(glob, 1);
+  }
+  std::vector<JobReflection> output_files_matching(const std::string &glob) {
+    return files_matching(glob, 2);
+  }
 
   std::vector<JobReflection> last_exe();
   std::vector<JobReflection> last_use();


### PR DESCRIPTION
This is the second PR on the path to  tag inspection of the database. After this PR any inspection flag that accepts a parameter can use the glob operators `*` and `?` as expected.

Example:
`wake --input "*.c" --output "*.o" --job "???"`
which says match any job that takes a `c` file as input,  outputs an `o` file, and has a 3 digit job id