### PR TITLE
rsc: Resolve Blobs on request

### DIFF
--- a/rust/rsc/src/common/config.rs
+++ b/rust/rsc/src/common/config.rs
@@ -7,8 +7,9 @@ pub struct RSCConfigOverride {
     pub database_url: Option<String>,
     pub server_addr: Option<String>,
     pub standalone: Option<bool>,
-    // TODO: the backing store should be configurable via URI
-    pub local_store: Option<String>,
+    // Active store is specified by setting the UUID of the store
+    // that should be processing uploads.
+    pub active_store: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -17,7 +18,7 @@ pub struct RSCConfig {
     // TODO: We should allow setting a domain as well
     pub server_addr: String,
     pub standalone: bool,
-    pub local_store: Option<String>,
+    pub active_store: Option<String>,
 }
 
 impl RSCConfig {
@@ -38,7 +39,7 @@ impl RSCConfig {
             .set_override_option("database_url", overrides.database_url)?
             .set_override_option("server_addr", overrides.server_addr)?
             .set_override_option("standalone", overrides.standalone)?
-            .set_override_option("local_store", overrides.local_store)?
+            .set_override_option("active_store", overrides.active_store)?
             .build()?;
 
         config.try_deserialize()

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -22,6 +22,8 @@ pub trait BlobStore {
         &self,
         stream: BoxStream<'a, Result<Bytes, std::io::Error>>,
     ) -> Result<String, std::io::Error>;
+
+    async fn download_url(&self, key: String) -> String;
 }
 
 pub trait DebugBlobStore: BlobStore + std::fmt::Debug {}
@@ -47,6 +49,10 @@ impl BlobStore for LocalBlobStore {
         tokio::io::copy(&mut reader, &mut file).await?;
 
         Ok(name)
+    }
+
+    async fn download_url(&self, key: String) -> String {
+        return format!("file://{0}/{key}", self.root);
     }
 }
 

--- a/rust/rsc/src/rsc/blob_store_service.rs
+++ b/rust/rsc/src/rsc/blob_store_service.rs
@@ -1,16 +1,22 @@
-use sea_orm::{prelude::Uuid, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use entity::local_blob_store;
+use entity::prelude::LocalBlobStore;
+use sea_orm::DbErr;
+use sea_orm::{prelude::Uuid, DatabaseConnection, EntityTrait};
 
 pub async fn fetch_local_blob_store(
     db: &DatabaseConnection,
 ) -> Result<Uuid, Box<dyn std::error::Error>> {
-    let active_store = entity::prelude::BlobStore::find()
-        .filter(entity::blob_store::Column::Type.eq("LocalBlobStore"))
-        .one(db)
-        .await?;
+    let active_store = LocalBlobStore::find().one(db).await?;
 
     let Some(active_store) = active_store else {
         return Err("Could not find active store".into());
     };
 
     Ok(active_store.id)
+}
+
+pub async fn fetch_local_blob_stores(
+    db: &DatabaseConnection,
+) -> Result<Vec<local_blob_store::Model>, DbErr> {
+    LocalBlobStore::find().all(db).await
 }

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -7,13 +7,14 @@ use clap::Parser;
 use data_encoding::HEXLOWER;
 use migration::{Migrator, MigratorTrait};
 use rand_core::{OsRng, RngCore};
+use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 use std::sync::Arc;
 use tracing;
 
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::*, ColumnTrait, ConnectionTrait, Database, DatabaseConnection,
-    DeleteResult, EntityTrait, QueryFilter,
+    prelude::Uuid, ActiveModelTrait, ActiveValue::*, ColumnTrait, ConnectionTrait, Database,
+    DatabaseConnection, DeleteResult, EntityTrait, QueryFilter,
 };
 
 use chrono::{Duration, Utc};
@@ -52,20 +53,49 @@ struct ServerOptions {
 
     #[arg(help = "Launches the cache without an external database", long)]
     standalone: bool,
-
-    #[arg(
-        help = "Specify an absolute path for a local directory based store",
-        value_name = "LOCAL_STORE",
-        long
-    )]
-    local_store: Option<String>,
 }
 
-fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) -> Router {
+// Maps databse store uuid -> dyn blob::DebugBlobStore
+// that represent said store.
+async fn activate_stores(
+    conn: Arc<DatabaseConnection>,
+) -> HashMap<Uuid, Arc<dyn blob::DebugBlobStore + Sync + Send>> {
+    let stores = match blob_store_service::fetch_local_blob_stores(&conn).await {
+        Ok(stores) => stores,
+        Err(_) => Vec::new(),
+    };
+
+    let mut active_stores: HashMap<Uuid, Arc<dyn blob::DebugBlobStore + Sync + Send>> =
+        HashMap::new();
+
+    for store in stores.into_iter() {
+        active_stores.insert(
+            store.id,
+            Arc::new(blob::LocalBlobStore { root: store.root }),
+        );
+    }
+
+    return active_stores;
+}
+
+fn create_router(
+    conn: Arc<DatabaseConnection>,
+    config: Arc<config::RSCConfig>,
+    blob_stores: &HashMap<Uuid, Arc<dyn blob::DebugBlobStore + Sync + Send>>,
+) -> Router {
     // If we can't create a store, just exit. The config is wrong and must be rectified.
-    let root = config.local_store.clone().unwrap();
-    let store: Arc<dyn blob::DebugBlobStore + Send + Sync> =
-        Arc::new(blob::LocalBlobStore { root });
+    let Some(active_store_uuid) = config.active_store.clone() else {
+        panic!("Active store uuid not set in configuration");
+    };
+
+    let Ok(active_store_uuid) = Uuid::parse_str(&active_store_uuid) else {
+        panic!("Failed to parse provided active store into uuid");
+    };
+
+    let Some(active_store) = blob_stores.get(&active_store_uuid).clone() else {
+        panic!("UUID for active store not in database");
+    };
+
     Router::new()
         .route(
             "/job",
@@ -82,7 +112,8 @@ fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) 
             "/job/matching",
             post({
                 let conn = conn.clone();
-                move |body| read_job::read_job(body, conn)
+                let blob_stores = blob_stores.clone();
+                move |body| read_job::read_job(body, conn, blob_stores)
             }),
         )
         .route(
@@ -96,7 +127,7 @@ fn create_router(conn: Arc<DatabaseConnection>, config: Arc<config::RSCConfig>) 
             "/blob",
             post({
                 let conn = conn.clone();
-                let store = store.clone();
+                let store = active_store.clone();
                 move |multipart: Multipart| blob::create_blob(multipart, conn, store)
             })
             .layer(DefaultBodyLimit::disable()),
@@ -206,7 +237,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             None
         },
-        local_store: args.local_store,
+        active_store: None,
     })?;
     let config = Arc::new(config);
 
@@ -223,7 +254,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     launch_eviction(connection.clone(), 60 * 10, 60 * 60 * 24 * 7);
 
     // Launch the server
-    let router = create_router(connection.clone(), config.clone());
+    let stores = activate_stores(connection.clone()).await;
+    let router = create_router(connection.clone(), config.clone(), &stores);
     axum::Server::bind(&config.server_addr.parse()?)
         .serve(router.into_make_service())
         .await?;

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -62,7 +62,10 @@ async fn activate_stores(
 ) -> HashMap<Uuid, Arc<dyn blob::DebugBlobStore + Sync + Send>> {
     let stores = match blob_store_service::fetch_local_blob_stores(&conn).await {
         Ok(stores) => stores,
-        Err(_) => Vec::new(),
+        Err(err) => {
+            tracing::warn!(%err, "No local stores available in database");
+            Vec::new()
+        },
     };
 
     let mut active_stores: HashMap<Uuid, Arc<dyn blob::DebugBlobStore + Sync + Send>> =

--- a/rust/rsc/src/rsc/read_job.rs
+++ b/rust/rsc/src/rsc/read_job.rs
@@ -95,7 +95,7 @@ pub async fn read_job(
 
                 let output_files = match output_files {
                     Err(err) => {
-                        tracing::error! {%err, "Failed to resolve all output files. Resoving job as a cache miss."};
+                        tracing::error! {%err, "Failed to resolve all output files. Resolving job as a cache miss."};
                         return Ok((None, ReadJobResponse::NoMatch))
                     },
                     Ok(files) => files,
@@ -125,7 +125,7 @@ pub async fn read_job(
 
                 let stdout_blob = match resolve_blob(matching_job.stdout_blob_id, txn, &blob_stores).await {
                     Err(err) => {
-                        tracing::error! {%err, "Failed to resolve stdout blob. Resoving job as a cache miss."};
+                        tracing::error! {%err, "Failed to resolve stdout blob. Resolving job as a cache miss."};
                         return Ok((None, ReadJobResponse::NoMatch))
                     },
                     Ok(blob) => blob,
@@ -133,7 +133,7 @@ pub async fn read_job(
 
                 let stderr_blob = match resolve_blob(matching_job.stderr_blob_id, txn, &blob_stores).await {
                     Err(err) => {
-                        tracing::error! {%err, "Failed to resolve stderr blob. Resoving job as a cache miss."};
+                        tracing::error! {%err, "Failed to resolve stderr blob. Resolving job as a cache miss."};
                         return Ok((None, ReadJobResponse::NoMatch))
                     },
                     Ok(blob) => blob,

--- a/rust/rsc/src/rsc/read_job.rs
+++ b/rust/rsc/src/rsc/read_job.rs
@@ -1,9 +1,7 @@
 use crate::blob;
-use crate::types::{
-    Dir, File, ReadJobPayload, ReadJobResponse, ResolvedBlob, ResolvedBlobFile, Symlink,
-};
+use crate::types::{Dir, ReadJobPayload, ReadJobResponse, ResolvedBlob, ResolvedBlobFile, Symlink};
 use axum::Json;
-use entity::{blob_store, job, job_use, output_dir, output_file, output_symlink};
+use entity::{job, job_use, output_dir, output_file, output_symlink};
 use hyper::StatusCode;
 use sea_orm::DatabaseTransaction;
 use sea_orm::{
@@ -57,8 +55,8 @@ pub async fn read_job(
     // If read_job becomes a bottleneck it should
     // be rewritten such that joining on promises
     // is delayed for as long as possible.
-    // Another option would be to collect all blob ids 
-    // ahead of time and make a single db query to list 
+    // Another option would be to collect all blob ids
+    // ahead of time and make a single db query to list
     // them all out instead of a query per blob id.
     let result = conn
         .as_ref()
@@ -83,8 +81,8 @@ pub async fn read_job(
                             let blob = resolve_blob(m.blob_id, txn, &blob_copy).await?;
 
                             Ok(ResolvedBlobFile {
-                                path: m.path.clone(),
-                                mode: m.mode.clone(),
+                                path: m.path,
+                                mode: m.mode,
                                 blob,
                             })
                         }

--- a/rust/rsc/src/rsc/read_job.rs
+++ b/rust/rsc/src/rsc/read_job.rs
@@ -94,8 +94,8 @@ pub async fn read_job(
                         .collect();
 
                 let output_files = match output_files {
-                    Err(msg) => {
-                        tracing::error! {%msg, "Failed to resolve all output files. Resoving job as a cache miss."};
+                    Err(err) => {
+                        tracing::error! {%err, "Failed to resolve all output files. Resoving job as a cache miss."};
                         return Ok((None, ReadJobResponse::NoMatch))
                     },
                     Ok(files) => files,
@@ -124,16 +124,16 @@ pub async fn read_job(
                     .collect();
 
                 let stdout_blob = match resolve_blob(matching_job.stdout_blob_id, txn, &blob_stores).await {
-                    Err(msg) => {
-                        tracing::error! {%msg, "Failed to resolve stdout blob. Resoving job as a cache miss."};
+                    Err(err) => {
+                        tracing::error! {%err, "Failed to resolve stdout blob. Resoving job as a cache miss."};
                         return Ok((None, ReadJobResponse::NoMatch))
                     },
                     Ok(blob) => blob,
                 };
 
                 let stderr_blob = match resolve_blob(matching_job.stderr_blob_id, txn, &blob_stores).await {
-                    Err(msg) => {
-                        tracing::error! {%msg, "Failed to resolve stderr blob. Resoving job as a cache miss."};
+                    Err(err) => {
+                        tracing::error! {%err, "Failed to resolve stderr blob. Resoving job as a cache miss."};
                         return Ok((None, ReadJobResponse::NoMatch))
                     },
                     Ok(blob) => blob,

--- a/rust/rsc/src/rsc/types.rs
+++ b/rust/rsc/src/rsc/types.rs
@@ -128,15 +128,28 @@ pub enum PostBlobResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct ResolvedBlob {
+    pub id: Uuid,
+    pub url: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ResolvedBlobFile {
+    pub path: String,
+    pub mode: i32,
+    pub blob: ResolvedBlob,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ReadJobResponse {
     NoMatch,
     Match {
         output_symlinks: Vec<Symlink>,
         output_dirs: Vec<Dir>,
-        output_files: Vec<File>,
-        stdout_blob_id: Uuid,
-        stderr_blob_id: Uuid,
+        output_files: Vec<ResolvedBlobFile>,
+        stdout_blob: ResolvedBlob,
+        stderr_blob: ResolvedBlob,
         status: i32,
         runtime: f64,
         cputime: f64,


### PR DESCRIPTION
Blobs returned to the client via a matching jobs now resolve and return the URL where that blob can be downloaded from.

Example:
```json
{
    "cputime": 1.0,
    "ibytes": 100000,
    "memory": 1000,
    "obytes": 1000,
    "output_dirs": [],
    "output_files": [
        {
            "blob": {
                "id": "4ad74b40-4a3f-4464-a488-77f6297c8121",
                "url": "file:///foo/bar/remote_cache_local_store/57KcxXl4PxMyjPcZIRJvDw=="
            },
            "mode": 0,
            "path": "foo"
        }
    ],
    "output_symlinks": [],
    "runtime": 1.0,
    "status": 0,
    "stderr_blob": {
        "id": "5bfb8a97-c244-4241-a091-5aa3388c20eb",
        "url": "file:///foo/bar/remote_cache_local_store/X1MS-Semg55oqRF3U9LAYA=="
    },
    "stdout_blob": {
        "id": "4ad74b40-4a3f-4464-a488-77f6297c8121",
        "url": "file:///foo/bar/remote_cache_local_store/57KcxXl4PxMyjPcZIRJvDw=="
    },
    "type": "Match"
}
```