### PR TITLE
rsc: Improve rust build api, fix rsc test, fix rsc test framework

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
             fetch-depth: 0
 
         - name: Install Deps
-          run: sudo apt-get update && sudo apt-get install -y build-essential fuse libfuse-dev libsqlite3-dev libgmp-dev libncurses5-dev pkg-config git g++ gcc libre2-dev python3-sphinx clang-format-12 postgresql
+          run: sudo apt-get update && sudo apt-get install -y build-essential fuse libfuse-dev libsqlite3-dev libgmp-dev libncurses5-dev pkg-config git g++ gcc libre2-dev python3-sphinx clang-format-12
 
         - name: Check C/C++ Formatting
           run: clang-format-12 --style=file --Werror -n $(./scripts/which_clang_files all)
@@ -33,26 +33,14 @@ jobs:
         - name: Check Wake Formatting
           run: ./bin/wake-format.native-cpp14-release --auto --dry-run
 
-        - name: Download rust
-          run: pushd /var/tmp && wget https://static.rust-lang.org/dist/rust-1.72.0-x86_64-unknown-linux-gnu.tar.gz && popd
-
-        - name: Unpack rust
-          run: pushd /var/tmp && tar -xf rust-1.72.0-x86_64-unknown-linux-gnu.tar.gz && popd
-
-        - name: Install rust
-          run: pushd /var/tmp && mkdir rust-install && ./rust-1.72.0-x86_64-unknown-linux-gnu/install.sh --prefix=/var/tmp/rust-install --verbose && popd
-
         - name: Checkout postgres
           run: pushd /var/tmp/ && git clone --depth 1 https://github.com/postgres/postgres.git && cd postgres && git fetch origin c372fbbd8e911f2412b80a8c39d7079366565d67 && git checkout c372fbbd8e911f2412b80a8c39d7079366565d67 && popd
 
         - name: Build postgres
           run: pushd /var/tmp/postgres && ./configure --prefix /var/tmp/pg-server && make install && popd
 
-        - name: Vendor remote cache deps
-          run: cd rust/rsc && cargo vendor --locked && cd ..
-
         - name: Run Remote Cache Tests
-          run: POSTGRES_DIR=/var/tmp/pg-server CARGO_HOME=/var/tmp/rust-install make remoteCacheTests
+          run: POSTGRES_DIR=/var/tmp/pg-server make remoteCacheTests
 
         - name: Generate Docs
           run: mkdir www && ./bin/wake --no-workspace --html > www/index.html

--- a/.github/workflows/dockerfiles/alpine
+++ b/.github/workflows/dockerfiles/alpine
@@ -1,6 +1,6 @@
 FROM alpine:3.14.0
 
-RUN apk add m4 g++ make pkgconf git tar xz gmp-dev re2-dev sqlite-dev fuse-dev ncurses-dev dash sqlite-static ncurses-static linux-headers jq libssl-dev
+RUN apk add m4 g++ make pkgconf git tar xz gmp-dev re2-dev sqlite-dev fuse-dev ncurses-dev dash sqlite-static ncurses-static linux-headers jq openssl-dev
 
 WORKDIR /build
 

--- a/.github/workflows/dockerfiles/alpine
+++ b/.github/workflows/dockerfiles/alpine
@@ -1,6 +1,6 @@
 FROM alpine:3.14.0
 
-RUN apk add m4 g++ make pkgconf git tar xz gmp-dev re2-dev sqlite-dev fuse-dev ncurses-dev dash sqlite-static ncurses-static linux-headers jq
+RUN apk add m4 g++ make pkgconf git tar xz gmp-dev re2-dev sqlite-dev fuse-dev ncurses-dev dash sqlite-static ncurses-static linux-headers jq libssl-dev
 
 WORKDIR /build
 

--- a/.github/workflows/dockerfiles/centos-7.6
+++ b/.github/workflows/dockerfiles/centos-7.6
@@ -3,7 +3,7 @@ FROM centos:7.6.1810
 RUN yum -y update && yum clean all
 RUN yum --setopt=skip_missing_names_on_install=False install -y rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools wget
 RUN yum --setopt=skip_missing_names_on_install=False install -y epel-release
-RUN yum --setopt=skip_missing_names_on_install=False install -y tar xz dash git which make gcc gcc-c++ fuse fuse-devel gmp-devel ncurses-devel sqlite-devel re2-devel squashfuse iproute jq
+RUN yum --setopt=skip_missing_names_on_install=False install -y tar xz dash git which make gcc gcc-c++ fuse fuse-devel gmp-devel ncurses-devel sqlite-devel re2-devel squashfuse iproute jq openssl-devel
 RUN yum --setopt=skip_missing_names_on_install=False install -y centos-release-scl
 RUN yum --setopt=skip_missing_names_on_install=False install -y devtoolset-9-gcc*
 RUN rpmdev-setuptree

--- a/.github/workflows/dockerfiles/debian-bullseye
+++ b/.github/workflows/dockerfiles/debian-bullseye
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-RUN apt-get update && apt-get install -y build-essential m4 devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse wget iproute2 jq
+RUN apt-get update && apt-get install -y build-essential m4 devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse wget iproute2 jq libssl-dev
 
 
 WORKDIR /build

--- a/.github/workflows/dockerfiles/fedora-38
+++ b/.github/workflows/dockerfiles/fedora-38
@@ -3,7 +3,7 @@ FROM fedora:38
 RUN echo fastestmirror=1 >> /etc/dnf/dnf.conf
 RUN dnf clean all
 RUN dnf update -y
-RUN dnf install -y rpm-build rpm-devel rpmlint make python39 bash diffutils patch rpmdevtools m4 tar xz dash git which make gcc gcc-c++ fuse fuse-devel gmp-devel ncurses-devel sqlite-devel re2-devel squashfuse wget iproute jq
+RUN dnf install -y rpm-build rpm-devel rpmlint make python39 bash diffutils patch rpmdevtools m4 tar xz dash git which make gcc gcc-c++ fuse fuse-devel gmp-devel ncurses-devel sqlite-devel re2-devel squashfuse wget iproute jq openssl-devel
 RUN rpmdev-setuptree
 
 

--- a/.github/workflows/dockerfiles/rocky-8
+++ b/.github/workflows/dockerfiles/rocky-8
@@ -3,7 +3,7 @@ FROM rockylinux/rockylinux:8
 RUN echo fastestmirror=1 >> /etc/dnf/dnf.conf
 RUN dnf clean all
 RUN dnf install -y epel-release
-RUN dnf install -y rpm-build rpm-devel rpmlint make python36 bash diffutils patch rpmdevtools m4 tar xz dash git which make gcc gcc-c++ fuse fuse-devel gmp-devel ncurses-devel sqlite-devel re2-devel squashfuse wget iproute jq
+RUN dnf install -y rpm-build rpm-devel rpmlint make python36 bash diffutils patch rpmdevtools m4 tar xz dash git which make gcc gcc-c++ fuse fuse-devel gmp-devel ncurses-devel sqlite-devel re2-devel squashfuse wget iproute jq openssl-devel
 RUN rpmdev-setuptree
 
 

--- a/.github/workflows/dockerfiles/rocky-9
+++ b/.github/workflows/dockerfiles/rocky-9
@@ -4,7 +4,7 @@ RUN echo fastestmirror=1 >> /etc/dnf/dnf.conf
 RUN dnf clean all
 RUN dnf install -y epel-release
 RUN dnf --enablerepo=crb install -y fuse-devel
-RUN dnf install -y rpm-build rpm-devel rpmlint make python3 bash diffutils patch rpmdevtools m4 tar xz dash git which make gcc gcc-c++ fuse gmp-devel ncurses-devel sqlite-devel re2-devel squashfuse dash wget iproute jq
+RUN dnf install -y rpm-build rpm-devel rpmlint make python3 bash diffutils patch rpmdevtools m4 tar xz dash git which make gcc gcc-c++ fuse gmp-devel ncurses-devel sqlite-devel re2-devel squashfuse dash wget iproute jq openssl-devel
 
 RUN rpmdev-setuptree
 

--- a/.github/workflows/dockerfiles/ubuntu-22.04
+++ b/.github/workflows/dockerfiles/ubuntu-22.04
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-RUN apt-get update && apt-get install -y build-essential m4 debhelper devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse wget iproute2 jq
+RUN apt-get update && apt-get install -y build-essential m4 debhelper devscripts git fuse libfuse-dev libgmp-dev libncurses5-dev libre2-dev libsqlite3-dev pkg-config squashfuse wget iproute2 jq libssl-dev
 
 WORKDIR /build
 ENV VERSION=1.70.0

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,3 @@ compile_commands.json
 /rust/entity/target/*
 /rust/log_viewer/target/*
 /rust/rsc/target/*
-/rust/rsc/vendor/*

--- a/.wakemanifest
+++ b/.wakemanifest
@@ -2,6 +2,7 @@ build.wake
 extensions/vscode/vscode.wake
 rust/log_viewer/build.wake
 rust/rsc/postgres-tests.wake
+rust/rsc/rsc.wake
 share/wake/lib/core/boolean.wake
 share/wake/lib/core/double.wake
 share/wake/lib/core/integer.wake

--- a/build.wake
+++ b/build.wake
@@ -104,9 +104,8 @@ def all variant =
 
 # Install wake into a target location
 def doInstall dest kind =
-    # kick off in parallel, but rsc and rsc tool can't run at smae time
-    # rsc and rsc_tool cannot be built the same time right now. Force them to be
-    # serial relative to each other.
+    # kick off in parallel, but rsc and rsc_tool cannot be built at the same time right now.
+    # Force them to be serial relative to each other.
     def install_rsc_bins =
         require Pass rsc = buildRSC Unit
         require Pass rsc = installAs "{dest}/bin/wake-remote-cache" rsc

--- a/build.wake
+++ b/build.wake
@@ -108,6 +108,10 @@ def doInstall dest kind =
     require Pass datfiles = sources "{@here}/share" `.*`
     require Pass log_viewer = buildWakeLogViewer Unit
     require Pass log_viewer = installAs "{dest}/bin/wake-log-viewer" log_viewer
+    require Pass rsc = buildRSC Unit
+    require Pass rsc = installAs "{dest}/bin/wake-remote-cache" rsc
+    require Pass rsc_tool = buildRSCTool Unit
+    require Pass rsc_tool = installAs "{dest}/bin/wake-remote-cache-tool" rsc_tool
 
     def binfilesResult = all variant
     def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
@@ -118,7 +122,7 @@ def doInstall dest kind =
     require Pass binfiles = binfilesResult
     require Pass bininstall = findFailFn releaseBin binfiles
 
-    def outputs = readme, log_viewer, bininstall ++ datinstall
+    def outputs = readme, log_viewer, rsc, rsc_tool, bininstall ++ datinstall
 
     Pass outputs
 

--- a/build.wake
+++ b/build.wake
@@ -104,27 +104,48 @@ def all variant =
 
 # Install wake into a target location
 def doInstall dest kind =
-    require Pass variant = toVariant kind
-    require Pass datfiles = sources "{@here}/share" `.*`
-    require Pass log_viewer = buildWakeLogViewer Unit
-    require Pass log_viewer = installAs "{dest}/bin/wake-log-viewer" log_viewer
-    require Pass rsc = buildRSC Unit
-    require Pass rsc = installAs "{dest}/bin/wake-remote-cache" rsc
-    require Pass rsc_tool = buildRSCTool Unit
-    require Pass rsc_tool = installAs "{dest}/bin/wake-remote-cache-tool" rsc_tool
+    # kick off in parallel, but rsc and rsc tool can't run at smae time
+    # rsc and rsc_tool cannot be built the same time right now. Force them to be
+    # serial relative to each other.
+    def install_rsc_bins =
+        require Pass rsc = buildRSC Unit
+        require Pass rsc = installAs "{dest}/bin/wake-remote-cache" rsc
+        require Pass rsc_tool = buildRSCTool Unit
+        require Pass rsc_tool = installAs "{dest}/bin/wake-remote-cache-tool" rsc_tool
 
-    def binfilesResult = all variant
+        Pass (Pair rsc rsc_tool)
+
+    def install_log_viewer =
+        buildWakeLogViewer Unit
+        | rmapPass (installAs "{dest}/bin/wake-log-viewer")
+
+    def install_datfiles =
+        sources "{@here}/share" `.*`
+        | rmapPass (\files findFailFn (installIn dest ".") files)
+
+    def install_readme =
+        source "README.md"
+        | rmapPass (\file installIn "{dest}/share/doc/wake" "." file)
+
+    require Pass variant = toVariant kind
+
     def releaseBin exe = installAs "{dest}/{replace `\.[^.]*$` '' exe.getPathName}" exe
 
-    require Pass datinstall = findFailFn (installIn dest ".") datfiles
-    require Pass readmeSource = source "README.md"
-    require Pass readme = installIn "{dest}/share/doc/wake" "." readmeSource
-    require Pass binfiles = binfilesResult
-    require Pass bininstall = findFailFn releaseBin binfiles
+    def install_binfiles =
+        all variant
+        | rmapPass (\files findFailFn releaseBin files)
 
-    def outputs = readme, log_viewer, rsc, rsc_tool, bininstall ++ datinstall
+    # Join on the installs now that everything has been kicked off
+    require Pass readme = install_readme
+    require Pass datfiles = install_datfiles
+    require Pass binfiles = install_binfiles
 
-    Pass outputs
+    # Rust builds are slow, delay blocking on them for as long as possible
+    require Pass (Pair rsc rsc_tool) = install_rsc_bins
+    require Pass log_viewer = install_log_viewer
+
+    (readme, log_viewer, rsc, rsc_tool, binfiles ++ datfiles)
+    | Pass
 
 # Replace @VERSION@ with 'release'
 def setVersion release file =

--- a/rust/log_viewer/build.wake
+++ b/rust/log_viewer/build.wake
@@ -19,8 +19,5 @@ from wake import _
 from rust import _
 
 def buildWakeLogViewer Unit =
-    require Pass root = mkdir "rust/log_viewer"
-    require Pass toolchain = makeReleaseCargoToolchain root "log_viewer"
-
-    toolchain
-    | cargoBuild
+    makeCargoExecutable "log_viewer" "rust/log_viewer"
+    |> cargoBuildWith (defaultCargoToolchain Unit)

--- a/rust/log_viewer/build.wake
+++ b/rust/log_viewer/build.wake
@@ -20,4 +20,4 @@ from rust import _
 
 def buildWakeLogViewer Unit =
     makeCargoExecutable "log_viewer" "rust/log_viewer"
-    |> cargoBuildWith (defaultCargoToolchain Unit)
+    | rmapPass (cargoBuildWith (defaultCargoToolchain Unit))

--- a/rust/log_viewer/build.wake
+++ b/rust/log_viewer/build.wake
@@ -19,14 +19,8 @@ from wake import _
 from rust import _
 
 def buildWakeLogViewer Unit =
-    require Pass cargoToml = source "rust/log_viewer/Cargo.toml"
-    require Pass cargoLock = source "rust/log_viewer/Cargo.lock"
-    require Pass main = source "rust/log_viewer/src/main.rs"
+    require Pass root = mkdir "rust/log_viewer"
+    require Pass toolchain = makeReleaseCargoToolchain root "log_viewer"
 
-    require Pass outputs =
-        cargoBuild (cargoToml, cargoLock, main, Nil) "rust/log_viewer" ("log_viewer", Nil)
-
-    require (logViewer, Nil) = outputs
-    else failWithError "More than one output returned when building log_viewer"
-
-    Pass logViewer
+    toolchain
+    | cargoBuild

--- a/rust/rsc/postgres-tests.wake
+++ b/rust/rsc/postgres-tests.wake
@@ -16,7 +16,6 @@
 package build_wake
 
 from wake import _
-from rust import findCargoPath
 
 def createFileOp dst =
     JObject (
@@ -36,21 +35,14 @@ def tmpMountOp dst =
         "destination" :-> JString dst,
     )
 
-def bindMountOp src dst =
-    JObject (
-        "type" :-> JString "bind",
-        "source" :-> JString src,
-        "destination" :-> JString dst,
-    )
-
-def postgresSpecJson stdinFile cargoPath =
+def postgresSpecJson stdinFile testBinary =
     JObject (
         "label" :-> JString "postgres cargo test",
-        "environment" :-> JArray (JString "PATH=/usr/lib64/ccache:/usr/bin:/usr/sbin:/bin:{dirname cargoPath}",),
+        "environment" :-> JArray (JString "PATH=/usr/lib64/ccache:/usr/bin:/usr/sbin:/bin",),
         "command" :-> JArray (JString "bash", Nil),
         "user-id" :-> JInteger 0,
         "group-id" :-> JInteger 0,
-        "visible" :-> JArray Nil,
+        "visible" :-> JArray (JString testBinary, Nil),
         "directory" :-> JString ".",
         "stdin" :-> JString "{stdinFile}",
         "resources" :-> JArray Nil,
@@ -69,11 +61,10 @@ def postgresSpecJson stdinFile cargoPath =
             tmpMountOp "/root",
             createDirOp "rust/rsc/.cargo",
             createFileOp "rust/rsc/.cargo/config.toml",
-            bindMountOp "rust/rsc/vendor-config.toml" "rust/rsc/.cargo/config.toml",
         ),
     )
 
-export target testPostgres Unit =
+export def testPostgres _ =
     # First we define a few directories, using various
     # environment variables
     def dataDir = "/tmp/pg_data"
@@ -86,12 +77,7 @@ export target testPostgres Unit =
 
             Pass (dirname postgresPath)
 
-    require Pass cargoPath = findCargoPath Unit
-
-    # This is normally unsafe but we're just using it for
-    # a warning, you should never depend on the result here
-    require _, _ = files "{@here}/vendor" `.*`
-    else failWithError "You forgot to run `cargo vendor --locked` inside {@here}"
+    require Pass testBinary = buildRSCTest Unit
 
     # This script is piped in via stdin so that
     # as shells are opened one after the other,
@@ -99,46 +85,39 @@ export target testPostgres Unit =
     def script =
         """
         set -ex
-        trap 'exit $(cat /tmp/status)' 0
         unshare -U
+        set -ex
         export HOME=/root
         mkdir %{dataDir}
-        echo $? > /tmp/status
         %{postgresDir}/initdb -D %{dataDir}
-        echo $? > /tmp/status
         %{postgresDir}/postgres -D %{dataDir} &
-        trap "kill $!" 0
+        trap "kill $! && sleep 2s" EXIT
         sleep 2s
         %{postgresDir}/createuser -h localhost root
-        echo $? > /tmp/status
         %{postgresDir}/createdb -h localhost shim
-        echo $? > /tmp/status
-        cd %{@here}
-        %{cargoPath} test
-        echo $? > /tmp/status
-        exit $(cat /tmp/status) # exit the unshare shell
+        %{testBinary.getPathName}
         """
 
     # Jobs require that we write stdin out to a file in order to
     # pipe it in
-
     require Pass scriptPath = write ".build/postgres-cargo.sh" script
 
-    def _ = println "Cargo Path: {cargoPath}"
-    def pgJson = postgresSpecJson scriptPath.getPathName cargoPath
+    def pgJson = postgresSpecJson scriptPath.getPathName testBinary.getPathName
 
     require Pass pgJsonPath = write ".build/postgres-cmd-spec.json" (prettyJSON pgJson)
 
-    def emitVendorWarning status =
+    def inspectStatus status =
         require (Exited 0) = status
-        else failWithError "cargo tests failed: Consider running `cargo vendor --locked` in {@here}"
+        else failWithError "cargo tests failed"
 
         Pass status
 
-    makeExecPlan ("{wakePath}/wakebox", "-p", pgJsonPath.getPathName, Nil) Nil
+    makeExecPlan
+    ("{wakePath}/wakebox", "-p", pgJsonPath.getPathName, Nil)
+    (testBinary, scriptPath, pgJsonPath, Nil)
     | editPlanEnvironment (addEnvironmentPath "/usr/sbin")
-    | setPlanPersistence ReRun
     | setPlanEcho logReport
+    | setPlanFnOutputs (\_ Nil)
     | runJobWith localRunner
     | getJobStatus
-    | emitVendorWarning
+    | inspectStatus

--- a/rust/rsc/postgres-tests.wake
+++ b/rust/rsc/postgres-tests.wake
@@ -86,6 +86,7 @@ export def testPostgres _ =
         """
         set -ex
         unshare -U
+        # Set set -ex inside of the unshare shell
         set -ex
         export HOME=/root
         mkdir %{dataDir}

--- a/rust/rsc/rsc.wake
+++ b/rust/rsc/rsc.wake
@@ -19,47 +19,25 @@ from wake import _
 from rust import _
 
 export def buildRSC _ =
-    require Pass root = mkdir "rust/rsc"
-    require Pass toolchain = makeReleaseCargoToolchain root "rsc"
-    require Pass entityRoot = mkdir "rust/entity"
-    require Pass migrationRoot = mkdir "rust/migration"
-
-    toolchain
-    | addCargoCrate entityRoot "entity"
-    | addCargoCrate migrationRoot "migration"
-    | cargoBuild
+    makeCargoExecutable "rsc" "rust/rsc"
+    |> addCargoCrate "entity" "rust/entity"
+    |> addCargoCrate "migration" "rust/migration"
+    |> cargoBuildWith (defaultCargoToolchain Unit)
 
 export def buildRSCTool _ =
-    require Pass root = mkdir "rust/rsc"
-    require Pass toolchain = makeReleaseCargoToolchain root "rsc_tool"
-    require Pass entityRoot = mkdir "rust/entity"
-    require Pass migrationRoot = mkdir "rust/migration"
-
-    toolchain
-    | addCargoCrate entityRoot "entity"
-    | addCargoCrate migrationRoot "migration"
-    | cargoBuild
+    makeCargoExecutable "rsc_tool" "rust/rsc"
+    |> addCargoCrate "entity" "rust/entity"
+    |> addCargoCrate "migration" "rust/migration"
+    |> cargoBuildWith (defaultCargoToolchain Unit)
 
 export def buildRSCTest _ =
-    require Pass root = mkdir "rust/rsc"
-    require Pass toolchain = makeReleaseCargoToolchain root "rsc"
-    require Pass entityRoot = mkdir "rust/entity"
-    require Pass migrationRoot = mkdir "rust/migration"
-
-    toolchain
-    | setCargoToolchainBuildConfig CargoToolchainBuildConfigDebug
-    | addCargoCrate entityRoot "entity"
-    | addCargoCrate migrationRoot "migration"
-    | cargoTestBuild
+    makeCargoTestExecutable "rsc" "rust/rsc"
+    |> addCargoCrate "entity" "rust/entity"
+    |> addCargoCrate "migration" "rust/migration"
+    |> cargoBuildWith (defaultCargoToolchain Unit)
 
 export def buildRSCToolTest _ =
-    require Pass root = mkdir "rust/rsc"
-    require Pass toolchain = makeReleaseCargoToolchain root "rsc_tool"
-    require Pass entityRoot = mkdir "rust/entity"
-    require Pass migrationRoot = mkdir "rust/migration"
-
-    toolchain
-    | setCargoToolchainBuildConfig CargoToolchainBuildConfigDebug
-    | addCargoCrate entityRoot "entity"
-    | addCargoCrate migrationRoot "migration"
-    | cargoTestBuild
+    makeCargoTestExecutable "rsc_tool" "rust/rsc"
+    |> addCargoCrate "entity" "rust/entity"
+    |> addCargoCrate "migration" "rust/migration"
+    |> cargoBuildWith (defaultCargoToolchain Unit)

--- a/rust/rsc/rsc.wake
+++ b/rust/rsc/rsc.wake
@@ -1,0 +1,65 @@
+# Copyright 2024 SiFive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You should have received a copy of LICENSE.Apache2 along with
+# this software. If not, you may obtain a copy at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package build_wake
+
+from wake import _
+from rust import _
+
+export def buildRSC _ =
+    require Pass root = mkdir "rust/rsc"
+    require Pass toolchain = makeReleaseCargoToolchain root "rsc"
+    require Pass entityRoot = mkdir "rust/entity"
+    require Pass migrationRoot = mkdir "rust/migration"
+
+    toolchain
+    | addCargoCrate entityRoot "entity"
+    | addCargoCrate migrationRoot "migration"
+    | cargoBuild
+
+export def buildRSCTool _ =
+    require Pass root = mkdir "rust/rsc"
+    require Pass toolchain = makeReleaseCargoToolchain root "rsc_tool"
+    require Pass entityRoot = mkdir "rust/entity"
+    require Pass migrationRoot = mkdir "rust/migration"
+
+    toolchain
+    | addCargoCrate entityRoot "entity"
+    | addCargoCrate migrationRoot "migration"
+    | cargoBuild
+
+export def buildRSCTest _ =
+    require Pass root = mkdir "rust/rsc"
+    require Pass toolchain = makeReleaseCargoToolchain root "rsc"
+    require Pass entityRoot = mkdir "rust/entity"
+    require Pass migrationRoot = mkdir "rust/migration"
+
+    toolchain
+    | setCargoToolchainBuildConfig CargoToolchainBuildConfigDebug
+    | addCargoCrate entityRoot "entity"
+    | addCargoCrate migrationRoot "migration"
+    | cargoTestBuild
+
+export def buildRSCToolTest _ =
+    require Pass root = mkdir "rust/rsc"
+    require Pass toolchain = makeReleaseCargoToolchain root "rsc_tool"
+    require Pass entityRoot = mkdir "rust/entity"
+    require Pass migrationRoot = mkdir "rust/migration"
+
+    toolchain
+    | setCargoToolchainBuildConfig CargoToolchainBuildConfigDebug
+    | addCargoCrate entityRoot "entity"
+    | addCargoCrate migrationRoot "migration"
+    | cargoTestBuild

--- a/rust/rsc/rsc.wake
+++ b/rust/rsc/rsc.wake
@@ -20,24 +20,24 @@ from rust import _
 
 export def buildRSC _ =
     makeCargoExecutable "rsc" "rust/rsc"
-    |> addCargoCrate "entity" "rust/entity"
-    |> addCargoCrate "migration" "rust/migration"
-    |> cargoBuildWith (defaultCargoToolchain Unit)
+    | rmapPass (addCargoCrate "entity" "rust/entity")
+    | rmapPass (addCargoCrate "migration" "rust/migration")
+    | rmapPass (cargoBuildWith (defaultCargoToolchain Unit))
 
 export def buildRSCTool _ =
     makeCargoExecutable "rsc_tool" "rust/rsc"
-    |> addCargoCrate "entity" "rust/entity"
-    |> addCargoCrate "migration" "rust/migration"
-    |> cargoBuildWith (defaultCargoToolchain Unit)
+    | rmapPass (addCargoCrate "entity" "rust/entity")
+    | rmapPass (addCargoCrate "migration" "rust/migration")
+    | rmapPass (cargoBuildWith (defaultCargoToolchain Unit))
 
 export def buildRSCTest _ =
     makeCargoTestExecutable "rsc" "rust/rsc"
-    |> addCargoCrate "entity" "rust/entity"
-    |> addCargoCrate "migration" "rust/migration"
-    |> cargoBuildWith (defaultCargoToolchain Unit)
+    | rmapPass (addCargoCrate "entity" "rust/entity")
+    | rmapPass (addCargoCrate "migration" "rust/migration")
+    | rmapPass (cargoBuildWith (defaultCargoToolchain Unit))
 
 export def buildRSCToolTest _ =
     makeCargoTestExecutable "rsc_tool" "rust/rsc"
-    |> addCargoCrate "entity" "rust/entity"
-    |> addCargoCrate "migration" "rust/migration"
-    |> cargoBuildWith (defaultCargoToolchain Unit)
+    | rmapPass (addCargoCrate "entity" "rust/entity")
+    | rmapPass (addCargoCrate "migration" "rust/migration")
+    | rmapPass (cargoBuildWith (defaultCargoToolchain Unit))

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -1,18 +1,13 @@
 use crate::types::{GetUploadUrlResponse, PostBlobResponse, PostBlobResponsePart};
 use async_trait::async_trait;
 use axum::{extract::Multipart, http::StatusCode, Json};
-use data_encoding::BASE64URL;
 use entity::blob;
 use futures::stream::BoxStream;
 use futures::TryStreamExt;
-use rand_core::{OsRng, RngCore};
 use sea_orm::prelude::Uuid;
 use sea_orm::{ActiveModelTrait, ActiveValue::*, DatabaseConnection};
 use std::sync::Arc;
-use tokio::fs::File;
-use tokio::io::BufWriter;
 use tokio_util::bytes::Bytes;
-use tokio_util::io::StreamReader;
 use tracing;
 
 // TODO: Update this trait to return the url for a given key
@@ -28,48 +23,6 @@ pub trait BlobStore {
 }
 
 pub trait DebugBlobStore: BlobStore + std::fmt::Debug {}
-
-#[derive(Debug, Clone)]
-pub struct LocalBlobStore {
-    pub root: String,
-}
-
-#[async_trait]
-impl BlobStore for LocalBlobStore {
-    async fn stream<'a>(
-        &self,
-        stream: BoxStream<'a, Result<Bytes, std::io::Error>>,
-    ) -> Result<String, std::io::Error> {
-        let reader = StreamReader::new(stream);
-        futures::pin_mut!(reader);
-
-        let key = create_temp_filename();
-        let path = std::path::Path::new(&self.root).join(key.clone());
-        let mut file = BufWriter::new(File::create(path).await?);
-
-        tokio::io::copy(&mut reader, &mut file).await?;
-
-        Ok(key)
-    }
-
-    async fn download_url(&self, key: String) -> String {
-        return format!("file://{0}/{key}", self.root);
-    }
-
-    async fn delete_key(&self, key: String) -> Result<(), std::io::Error> {
-        let path = std::path::Path::new(&self.root).join(key);
-        tokio::fs::remove_file(path).await
-    }
-}
-
-impl DebugBlobStore for LocalBlobStore {}
-
-fn create_temp_filename() -> String {
-    let mut key = [0u8; 16];
-    OsRng.fill_bytes(&mut key);
-    // URL must be used as files can't contain /
-    BASE64URL.encode(&key)
-}
 
 #[tracing::instrument]
 pub async fn get_upload_url(server_addr: String) -> Json<GetUploadUrlResponse> {

--- a/rust/rsc/src/rsc/blob_store_impls.rs
+++ b/rust/rsc/src/rsc/blob_store_impls.rs
@@ -1,0 +1,77 @@
+use crate::blob::*;
+use async_trait::async_trait;
+use data_encoding::BASE64URL;
+use futures::stream::BoxStream;
+use rand_core::{OsRng, RngCore};
+use sea_orm::prelude::Uuid;
+use tokio::fs::File;
+use tokio::io::BufWriter;
+use tokio_util::bytes::Bytes;
+use tokio_util::io::StreamReader;
+
+fn create_temp_filename() -> String {
+    let mut key = [0u8; 16];
+    OsRng.fill_bytes(&mut key);
+    // URL must be used as files can't contain /
+    BASE64URL.encode(&key)
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalBlobStore {
+    pub root: String,
+}
+
+#[async_trait]
+impl BlobStore for LocalBlobStore {
+    async fn stream<'a>(
+        &self,
+        stream: BoxStream<'a, Result<Bytes, std::io::Error>>,
+    ) -> Result<String, std::io::Error> {
+        let reader = StreamReader::new(stream);
+        futures::pin_mut!(reader);
+
+        let key = create_temp_filename();
+        let path = std::path::Path::new(&self.root).join(key.clone());
+        let mut file = BufWriter::new(File::create(path).await?);
+
+        tokio::io::copy(&mut reader, &mut file).await?;
+
+        Ok(key)
+    }
+
+    async fn download_url(&self, key: String) -> String {
+        return format!("file://{0}/{key}", self.root);
+    }
+
+    async fn delete_key(&self, key: String) -> Result<(), std::io::Error> {
+        let path = std::path::Path::new(&self.root).join(key);
+        tokio::fs::remove_file(path).await
+    }
+}
+
+impl DebugBlobStore for LocalBlobStore {}
+
+#[derive(Debug, Clone)]
+pub struct TestBlobStore {
+    pub id: Uuid,
+}
+
+#[async_trait]
+impl BlobStore for TestBlobStore {
+    async fn stream<'a>(
+        &self,
+        _stream: BoxStream<'a, Result<Bytes, std::io::Error>>,
+    ) -> Result<String, std::io::Error> {
+        Ok(create_temp_filename())
+    }
+
+    async fn download_url(&self, key: String) -> String {
+        return format!("test://{0}/{key}", self.id);
+    }
+
+    async fn delete_key(&self, _key: String) -> Result<(), std::io::Error> {
+        Ok(())
+    }
+}
+
+impl DebugBlobStore for TestBlobStore {}

--- a/rust/rsc/src/rsc/blob_store_service.rs
+++ b/rust/rsc/src/rsc/blob_store_service.rs
@@ -1,25 +1,22 @@
 use chrono::NaiveDateTime;
-use entity::prelude::{Blob, LocalBlobStore};
-use entity::{blob, local_blob_store};
+use entity::prelude::{Blob, BlobStore, LocalBlobStore};
+use entity::{blob, blob_store, local_blob_store};
 use sea_orm::{prelude::Uuid, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use sea_orm::{DbBackend, DbErr, Statement};
-
-pub async fn fetch_local_blob_store(
-    db: &DatabaseConnection,
-) -> Result<Uuid, Box<dyn std::error::Error>> {
-    let active_store = LocalBlobStore::find().one(db).await?;
-
-    let Some(active_store) = active_store else {
-        return Err("Could not find active store".into());
-    };
-
-    Ok(active_store.id)
-}
 
 pub async fn fetch_local_blob_stores(
     db: &DatabaseConnection,
 ) -> Result<Vec<local_blob_store::Model>, DbErr> {
     LocalBlobStore::find().all(db).await
+}
+
+pub async fn fetch_test_blob_stores(
+    db: &DatabaseConnection,
+) -> Result<Vec<blob_store::Model>, DbErr> {
+    BlobStore::find()
+        .filter(blob_store::Column::Type.eq("TestBlobStore"))
+        .all(db)
+        .await
 }
 
 // Fetches blobs from the database that are unreferenced and have surpaced the alllotated grace

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -64,6 +64,7 @@ async fn activate_stores(
 ) -> HashMap<Uuid, Arc<dyn blob::DebugBlobStore + Sync + Send>> {
     let mut active_stores: HashMap<Uuid, Arc<dyn blob::DebugBlobStore + Sync + Send>> =
         HashMap::new();
+
     // --- Activate Test Blob Stores  ---
     let test_stores = match blob_store_service::fetch_test_blob_stores(&conn).await {
         Ok(stores) => stores,
@@ -393,7 +394,6 @@ mod tests {
         };
         let inserted = test_store.insert(db).await?;
 
-        // OTHER: remove CI stuff for weirdly installed cargo/rust
         Ok(inserted.id)
     }
 

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -366,13 +366,24 @@ mod tests {
     use serde_json::{json, Value};
     use tower::Service;
 
+    async fn seed_db(db: &DatabaseConnection) -> Result<(), Box<dyn std::error::Error>> {
+        // Create a blob store
+        // Create a memory blob store
+        // Activate the memory blob store
+        // Return the memory blob store UUID and set in the config
+        // (use api to create a blob??)
+
+        // OTHER: remove CI stuff for weirdly installed cargo/rust
+        Ok(())
+    }
+
     fn create_config() -> Result<config::RSCConfig, Box<dyn std::error::Error>> {
         Ok(config::RSCConfig::new(config::RSCConfigOverride {
             config_override: Some("".into()),
             server_addr: Some("test:0000".into()),
             database_url: Some("".into()),
             standalone: Some(true),
-            local_store: Some("".into()),
+            active_store: Some("".into()),
         })?)
     }
 
@@ -397,7 +408,9 @@ mod tests {
         let api_key = create_insecure_api_key(&db).await.unwrap();
         let blob_id = create_fake_blob(&db).await.unwrap();
         let config = create_config().unwrap();
-        let mut router = create_router(Arc::new(db), Arc::new(config));
+        let db = Arc::new(db);
+        let stores = activate_stores(db.clone()).await;
+        let mut router = create_router(db.clone(), Arc::new(config), &stores);
 
         // Non-existant route should 404
         let res = router

--- a/rust/rsc/vendor-config.toml
+++ b/rust/rsc/vendor-config.toml
@@ -1,5 +1,0 @@
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"

--- a/share/wake/lib/core/syntax.wake
+++ b/share/wake/lib/core/syntax.wake
@@ -27,6 +27,16 @@ export def (argument: a).(memberFn: a => b): b =
 export def (argument: a) | (pipeFn: a => b): b =
     pipeFn argument
 
+# Like '|' above but rmapPass the pipeFn to enter a "Result pipeline"
+# rmapPass (catWith " " _) (Pass (seq 10)) = Pass (seq 10) |> catWith " "
+export def (argument: Result a b) |> (pipeFn: a => Result c b): Result c b =
+    rmapPass (\a pipeFn a) argument
+
+# Like '|' above but rmapPass the pipeFn to enter a "Result pipeline"
+# rmapPass (catWith " " _) (Pass (seq 10)) = Pass (seq 10) |> catWith " "
+export def (argument: Result a b) |< (pipeFn: a => c): Result c b =
+    rmap (\a pipeFn a) argument
+
 # Avoid ()s without changing order.
 # catWith " " $ map str $ seq 10 = catWith " " (map str (seq 10))
 export def (dollarFn: a => b) $ (argument: a): b =

--- a/share/wake/lib/core/syntax.wake
+++ b/share/wake/lib/core/syntax.wake
@@ -27,16 +27,6 @@ export def (argument: a).(memberFn: a => b): b =
 export def (argument: a) | (pipeFn: a => b): b =
     pipeFn argument
 
-# Like '|' above but rmapPass the pipeFn to enter a "Result pipeline"
-# rmapPass (catWith " " _) (Pass (seq 10)) = Pass (seq 10) |> catWith " "
-export def (argument: Result a b) |> (pipeFn: a => Result c b): Result c b =
-    rmapPass (\a pipeFn a) argument
-
-# Like '|' above but rmapPass the pipeFn to enter a "Result pipeline"
-# rmapPass (catWith " " _) (Pass (seq 10)) = Pass (seq 10) |> catWith " "
-export def (argument: Result a b) |< (pipeFn: a => c): Result c b =
-    rmap (\a pipeFn a) argument
-
 # Avoid ()s without changing order.
 # catWith " " $ map str $ seq 10 = catWith " " (map str (seq 10))
 export def (dollarFn: a => b) $ (argument: a): b =

--- a/share/wake/lib/rust_wake/cargo.wake
+++ b/share/wake/lib/rust_wake/cargo.wake
@@ -114,12 +114,12 @@ def buildConfigToString = match _
 # helper function for common code between building a cargo binary and a cargo test binary
 def cargoBuildCommon (subcommand: String) (fnOutputsFilter: RegExp) (toolchain: CargoToolchain): Result Path Error =
     def buildConfigToFlag = match _
-        CargoToolchainBuildConfigRelease -> Some ("--release", Nil)
+        CargoToolchainBuildConfigRelease -> Some "--release"
         # Debug is the default, and cargo doesn't have a flag to explictly set it
         CargoToolchainBuildConfigDebug -> None
 
     def lockedToFlag = match _
-        True -> Some ("--locked", Nil)
+        True -> Some "--locked"
         False -> None
 
     # Locates all the sources needed to build a CargoCrate
@@ -147,8 +147,8 @@ def cargoBuildCommon (subcommand: String) (fnOutputsFilter: RegExp) (toolchain: 
         subcommand,
         "--quiet",
         "--bin", binaryName,
-        ((buildConfigToFlag config) | getOrElse Nil) ++
-        ((lockedToFlag locked) | getOrElse Nil) ++
+        ((buildConfigToFlag config) | optionToList) ++
+        ((lockedToFlag locked) | optionToList) ++
         # To not incur a O(n^2) cost, flags are appended in reverse of the callers expectations.
         # Reverse here to correct them.
         (flags | reverse)

--- a/share/wake/lib/rust_wake/cargo.wake
+++ b/share/wake/lib/rust_wake/cargo.wake
@@ -30,93 +30,121 @@ export target findCargoPath Unit =
     Pass "{cargo_home}/bin/cargo"
 
 # The configuration for a given build
-export data CargoToolchainBuildConfig =
+export data CargoBuildConfig =
     # Debug has less optimizations and debug info
-    CargoToolchainBuildConfigDebug
+    CargoBuildConfigDebug
     # Release is optimized with debug info stripped
-    CargoToolchainBuildConfigRelease
+    CargoBuildConfigRelease
 
 # An on-disk cargo crate
 #
 # Used to specify the root/main crate for the build and any other on-disk crate deps
 export tuple CargoCrate =
+    # Name of the binary to be build
+    export Name: String
     # Root directory of the crate 
     export Root: Path
-    # Name of the binary to be build
-    export BinaryName: String
 
 # The cargo build toolchain
 #
-# Describes a specific rust binary to be built using cargo
+# Describes the tooling and default config to build a rust binary
 export tuple CargoToolchain =
     # Path to cargo binary
     export Cargo: String
     # Build target to use
-    export BuildConfig: CargoToolchainBuildConfig
+    export BuildConfig: CargoBuildConfig
+    # Force cargo to use the Cargo.lock file for reproducible builds
+    export Locked: Boolean
+
+# A cargo executable
+#
+# Describes a specific rust binary to be built using cargo
+export tuple CargoExecutable =
     # Root level crate to build
     export RootCrate: CargoCrate
     # List of dependancies to crates on disk
     export LocalCrates: List CargoCrate
-    # Force cargo to use the Cargo.lock file for reproducible builds
-    export Locked: Boolean
     # Extra cargo flags defined by caller
     export Flags: List String
+    # Determines if this is a cargo test binary
+    export IsTest: Boolean
 
 # Makes a simple default cargo toolchain for locked release builds.
 #
 # Relies on the system install of cargo so it is not reproducable across machines. For a more reproducable
 # option, use makeCargoToolchain
-export def makeReleaseCargoToolchain (root: Path) (binaryName: String): Result CargoToolchain Error =
+export target defaultCargoToolchain _: Result CargoToolchain Error =
     require Pass cargo = findCargoPath Unit
 
-    makeCargoToolchain cargo root binaryName CargoToolchainBuildConfigRelease True
+    makeCargoToolchain cargo CargoBuildConfigRelease True
     | Pass
 
 # Makes a cargo toolchain without assuming any defaults. Local crates and extra flags must be manually set later
-export def makeCargoToolchain (cargo: String) (root: Path) (binaryName: String) (config: CargoToolchainBuildConfig) (locked: Boolean): CargoToolchain =
-    CargoToolchain cargo config (CargoCrate root binaryName) Nil locked Nil
+export def makeCargoToolchain (cargo: String) (config: CargoBuildConfig) (locked: Boolean): CargoToolchain =
+    CargoToolchain cargo config locked
+
+# Makes a simple cargo executable
+export def makeCargoExecutable (name: String) (root: String): Result CargoExecutable Error =
+    require Pass path = mkdir root
+
+    CargoExecutable (CargoCrate name path) Nil Nil False
+    | Pass
+
+# Makes a simple cargo test executable
+export def makeCargoTestExecutable (name: String) (root: String): Result CargoExecutable Error =
+    require Pass path = mkdir root
+
+    CargoExecutable (CargoCrate name path) Nil Nil True
+    | Pass
 
 # Adds a crate to the toolchains list of local crates. Chain calls together to build up a binary
 # with local crate deps.
 #
 # Ex:
 # ```
-# require Pass foo = mkdir "foo"
-# require Pass crate1 = mkdir "foo"
-# require Pass crate2 = mkdir "foo"
-# require Pass toolchain = makeReleaseCargoToolchain foo "bar" 
-# toolchain
-# | addCargoCrate crate1 "one"
-# | addCargoCrate crate2 "two"
+# makeCargoExecutable "foo" "rust/foo"
+# |> addCargoCrate "one" "rust/bar"
+# |> addCargoCrate "two" "rust/bat"
+# |> buildWith (defaultCargoToolchain Unit)
 # ```
-export def addCargoCrate (root: Path) (binaryName: String): CargoToolchain => CargoToolchain =
-    editCargoToolchainLocalCrates ((CargoCrate root binaryName), _)
+export def addCargoCrate (name: String) (root: String): CargoExecutable => Result CargoExecutable Error =
+    def do (in: CargoExecutable): Result CargoExecutable Error =
+        require Pass path = mkdir root
+
+        editCargoExecutableLocalCrates ((CargoCrate name path), _) in
+        | Pass
+
+    do
 
 # Adds a flag to the list of flags. Will be forwared to cargo in order after all other flags
 #
 # Ex:
 # ```
-# require Pass foo = mkdir "foo"
-# require Pass toolchain = makeReleaseCargoToolchain foo "bar" 
-# toolchain
-# | addCargoFlag "--foo"
-# | addCargoFlag "bar"
-# | addCargoFlag "--bat"
+# makeCargoExecutable "foo" "rust/foo"
+# |> addCargoFlag "--foo"
+# |> addCargoFlag "bar"
+# |> addCargoFlag "--bat"
+# |> buildWith (defaultCargoToolchain Unit)
 # ```
-export def addCargoFlag (flag: String): CargoToolchain => CargoToolchain =
-    editCargoToolchainFlags (flag, _)
+export def addCargoFlag (flag: String): CargoExecutable => Result CargoExecutable Error =
+    def do (in: CargoExecutable): Result CargoExecutable Error =
+        editCargoExecutableFlags (flag, _) in
+        | Pass
+
+    do
 
 # helper function to map build config to a human name
 def buildConfigToString = match _
-    CargoToolchainBuildConfigRelease -> "release"
-    CargoToolchainBuildConfigDebug -> "debug"
+    CargoBuildConfigRelease -> "release"
+    CargoBuildConfigDebug -> "debug"
 
 # helper function for common code between building a cargo binary and a cargo test binary
-def cargoBuildCommon (subcommand: String) (fnOutputsFilter: RegExp) (toolchain: CargoToolchain): Result Path Error =
+# fnOutputsFilter must only match a single file otherwise this function will fail.
+def cargoBuildCommon (subcommand: String) (fnOutputsFilter: RegExp) (toolchain: CargoToolchain) (executable: CargoExecutable): Result Path Error =
     def buildConfigToFlag = match _
-        CargoToolchainBuildConfigRelease -> Some "--release"
+        CargoBuildConfigRelease -> Some "--release"
         # Debug is the default, and cargo doesn't have a flag to explictly set it
-        CargoToolchainBuildConfigDebug -> None
+        CargoBuildConfigDebug -> None
 
     def lockedToFlag = match _
         True -> Some "--locked"
@@ -134,8 +162,9 @@ def cargoBuildCommon (subcommand: String) (fnOutputsFilter: RegExp) (toolchain: 
 
         Pass (toml, lock, srcs)
 
-    def (CargoToolchain cargo config rootCrate localCrates locked flags) = toolchain
-    def (CargoCrate rootPath binaryName) = rootCrate
+    def (CargoExecutable rootCrate localCrates flags _) = executable
+    def (CargoToolchain cargo config locked) = toolchain
+    def (CargoCrate binaryName rootPath) = rootCrate
 
     def root =
         rootPath.getPathName
@@ -176,8 +205,15 @@ def cargoBuildCommon (subcommand: String) (fnOutputsFilter: RegExp) (toolchain: 
         job
         | getJobOutputs
 
+    # fnOutputsFilter must only match the single built binary. Certain binary names are not stable
+    # (specically rust test binary names) so its not possible to just directly list the file.
     require (bin, Nil) = outputs
-    else failWithError "More than one output returned when building with cargo"
+    else
+        def outputString =
+            outputs
+            | foldl (\acc \elem (acc, ", ", elem.getPathName, Nil) | cat) ""
+
+        failWithError "Expected exactly one output from cargo. Saw: {outputString}"
 
     Pass bin
 
@@ -186,36 +222,27 @@ def cargoBuildCommon (subcommand: String) (fnOutputsFilter: RegExp) (toolchain: 
 # Cargo will not reuse work because the sandbox will not contain its extra info, inside of target.
 # TODO: Add an environment variable to opt-in to localRunner cargo builds if we detect
 #       existing outputs in {root}/target/release
-export def cargoBuild (toolchain: CargoToolchain): Result Path Error =
-    def (CargoToolchain _ config rootCrate _ _ _) = toolchain
-    def (CargoCrate rootPath binaryName) = rootCrate
+export def cargoBuildWith (toolchain: Result CargoToolchain Error) (executable: CargoExecutable): Result Path Error =
+    require Pass toolchain = toolchain
+
+    def (CargoExecutable rootCrate _ _ isTestBinary) = executable
+    def (CargoToolchain _ config _) = toolchain
+    def (CargoCrate binaryName rootPath) = rootCrate
 
     def root =
         rootPath.getPathName
         | simplify
 
-    require Pass regex = stringToRegExp "{root}/target/{buildConfigToString config}/{binaryName}"
+    if isTestBinary then
+        require Pass regex =
+            stringToRegExp "{root}/target/{buildConfigToString config}/deps/{binaryName}-[a-z0-9]\{16\}"
 
-    toolchain
-    | cargoBuildCommon "build" regex
+        Pass executable
+        |> addCargoFlag "--no-run"
+        |> cargoBuildCommon "test" regex toolchain
+    else
+        require Pass regex =
+            stringToRegExp "{root}/target/{buildConfigToString config}/{binaryName}"
 
-# Builds a cargo test binary from the CargoToolchain
-# 
-# Cargo will not reuse work because the sandbox will not contain its extra info, inside of target.
-# TODO: Add an environment variable to opt-in to localRunner cargo builds if we detect
-#       existing outputs in {root}/target/release
-export def cargoTestBuild (toolchain: CargoToolchain): Result Path Error =
-    def (CargoToolchain _ config rootCrate _ _ _) = toolchain
-    def (CargoCrate rootPath binaryName) = rootCrate
-
-    def root =
-        rootPath.getPathName
-        | simplify
-
-    require Pass regex =
-        stringToRegExp "{root}/target/{buildConfigToString config}/deps/{binaryName}-[a-z0-9]\{16\}"
-
-    toolchain
-    | addCargoFlag "--no-run"
-    | cargoBuildCommon "test" regex
-
+        executable
+        | cargoBuildCommon "build" regex toolchain

--- a/share/wake/lib/rust_wake/cargo.wake
+++ b/share/wake/lib/rust_wake/cargo.wake
@@ -42,7 +42,7 @@ export data CargoBuildConfig =
 export tuple CargoCrate =
     # Name of the binary to be build
     export Name: String
-    # Root directory of the crate 
+    # Root directory of the crate
     export Root: Path
 
 # The cargo build toolchain
@@ -72,16 +72,12 @@ export tuple CargoExecutable =
 # Makes a simple default cargo toolchain for locked release builds.
 #
 # Relies on the system install of cargo so it is not reproducable across machines. For a more reproducable
-# option, use makeCargoToolchain
+# option manually construct a CargoToolchain with a reproducibly sourced cargo.
 export target defaultCargoToolchain _: Result CargoToolchain Error =
     require Pass cargo = findCargoPath Unit
 
-    makeCargoToolchain cargo CargoBuildConfigRelease True
+    CargoToolchain cargo CargoBuildConfigRelease True
     | Pass
-
-# Makes a cargo toolchain without assuming any defaults. Local crates and extra flags must be manually set later
-export def makeCargoToolchain (cargo: String) (config: CargoBuildConfig) (locked: Boolean): CargoToolchain =
-    CargoToolchain cargo config locked
 
 # Makes a simple cargo executable
 export def makeCargoExecutable (name: String) (root: String): Result CargoExecutable Error =
@@ -103,9 +99,9 @@ export def makeCargoTestExecutable (name: String) (root: String): Result CargoEx
 # Ex:
 # ```
 # makeCargoExecutable "foo" "rust/foo"
-# |> addCargoCrate "one" "rust/bar"
-# |> addCargoCrate "two" "rust/bat"
-# |> buildWith (defaultCargoToolchain Unit)
+# | rmapPass addCargoCrate "one" "rust/bar"
+# | rmapPass addCargoCrate "two" "rust/bat"
+# | rmapPass buildWith (defaultCargoToolchain Unit)
 # ```
 export def addCargoCrate (name: String) (root: String): CargoExecutable => Result CargoExecutable Error =
     def do (in: CargoExecutable): Result CargoExecutable Error =
@@ -121,10 +117,10 @@ export def addCargoCrate (name: String) (root: String): CargoExecutable => Resul
 # Ex:
 # ```
 # makeCargoExecutable "foo" "rust/foo"
-# |> addCargoFlag "--foo"
-# |> addCargoFlag "bar"
-# |> addCargoFlag "--bat"
-# |> buildWith (defaultCargoToolchain Unit)
+# | rmapPass addCargoFlag "--foo"
+# | rmapPass addCargoFlag "bar"
+# | rmapPass addCargoFlag "--bat"
+# | rmapPass buildWith (defaultCargoToolchain Unit)
 # ```
 export def addCargoFlag (flag: String): CargoExecutable => Result CargoExecutable Error =
     def do (in: CargoExecutable): Result CargoExecutable Error =
@@ -218,7 +214,7 @@ def cargoBuildCommon (subcommand: String) (fnOutputsFilter: RegExp) (toolchain: 
     Pass bin
 
 # Builds a cargo project from the CargoToolchain
-# 
+#
 # Cargo will not reuse work because the sandbox will not contain its extra info, inside of target.
 # TODO: Add an environment variable to opt-in to localRunner cargo builds if we detect
 #       existing outputs in {root}/target/release
@@ -238,8 +234,8 @@ export def cargoBuildWith (toolchain: Result CargoToolchain Error) (executable: 
             stringToRegExp "{root}/target/{buildConfigToString config}/deps/{binaryName}-[a-z0-9]\{16\}"
 
         Pass executable
-        |> addCargoFlag "--no-run"
-        |> cargoBuildCommon "test" regex toolchain
+        | rmapPass (addCargoFlag "--no-run")
+        | rmapPass (cargoBuildCommon "test" regex toolchain)
     else
         require Pass regex =
             stringToRegExp "{root}/target/{buildConfigToString config}/{binaryName}"

--- a/share/wake/lib/rust_wake/cargo.wake
+++ b/share/wake/lib/rust_wake/cargo.wake
@@ -15,6 +15,10 @@
 
 package rust
 
+# Finds the cargo binary by searching env var CARGO_HOME then falling back to env var PATH
+#
+# The returned binary depends on the system and thus is not guarenteed to be consistent
+# nor reproducable. Use with caution.
 export target findCargoPath Unit =
     require Some cargo_home = getenv "CARGO_HOME"
     else
@@ -25,21 +29,194 @@ export target findCargoPath Unit =
 
     Pass "{cargo_home}/bin/cargo"
 
-# Builds a cargo project, the Cargo.toml file must be listed as well as the outputs of interest.
-# All source files must be listed as well. Cargo will not reuse work because the sandbox
-# will not contain its extra info, inside of target.
-# TODO: Add an environment variable to opt-in to localRunner cargo builds if we detect
-#       existing outputs in {pathToCrate}/target/release
-export def cargoBuild (sources: List Path) (pathToCrate: String) (outputs: List String) =
-    require Pass cargoPath = findCargoPath Unit
+# The configuration for a given build
+#
+# Debug has less optimizations and debug info
+# Release is optimized with debug info stripped
+export data CargoToolchainBuildConfig =
+    CargoToolchainBuildConfigDebug
+    CargoToolchainBuildConfigRelease
+
+# An on-disk cargo crate
+#
+# Used to specify the root/main crate for the build and any other on-disk crate deps
+export tuple CargoCrate =
+    # Root directory of the crate 
+    export Root: Path
+    # Name of the binary to be build
+    export BinaryName: String
+
+# The cargo build toolchain
+#
+# Describes a specific rust binary to be built using cargo
+export tuple CargoToolchain =
+    # Path to cargo binary
+    export Cargo: String
+    # Build target to use
+    export BuildConfig: CargoToolchainBuildConfig
+    # Root level crate to build
+    export RootCrate: CargoCrate
+    # List of dependancies to crates on disk
+    export LocalCrates: List CargoCrate
+    # Locked Flag
+    export Locked: Boolean
+    # Extra cargo flags defined by caller
+    export Flags: List String
+
+# Makes a simple default cargo toolchain for locked release builds.
+#
+# Relies on the system install of cargo so it is not reproducable across machines. For a more reproducable
+# option, use makeCargoToolchain
+export def makeReleaseCargoToolchain (root: Path) (binaryName: String): Result CargoToolchain Error =
+    require Pass cargo = findCargoPath Unit
+
+    makeCargoToolchain cargo root binaryName CargoToolchainBuildConfigRelease True
+    | Pass
+
+# Makes a cargo toolchain without assuming any defaults. Local crates and extra flags must be manually set later
+export def makeCargoToolchain (cargo: String) (root: Path) (binaryName: String) (config: CargoToolchainBuildConfig) (locked: Boolean): CargoToolchain =
+    CargoToolchain cargo config (CargoCrate root binaryName) Nil locked Nil
+
+# Adds a crate to the toolchains list of local crates. Chain calls together to build up a binary
+# with local crate deps.
+#
+# Ex:
+# ```
+# require Pass foo = mkdir "foo"
+# require Pass crate1 = mkdir "foo"
+# require Pass crate2 = mkdir "foo"
+# require Pass toolchain = makeReleaseCargoToolchain foo "bar" 
+# toolchain
+# | addCargoCrate crate1 "one"
+# | addCargoCrate crate2 "two"
+# ```
+export def addCargoCrate (root: Path) (binaryName: String): CargoToolchain => CargoToolchain =
+    editCargoToolchainLocalCrates ((CargoCrate root binaryName), _)
+
+# Adds a flag to the list of flags. Will be forwared to cargo in order after all other flags
+#
+# Ex:
+# ```
+# require Pass foo = mkdir "foo"
+# require Pass toolchain = makeReleaseCargoToolchain foo "bar" 
+# toolchain
+# | addCargoFlag "--foo"
+# | addCargoFlag "bar"
+# | addCargoFlag "--bat"
+# ```
+export def addCargoFlag (flag: String): CargoToolchain => CargoToolchain =
+    editCargoToolchainFlags (flag, _)
+
+# helper function to map build config to a human name
+def buildConfigToString = match _
+    CargoToolchainBuildConfigRelease -> "release"
+    CargoToolchainBuildConfigDebug -> "debug"
+
+# helper function for common code between building a cargo binary and a cargo test binary
+def cargoBuildCommon (subcommand: String) (fnOutputsFilter: RegExp) (toolchain: CargoToolchain): Result Path Error =
+    def buildConfigToFlag = match _
+        CargoToolchainBuildConfigRelease -> Some ("--release", Nil)
+        # Debug is the default, and cargo doesn't have a flag to explictly set it
+        CargoToolchainBuildConfigDebug -> None
+
+    def lockedToFlag = match _
+        True -> Some ("--locked", Nil)
+        False -> None
+
+    # Locates all the sources needed to build a CargoCrate
+    def findSources (crate: CargoCrate): Result (List Path) Error =
+        def root =
+            crate.getCargoCrateRoot.getPathName
+            | simplify
+
+        require Pass toml = source "{root}/Cargo.toml"
+        require Pass lock = source "{root}/Cargo.lock"
+        require Pass srcs = sources "{root}/src" `.*`
+
+        Pass (toml, lock, srcs)
+
+    def (CargoToolchain cargo config rootCrate localCrates locked flags) = toolchain
+    def (CargoCrate rootPath binaryName) = rootCrate
+
+    def root =
+        rootPath.getPathName
+        | simplify
+
+    # wake-format off
+    def cmd =
+        cargo,
+        subcommand,
+        "--quiet",
+        "--bin", binaryName,
+        ((buildConfigToFlag config) | getOrElse Nil) ++
+        ((lockedToFlag locked) | getOrElse Nil) ++
+        # To not incur a O(n^2) cost, flags are appended in reverse of the callers expectations.
+        # Reverse here to correct them.
+        (flags | reverse)
+
+    require Pass sources =
+        (rootCrate, localCrates)
+        | map findSources
+        | findFail
+        | rmap flatten
+
+    def job =
+        makeExecPlan cmd (sources)
+        | setPlanLabel "cargo {subcommand}: {binaryName} [{buildConfigToString config}]"
+        | setPlanDirectory root
+        | setPlanFilterOutputs (matches fnOutputsFilter)
+        | setPlanIsAtty True
+        # Adds cargo and rustc to the environment
+        | prependPlanPath (dirname cargo)
+        | runJobWith defaultRunner
+
+    require True = job.isJobOk
+    else failWithError "Failed to build with cargo"
 
     require Pass outputs =
-        makeExecPlan (cargoPath, "build", "--release", "--locked", Nil) sources
-        | setPlanLabel "cargo: {pathToCrate}"
-        | setPlanDirectory pathToCrate
-        | setPlanFnOutputs (\_ map ("{pathToCrate}/target/release/{_}") outputs)
-        | prependPlanPath (dirname cargoPath)
-        | runJobWith defaultRunner
+        job
         | getJobOutputs
 
-    Pass outputs
+    require (bin, Nil) = outputs
+    else failWithError "More than one output returned when building with cargo"
+
+    Pass bin
+
+# Builds a cargo project from the CargoToolchain
+# 
+# Cargo will not reuse work because the sandbox will not contain its extra info, inside of target.
+# TODO: Add an environment variable to opt-in to localRunner cargo builds if we detect
+#       existing outputs in {root}/target/release
+export def cargoBuild (toolchain: CargoToolchain): Result Path Error =
+    def (CargoToolchain _ config rootCrate _ _ _) = toolchain
+    def (CargoCrate rootPath binaryName) = rootCrate
+
+    def root =
+        rootPath.getPathName
+        | simplify
+
+    require Pass regex = stringToRegExp "{root}/target/{buildConfigToString config}/{binaryName}"
+
+    toolchain
+    | cargoBuildCommon "build" regex
+
+# Builds a cargo test binary from the CargoToolchain
+# 
+# Cargo will not reuse work because the sandbox will not contain its extra info, inside of target.
+# TODO: Add an environment variable to opt-in to localRunner cargo builds if we detect
+#       existing outputs in {root}/target/release
+export def cargoTestBuild (toolchain: CargoToolchain): Result Path Error =
+    def (CargoToolchain _ config rootCrate _ _ _) = toolchain
+    def (CargoCrate rootPath binaryName) = rootCrate
+
+    def root =
+        rootPath.getPathName
+        | simplify
+
+    require Pass regex =
+        stringToRegExp "{root}/target/{buildConfigToString config}/deps/{binaryName}-[a-z0-9]\{16\}"
+
+    toolchain
+    | addCargoFlag "--no-run"
+    | cargoBuildCommon "test" regex
+

--- a/share/wake/lib/rust_wake/cargo.wake
+++ b/share/wake/lib/rust_wake/cargo.wake
@@ -30,11 +30,10 @@ export target findCargoPath Unit =
     Pass "{cargo_home}/bin/cargo"
 
 # The configuration for a given build
-#
-# Debug has less optimizations and debug info
-# Release is optimized with debug info stripped
 export data CargoToolchainBuildConfig =
+    # Debug has less optimizations and debug info
     CargoToolchainBuildConfigDebug
+    # Release is optimized with debug info stripped
     CargoToolchainBuildConfigRelease
 
 # An on-disk cargo crate
@@ -58,7 +57,7 @@ export tuple CargoToolchain =
     export RootCrate: CargoCrate
     # List of dependancies to crates on disk
     export LocalCrates: List CargoCrate
-    # Locked Flag
+    # Force cargo to use the Cargo.lock file for reproducible builds
     export Locked: Boolean
     # Extra cargo flags defined by caller
     export Flags: List String

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -176,7 +176,8 @@ static bool is_op_suffix(const CSTElement& op) {
     case TOKEN_OP_DOLLAR:
       return !is_binop_matching_str(op, TOKEN_OP_DOLLAR, "$");
     case TOKEN_OP_OR:
-      return !is_binop_matching_str(op, TOKEN_OP_OR, "|");
+      return !is_binop_matching_str(op, TOKEN_OP_OR, "|") &&
+             !is_binop_matching_str(op, TOKEN_OP_OR, "|>");
     case TOKEN_OP_DOT:
       return false;
 
@@ -1388,8 +1389,10 @@ wcl::doc Emitter::walk_binary(ctx_t ctx, CSTElement node) {
     }
   }
 
+  // Binops of '$', '|', and '|>' should always pipeline unless they are already nested
   if (!ctx.nested_binop && (is_binop_matching_str(op_token, TOKEN_OP_DOLLAR, "$") ||
-                            is_binop_matching_str(op_token, TOKEN_OP_OR, "|"))) {
+                            is_binop_matching_str(op_token, TOKEN_OP_OR, "|") ||
+                            is_binop_matching_str(op_token, TOKEN_OP_OR, "|>"))) {
     MEMO_RET(select_best_choice({
         combine_explode_first(ctx.binop(), parts),
         combine_explode_last(ctx.binop(), parts),

--- a/tools/wake-format/emitter.cpp
+++ b/tools/wake-format/emitter.cpp
@@ -176,8 +176,7 @@ static bool is_op_suffix(const CSTElement& op) {
     case TOKEN_OP_DOLLAR:
       return !is_binop_matching_str(op, TOKEN_OP_DOLLAR, "$");
     case TOKEN_OP_OR:
-      return !is_binop_matching_str(op, TOKEN_OP_OR, "|") &&
-             !is_binop_matching_str(op, TOKEN_OP_OR, "|>");
+      return !is_binop_matching_str(op, TOKEN_OP_OR, "|");
     case TOKEN_OP_DOT:
       return false;
 
@@ -1389,10 +1388,8 @@ wcl::doc Emitter::walk_binary(ctx_t ctx, CSTElement node) {
     }
   }
 
-  // Binops of '$', '|', and '|>' should always pipeline unless they are already nested
   if (!ctx.nested_binop && (is_binop_matching_str(op_token, TOKEN_OP_DOLLAR, "$") ||
-                            is_binop_matching_str(op_token, TOKEN_OP_OR, "|") ||
-                            is_binop_matching_str(op_token, TOKEN_OP_OR, "|>"))) {
+                            is_binop_matching_str(op_token, TOKEN_OP_OR, "|"))) {
     MEMO_RET(select_best_choice({
         combine_explode_first(ctx.binop(), parts),
         combine_explode_last(ctx.binop(), parts),

--- a/wake.spec.in
+++ b/wake.spec.in
@@ -33,6 +33,8 @@ mkdir -p %{buildroot}/var/cache/wake
 /usr/bin/wake
 /usr/bin/wakebox
 /usr/bin/wake-log-viewer
+/usr/bin/wake-remote-cache
+/usr/bin/wake-remote-cache-tool
 /usr/bin/wake-format
 /usr/bin/job-cache
 /usr/lib/wake


### PR DESCRIPTION
This PR does a few subtle things, but all in the same vein. The old version of the RSC unit test was both annoying to run locally and also always returning a pass regardless of the result. This is a perfect combination to result in the tests breaking immediately. The goal of this PR is to generally address that 

1) A failing test now actually fails CI
2) The tests have been updated to pass again
3) I've changed how rust tests are handled/built which makes is way less annoying to run the tests locally
4) The previous item also simplifies CI quite a bit so now unnecessary things have been removed
5) As a bonus from 3, rsc and rsc tool are now built as installed as part of the wake install flow