### PR TITLE
Implement tag filters for database inspection

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -435,8 +435,6 @@ std::string Database::open(bool wait, bool memory, bool tty) {
       " from jobs j left join stats s on j.stat_id=s.stat_id join runs r on j.run_id=r.run_id "
       "inner join tags t on j.job_id = t.job_id"
       " where t.uri like ? AND t.content like ? order by j.job_id";
-
-  // const char *sql_get_tags = "select job_id, uri, content from tags where job_id=?";
   const char *sql_fetch_hash = "select hash from files where path=? and modified=?";
   const char *sql_delete_jobs =
       "delete from jobs where job_id in"

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -153,8 +153,10 @@ struct Database {
 
   std::vector<JobReflection> failed();
 
-  std::vector<JobReflection> job_ids_matching(const std::string glob);
-  std::vector<JobReflection> labels_matching(const std::string glob);
+  std::vector<JobReflection> job_ids_matching(const std::string &glob);
+  std::vector<JobReflection> labels_matching(const std::string &glob);
+  std::vector<JobReflection> tags_matching(const std::string &uri_glob,
+                                           const std::string &content_glob);
   std::vector<JobReflection> files_matching(const std::string &glob, int use);
   std::vector<JobReflection> input_files_matching(const std::string &glob) {
     return files_matching(glob, 1);
@@ -162,7 +164,8 @@ struct Database {
   std::vector<JobReflection> output_files_matching(const std::string &glob) {
     return files_matching(glob, 2);
   }
-
+  // Helper function to split 'uri=content' into 'uri, content'
+  std::vector<JobReflection> tags_matching(const std::string &glob);
   std::vector<JobReflection> last_exe();
   std::vector<JobReflection> last_use();
 

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -71,7 +71,6 @@ struct CommandLineOptions {
   const char *exec;
   char *shebang;
   const char *tagdag;
-  const char *tag;
   const char *api;
   const char *fd1;
   const char *fd2;
@@ -88,6 +87,7 @@ struct CommandLineOptions {
   std::vector<std::vector<std::string>> input_files = {};
   std::vector<std::vector<std::string>> output_files = {};
   std::vector<std::vector<std::string>> labels = {};
+  std::vector<std::vector<std::string>> tags = {};
 
   int argc;
   char **argv;
@@ -98,6 +98,7 @@ struct CommandLineOptions {
     std::vector<char *> input_files_buffer(argc_in, nullptr);
     std::vector<char *> output_files_buffer(argc_in, nullptr);
     std::vector<char *> labels_buffer(argc_in, nullptr);
+    std::vector<char *> tags_buffer(argc_in, nullptr);
 
     // clang-format off
     struct option options[] {
@@ -122,6 +123,7 @@ struct CommandLineOptions {
       {'i', "input", GOPT_ARGUMENT_REQUIRED | GOPT_REPEATABLE_VALUE, input_files_buffer.data(), (unsigned int)argc_in},
       {'o', "output", GOPT_ARGUMENT_REQUIRED | GOPT_REPEATABLE_VALUE, output_files_buffer.data(), (unsigned int)argc_in},
       {0, "label", GOPT_ARGUMENT_REQUIRED | GOPT_REPEATABLE_VALUE, labels_buffer.data(), (unsigned int)argc_in},
+      {0, "tag", GOPT_ARGUMENT_REQUIRED | GOPT_REPEATABLE_VALUE, tags_buffer.data(), (unsigned int)argc_in},
       {'l', "last", GOPT_ARGUMENT_FORBIDDEN},
       {0, "last-used", GOPT_ARGUMENT_FORBIDDEN},
       {0, "last-executed", GOPT_ARGUMENT_FORBIDDEN},
@@ -143,7 +145,6 @@ struct CommandLineOptions {
       {0, "stop-after-ssa", GOPT_ARGUMENT_FORBIDDEN},
       {0, "no-optimize", GOPT_ARGUMENT_FORBIDDEN},
       {0, "tag-dag", GOPT_ARGUMENT_REQUIRED},
-      {0, "tag", GOPT_ARGUMENT_REQUIRED},
       {0, "export-api", GOPT_ARGUMENT_REQUIRED},
       {0, "stdout", GOPT_ARGUMENT_REQUIRED},
       {0, "stderr", GOPT_ARGUMENT_REQUIRED},
@@ -209,7 +210,6 @@ struct CommandLineOptions {
     exec = arg(options, "exec")->argument;
     shebang = arg(options, "shebang")->argument;
     tagdag = arg(options, "tag-dag")->argument;
-    tag = arg(options, "tag")->argument;
     api = arg(options, "export-api")->argument;
     fd1 = arg(options, "stdout")->argument;
     fd2 = arg(options, "stderr")->argument;
@@ -265,6 +265,13 @@ struct CommandLineOptions {
       std::vector<std::string> parts = wcl::split_by_fn(
           ',', line.begin(), line.end(), [](auto a, auto b) { return std::string(a, b); });
       labels.emplace_back(std::move(parts));
+    }
+
+    for (unsigned int i = 0; i < arg(options, "tag")->count; i++) {
+      std::string line(tags_buffer[i]);
+      std::vector<std::string> parts = wcl::split_by_fn(
+          ',', line.begin(), line.end(), [](auto a, auto b) { return std::string(a, b); });
+      tags.emplace_back(std::move(parts));
     }
 
     if (!percent_str) {

--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -212,7 +212,17 @@ void describe_human(const std::vector<JobReflection> &jobs) {
   std::ostream out(&tbuf);
   for (size_t i = 0; i < jobs.size(); i++) {
     const auto &job = jobs[i];
-    out << term_colour(TERM_GREEN) << "# " << job.label << "(" << job.job << ")\n";
+    out << term_colour(TERM_GREEN) << "# " << job.label << " (" << job.job << ")";
+
+    if (!job.tags.empty()) {
+      out << " [";
+      for (auto &tag : job.tags) {
+        out << tag.uri << "=" << tag.content << ",";
+      }
+      out << "]";
+    }
+
+    out << "\n";
     out << term_normal() << "$ " << term_colour(TERM_CYAN);
     for (size_t i = 0; i < job.commandline.size(); i++) {
       const auto &cmd_part = job.commandline[i];
@@ -244,12 +254,6 @@ void describe(const std::vector<JobReflection> &jobs, DescribePolicy policy) {
     }
     case DescribePolicy::HUMAN: {
       describe_human(jobs);
-      break;
-    }
-    case DescribePolicy::TAG_URI: {
-      for (auto &job : jobs)
-        for (auto &tag : job.tags)
-          if (tag.uri == policy.tag_uri) std::cout << tag.content << std::endl;
       break;
     }
     case DescribePolicy::METADATA: {

--- a/tools/wake/describe.h
+++ b/tools/wake/describe.h
@@ -24,17 +24,10 @@
 #include "runtime/database.h"
 
 struct DescribePolicy {
-  enum type { TAG_URI, SCRIPT, HUMAN, METADATA, DEBUG, VERBOSE } type;
+  enum type { SCRIPT, HUMAN, METADATA, DEBUG, VERBOSE } type;
   union {
     const char *tag_uri;
   };
-
-  static DescribePolicy tag_url(const char *tag_uri) {
-    DescribePolicy policy;
-    policy.type = TAG_URI;
-    policy.tag_uri = tag_uri;
-    return policy;
-  }
 
   static DescribePolicy script() {
     DescribePolicy policy;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -149,10 +149,6 @@ DescribePolicy get_describe_policy(const CommandLineOptions &clo) {
     return DescribePolicy::script();
   }
 
-  if (clo.tag) {
-    return DescribePolicy::tag_url(clo.tag);
-  }
-
   return DescribePolicy::human();
 }
 
@@ -190,6 +186,12 @@ void inspect_database(const CommandLineOptions &clo, Database &db, const std::st
     intersected_job_ids =
         apply_inspection_query(captured_jobs, std::move(intersected_job_ids), clo.labels,
                                [&](auto a) { return db.labels_matching(a); });
+  }
+
+  if (!clo.tags.empty()) {
+    intersected_job_ids =
+        apply_inspection_query(captured_jobs, std::move(intersected_job_ids), clo.tags,
+                               [&](auto a) { return db.tags_matching(a); });
   }
 
   if (clo.last_use) {
@@ -406,8 +408,8 @@ int main(int argc, char **argv) {
   }
 
   bool is_db_inspection = !clo.job_ids.empty() || !clo.output_files.empty() ||
-                          !clo.input_files.empty() || !clo.labels.empty() || clo.last_use ||
-                          clo.last_exe || clo.failed || clo.tagdag;
+                          !clo.input_files.empty() || !clo.labels.empty() || !clo.tags.empty() ||
+                          clo.last_use || clo.last_exe || clo.failed || clo.tagdag;
   // Arguments are forbidden with these options
   bool noargs =
       is_db_inspection || clo.init || clo.html || clo.global || clo.exports || clo.api || clo.exec;


### PR DESCRIPTION
Implements database inspection for filtering on tags. Using the same semantics as all other filters except that two values are provided with a `=` between them. `--tag a=b` filters for all tags where the URI is `a` and the content is `b`. `*` and `?` work as expected.