### PR TITLE
Add support for complex intersection/union filters

### DIFF
--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -124,8 +124,6 @@ Set<long> apply_inspection_query(std::unordered_map<long, JobReflection> &captur
   for (const std::vector<std::string> &and_part : query) {
     std::vector<JobReflection> hits = {};
     for (const std::string &or_part : and_part) {
-      if (or_part == "") continue;
-
       std::vector<JobReflection> results = qf(globish_to_like(or_part));
       std::move(results.begin(), results.end(), std::back_inserter(hits));
     }


### PR DESCRIPTION
Improves/increases the types of queries that can be spelled out with the db inspection subsystem.

The syntax is as follows
  - repeating a flag is intersection
  - `,` in a flag unions the parts (`,` can be repeated for multiple parts)
  - `*` matches 0 or more  of any character
  - `?` matches exactly 1 of any character

Example
`wake --job "5??,6??" --label "*c++*" --label "*.c" --output "*.o"` is

 - AND
   - label contains `c++`
   - label ends with `.c`
   - job output a file ending in `.o`
   - OR
     - job id is 3 digits starting with 5
     - job id is 3 digits starting with 6