### PR TITLE
Eliminate eviction process; use same connection

### DIFF
--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -653,8 +653,9 @@ struct CacheDbImpl {
   OutputSymlinks output_symlinks;
   Transaction transact;
   SelectMatchingJobs matching_jobs;
+  std::unique_ptr<EvictionPolicy> policy;
 
-  CacheDbImpl(const std::string &_dir)
+  CacheDbImpl(EvictionConfig config, const std::string &_dir)
       : db(std::make_unique<job_cache::Database>(_dir)),
         jobs(db),
         input_files(db),
@@ -663,7 +664,21 @@ struct CacheDbImpl {
         output_dirs(db),
         output_symlinks(db),
         transact(db),
-        matching_jobs(db) {}
+        matching_jobs(db) {
+    switch (config.type) {
+      case EvictionPolicyType::TTL:
+        wcl::log::info("Using TTL eviction policy, seconds_to_live = %lu",
+                       config.ttl.seconds_to_live)();
+        policy = std::make_unique<TTLEvictionPolicy>(config.ttl.seconds_to_live);
+        break;
+      case EvictionPolicyType::LRU:
+        wcl::log::info("Using LRU eviction policy, low = %lu, max = %lu", config.lru.low_size,
+                       config.lru.max_size)();
+        policy = std::make_unique<LRUEvictionPolicy>(config.lru.low_size, config.lru.max_size);
+        break;
+    }
+    policy->init(db, _dir);
+  }
 };
 
 DaemonCache::DaemonCache(std::string dir, std::string bulk_dir, EvictionConfig config)
@@ -679,7 +694,7 @@ DaemonCache::DaemonCache(std::string dir, std::string bulk_dir, EvictionConfig c
   key = rng.unique_name();
   listen_socket_fd = create_cache_socket(".", key);
 
-  impl = std::make_unique<CacheDbImpl>(".");
+  impl = std::make_unique<CacheDbImpl>(config, ".");
 
   launch_evict_loop();
 }
@@ -983,17 +998,7 @@ FindJobResponse DaemonCache::read(const FindJobRequest &find_request) {
     redirect_path(input_dir);
   }
 
-  EvictionCommand cmd(EvictionCommandType::Read, job_id);
-
-  std::string msg = cmd.serialize();
-  msg += '\0';
-
-  wcl::log::info("Sending Read command to eviction loop")();
-  if (write(evict_stdin, msg.data(), msg.size()) == -1) {
-    wcl::log::warning("Failed to send eviction update: %s", strerror(errno))();
-  } else {
-    wcl::log::info("Successfully sent eviction the job")();
-  }
+  impl->policy->read(job_id);
 
   return FindJobResponse(wcl::make_some<MatchingJob>(std::move(result)));
 }
@@ -1078,99 +1083,7 @@ void DaemonCache::add(const AddJobRequest &add_request) {
   std::string job_dir = wcl::join_paths(job_group_dir, std::to_string(job_id));
   rename_no_fail(tmp_job_dir.c_str(), job_dir.c_str());
 
-  EvictionCommand cmd(EvictionCommandType::Write, job_id);
-
-  std::string msg = cmd.serialize();
-  msg += '\0';
-
-  wcl::log::info("Sending Write command to eviction loop")();
-  if (write(evict_stdin, msg.data(), msg.size()) == -1) {
-    wcl::log::warning("Failed to send eviction update: %s", strerror(errno))();
-  } else {
-    wcl::log::info("Sucessfully sent eviction add update")();
-  }
-}
-
-void DaemonCache::launch_evict_loop() {
-  const size_t read_side = 0;
-  const size_t write_side = 1;
-
-  int stdinPipe[2];
-  int stdoutPipe[2];
-
-  if (pipe(stdinPipe) < 0) {
-    wcl::log::error("Failed to allocate eviction pipe: %s", strerror(errno)).urgent()();
-    exit(1);
-  }
-
-  if (pipe(stdoutPipe) < 0) {
-    wcl::log::error("Failed to allocate eviction pipe: %s", strerror(errno)).urgent()();
-    exit(1);
-  }
-
-  int pid = fork();
-
-  // error forking
-  if (pid < 0) {
-    wcl::log::error("Failed to fork eviction process: %s", strerror(errno)).urgent()();
-    exit(1);
-  }
-
-  // child
-  if (pid == 0) {
-    if (dup2(stdinPipe[read_side], STDIN_FILENO) == -1) {
-      wcl::log::error("Failed to dup2 stdin pipe for eviction process: %s", strerror(errno))
-          .urgent()();
-      exit(1);
-    }
-
-    if (dup2(stdoutPipe[write_side], STDOUT_FILENO) == -1) {
-      wcl::log::error("Failed to dup2 stdin pipe for eviction process: %s", strerror(errno))
-          .urgent()();
-      exit(1);
-    }
-
-    close(stdinPipe[read_side]);
-    close(stdinPipe[write_side]);
-    close(stdoutPipe[read_side]);
-    close(stdoutPipe[write_side]);
-
-    wcl::log::info("Launching eviction loop")();
-
-    // Finally enter the eviction loop, if it exits cleanly
-    // go ahead and exit with its result.
-    std::unique_ptr<EvictionPolicy> policy;
-    switch (config.type) {
-      case EvictionPolicyType::TTL:
-        wcl::log::info("Using TTL eviction policy, seconds_to_live = %lu",
-                       config.ttl.seconds_to_live)();
-        policy = std::make_unique<TTLEvictionPolicy>(config.ttl.seconds_to_live);
-        break;
-      case EvictionPolicyType::LRU:
-        wcl::log::info("Using LRU eviction policy, low = %lu, max = %lu", config.lru.low_size,
-                       config.lru.max_size)();
-        policy = std::make_unique<LRUEvictionPolicy>(config.lru.low_size, config.lru.max_size);
-        break;
-    }
-    int result = eviction_loop(".", std::move(policy));
-    exit(result);
-  }
-
-  // parent
-  if (pid > 0) {
-    close(stdinPipe[read_side]);
-    close(stdoutPipe[write_side]);
-
-    evict_pid = pid;
-    evict_stdin = stdinPipe[write_side];
-    evict_stdout = stdoutPipe[read_side];
-  }
-}
-
-void DaemonCache::reap_evict_loop() {
-  close(evict_stdin);
-  close(evict_stdout);
-  waitpid(evict_pid, nullptr, 0);
+  impl->policy->write(job_id);
 }
 
 DaemonCache::~DaemonCache() { reap_evict_loop(); }

--- a/src/job_cache/daemon_cache.cpp
+++ b/src/job_cache/daemon_cache.cpp
@@ -695,8 +695,6 @@ DaemonCache::DaemonCache(std::string dir, std::string bulk_dir, EvictionConfig c
   listen_socket_fd = create_cache_socket(".", key);
 
   impl = std::make_unique<CacheDbImpl>(config, ".");
-
-  launch_evict_loop();
 }
 
 int DaemonCache::run() {
@@ -1086,7 +1084,7 @@ void DaemonCache::add(const AddJobRequest &add_request) {
   impl->policy->write(job_id);
 }
 
-DaemonCache::~DaemonCache() { reap_evict_loop(); }
+DaemonCache::~DaemonCache() {}
 
 void DaemonCache::handle_new_client() {
   // Accept the new client socket. We accept as non-blocking so that we can

--- a/src/job_cache/daemon_cache.h
+++ b/src/job_cache/daemon_cache.h
@@ -52,9 +52,6 @@ class DaemonCache {
   std::unordered_map<int, MessageSender> message_senders;
   bool exit_now = false;
 
-  void launch_evict_loop();
-  void reap_evict_loop();
-
   FindJobResponse read(const FindJobRequest &find_request);
   void add(const AddJobRequest &add_request);
   void remove_corrupt_job(int64_t job_id);


### PR DESCRIPTION
This change eliminates the eviction process which is now quite apparently an over optimization IMO. With this new change there will be small pauses in wake here and there while the eviction tasks are occurring but on the plus side we now have a single DB connection, guarded by a file system lock, per cache.

Additionally I spotted a couple cases where I was improperly using the database on two separate threads which is a big no no for SQLite and may have been causing some of our issues. I've removed those at additional cost (but it should be a small cost).

With these changes things should be both easier to debug, and possibly more stable.

And remember kids, friends don't let friends write multi-threaded C++ code when Rust is an option ;)