### PR TITLE
Tag temp files created by the shared cache

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -906,7 +906,7 @@ FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {
 
       // Finally copy the file (as efficently as we can) to
       // the destination.
-      std::string tmp_dst = pair.first ".local-cache-tmp." + rng.unique_name();
+      std::string tmp_dst = pair.first + ".local-cache-tmp." + rng.unique_name();
       copy_or_reflink(tmp_file.c_str(), tmp_dst.c_str(), mode, O_EXCL);
       rename_no_fail(tmp_dst.c_str(), pair.first.c_str());
     }

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -906,7 +906,7 @@ FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {
 
       // Finally copy the file (as efficently as we can) to
       // the destination.
-      std::string tmp_dst = pair.first + "." + rng.unique_name();
+      std::string tmp_dst = pair.first ".local-cache-tmp." + rng.unique_name();
       copy_or_reflink(tmp_file.c_str(), tmp_dst.c_str(), mode, O_EXCL);
       rename_no_fail(tmp_dst.c_str(), pair.first.c_str());
     }
@@ -927,7 +927,7 @@ FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {
       mkdir_all(pair.second.begin(), pair.second.end());
 
       // Lastly make the symlink
-      std::string tmp_link = pair.first + "." + rng.unique_name();
+      std::string tmp_link = pair.first + ".local-cache-tmp." + rng.unique_name();
       symlink_no_fail(output_symlink.value.c_str(), tmp_link.c_str());
       rename_no_fail(tmp_link.c_str(), pair.first.c_str());
     }


### PR DESCRIPTION
If the daemon is killed by an external agent at *just* the right time, there's a about a 1/1000 chance that it will happen between the creation of a temp file and the rename. This will leave a temp file sitting around. This on its own is not really a problem. The temp file can be confusing to debug the existence however and if you have tools in place to track that cleaning your workspace actually cleans everything, this will trigger that check.

A full solution would be to have the client copy out of the cache instead of having the daemon do the copy. But even that might leave temp files sitting around that you might not want. To combat this we need to tag these files so that such a tool can identify them. Later we will move the copy to the client where the odds of this sort of thing occurring drastically shrink and the odds of a user caring for that particular failure mode are even lower.