### PR TITLE
Revert "Remove filesearch index (#1457)"

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -241,7 +241,7 @@ std::string Database::open(bool wait, bool memory, bool tty) {
       "  job_id   integer not null references jobs(job_id) on delete cascade,"
       "  file_id  integer not null references files(file_id),"
       "  unique(job_id, access, file_id) on conflict ignore);"
-      "drop index if exists filesearch;"
+      "create index if not exists filesearch on filetree(file_id, access, job_id);"
       "create table if not exists log("
       "  log_id     integer primary key autoincrement,"
       "  job_id     integer not null references jobs(job_id) on delete cascade,"


### PR DESCRIPTION
This reverts commit a964d7fd28dd581bc8ee3931db0fca2e3b01a77d  which introduced a significant performance regression to `db.clean()`