### PR TITLE
Add timeout configs

### DIFF
--- a/src/job_cache/job_cache.cpp
+++ b/src/job_cache/job_cache.cpp
@@ -244,11 +244,13 @@ static void mkdir_all(std::string acc, Iter begin, Iter end) {
   }
 }
 
-Cache::Cache(std::string dir, std::string bulk_dir, EvictionConfig cfg, bool miss) {
+Cache::Cache(std::string dir, std::string bulk_dir, EvictionConfig cfg, TimeoutConfig tcfg,
+             bool miss) {
   cache_dir = dir;
   bulk_logging_dir = bulk_dir;
   miss_on_failure = miss;
   config = cfg;
+  timeout_config = tcfg;
 
   auto fp_range = wcl::make_filepath_range_ref(cache_dir);
   mkdir_all(wcl::is_relative(cache_dir) ? "" : "/", fp_range.begin(), fp_range.end());
@@ -261,22 +263,20 @@ wcl::result<FindJobResponse, FindJobError> Cache::read_impl(const FindJobRequest
   request.add("method", "cache/read");
   request.add("params", find_request.to_json());
 
-  auto tconfig = WakeConfig::get()->timeout_config;
-
   // serialize the request, send it, deserialize the response, return it
-  auto socket_fd = backoff_try_connect(tconfig.connect_retries);
+  auto socket_fd = backoff_try_connect(timeout_config.connect_retries);
   if (!socket_fd) {
     return wcl::result_error<FindJobResponse>(FindJobError::CouldNotConnect);
   }
-  auto write_error = sync_send_json_message(socket_fd->get(), request, tconfig.message_timeout_seconds);
+  auto write_error =
+      sync_send_json_message(socket_fd->get(), request, timeout_config.message_timeout_seconds);
 
   if (write_error) {
     return wcl::result_error<FindJobResponse>(FindJobError::FailedRequest);
   }
-  //MessageParser parser(socket_fd->get(), tconfig.message_timeout_seconds);
 
   // Read the message with a 10 second timeout.
-  auto messages_res = sync_read_message(socket_fd->get(), tconfig.message_timeout_seconds);
+  auto messages_res = sync_read_message(socket_fd->get(), timeout_config.message_timeout_seconds);
 
   if (!messages_res) {
     if (messages_res.error() == SyncMessageReadError::Fail) {
@@ -328,10 +328,8 @@ FindJobResponse Cache::read(const FindJobRequest &find_request) {
   wcl::xoshiro_256 rng(wcl::xoshiro_256::get_rng_seed());
   useconds_t backoff = 1000;
 
-  auto tconfig = WakeConfig::get()->timeout_config;
-
   bool failed_on_connect = false;
-  for (int i = 0; i < tconfig.read_retries; i++) {
+  for (int i = 0; i < timeout_config.read_retries; i++) {
     auto response = read_impl(find_request);
     if (response) {
       wcl::log::info("Returning job response: cache_hit = %d", int(bool(response->match)))();
@@ -340,7 +338,7 @@ FindJobResponse Cache::read(const FindJobRequest &find_request) {
 
     failed_on_connect |= response.error() == FindJobError::CouldNotConnect;
 
-    if (miss_on_failure && misses_from_failure > tconfig.max_misses_from_failure) {
+    if (miss_on_failure && misses_from_failure > timeout_config.max_misses_from_failure) {
       wcl::log::warning(
           "Cache::read(): reached maximum cache misses for this invocation. Triggering early "
           "miss.")();

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -84,6 +84,13 @@ struct EvictionConfig {
   }
 };
 
+struct TimeoutConfig {
+  int read_retries = 3;
+  int connect_retries = 14;
+  int max_misses_from_failure = 300;
+  int message_timeout_seconds = 10;
+};
+
 class Cache {
  private:
   bool miss_on_failure = false;
@@ -92,6 +99,7 @@ class Cache {
   std::string cache_dir;
   std::string bulk_logging_dir;
   EvictionConfig config;
+  TimeoutConfig timeout_config;
 
   void launch_daemon();
   wcl::result<wcl::unique_fd, ConnectError> backoff_try_connect(int attempts);
@@ -101,7 +109,8 @@ class Cache {
   Cache() = delete;
   Cache(const Cache &) = delete;
 
-  Cache(std::string dir, std::string bulk_logging_dir, EvictionConfig config, bool miss);
+  Cache(std::string dir, std::string bulk_logging_dir, EvictionConfig config, TimeoutConfig tconfig,
+        bool miss);
 
   FindJobResponse read(const FindJobRequest &find_request);
   void add(const AddJobRequest &add_request);

--- a/src/job_cache/job_cache.h
+++ b/src/job_cache/job_cache.h
@@ -87,7 +87,7 @@ struct EvictionConfig {
 struct TimeoutConfig {
   int read_retries = 3;
   int connect_retries = 14;
-  int max_misses_from_failure = 300;
+  int max_misses_from_failure = 20;
   int message_timeout_seconds = 10;
 };
 

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -216,6 +216,7 @@ POLICY_STATIC_DEFINES(SharedCacheMissOnFailure)
 POLICY_STATIC_DEFINES(LogHeaderAlignPolicy)
 POLICY_STATIC_DEFINES(BulkLoggingDirPolicy)
 POLICY_STATIC_DEFINES(EvictionConfigPolicy)
+POLICY_STATIC_DEFINES(SharedCacheTimeoutConfig)
 
 /********************************************************************
  * Non-Trivial Defaults
@@ -301,6 +302,25 @@ void EvictionConfigPolicy::set(EvictionConfigPolicy& p, const JAST& json) {
       p.eviction_config.lru.max_size = *json_max;
       p.eviction_config.type = job_cache::EvictionPolicyType::LRU;
     }
+  }
+}
+
+void SharedCacheTimeoutConfig::set(SharedCacheTimeoutConfig& p, const JAST& json) {
+  auto json_read_retries = json.get("read_retries").expect_integer();
+  auto json_connect_retries = json.get("connect_retries").expect_integer();
+  auto json_max_misses = json.get("max_misses_from_failure").expect_integer();
+  auto json_message_timeout = json.get("message_timeout_seconds").expect_integer();
+  if (json_read_retries) {
+    p.timeout_config.read_retries = *json_read_retries;
+  }
+  if (json_connect_retries) {
+    p.timeout_config.connect_retries = *json_connect_retries;
+  }
+  if (json_max_misses) {
+    p.timeout_config.max_misses_from_failure = *json_max_misses;
+  }
+  if (json_message_timeout) {
+    p.timeout_config.message_timeout_seconds = *json_message_timeout;
   }
 }
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -265,6 +265,37 @@ struct EvictionConfigPolicy {
   static void set_env_var(EvictionConfigPolicy& p, const char* env_var) {}
 };
 
+struct TimeoutConfig {
+  int read_retries = 3;
+  int connect_retries = 14;
+  int max_misses_from_failure = 300;
+  int message_timeout_seconds = 10;
+};
+
+struct SharedCacheTimeoutConfig {
+  using type = TimeoutConfig;
+  using input_type = type;
+  static constexpr const char* key = "shared_cache_timeout_config";
+  static constexpr bool allowed_in_wakeroot = true;
+  static constexpr bool allowed_in_userconfig = true;
+  type timeout_config;
+  static constexpr type SharedCacheTimeoutConfig::*value = &SharedCacheTimeoutConfig::timeout_config;
+  static constexpr Override<input_type> override_value = nullptr;
+  static constexpr const char* env_var = nullptr;
+  SharedCacheTimeoutConfig() : timeout_config() {}
+  static void set(SharedCacheTimeoutConfig& p, const JAST& json);
+  static void set_input(SharedCacheTimeoutConfig& p, const input_type& v) { p.*value = v; }
+  static void emit(const SharedCacheTimeoutConfig &p, std::ostream& os) {
+    os << "{\n";
+    os << "    read_retries = " << p.timeout_config.read_retries << ",\n";
+    os << "    connect_retries = " << p.timeout_config.connect_retries << ",\n";
+    os << "    max_misses_from_failure = " << p.timeout_config.max_misses_from_failure << ",\n";
+    os << "    message_timeout_seconds = " << p.timeout_config.message_timeout_seconds << ",\n";
+    os << "  }";
+  }
+  static void set_env_var(SharedCacheTimeoutConfig& p, const char* env_var) {}
+};
+
 /********************************************************************
  * Generic WakeConfig implementation
  *********************************************************************/
@@ -410,7 +441,7 @@ struct WakeConfigImpl : public Policies... {
 using WakeConfigImplFull =
     WakeConfigImpl<UserConfigPolicy, VersionPolicy, LogHeaderPolicy, LogHeaderSourceWidthPolicy,
                    LabelFilterPolicy, EvictionConfigPolicy, SharedCacheMissOnFailure,
-                   LogHeaderAlignPolicy, BulkLoggingDirPolicy>;
+                   LogHeaderAlignPolicy, BulkLoggingDirPolicy, SharedCacheTimeoutConfig>;
 
 struct WakeConfig final : public WakeConfigImplFull {
   static bool init(const std::string& wakeroot_path, const WakeConfigOverrides& overrides);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -265,27 +265,21 @@ struct EvictionConfigPolicy {
   static void set_env_var(EvictionConfigPolicy& p, const char* env_var) {}
 };
 
-struct TimeoutConfig {
-  int read_retries = 3;
-  int connect_retries = 14;
-  int max_misses_from_failure = 300;
-  int message_timeout_seconds = 10;
-};
-
 struct SharedCacheTimeoutConfig {
-  using type = TimeoutConfig;
+  using type = job_cache::TimeoutConfig;
   using input_type = type;
   static constexpr const char* key = "shared_cache_timeout_config";
   static constexpr bool allowed_in_wakeroot = true;
   static constexpr bool allowed_in_userconfig = true;
   type timeout_config;
-  static constexpr type SharedCacheTimeoutConfig::*value = &SharedCacheTimeoutConfig::timeout_config;
+  static constexpr type SharedCacheTimeoutConfig::*value =
+      &SharedCacheTimeoutConfig::timeout_config;
   static constexpr Override<input_type> override_value = nullptr;
   static constexpr const char* env_var = nullptr;
   SharedCacheTimeoutConfig() : timeout_config() {}
   static void set(SharedCacheTimeoutConfig& p, const JAST& json);
   static void set_input(SharedCacheTimeoutConfig& p, const input_type& v) { p.*value = v; }
-  static void emit(const SharedCacheTimeoutConfig &p, std::ostream& os) {
+  static void emit(const SharedCacheTimeoutConfig& p, std::ostream& os) {
     os << "{\n";
     os << "    read_retries = " << p.timeout_config.read_retries << ",\n";
     os << "    connect_retries = " << p.timeout_config.connect_retries << ",\n";

--- a/tests/config/empty/stdout
+++ b/tests/config/empty/stdout
@@ -11,6 +11,6 @@ Wake config:
   shared_cache_timeout_config = '{
     read_retries = 3,
     connect_retries = 14,
-    max_misses_from_failure = 300,
+    max_misses_from_failure = 20,
     message_timeout_seconds = 10,
   }' (Default)

--- a/tests/config/empty/stdout
+++ b/tests/config/empty/stdout
@@ -8,3 +8,9 @@ Wake config:
   cache_miss_on_failure = 'false' (Default)
   log_header_align = 'false' (Default)
   bulk_logging_dir = '' (Default)
+  shared_cache_timeout_config = '{
+    read_retries = 3,
+    connect_retries = 14,
+    max_misses_from_failure = 300,
+    message_timeout_seconds = 10,
+  }' (Default)

--- a/tests/config/extra_keys/stdout
+++ b/tests/config/extra_keys/stdout
@@ -11,6 +11,6 @@ Wake config:
   shared_cache_timeout_config = '{
     read_retries = 3,
     connect_retries = 14,
-    max_misses_from_failure = 300,
+    max_misses_from_failure = 20,
     message_timeout_seconds = 10,
   }' (Default)

--- a/tests/config/extra_keys/stdout
+++ b/tests/config/extra_keys/stdout
@@ -8,3 +8,9 @@ Wake config:
   cache_miss_on_failure = 'false' (Default)
   log_header_align = 'false' (Default)
   bulk_logging_dir = '' (Default)
+  shared_cache_timeout_config = '{
+    read_retries = 3,
+    connect_retries = 14,
+    max_misses_from_failure = 300,
+    message_timeout_seconds = 10,
+  }' (Default)

--- a/tests/config/missing_user_config/stdout
+++ b/tests/config/missing_user_config/stdout
@@ -11,6 +11,6 @@ Wake config:
   shared_cache_timeout_config = '{
     read_retries = 3,
     connect_retries = 14,
-    max_misses_from_failure = 300,
+    max_misses_from_failure = 20,
     message_timeout_seconds = 10,
   }' (Default)

--- a/tests/config/missing_user_config/stdout
+++ b/tests/config/missing_user_config/stdout
@@ -8,3 +8,9 @@ Wake config:
   cache_miss_on_failure = 'false' (Default)
   log_header_align = 'false' (Default)
   bulk_logging_dir = '' (Default)
+  shared_cache_timeout_config = '{
+    read_retries = 3,
+    connect_retries = 14,
+    max_misses_from_failure = 300,
+    message_timeout_seconds = 10,
+  }' (Default)

--- a/tests/config/nominal/.wakeroot
+++ b/tests/config/nominal/.wakeroot
@@ -4,5 +4,11 @@
   "log_header_source_width": 13,
   "log_header_align": true,
   "cache_miss_on_failure": true,
-  "eviction_config": {"type": "lru", "low_cache_size": 512, "max_cache_size": 1024}
+  "eviction_config": {"type": "lru", "low_cache_size": 512, "max_cache_size": 1024},
+  "shared_cache_timeout_config": {
+    "read_retries": 20,
+    "connect_retries": 3,
+    "max_misses_from_failure": 20,
+    "message_timeout_seconds": 100
+  }
 }

--- a/tests/config/nominal/stdout
+++ b/tests/config/nominal/stdout
@@ -8,3 +8,9 @@ Wake config:
   cache_miss_on_failure = 'true' (WakeRoot)
   log_header_align = 'true' (WakeRoot)
   bulk_logging_dir = '/tmp/wake_bulk_logs' (UserConfig)
+  shared_cache_timeout_config = '{
+    read_retries = 20,
+    connect_retries = 3,
+    max_misses_from_failure = 20,
+    message_timeout_seconds = 100,
+  }' (WakeRoot)

--- a/tools/wake-unit/fuzz_test_job_cache.cpp
+++ b/tools/wake-unit/fuzz_test_job_cache.cpp
@@ -384,7 +384,8 @@ TEST_FUNC(void, fuzz_loop, const FuzzLoopConfig& config, bool lru, wcl::xoshiro_
   uint64_t seconds_to_live = 10;
   job_cache::EvictionConfig lru_config = job_cache::EvictionConfig::lru_config(low_size, max_size);
   job_cache::EvictionConfig ttl_config = job_cache::EvictionConfig::ttl_config(seconds_to_live);
-  job_cache::Cache cache(config.cache_dir, "", (lru ? lru_config : ttl_config), false);
+  job_cache::TimeoutConfig tconfig;
+  job_cache::Cache cache(config.cache_dir, "", (lru ? lru_config : ttl_config), tconfig, false);
 
   std::string out_dir = wcl::join_paths(config.dir, "outputs");
   for (size_t i = 0; i < config.number_of_steps; ++i) {

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -531,9 +531,9 @@ int main(int argc, char **argv) {
   const char *job_cache_dir = getenv("WAKE_LOCAL_JOB_CACHE");
   // TODO: construct an eviction config from the config
   if (job_cache_dir != nullptr) {
-    cache = std::make_unique<job_cache::Cache>(job_cache_dir, WakeConfig::get()->bulk_logging_dir,
-                                               WakeConfig::get()->eviction_config,
-                                               WakeConfig::get()->cache_miss_on_failure);
+    cache = std::make_unique<job_cache::Cache>(
+        job_cache_dir, WakeConfig::get()->bulk_logging_dir, WakeConfig::get()->eviction_config,
+        WakeConfig::get()->timeout_config, WakeConfig::get()->cache_miss_on_failure);
     set_job_cache(cache.get());
   }
 


### PR DESCRIPTION
This change adds the ability to adjust timeout configs because its hard to find a one size fits all solution. I think we can probably lower our number of read failures from 300 to 20 by default which would help a lot, but we can also lower these other ones sometimes. complete read failures that are recovered from are quite rare but they do happen. In practice we only seem complete read failures that recover at most about 3 times per wake run so 20 is a good upper bound compared to 300 in practice.