### PR TITLE
bsp: restore --tag functionality for bsp-wake

### DIFF
--- a/tools/bsp-wake/main.cpp
+++ b/tools/bsp-wake/main.cpp
@@ -416,16 +416,19 @@ struct ExtractBSPDocument : public ExecuteWakeProcess {
 
 ExtractBSPDocument::ExtractBSPDocument(const std::string &method, const JAST &params)
     : items(result.add("items", JSON_ARRAY)) {
-  cmdline.push_back("--last");
   cmdline.push_back("--tag-uri");
   cmdline.push_back("bsp." + method);
+
+  std::string outputs;
   for (auto &x : params.get("targets").children) {
     const std::string &uri = x.second.get("uri").value;
     if (uri.compare(0, sizeof(bsp) - 1, &bsp[0]) != 0) continue;
 
-    cmdline.push_back("-o");
-    cmdline.emplace_back(uri.substr(sizeof(bsp) - 1));
+    outputs += uri.substr(sizeof(bsp) - 1) + ",";
   }
+
+  cmdline.push_back("-o");
+  cmdline.push_back(outputs);
 }
 
 void ExtractBSPDocument::gotLine(JAST &row) {

--- a/tools/bsp-wake/main.cpp
+++ b/tools/bsp-wake/main.cpp
@@ -416,7 +416,8 @@ struct ExtractBSPDocument : public ExecuteWakeProcess {
 
 ExtractBSPDocument::ExtractBSPDocument(const std::string &method, const JAST &params)
     : items(result.add("items", JSON_ARRAY)) {
-  cmdline.push_back("--tag");
+  cmdline.push_back("--last");
+  cmdline.push_back("--tag-uri");
   cmdline.push_back("bsp." + method);
   for (auto &x : params.get("targets").children) {
     const std::string &uri = x.second.get("uri").value;

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -71,6 +71,7 @@ struct CommandLineOptions {
   const char *exec;
   char *shebang;
   const char *tagdag;
+  const char *taguri;
   const char *api;
   const char *fd1;
   const char *fd2;
@@ -145,6 +146,7 @@ struct CommandLineOptions {
       {0, "stop-after-ssa", GOPT_ARGUMENT_FORBIDDEN},
       {0, "no-optimize", GOPT_ARGUMENT_FORBIDDEN},
       {0, "tag-dag", GOPT_ARGUMENT_REQUIRED},
+      {0, "tag-uri", GOPT_ARGUMENT_REQUIRED},
       {0, "export-api", GOPT_ARGUMENT_REQUIRED},
       {0, "stdout", GOPT_ARGUMENT_REQUIRED},
       {0, "stderr", GOPT_ARGUMENT_REQUIRED},
@@ -210,6 +212,7 @@ struct CommandLineOptions {
     exec = arg(options, "exec")->argument;
     shebang = arg(options, "shebang")->argument;
     tagdag = arg(options, "tag-dag")->argument;
+    taguri = arg(options, "tag-uri")->argument;
     api = arg(options, "export-api")->argument;
     fd1 = arg(options, "stdout")->argument;
     fd2 = arg(options, "stderr")->argument;

--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -300,6 +300,12 @@ void describe(const std::vector<JobReflection> &jobs, DescribePolicy policy, con
       describe_metadata(jobs, false, true);
       break;
     }
+    case DescribePolicy::TAG_URI: {
+      for (auto &job : jobs)
+        for (auto &tag : job.tags)
+          if (tag.uri == policy.tag) std::cout << tag.content << std::endl;
+      break;
+    }
     case DescribePolicy::TIMELINE: {
       std::unordered_set<long> job_ids;
       for (const JobReflection &job : jobs) {

--- a/tools/wake/describe.h
+++ b/tools/wake/describe.h
@@ -24,9 +24,9 @@
 #include "runtime/database.h"
 
 struct DescribePolicy {
-  enum type { SCRIPT, HUMAN, METADATA, DEBUG, VERBOSE, TIMELINE } type;
+  enum type { TAG_URI, SCRIPT, HUMAN, METADATA, DEBUG, VERBOSE, TIMELINE } type;
   union {
-    const char *tag_uri;
+    const char *tag;
   };
 
   static DescribePolicy script() {
@@ -62,6 +62,13 @@ struct DescribePolicy {
   static DescribePolicy timeline() {
     DescribePolicy policy;
     policy.type = TIMELINE;
+    return policy;
+  }
+
+  static DescribePolicy tag_uri(const char *tag_uri) {
+    DescribePolicy policy;
+    policy.type = TAG_URI;
+    policy.tag = tag_uri;
     return policy;
   }
 };

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -152,6 +152,10 @@ DescribePolicy get_describe_policy(const CommandLineOptions &clo) {
     return DescribePolicy::script();
   }
 
+  if (clo.taguri) {
+    return DescribePolicy::tag_uri(clo.taguri);
+  }
+
   return DescribePolicy::human();
 }
 
@@ -415,7 +419,8 @@ int main(int argc, char **argv) {
 
   bool is_db_inspection = !clo.job_ids.empty() || !clo.output_files.empty() ||
                           !clo.input_files.empty() || !clo.labels.empty() || !clo.tags.empty() ||
-                          clo.last_use || clo.last_exe || clo.failed || clo.tagdag || clo.timeline;
+                          clo.last_use || clo.last_exe || clo.failed || clo.tagdag ||
+                          clo.timeline || clo.taguri;
   // Arguments are forbidden with these options
   bool noargs =
       is_db_inspection || clo.init || clo.html || clo.global || clo.exports || clo.api || clo.exec;


### PR DESCRIPTION
`--tag` was changed to be more flexible and filterable in #1454 however bsp-wake depended on the previous functionality.

This PR adds a new flag `--tag-uri` that acts like `--tag` used to and updates bsp-wake to use it