### PR TITLE
Identify `write` job with mode as octal, not decimal

### DIFF
--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -68,8 +68,8 @@ target writeImp inputs mode path content =
 
     # If all those checks pass we go ahead and perform the write. The write will
     # overwrite single files but it will not overwrite a whole directory with a file.
-    makeExecPlan ("<write>", str mode, path, Nil) inputs
-    | setPlanLabel "write: {path} {str mode}"
+    makeExecPlan ("<write>", "0{strOctal mode}", path, Nil) inputs
+    | setPlanLabel "write: {path} 0{strOctal mode}"
     | setPlanOnce False
     | setPlanEnvironment Nil
     | runJobWith writeRunner


### PR DESCRIPTION
In trying to debug an odd `write` job, @maniltongya and I couldn't find where it was being called despite what seemed like a very unique `420` mode being printed in the job metadata.  I eventually realized that was being printed as *decimal* instead, and was the much more typical `0644`.  This PR still doesn't help us find where the offending `write` is happening, but it will at least avoid the same confusion over what's being set.

This and `mkdirImp` seem to be the only jobs which specify the mode, and that one already uses the proper base.  There shouldn't be any issue with updating this (beyond all `write` jobs having to be rerun) as the actual `prim` call never interacts with the label/cmdline, and a very simple `wake -x 'write "tmp.txt" "Test"'` shows everything being correct.