### PR TITLE
Make `stat` actually recognize symlinks

### DIFF
--- a/src/runtime/string.cpp
+++ b/src/runtime/string.cpp
@@ -215,7 +215,7 @@ static PRIMFN(prim_stat) {
   size_t max_error = path->size() + 100;
 
   struct stat buf;
-  if (stat(path->c_str(), &buf) < 0) {
+  if (lstat(path->c_str(), &buf) < 0) {
     std::stringstream str;
     str << "stat " << path->c_str() << ": " << strerror(errno);
     std::string s = str.str();


### PR DESCRIPTION
Whose bright idea was it to make the syscall you use to check the type of a path, *not* actually check the type of all paths, and instead hide the uniform behaviour behind a one-letter difference?

Regardless, the `stat` function was previously returning `PathTypeRegularFile` (and permissions/size of the target file) when called on symlinks.  It now returns `PathTypeSymlink` (and less helpful but more accurate permissions/size).