### PR TITLE
Add split_by to wcl

### DIFF
--- a/src/wcl/iterator.h
+++ b/src/wcl/iterator.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+
+namespace wcl {
+template <class T, class Iter, class F>
+auto split_by_fn(const T& v, Iter begin, Iter end, F f) -> std::vector<decltype(f(begin, end))> {
+  auto start_part = begin;
+  auto end_part = begin;
+  std::vector<decltype(f(begin, end))> out;
+  while (end_part < end) {
+    if (*end_part == v) {
+      out.emplace_back(f(start_part, end_part));
+      end_part++;
+      start_part = end_part;
+    } else {
+      end_part++;
+    }
+  }
+  out.emplace_back(start_part, end_part);
+  return out;
+}
+
+}  // namespace wcl

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -30,6 +30,10 @@ PASSED:
   filepath_range_only_slash
   filepath_range_two_slash
   filepath_relative_to
+  iterator_split_by_empty
+  iterator_split_by_no_delim
+  iterator_split_by_nominal
+  iterator_split_by_only_delim
   job_cache_basic_fuzz
   job_cache_basic_par_fuzz
   option_assign1

--- a/tools/wake-unit/iterator.cpp
+++ b/tools/wake-unit/iterator.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <wcl/iterator.h>
+
+#include "unit.h"
+
+TEST(iterator_split_by_nominal) {
+  std::string str = "an,input,text";
+
+  std::vector<std::string> parts = wcl::split_by_fn(
+      ',', str.begin(), str.end(), [](auto a, auto b) { return std::string(a, b); });
+
+  EXPECT_EQUAL(parts.size(), 3u);
+  EXPECT_EQUAL(parts[0], "an");
+  EXPECT_EQUAL(parts[1], "input");
+  EXPECT_EQUAL(parts[2], "text");
+}
+
+TEST(iterator_split_by_no_delim) {
+  std::string str = "an input text";
+
+  std::vector<std::string> parts = wcl::split_by_fn(
+      ',', str.begin(), str.end(), [](auto a, auto b) { return std::string(a, b); });
+
+  EXPECT_EQUAL(parts.size(), 1u);
+  EXPECT_EQUAL(parts[0], "an input text");
+}
+
+TEST(iterator_split_by_only_delim) {
+  std::string str = ",,,,,";
+
+  std::vector<std::string> parts = wcl::split_by_fn(
+      ',', str.begin(), str.end(), [](auto a, auto b) { return std::string(a, b); });
+
+  EXPECT_EQUAL(parts.size(), 6u);
+  EXPECT_EQUAL(parts[0], "");
+  EXPECT_EQUAL(parts[1], "");
+  EXPECT_EQUAL(parts[2], "");
+  EXPECT_EQUAL(parts[3], "");
+  EXPECT_EQUAL(parts[4], "");
+  EXPECT_EQUAL(parts[5], "");
+}
+
+TEST(iterator_split_by_empty) {
+  std::string str = "";
+
+  std::vector<std::string> parts = wcl::split_by_fn(
+      ',', str.begin(), str.end(), [](auto a, auto b) { return std::string(a, b); });
+
+  EXPECT_EQUAL(parts.size(), 1u);
+  EXPECT_EQUAL(parts[0], "");
+}


### PR DESCRIPTION
Implements and tests a split-by function for exploding something iteratable (usually a string) into parts over a  delimiter 