### PR TITLE
db: Order job queries by job id

### DIFF
--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -224,6 +224,10 @@ void inspect_database(const CommandLineOptions &clo, Database &db, const std::st
     exit(1);
   }
 
+  std::sort(intersected_jobs.begin(), intersected_jobs.end(), [](JobReflection const& lhs, JobReflection const& rhs) {
+    return lhs.job < rhs.job;
+  });
+
   describe(intersected_jobs, get_describe_policy(clo), db);
 }
 

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -224,9 +224,8 @@ void inspect_database(const CommandLineOptions &clo, Database &db, const std::st
     exit(1);
   }
 
-  std::sort(intersected_jobs.begin(), intersected_jobs.end(), [](JobReflection const& lhs, JobReflection const& rhs) {
-    return lhs.job < rhs.job;
-  });
+  std::sort(intersected_jobs.begin(), intersected_jobs.end(),
+            [](JobReflection const &lhs, JobReflection const &rhs) { return lhs.job < rhs.job; });
 
   describe(intersected_jobs, get_describe_policy(clo), db);
 }


### PR DESCRIPTION
During the database inspection refactor job ordering for inspection responses was lost. This is confusing and actively unhelpful when debugged troublesome builds.

This PR restores the previous functionality 