### PR TITLE
Remove filesearch index

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -37,7 +37,7 @@
 #include "wcl/iterator.h"
 
 // Increment every time the database schema changes
-#define SCHEMA_VERSION "6"
+#define SCHEMA_VERSION "7"
 
 #define VISIBLE 0
 #define INPUT 1
@@ -241,7 +241,6 @@ std::string Database::open(bool wait, bool memory, bool tty) {
       "  job_id   integer not null references jobs(job_id) on delete cascade,"
       "  file_id  integer not null references files(file_id),"
       "  unique(job_id, access, file_id) on conflict ignore);"
-      "create index if not exists filesearch on filetree(file_id, access, job_id);"
       "create table if not exists log("
       "  log_id     integer primary key autoincrement,"
       "  job_id     integer not null references jobs(job_id) on delete cascade,"

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -37,7 +37,7 @@
 #include "wcl/iterator.h"
 
 // Increment every time the database schema changes
-#define SCHEMA_VERSION "7"
+#define SCHEMA_VERSION "6"
 
 #define VISIBLE 0
 #define INPUT 1
@@ -241,6 +241,7 @@ std::string Database::open(bool wait, bool memory, bool tty) {
       "  job_id   integer not null references jobs(job_id) on delete cascade,"
       "  file_id  integer not null references files(file_id),"
       "  unique(job_id, access, file_id) on conflict ignore);"
+      "drop index if exists filesearch;"
       "create table if not exists log("
       "  log_id     integer primary key autoincrement,"
       "  job_id     integer not null references jobs(job_id) on delete cascade,"


### PR DESCRIPTION
This change removes the `filesearch` index which was previously being used by the query to find jobs that output a particular file. We have sense opted to search for those files via a glob instead which means that the index is no longer being used. For jobs that output/input huge numbers of files, this index can take up to about 1/3rd of the database size. Given that we're not actually using it this PR deletes it.

The schema remains compatible but if we do not explicitly add a "drop index if exists" the index will keep existing in people's databases. I considered bumping the schema version but I think using drop index if exists acts as an effective migration. If an older version of wake is used after a newer version, it will re-build the index. If a newer version of wake is used after an old one, it will drop the index. Rebuilding and dropping the index should be fast enough, and the likelihood of this happening repeatedly low enough, that this is acceptable.