### PR TITLE
rsc: Paydown JobUse tech debt

### DIFF
--- a/rust/entity/src/job.rs
+++ b/rust/entity/src/job.rs
@@ -34,8 +34,8 @@ pub struct Model {
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {
-    #[sea_orm(has_many = "super::job_uses::Entity")]
-    JobUses,
+    #[sea_orm(has_many = "super::job_use::Entity")]
+    JobUse,
     #[sea_orm(has_many = "super::output_dir::Entity")]
     OutputDir,
     #[sea_orm(has_many = "super::output_file::Entity")]
@@ -46,9 +46,9 @@ pub enum Relation {
     VisibleFile,
 }
 
-impl Related<super::job_uses::Entity> for Entity {
+impl Related<super::job_use::Entity> for Entity {
     fn to() -> RelationDef {
-        Relation::JobUses.def()
+        Relation::JobUse.def()
     }
 }
 

--- a/rust/entity/src/job_use.rs
+++ b/rust/entity/src/job_use.rs
@@ -3,7 +3,7 @@
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
-#[sea_orm(table_name = "job_uses")]
+#[sea_orm(table_name = "job_use")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,

--- a/rust/entity/src/mod.rs
+++ b/rust/entity/src/mod.rs
@@ -4,7 +4,7 @@ pub mod prelude;
 
 pub mod api_key;
 pub mod job;
-pub mod job_uses;
+pub mod job_use;
 pub mod output_dir;
 pub mod output_file;
 pub mod output_symlink;

--- a/rust/entity/src/prelude.rs
+++ b/rust/entity/src/prelude.rs
@@ -2,7 +2,7 @@
 
 pub use super::api_key::Entity as ApiKey;
 pub use super::job::Entity as Job;
-pub use super::job_uses::Entity as JobUses;
+pub use super::job_use::Entity as JobUse;
 pub use super::output_dir::Entity as OutputDir;
 pub use super::output_file::Entity as OutputFile;
 pub use super::output_symlink::Entity as OutputSymlink;

--- a/rust/migration/src/lib.rs
+++ b/rust/migration/src/lib.rs
@@ -4,6 +4,8 @@ mod m20220101_000001_create_table;
 mod m20230706_104843_api_keys;
 mod m20230707_144317_record_uses;
 mod m20231117_162713_add_created_at;
+mod m20231127_232833_drop_use_time;
+mod m20231128_000751_normalize_uses_table;
 
 pub struct Migrator;
 
@@ -15,6 +17,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20230706_104843_api_keys::Migration),
             Box::new(m20230707_144317_record_uses::Migration),
             Box::new(m20231117_162713_add_created_at::Migration),
+            Box::new(m20231127_232833_drop_use_time::Migration),
+            Box::new(m20231128_000751_normalize_uses_table::Migration),
         ]
     }
 }

--- a/rust/migration/src/m20231127_232833_drop_use_time.rs
+++ b/rust/migration/src/m20231127_232833_drop_use_time.rs
@@ -1,0 +1,40 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(JobUses::Table)
+                    .drop_column(JobUses::Time)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(JobUses::Table)
+                    .add_column(
+                        ColumnDef::new(JobUses::Time)
+                            .timestamp()
+                            .not_null()
+                            .default(SimpleExpr::Keyword(Keyword::CurrentTimestamp)),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum JobUses {
+    Table,
+    Time,
+}

--- a/rust/migration/src/m20231128_000751_normalize_uses_table.rs
+++ b/rust/migration/src/m20231128_000751_normalize_uses_table.rs
@@ -1,0 +1,37 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .rename_table(
+                Table::rename()
+                    .table(JobUses::Table, JobUse::Table)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .rename_table(
+                Table::rename()
+                    .table(JobUse::Table, JobUses::Table)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum JobUses {
+    Table,
+}
+
+#[derive(DeriveIden)]
+enum JobUse {
+    Table,
+}

--- a/rust/rsc/src/rsc/read_job.rs
+++ b/rust/rsc/src/rsc/read_job.rs
@@ -1,7 +1,6 @@
 use crate::types::{Dir, File, ReadJobPayload, ReadJobResponse, Symlink};
 use axum::Json;
-use chrono::Utc;
-use entity::{job, job_uses, output_dir, output_file, output_symlink};
+use entity::{job, job_use, output_dir, output_file, output_symlink};
 use sea_orm::{
     ActiveModelTrait, ActiveValue::*, ColumnTrait, DatabaseConnection, DbErr, EntityTrait,
     ModelTrait, QueryFilter, TransactionTrait,
@@ -11,12 +10,10 @@ use tracing;
 
 #[tracing::instrument]
 async fn record_use(job_id: i32, conn: Arc<DatabaseConnection>) {
-    let timestamp = Utc::now().naive_utc();
-    let usage = job_uses::ActiveModel {
+    let usage = job_use::ActiveModel {
         id: NotSet,
         created_at: NotSet,
         job_id: Set(job_id),
-        time: Set(timestamp),
     };
     let _ = usage.insert(conn.as_ref()).await;
 }


### PR DESCRIPTION
Last bit of tech debt cleanup before digging in to new feature work.

- Removes `time` from `JobUses` now that its covered by `CreatedAt`
- Renames `JobUses` to `JobUse` to match all other models.