### PR TITLE
rsc: Basic attempt at uuid as id

### DIFF
--- a/rust/entity/src/api_key.rs
+++ b/rust/entity/src/api_key.rs
@@ -5,8 +5,8 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "api_key")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i32,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
     #[sea_orm(unique)]
     pub key: String,
     pub desc: String,

--- a/rust/entity/src/blob.rs
+++ b/rust/entity/src/blob.rs
@@ -5,10 +5,10 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "blob")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i32,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
     pub key: String,
-    pub store_id: i32,
+    pub store_id: Uuid,
     pub created_at: DateTime,
 }
 

--- a/rust/entity/src/blob_store.rs
+++ b/rust/entity/src/blob_store.rs
@@ -5,8 +5,8 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "blob_store")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i32,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
     pub r#type: String,
 }
 

--- a/rust/entity/src/job.rs
+++ b/rust/entity/src/job.rs
@@ -5,8 +5,8 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
 #[sea_orm(table_name = "job")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i32,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
     #[sea_orm(column_type = "Binary(BlobSize::Blob(None))", unique)]
     pub hash: Vec<u8>,
     pub cmd: String,
@@ -17,8 +17,8 @@ pub struct Model {
     pub is_atty: bool,
     #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
     pub hidden_info: Vec<u8>,
-    pub stdout_blob_id: i32,
-    pub stderr_blob_id: i32,
+    pub stdout_blob_id: Uuid,
+    pub stderr_blob_id: Uuid,
     pub status: i32,
     #[sea_orm(column_type = "Double")]
     pub runtime: f64,

--- a/rust/entity/src/job_use.rs
+++ b/rust/entity/src/job_use.rs
@@ -5,9 +5,9 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "job_use")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i32,
-    pub job_id: i32,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub job_id: Uuid,
     pub created_at: DateTime,
 }
 

--- a/rust/entity/src/local_blob_store.rs
+++ b/rust/entity/src/local_blob_store.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 #[sea_orm(table_name = "local_blob_store")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
-    pub id: i32,
+    pub id: Uuid,
     pub root: String,
     pub created_at: DateTime,
 }

--- a/rust/entity/src/output_dir.rs
+++ b/rust/entity/src/output_dir.rs
@@ -5,11 +5,11 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "output_dir")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i32,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
     pub path: String,
     pub mode: i32,
-    pub job_id: i32,
+    pub job_id: Uuid,
     pub created_at: DateTime,
 }
 

--- a/rust/entity/src/output_file.rs
+++ b/rust/entity/src/output_file.rs
@@ -5,12 +5,12 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "output_file")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i32,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
     pub path: String,
     pub mode: i32,
-    pub job_id: i32,
-    pub blob_id: i32,
+    pub job_id: Uuid,
+    pub blob_id: Uuid,
     pub created_at: DateTime,
 }
 

--- a/rust/entity/src/output_symlink.rs
+++ b/rust/entity/src/output_symlink.rs
@@ -5,12 +5,12 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "output_symlink")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i32,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
     pub path: String,
     #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
     pub content: Vec<u8>,
-    pub job_id: i32,
+    pub job_id: Uuid,
     pub created_at: DateTime,
 }
 

--- a/rust/entity/src/visible_file.rs
+++ b/rust/entity/src/visible_file.rs
@@ -5,12 +5,12 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "visible_file")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i32,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
     pub path: String,
     #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
     pub hash: Vec<u8>,
-    pub job_id: i32,
+    pub job_id: Uuid,
     pub created_at: DateTime,
 }
 

--- a/rust/migration/src/m20220101_000001_create_blob_tables.rs
+++ b/rust/migration/src/m20220101_000001_create_blob_tables.rs
@@ -12,10 +12,10 @@ impl MigrationTrait for Migration {
                     .table(BlobStore::Table)
                     .col(
                         ColumnDef::new(BlobStore::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
-                            .primary_key(),
+                            .primary_key()
+                            .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(BlobStore::Type).string().not_null())
                     .to_owned(),
@@ -25,8 +25,8 @@ impl MigrationTrait for Migration {
         // Insert basic backing store since it must always exist.
         let insert = Query::insert()
             .into_table(BlobStore::Table)
-            .columns([BlobStore::Id, BlobStore::Type])
-            .values_panic([1.into(), "LocalBlobStore".into()])
+            .columns([BlobStore::Type])
+            .values_panic(["LocalBlobStore".into()])
             .to_owned();
 
         manager.exec_stmt(insert).await?;
@@ -37,13 +37,13 @@ impl MigrationTrait for Migration {
                     .table(Blob::Table)
                     .col(
                         ColumnDef::new(Blob::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
-                            .primary_key(),
+                            .primary_key()
+                            .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(Blob::Key).string().not_null())
-                    .col(ColumnDef::new(Blob::StoreId).integer().not_null())
+                    .col(ColumnDef::new(Blob::StoreId).uuid().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
                             .name("fk-store_id-blob_store")
@@ -65,7 +65,7 @@ impl MigrationTrait for Migration {
                     .table(LocalBlobStore::Table)
                     .col(
                         ColumnDef::new(LocalBlobStore::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
                             .primary_key(),
                     )

--- a/rust/migration/src/m20220101_000002_create_table.rs
+++ b/rust/migration/src/m20220101_000002_create_table.rs
@@ -24,10 +24,10 @@ impl MigrationTrait for Migration {
                     .table(Job::Table)
                     .col(
                         ColumnDef::new(Job::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
-                            .primary_key(),
+                            .primary_key()
+                            .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(Job::Hash).ezblob().unique_key())
                     .col(ColumnDef::new(Job::Cmd).string().not_null())
@@ -36,8 +36,8 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Job::Stdin).string().not_null())
                     .col(ColumnDef::new(Job::IsAtty).boolean().not_null())
                     .col(ColumnDef::new(Job::HiddenInfo).ezblob())
-                    .col(ColumnDef::new(Job::StdoutBlobId).integer().not_null())
-                    .col(ColumnDef::new(Job::StderrBlobId).integer().not_null())
+                    .col(ColumnDef::new(Job::StdoutBlobId).uuid().not_null())
+                    .col(ColumnDef::new(Job::StderrBlobId).uuid().not_null())
                     .col(ColumnDef::new(Job::Status).integer().not_null())
                     .col(ColumnDef::new(Job::Runtime).double().not_null())
                     .col(ColumnDef::new(Job::Cputime).double().not_null())
@@ -78,14 +78,14 @@ impl MigrationTrait for Migration {
                     .table(VisibleFile::Table)
                     .col(
                         ColumnDef::new(VisibleFile::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
-                            .primary_key(),
+                            .primary_key()
+                            .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(VisibleFile::Path).string().not_null())
                     .col(ColumnDef::new(VisibleFile::Hash).ezblob())
-                    .col(ColumnDef::new(VisibleFile::JobId).integer().not_null())
+                    .col(ColumnDef::new(VisibleFile::JobId).uuid().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
                             .name("fk-visible_file-job")
@@ -105,15 +105,15 @@ impl MigrationTrait for Migration {
                     .table(OutputFile::Table)
                     .col(
                         ColumnDef::new(OutputFile::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
                             .primary_key()
-                            .auto_increment(),
+                            .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(OutputFile::Path).string().not_null())
                     .col(ColumnDef::new(OutputFile::Mode).integer().not_null())
-                    .col(ColumnDef::new(OutputFile::JobId).integer().not_null())
-                    .col(ColumnDef::new(OutputFile::BlobId).integer().not_null())
+                    .col(ColumnDef::new(OutputFile::JobId).uuid().not_null())
+                    .col(ColumnDef::new(OutputFile::BlobId).uuid().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
                             .name("fk-output_file-job")
@@ -144,14 +144,14 @@ impl MigrationTrait for Migration {
                     .table(OutputSymlink::Table)
                     .col(
                         ColumnDef::new(OutputSymlink::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
                             .primary_key()
-                            .auto_increment(),
+                            .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(OutputSymlink::Path).string().not_null())
                     .col(ColumnDef::new(OutputSymlink::Content).ezblob())
-                    .col(ColumnDef::new(OutputSymlink::JobId).integer().not_null())
+                    .col(ColumnDef::new(OutputSymlink::JobId).uuid().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
                             .name("fk-output_file-job")
@@ -171,14 +171,14 @@ impl MigrationTrait for Migration {
                     .table(OutputDir::Table)
                     .col(
                         ColumnDef::new(OutputDir::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
                             .primary_key()
-                            .auto_increment(),
+                            .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(OutputDir::Path).string().not_null())
                     .col(ColumnDef::new(OutputDir::Mode).integer().not_null())
-                    .col(ColumnDef::new(OutputDir::JobId).integer().not_null())
+                    .col(ColumnDef::new(OutputDir::JobId).uuid().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
                             .name("fk-output_file-job")

--- a/rust/migration/src/m20230706_104843_api_keys.rs
+++ b/rust/migration/src/m20230706_104843_api_keys.rs
@@ -12,10 +12,10 @@ impl MigrationTrait for Migration {
                     .table(ApiKey::Table)
                     .col(
                         ColumnDef::new(ApiKey::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
-                            .primary_key(),
+                            .primary_key()
+                            .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(ApiKey::Key).string().not_null().unique_key())
                     .col(ColumnDef::new(ApiKey::Desc).string().not_null())

--- a/rust/migration/src/m20230707_144317_record_uses.rs
+++ b/rust/migration/src/m20230707_144317_record_uses.rs
@@ -14,13 +14,13 @@ impl MigrationTrait for Migration {
                     .table(JobUses::Table)
                     .col(
                         ColumnDef::new(JobUses::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
-                            .primary_key(),
+                            .primary_key()
+                            .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(JobUses::Time).timestamp().not_null())
-                    .col(ColumnDef::new(JobUses::JobId).integer().not_null())
+                    .col(ColumnDef::new(JobUses::JobId).uuid().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
                             .name("fk-job-use-job")

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -6,7 +6,7 @@ use entity::blob;
 use futures::stream::BoxStream;
 use futures::TryStreamExt;
 use rand_core::{OsRng, RngCore};
-use sea_orm::{ActiveModelTrait, ActiveValue::*, DatabaseConnection};
+use sea_orm::{prelude::Uuid, ActiveModelTrait, ActiveValue::*, DatabaseConnection};
 use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::BufWriter;
@@ -69,9 +69,9 @@ pub async fn create_blob(
     mut multipart: Multipart,
     db: Arc<DatabaseConnection>,
     store: Arc<dyn DebugBlobStore + Send + Sync>,
-    store_id: i32,
 ) -> (StatusCode, Json<PostBlobResponse>) {
     let mut parts: Vec<PostBlobResponsePart> = Vec::new();
+    let store_id = Uuid::parse_str("07686ebe-96b6-42f5-a211-c40000533794").unwrap();
 
     while let Ok(Some(field)) = multipart.next_field().await {
         let name = match field.name() {
@@ -102,7 +102,6 @@ pub async fn create_blob(
         }
 
         let active_blob = blob::ActiveModel {
-            // TODO: these ids should be migrated to UUIDs
             id: NotSet,
             created_at: NotSet,
             key: Set(result.unwrap()),

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -72,14 +72,17 @@ pub async fn create_blob(
     store: Arc<dyn DebugBlobStore + Send + Sync>,
 ) -> (StatusCode, Json<PostBlobResponse>) {
     let mut parts: Vec<PostBlobResponsePart> = Vec::new();
-    // let store_id = Uuid::parse_str("07686ebe-96b6-42f5-a211-c40000533794").unwrap();
-    let Ok(store_id) = fetch_local_blob_store(&db).await else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(PostBlobResponse::Error {
-                message: "boop".into(),
-            }),
-        );
+
+    let store_id = match fetch_local_blob_store(&db).await {
+        Ok(id) => id,
+        Err(msg) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(PostBlobResponse::Error {
+                    message: msg.to_string(),
+                }),
+            )
+        }
     };
 
     while let Ok(Some(field)) = multipart.next_field().await {

--- a/rust/rsc/src/rsc/blob_store_service.rs
+++ b/rust/rsc/src/rsc/blob_store_service.rs
@@ -1,0 +1,16 @@
+use sea_orm::{prelude::Uuid, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+
+pub async fn fetch_local_blob_store(
+    db: &DatabaseConnection,
+) -> Result<Uuid, Box<dyn std::error::Error>> {
+    let active_store = entity::prelude::BlobStore::find()
+        .filter(entity::blob_store::Column::Type.eq("LocalBlobStore"))
+        .one(db)
+        .await?;
+
+    let Some(active_store) = active_store else {
+        return Err("Could not find active store".into());
+    };
+
+    Ok(active_store.id)
+}

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -97,7 +97,7 @@ fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) 
                 let conn = conn.clone();
                 let store = store.clone();
                 // TODO: Don't hardcode store type here
-                move |multipart: Multipart| blob::create_blob(multipart, conn, store, 1)
+                move |multipart: Multipart| blob::create_blob(multipart, conn, store)
             })
             .layer(DefaultBodyLimit::disable()),
         )

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -21,6 +21,7 @@ use chrono::{Duration, Utc};
 mod add_job;
 mod api_key_check;
 mod blob;
+mod blob_store_service;
 mod read_job;
 mod types;
 
@@ -96,7 +97,6 @@ fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) 
             post({
                 let conn = conn.clone();
                 let store = store.clone();
-                // TODO: Don't hardcode store type here
                 move |multipart: Multipart| blob::create_blob(multipart, conn, store)
             })
             .layer(DefaultBodyLimit::disable()),
@@ -234,7 +234,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sea_orm::{ActiveModelTrait, PaginatorTrait};
+    use sea_orm::{prelude::Uuid, ActiveModelTrait, PaginatorTrait};
     use std::sync::Arc;
 
     use axum::{
@@ -254,12 +254,14 @@ mod tests {
         })?)
     }
 
-    async fn create_fake_blob(db: &DatabaseConnection) -> Result<i32, Box<dyn std::error::Error>> {
+    async fn create_fake_blob(db: &DatabaseConnection) -> Result<Uuid, Box<dyn std::error::Error>> {
+        let store_uuid = blob_store_service::fetch_local_blob_store(db).await?;
+
         let active_key = entity::blob::ActiveModel {
             id: NotSet,
             created_at: Set((Utc::now() - Duration::days(5)).naive_utc()),
             key: Set("InsecureKey".into()),
-            store_id: Set(1),
+            store_id: Set(store_uuid),
         };
 
         let inserted_key = active_key.insert(db).await?;

--- a/rust/rsc/src/rsc/types.rs
+++ b/rust/rsc/src/rsc/types.rs
@@ -1,4 +1,5 @@
 use blake3;
+use sea_orm::prelude::Uuid;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -11,7 +12,7 @@ pub struct VisibleFile {
 pub struct File {
     pub path: String,
     pub mode: i32,
-    pub blob_id: i32,
+    pub blob_id: Uuid,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -40,8 +41,8 @@ pub struct AddJobPayload {
     pub output_dirs: Vec<Dir>,
     pub output_symlinks: Vec<Symlink>,
     pub output_files: Vec<File>,
-    pub stdout_blob_id: i32,
-    pub stderr_blob_id: i32,
+    pub stdout_blob_id: Uuid,
+    pub stderr_blob_id: Uuid,
     pub status: i32,
     pub runtime: f64,
     pub cputime: f64,
@@ -115,7 +116,7 @@ impl ReadJobPayload {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PostBlobResponsePart {
-    pub id: i32,
+    pub id: Uuid,
     pub name: String,
 }
 
@@ -134,8 +135,8 @@ pub enum ReadJobResponse {
         output_symlinks: Vec<Symlink>,
         output_dirs: Vec<Dir>,
         output_files: Vec<File>,
-        stdout_blob_id: i32,
-        stderr_blob_id: i32,
+        stdout_blob_id: Uuid,
+        stderr_blob_id: Uuid,
         status: i32,
         runtime: f64,
         cputime: f64,


### PR DESCRIPTION
This change is updates all models/tables to use UUIDs. This is important for concurrently/db destruction/multi-client as we can't guarentee that two different clients won't ever get the same integer id representing 2 different jobs. With this change, even if bad db stuff happens we ensure running clients don't confuse jobs as every new job will always get a unique id regardless of the previous state of the db. 

It properly generates new UUIDs by default but it takes a hard dependence on Postgres. To land this PR we would have to drop sqlite3 support which has now been completed.

This change rewrites history but we just did that in the last PR so might as well get them all in at once

The standalone tests have been updated and now properly use a sandboxed postgres