### PR TITLE
Add basic implementation of blob upload

### DIFF
--- a/rust/rsc/Cargo.lock
+++ b/rust/rsc/Cargo.lock
@@ -273,9 +273,9 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2235,6 +2235,7 @@ dependencies = [
 name = "rsc"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "atty",
  "axum",
  "blake3",

--- a/rust/rsc/Cargo.lock
+++ b/rust/rsc/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -848,6 +849,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1544,6 +1554,24 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]

--- a/rust/rsc/Cargo.lock
+++ b/rust/rsc/Cargo.lock
@@ -975,12 +975,13 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -989,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -999,15 +1000,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1027,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-lite"
@@ -1047,26 +1048,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.28"
+name = "futures-macro"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2230,6 +2243,7 @@ dependencies = [
  "config",
  "data-encoding",
  "entity",
+ "futures",
  "hyper",
  "inquire",
  "is-terminal",
@@ -2242,6 +2256,7 @@ dependencies = [
  "serde_json",
  "textwrap",
  "tokio",
+ "tokio-util",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -3154,6 +3169,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]

--- a/rust/rsc/Cargo.toml
+++ b/rust/rsc/Cargo.toml
@@ -16,7 +16,9 @@ entity = { path = "../entity" }
 migration = { path = "../migration" }
 sea-orm = { version = "0.12.6", features = ["sqlx-postgres", "runtime-tokio-native-tls"]}
 serde = "1.0.164"
+futures = "0.3.29"
 tokio = { version = "1.28.2", features = ["full"] }
+tokio-util = { version = "0.7.1", features = ["io"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 axum = { version = "0.6.18", features = ["multipart"] }

--- a/rust/rsc/Cargo.toml
+++ b/rust/rsc/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0.164"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-axum = "0.6.18"
+axum = { version = "0.6.18", features = ["multipart"] }
 tower = "0.4.12"
 hyper = "0.14.27"
 serde_bytes = "0.11.9"

--- a/rust/rsc/Cargo.toml
+++ b/rust/rsc/Cargo.toml
@@ -37,3 +37,4 @@ config = "0.13.3"
 serde_json = "1.0.100"
 clap = { version = "4.3.23", features = ["derive"] }
 is-terminal = "0.4.9"
+async-trait = "0.1.74"

--- a/rust/rsc/src/common/config.rs
+++ b/rust/rsc/src/common/config.rs
@@ -7,6 +7,7 @@ pub struct RSCConfigOverride {
     pub database_url: Option<String>,
     pub server_addr: Option<String>,
     pub standalone: Option<bool>,
+    pub local_store: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -15,6 +16,7 @@ pub struct RSCConfig {
     // TODO: We should allow setting a domain as well
     pub server_addr: String,
     pub standalone: bool,
+    pub local_store: Option<String>,
 }
 
 impl RSCConfig {
@@ -35,6 +37,7 @@ impl RSCConfig {
             .set_override_option("database_url", overrides.database_url)?
             .set_override_option("server_addr", overrides.server_addr)?
             .set_override_option("standalone", overrides.standalone)?
+            .set_override_option("local_store", overrides.local_store)?
             .build()?;
 
         config.try_deserialize()

--- a/rust/rsc/src/common/config.rs
+++ b/rust/rsc/src/common/config.rs
@@ -7,6 +7,7 @@ pub struct RSCConfigOverride {
     pub database_url: Option<String>,
     pub server_addr: Option<String>,
     pub standalone: Option<bool>,
+    // TODO: the backing store should be configurable via URI
     pub local_store: Option<String>,
 }
 

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -1,8 +1,9 @@
 use crate::config::RSCConfig;
 use crate::types::GetUploadUrlResponse;
+use async_trait::async_trait;
 use axum::{body::Bytes, extract::Multipart, http::StatusCode, BoxError, Json};
 use data_encoding::BASE64URL;
-use futures::{Stream, TryStreamExt};
+use futures::{Stream, TryStream, TryStreamExt};
 use rand_core::{OsRng, RngCore};
 use sea_orm::DatabaseConnection;
 use std::sync::Arc;
@@ -11,37 +12,40 @@ use tokio::io::BufWriter;
 use tokio_util::io::StreamReader;
 use tracing;
 
+#[async_trait]
+pub trait BlobStore {
+    async fn stream<A, B>(&self, reader: StreamReader<A, B>) -> Result<String, std::io::Error>
+    where
+        StreamReader<A, B>: tokio::io::AsyncRead + std::marker::Send;
+}
+
+pub struct LocalBlobStore {
+    pub root: String,
+}
+
+#[async_trait]
+impl BlobStore for LocalBlobStore {
+    async fn stream<A, B>(&self, reader: StreamReader<A, B>) -> Result<String, std::io::Error>
+    where
+        StreamReader<A, B>: tokio::io::AsyncRead + std::marker::Send,
+    {
+        futures::pin_mut!(reader);
+
+        let name = create_temp_filename();
+        let path = std::path::Path::new(&self.root).join(name.clone());
+        let mut file = BufWriter::new(File::create(path).await?);
+
+        tokio::io::copy(&mut reader, &mut file).await?;
+
+        Ok(name)
+    }
+}
+
 fn create_temp_filename() -> String {
     let mut key = [0u8; 16];
     OsRng.fill_bytes(&mut key);
     // URL must be used as files can't contain /
     BASE64URL.encode(&key)
-}
-
-async fn stream_to_file<S, E>(parent: &str, stream: S) -> Result<String, (StatusCode, String)>
-where
-    S: Stream<Item = Result<Bytes, E>>,
-    E: Into<BoxError>,
-{
-    async {
-        // Convert the stream into an `AsyncRead`.
-        let body_with_io_error =
-            stream.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err));
-        let body_reader = StreamReader::new(body_with_io_error);
-        futures::pin_mut!(body_reader);
-
-        // Create the file. `File` implements `AsyncWrite`.
-        let name = create_temp_filename();
-        let path = std::path::Path::new(parent).join(name.clone());
-        let mut file = BufWriter::new(File::create(path).await?);
-
-        // Copy the body into the file.
-        tokio::io::copy(&mut body_reader, &mut file).await?;
-
-        Ok::<String, std::io::Error>(name)
-    }
-    .await
-    .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))
 }
 
 #[tracing::instrument]
@@ -56,16 +60,20 @@ pub async fn create_blob(
     _conn: Arc<DatabaseConnection>,
     config: Arc<RSCConfig>,
 ) -> (StatusCode, String) {
-    while let Ok(Some(field)) = multipart.next_field().await {
-        let Some(ref local_store) = config.local_store else {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Invalid configuration".into(),
-            );
-        };
+    let Some(local_store) = config.local_store.clone() else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Invalid configuration".into(),
+        );
+    };
 
-        if let Err(inner) = stream_to_file(local_store, field).await {
-            return inner;
+    let store = LocalBlobStore { root: local_store };
+
+    while let Ok(Some(field)) = multipart.next_field().await {
+        let body = field.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err));
+        match store.stream(StreamReader::new(body)).await {
+            Ok(key) => println!("{:?}", key),
+            Err(msg) => return (StatusCode::INTERNAL_SERVER_ERROR, msg.to_string()),
         }
     }
 

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -1,9 +1,9 @@
 use crate::config::RSCConfig;
 use crate::types::GetUploadUrlResponse;
 use async_trait::async_trait;
-use axum::{body::Bytes, extract::Multipart, http::StatusCode, BoxError, Json};
+use axum::{extract::Multipart, http::StatusCode, Json};
 use data_encoding::BASE64URL;
-use futures::{Stream, TryStream, TryStreamExt};
+use futures::TryStreamExt;
 use rand_core::{OsRng, RngCore};
 use sea_orm::DatabaseConnection;
 use std::sync::Arc;

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -1,0 +1,71 @@
+use crate::config::RSCConfig;
+use crate::types::GetUploadUrlResponse;
+use axum::{extract::Multipart, Json};
+use sea_orm::DatabaseConnection;
+use std::sync::Arc;
+use tracing;
+
+#[tracing::instrument]
+pub async fn get_upload_url(
+    _conn: Arc<DatabaseConnection>,
+    config: Arc<RSCConfig>,
+) -> Json<GetUploadUrlResponse> {
+    let url = config.server_addr.clone() + "/blob";
+    Json(GetUploadUrlResponse { url })
+}
+
+pub async fn create_blob(mut multipart: Multipart, config: Arc<RSCConfig>) -> hyper::StatusCode {
+    let mut hash: Option<String> = None;
+    let mut contents: Option<axum::body::Bytes> = None;
+
+    let exhausted_without_err = loop {
+        let Ok(field) = multipart.next_field().await else {
+            break false;
+        };
+
+        // if field is None, then we have exhausted the input.
+        let Some(field) = field else {
+            break true;
+        };
+
+        if field.name().is_none() {
+            break false;
+        }
+        let name = field.name().unwrap().to_string();
+        let Ok(data) = field.bytes().await else {
+            break false;
+        };
+
+        if name == "hash" {
+            let key = String::from_utf8(data.to_ascii_lowercase()).unwrap();
+            hash = Some(key);
+        }
+
+        if name == "file" {
+            contents = Some(data);
+        }
+    };
+
+    if !exhausted_without_err {
+        return hyper::StatusCode::BAD_REQUEST;
+    }
+
+    let Some(hash) = hash else {
+        return hyper::StatusCode::BAD_REQUEST;
+    };
+
+    let Some(contents) = contents else {
+        return hyper::StatusCode::BAD_REQUEST;
+    };
+
+    let Some(local_store) = config.local_store.clone() else {
+        return hyper::StatusCode::INTERNAL_SERVER_ERROR;
+    };
+
+    let dest = local_store + &hash;
+    let Ok(_) = std::fs::write(dest, contents) else {
+        return hyper::StatusCode::INTERNAL_SERVER_ERROR;
+    };
+
+    hyper::StatusCode::OK
+}

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -1,71 +1,96 @@
 use crate::config::RSCConfig;
 use crate::types::GetUploadUrlResponse;
-use axum::{extract::Multipart, Json};
+use axum::{body::Bytes, extract::Multipart, http::StatusCode, BoxError, Json};
 use sea_orm::DatabaseConnection;
 use std::sync::Arc;
 use tracing;
 
+use futures::{Stream, TryStreamExt};
+use tokio::fs::File;
+use tokio::io::BufWriter;
+use tokio_util::io::StreamReader;
+
+// to prevent directory traversal attacks we ensure the path consists of exactly one normal
+// component
+fn path_is_valid(path: &str) -> bool {
+    let path = std::path::Path::new(path);
+    let mut components = path.components().peekable();
+
+    if let Some(first) = components.peek() {
+        if !matches!(first, std::path::Component::Normal(_)) {
+            return false;
+        }
+    }
+
+    components.count() == 1
+}
+
+async fn stream_to_file<S, E>(
+    parent: &str,
+    path: &str,
+    stream: S,
+) -> Result<(), (StatusCode, String)>
+where
+    S: Stream<Item = Result<Bytes, E>>,
+    E: Into<BoxError>,
+{
+    if !path_is_valid(path) {
+        return Err((StatusCode::BAD_REQUEST, "Invalid path".to_owned()));
+    }
+
+    async {
+        // Convert the stream into an `AsyncRead`.
+        let body_with_io_error =
+            stream.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err));
+        let body_reader = StreamReader::new(body_with_io_error);
+        futures::pin_mut!(body_reader);
+
+        // Create the file. `File` implements `AsyncWrite`.
+        let path = std::path::Path::new(parent).join(path);
+        let mut file = BufWriter::new(File::create(path).await?);
+
+        // Copy the body into the file.
+        tokio::io::copy(&mut body_reader, &mut file).await?;
+
+        Ok::<_, std::io::Error>(())
+    }
+    .await
+    .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))
+}
+
 #[tracing::instrument]
-pub async fn get_upload_url(
-    _conn: Arc<DatabaseConnection>,
-    config: Arc<RSCConfig>,
-) -> Json<GetUploadUrlResponse> {
-    let url = config.server_addr.clone() + "/blob";
+pub async fn get_upload_url(server_addr: String) -> Json<GetUploadUrlResponse> {
+    let url = server_addr + "/blob";
     Json(GetUploadUrlResponse { url })
 }
 
-pub async fn create_blob(mut multipart: Multipart, config: Arc<RSCConfig>) -> hyper::StatusCode {
-    let mut hash: Option<String> = None;
-    let mut contents: Option<axum::body::Bytes> = None;
-
-    let exhausted_without_err = loop {
-        let Ok(field) = multipart.next_field().await else {
-            break false;
+#[tracing::instrument]
+pub async fn create_blob(
+    mut multipart: Multipart,
+    _conn: Arc<DatabaseConnection>,
+    config: Arc<RSCConfig>,
+) -> (StatusCode, String) {
+    while let Ok(Some(field)) = multipart.next_field().await {
+        let file_name = if let Some(file_name) = field.name() {
+            file_name.to_owned()
+        } else {
+            tracing::warn!("Skipping part upload due to missing key.");
+            continue;
         };
 
-        // if field is None, then we have exhausted the input.
-        let Some(field) = field else {
-            break true;
+        let Some(ref local_store) = config.local_store else {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Invalid configuration".into(),
+            );
         };
 
-        if field.name().is_none() {
-            break false;
+        // TODO: instead of writing the user provided field name to disk we should
+        // generate a random temporary name.
+        if let Err(inner) = stream_to_file(local_store, &file_name, field).await {
+            return inner;
         }
-        let name = field.name().unwrap().to_string();
-        let Ok(data) = field.bytes().await else {
-            break false;
-        };
-
-        if name == "hash" {
-            let key = String::from_utf8(data.to_ascii_lowercase()).unwrap();
-            hash = Some(key);
-        }
-
-        if name == "file" {
-            contents = Some(data);
-        }
-    };
-
-    if !exhausted_without_err {
-        return hyper::StatusCode::BAD_REQUEST;
     }
 
-    let Some(hash) = hash else {
-        return hyper::StatusCode::BAD_REQUEST;
-    };
-
-    let Some(contents) = contents else {
-        return hyper::StatusCode::BAD_REQUEST;
-    };
-
-    let Some(local_store) = config.local_store.clone() else {
-        return hyper::StatusCode::INTERNAL_SERVER_ERROR;
-    };
-
-    let dest = local_store + &hash;
-    let Ok(_) = std::fs::write(dest, contents) else {
-        return hyper::StatusCode::INTERNAL_SERVER_ERROR;
-    };
-
-    hyper::StatusCode::OK
+    (StatusCode::OK, "ok".into())
 }

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -59,6 +59,9 @@ struct ServerOptions {
 }
 
 fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) -> Router {
+    // If we can't create a store, just exit. The config is wrong and must be rectified.
+    let root = config.local_store.clone().unwrap();
+    let store = blob::LocalBlobStore { root };
     Router::new()
         .route(
             "/job",
@@ -89,8 +92,8 @@ fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) 
             "/blob",
             post({
                 let conn = conn.clone();
-                let config = config.clone();
-                move |multipart: Multipart| blob::create_blob(multipart, conn, config)
+                let store = store.clone();
+                move |multipart: Multipart| blob::create_blob(multipart, conn, store)
             })
             .layer(DefaultBodyLimit::disable()),
         )

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -81,16 +81,16 @@ fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) 
         .route(
             "/blob",
             get({
-                let conn = conn.clone();
                 let config = config.clone();
-                move || blob::get_upload_url(conn, config)
+                move || blob::get_upload_url(config.server_addr.clone())
             }),
         )
         .route(
             "/blob",
             post({
+                let conn = conn.clone();
                 let config = config.clone();
-                move |multipart: Multipart| blob::create_blob(multipart, config)
+                move |multipart: Multipart| blob::create_blob(multipart, conn, config)
             })
             .layer(DefaultBodyLimit::disable()),
         )
@@ -234,6 +234,7 @@ mod tests {
             server_addr: Some("test:0000".into()),
             database_url: Some("".into()),
             standalone: Some(true),
+            local_store: None,
         })?)
     }
 

--- a/rust/rsc/src/rsc/types.rs
+++ b/rust/rsc/src/rsc/types.rs
@@ -136,3 +136,8 @@ pub enum ReadJobResponse {
         obytes: u64,
     },
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetUploadUrlResponse {
+    pub url: String,
+}


### PR DESCRIPTION
This change introduces two new routes.

1) `GET /blob` which returns the url that blobs should be POSTed to
2) `POST /blob` which right now accepts a blob and writes it to the location specified by `config.local_store`. 

The POST route isn't complete since the blobs should be tracked in a blob database and a detailed response should be given to the client however that is a sizable chunk of work and so I wanted to split  the review into two parts. This one that handles file upload, and the next one that handle blob tracking.

Future work will be to support multiple backing stores so the routes are being implemented with that in mind.