### PR TITLE
Use Arc dyn BlobStore insteadl of impl

### DIFF
--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -2,21 +2,24 @@ use crate::types::GetUploadUrlResponse;
 use async_trait::async_trait;
 use axum::{extract::Multipart, http::StatusCode, Json};
 use data_encoding::BASE64URL;
+use futures::stream::BoxStream;
 use futures::TryStreamExt;
 use rand_core::{OsRng, RngCore};
 use sea_orm::DatabaseConnection;
 use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::BufWriter;
+use tokio_util::bytes::Bytes;
 use tokio_util::io::StreamReader;
 use tracing;
 
 // TODO: Update this trait to return the url for a given key
 #[async_trait]
 pub trait BlobStore {
-    async fn stream<A, B>(&self, reader: StreamReader<A, B>) -> Result<String, std::io::Error>
-    where
-        StreamReader<A, B>: tokio::io::AsyncRead + std::marker::Send;
+    async fn stream<'a>(
+        &self,
+        stream: BoxStream<'a, Result<Bytes, std::io::Error>>,
+    ) -> Result<String, std::io::Error>;
 }
 
 pub trait DebugBlobStore: BlobStore + std::fmt::Debug {}
@@ -28,10 +31,11 @@ pub struct LocalBlobStore {
 
 #[async_trait]
 impl BlobStore for LocalBlobStore {
-    async fn stream<A, B>(&self, reader: StreamReader<A, B>) -> Result<String, std::io::Error>
-    where
-        StreamReader<A, B>: tokio::io::AsyncRead + std::marker::Send,
-    {
+    async fn stream<'a>(
+        &self,
+        stream: BoxStream<'a, Result<Bytes, std::io::Error>>,
+    ) -> Result<String, std::io::Error> {
+        let reader = StreamReader::new(stream);
         futures::pin_mut!(reader);
 
         let name = create_temp_filename();
@@ -63,11 +67,15 @@ pub async fn get_upload_url(server_addr: String) -> Json<GetUploadUrlResponse> {
 pub async fn create_blob(
     mut multipart: Multipart,
     _conn: Arc<DatabaseConnection>,
-    store: impl DebugBlobStore,
+    store: Arc<dyn DebugBlobStore + Send + Sync>,
 ) -> (StatusCode, String) {
     while let Ok(Some(field)) = multipart.next_field().await {
-        let body = field.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err));
-        match store.stream(StreamReader::new(body)).await {
+        match store
+            .stream(Box::pin(field.map_err(|err| {
+                std::io::Error::new(std::io::ErrorKind::Other, err)
+            })))
+            .await
+        {
             // TODO: The blob should be inserted into the db instead of just printing the key
             Ok(key) => println!("{:?}", key),
             Err(msg) => return (StatusCode::INTERNAL_SERVER_ERROR, msg.to_string()),

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -61,7 +61,9 @@ struct ServerOptions {
 fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) -> Router {
     // If we can't create a store, just exit. The config is wrong and must be rectified.
     let root = config.local_store.clone().unwrap();
-    let store = blob::LocalBlobStore { root };
+    //let store = blob::LocalBlobStore { root };
+    let store: Arc<dyn blob::DebugBlobStore + Send + Sync> =
+        Arc::new(blob::LocalBlobStore { root });
     Router::new()
         .route(
             "/job",

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -61,7 +61,6 @@ struct ServerOptions {
 fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) -> Router {
     // If we can't create a store, just exit. The config is wrong and must be rectified.
     let root = config.local_store.clone().unwrap();
-    //let store = blob::LocalBlobStore { root };
     let store: Arc<dyn blob::DebugBlobStore + Send + Sync> =
         Arc::new(blob::LocalBlobStore { root });
     Router::new()


### PR DESCRIPTION
This changes the BlobStore trait to be object safe while maintaining most of the generality of the previous implementation.