### PR TITLE
Update wake-format's search libdir to match wake's libdir

### DIFF
--- a/tools/wake-format/main.cpp
+++ b/tools/wake-format/main.cpp
@@ -21,6 +21,7 @@
 
 #include <stdio.h>
 #include <wcl/doc.h>
+#include <wcl/filepath.h>
 
 #include <fstream>
 #include <iostream>
@@ -35,6 +36,7 @@
 #include "parser/syntax.h"
 #include "parser/wakefiles.h"
 #include "util/diagnostic.h"
+#include "util/execpath.h"
 #include "util/file.h"
 #include "wcl/diff.h"
 #include "wcl/xoshiro_256.h"
@@ -199,7 +201,9 @@ int main(int argc, char **argv) {
   user_warn = fopen("/dev/null", "w");
   if (auto_find_files) {
     bool ok = true;
-    wakefiles = find_all_wakefiles(ok, true, false, ".", ".", user_warn);
+    // Use the standard libdir to more closely match wake discovery
+    std::string libdir = wcl::make_canonical(find_execpath() + "/../share/wake/lib");
+    wakefiles = find_all_wakefiles(ok, true, false, libdir, ".", user_warn);
     if (!ok) {
       std::cerr << "Failed to automatically discover wake files" << std::endl;
       exit(EXIT_FAILURE);


### PR DESCRIPTION
Currently setting `libdir` to `.` causes the code to operate as if no manifest is present because `find_external_stdlib_files` searches libdir and finds all wakefiles regardless of their presence in the manifest.

This behavior does not match the claim of `--auto` which is that is "matches wake discovery".

There is probably some alternative implementation that inlines this finding of the standard libdir but its a little complicated because the lsp's call has an extra level of directories for some reason.
```
$ rg -i "make_canonical.*execpath.*lib\""
tools/lsp-wake/main.cpp
325:    std::string stdLibPath = wcl::make_canonical(find_execpath() + "/../../share/wake/lib");

tools/wake-format/main.cpp
205:    std::string libdir = wcl::make_canonical(find_execpath() + "/../share/wake/lib");

tools/wake/main.cpp
637:  std::string libdir = wcl::make_canonical(find_execpath() + "/../share/wake/lib");
```