### PR TITLE
Ensure copied file from `claimFileAsPath` is writable

### DIFF
--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -168,10 +168,16 @@ export def claimFileAsPathIn (outputDirectory: Path) (existingFile: String) (des
     else
         def desiredWorkspacePath = simplify "{outputDirectory.getPathName}/{desiredName}"
         def visible = outputDirectory, Nil
-        def cmdline = which "cp", existingFile, desiredWorkspacePath, Nil
 
-        makeExecPlan cmdline visible
-        | setPlanLabel "claim: {existingFile} -> {desiredWorkspacePath}"
+        # Very specifically target `u+rw` as the minimum change required to ensure functionality;
+        # `cp --no-preserve=mode` would also avoid issues when re-claiming read-only files in a
+        # subsequent invocation, but it might drop an expected executable permission as well.
+        """
+        set -e
+        cp %{existingFile} %{desiredWorkspacePath}
+        chmod u+rw %{desiredWorkspacePath}
+        """
+        | makePlan "claim: {existingFile} -> {desiredWorkspacePath}" visible
         | setPlanPersistence Once
         | setPlanFnOutputs (\_ desiredWorkspacePath, Nil)
         | runJobWith localRunner


### PR DESCRIPTION
We generally don't want to promote `claimFileAsPath` on external files as it makes builds harder to reproduce (though it does still maintain cache safety), but when people *do* use it to copy files, trying to claim a read-only file would previously work in the first invocation but fail in the second due to not being able to overwrite the previous result.  This sets the permissions on the resulting file to close that hole in invocation-level reproducibility.

Of note, the file permissions are already subject to a bit of semantic change, as `cp`[^1] sets the owner of the new file to the user+group who ran the command; in the odd case of 0477 permissions, assuming the file was originally owned by a different user, by running `claimFileAsPath` with the old implementation the user would suddenly *lose* the ability to write to it even when they previously could.

[^1]: This is *not* actually due to Wake sandboxing as I originally speculated -- especially since it uses the `localRunner` -- as running `cp` in the shell directly also exhibits this behaviour; I had been thrown off by the manpage description of `--preserve` listing `mode,ownership,timestamps` as its default.  Either way, though, the owner's changed and the mode isn't.