### PR TITLE
rsc: Track blobs in the database

### DIFF
--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -102,6 +102,7 @@ pub async fn create_blob(
         }
 
         let active_blob = blob::ActiveModel {
+            // TODO: these ids should be migrated to UUIDs
             id: NotSet,
             created_at: NotSet,
             key: Set(result.unwrap()),

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -94,7 +94,8 @@ fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) 
             post({
                 let conn = conn.clone();
                 let store = store.clone();
-                move |multipart: Multipart| blob::create_blob(multipart, conn, store)
+                // TODO: Don't hardcode store type here
+                move |multipart: Multipart| blob::create_blob(multipart, conn, store, 1)
             })
             .layer(DefaultBodyLimit::disable()),
         )
@@ -339,7 +340,7 @@ mod tests {
 
         assert_eq!(res.status(), StatusCode::OK);
 
-        // Non-matching job should 200 with expected body
+        // Non-matching job should 404 with expected body
         let res = router
             .call(
                 Request::builder()
@@ -363,7 +364,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
         let body = hyper::body::to_bytes(res).await.unwrap();
         let body: Value = serde_json::from_slice(&body).unwrap();

--- a/rust/rsc/src/rsc/types.rs
+++ b/rust/rsc/src/rsc/types.rs
@@ -114,6 +114,19 @@ impl ReadJobPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct PostBlobResponsePart {
+    pub id: i32,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum PostBlobResponse {
+    Error { message: String },
+    Ok { blobs: Vec<PostBlobResponsePart> },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ReadJobResponse {
     NoMatch,


### PR DESCRIPTION
`POST /blob` has been updated so that it now creates a database entry for each blob when it has been uploaded and returns it back to the client.

The ids returned back to the client are mapped using the client provided names.

Example response
```
HTTP/1.1 200 OK
content-length: 125
content-type: application/json
date: Fri, 15 Dec 2023 21:39:37 GMT

{
    "blobs": [
        {
            "id": 1,
            "name": "foo"
        },
        {
            "id": 2,
            "name": "bar"
        },
        {
            "id": 3,
            "name": "bat"
        },
        {
            "id": 4,
            "name": "bazz"
        }
    ],
    "type": "Ok"
}

```