### PR TITLE
[LSC] Aquire daemon lock before opening db

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -675,11 +675,11 @@ DaemonCache::DaemonCache(std::string dir, std::string bulk_dir, EvictionConfig c
 
   wcl::log::info("Launching DaemonCache. dir = %s", dir.c_str())();
 
-  impl = std::make_unique<CacheDbImpl>(".");
-
   // Get some random bits to name our domain socket with
   key = rng.unique_name();
   listen_socket_fd = create_cache_socket(".", key);
+
+  impl = std::make_unique<CacheDbImpl>(".");
 
   launch_evict_loop();
 }


### PR DESCRIPTION
Previously we (unintentionally) would open the database BEFORE inquiring the cache lock. The vast majority of the time this is harmless because we connect to the database with randomized exponential backoff and sqlite3 does a good enough job at this with this back off strategy. Later once the cache fails to aquire the cache lock the connection is closed and no harm was done. However it can get overwhelmed and cause issues. The solution is simple, just move the lock acquire to be first like it should have always been.