### PR TITLE
rsc_tool: Structure tool to support model bootstrapping

### DIFF
--- a/rust/migration/src/m20220101_000001_create_blob_tables.rs
+++ b/rust/migration/src/m20220101_000001_create_blob_tables.rs
@@ -22,15 +22,6 @@ impl MigrationTrait for Migration {
             )
             .await?;
 
-        // Insert basic backing store since it must always exist.
-        let insert = Query::insert()
-            .into_table(BlobStore::Table)
-            .columns([BlobStore::Type])
-            .values_panic(["LocalBlobStore".into()])
-            .to_owned();
-
-        manager.exec_stmt(insert).await?;
-
         manager
             .create_table(
                 Table::create()

--- a/rust/rsc/src/common/database.rs
+++ b/rust/rsc/src/common/database.rs
@@ -1,0 +1,131 @@
+use data_encoding::BASE64;
+use entity::{api_key, blob_store, job, local_blob_store};
+use rand_core::{OsRng, RngCore};
+use sea_orm::prelude::Uuid;
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::*, DatabaseConnection, DbErr, DeleteResult, EntityTrait,
+};
+use tracing;
+
+// --------------------------------------------------
+// ----------          Api Key             ----------
+// --------------------------------------------------
+
+// ----------            Create            ----------
+pub async fn create_api_key(
+    db: &DatabaseConnection,
+    key: Option<String>,
+    description: String,
+) -> Result<api_key::Model, DbErr> {
+    // If a key hasn't specified a key generate one.
+    let key = match key {
+        None => {
+            let mut buf = [0u8; 24];
+            OsRng.fill_bytes(&mut buf);
+            BASE64.encode(&buf)
+        }
+        Some(key) => key,
+    };
+
+    tracing::info!("Adding key = {} as valid API key", &key);
+    let active_key = api_key::ActiveModel {
+        id: NotSet,
+        created_at: NotSet,
+        key: Set(key),
+        desc: Set(description),
+    };
+
+    active_key.insert(db).await
+}
+
+// ----------             Read             ----------
+pub async fn read_api_key(
+    db: &DatabaseConnection,
+    id: Uuid,
+) -> Result<Option<api_key::Model>, DbErr> {
+    api_key::Entity::find_by_id(id).one(db).await
+}
+
+pub async fn read_api_keys(db: &DatabaseConnection) -> Result<Vec<api_key::Model>, DbErr> {
+    api_key::Entity::find().all(db).await
+}
+
+// ----------            Update            ----------
+
+// ----------            Delete            ----------
+pub async fn delete_api_key(
+    db: &DatabaseConnection,
+    key: api_key::Model,
+) -> Result<DeleteResult, DbErr> {
+    tracing::info!("Deleting api key {}", key.key);
+    api_key::Entity::delete_by_id(key.id).exec(db).await
+}
+
+// --------------------------------------------------
+// ----------       Local Blob Store       ----------
+// --------------------------------------------------
+
+// ----------            Create            ----------
+pub async fn create_local_blob_store(
+    db: &DatabaseConnection,
+    root: String,
+) -> Result<local_blob_store::Model, DbErr> {
+    let active_blob_store = blob_store::ActiveModel {
+        id: NotSet,
+        r#type: Set("LocalBlobStore".to_string()),
+    };
+
+    let store = active_blob_store.insert(db).await?;
+
+    let active_local_blob_store = local_blob_store::ActiveModel {
+        id: Set(store.id),
+        created_at: NotSet,
+        root: Set(root),
+    };
+
+    active_local_blob_store.insert(db).await
+}
+
+// ----------             Read             ----------
+pub async fn read_local_blob_store(
+    db: &DatabaseConnection,
+    id: Uuid,
+) -> Result<Option<local_blob_store::Model>, DbErr> {
+    local_blob_store::Entity::find_by_id(id).one(db).await
+}
+
+pub async fn read_local_blob_stores(
+    db: &DatabaseConnection,
+) -> Result<Vec<local_blob_store::Model>, DbErr> {
+    local_blob_store::Entity::find().all(db).await
+}
+
+// ----------            Update            ----------
+
+// ----------            Delete            ----------
+pub async fn delete_local_blob_store(
+    db: &DatabaseConnection,
+    store: local_blob_store::Model,
+) -> Result<DeleteResult, DbErr> {
+    tracing::info!("Deleting local blob store {}", store.id);
+    local_blob_store::Entity::delete_by_id(store.id)
+        .exec(db)
+        .await?;
+    blob_store::Entity::delete_by_id(store.id).exec(db).await
+}
+
+// --------------------------------------------------
+// ----------             Job              ----------
+// --------------------------------------------------
+
+// ----------            Create            ----------
+
+// ----------             Read             ----------
+
+// ----------            Update            ----------
+
+// ----------            Delete            ----------
+pub async fn delete_all_jobs(db: &DatabaseConnection) -> Result<DeleteResult, DbErr> {
+    tracing::info!("Deleting ALL jobs");
+    job::Entity::delete_many().exec(db).await
+}

--- a/rust/rsc/src/common/database.rs
+++ b/rust/rsc/src/common/database.rs
@@ -17,7 +17,7 @@ pub async fn create_api_key(
     key: Option<String>,
     description: String,
 ) -> Result<api_key::Model, DbErr> {
-    // If a key hasn't specified a key generate one.
+    // If a key wasn't specified, generate one.
     let key = match key {
         None => {
             let mut buf = [0u8; 24];

--- a/rust/rsc/src/rsc_tool/main.rs
+++ b/rust/rsc/src/rsc_tool/main.rs
@@ -135,26 +135,28 @@ async fn remove_local_blob_store(
 }
 
 async fn remove_all_jobs(db: &DatabaseConnection) -> Result<(), Box<dyn std::error::Error>> {
-    // We only want to prompt the user if the user can type into the terminal
-    if std::io::stdin().is_terminal() {
-        let mut should_delete = Confirm::new("Are you REALLY sure you want to delete ALL jobs?")
-            .with_default(false)
-            .prompt()?;
+    // Only let a human perform this action
+    if !std::io::stdin().is_terminal() {
+        println!("Remove all jobs may only be triggered manually by a human.");
+        std::process::exit(2);
+    }
 
-        if !should_delete {
-            println!("Aborting removal");
-            return Ok(());
-        }
+    let mut should_delete = Confirm::new("Are you REALLY sure you want to delete ALL jobs?")
+        .with_default(false)
+        .prompt()?;
 
-        should_delete =
-            Confirm::new("Last chance: Are you REALLY sure you want to delete ALL jobs?")
-                .with_default(false)
-                .prompt()?;
+    if !should_delete {
+        println!("Aborting removal");
+        return Ok(());
+    }
 
-        if !should_delete {
-            println!("Aborting removal");
-            return Ok(());
-        }
+    should_delete = Confirm::new("Last chance: Are you REALLY sure you want to delete ALL jobs?")
+        .with_default(false)
+        .prompt()?;
+
+    if !should_delete {
+        println!("Aborting removal");
+        return Ok(());
     }
 
     // Ok now that we're really sure we want to delete this key

--- a/rust/rsc/src/rsc_tool/main.rs
+++ b/rust/rsc/src/rsc_tool/main.rs
@@ -1,13 +1,8 @@
 use clap::{Parser, Subcommand};
-use data_encoding::BASE64;
-use entity::api_key;
 use inquire::Confirm;
 use is_terminal::IsTerminal;
 use migration::{DbErr, Migrator, MigratorTrait};
-use rand_core::{OsRng, RngCore};
-use sea_orm::{
-    ActiveModelTrait, ActiveValue::*, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
-};
+use sea_orm::{prelude::Uuid, DatabaseConnection};
 use std::io::{Error, ErrorKind};
 use tracing;
 
@@ -15,44 +10,20 @@ mod table;
 
 #[path = "../common/config.rs"]
 mod config;
+#[path = "../common/database.rs"]
+mod database;
 
-#[tracing::instrument]
 async fn add_api_key(
-    opts: AddKeyOpts,
-    conn: &DatabaseConnection,
+    opts: AddApiKeyOpts,
+    db: &DatabaseConnection,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // If the user hasn't specified a key generate one. This is
-    // the expected way for this tool to be used.
-    let key = match &opts.key {
-        None => {
-            let mut buf = [0u8; 24];
-            OsRng.fill_bytes(&mut buf);
-            BASE64.encode(&buf)
-        }
-        Some(key) => key.clone(),
-    };
-
-    // Go ahead and insert the key
-    let insert_key = api_key::ActiveModel {
-        id: NotSet,
-        created_at: NotSet,
-        key: Set(key.clone()),
-        desc: Set(opts.desc.clone()),
-    };
-    tracing::info!("Adding key = {} as valid API key", &key);
-    insert_key.insert(conn).await?;
-
-    // If everything was a success go ahead and tell the user the
-    // API key.
-    tracing::info!("Key {} Added", &key);
-    println!("\nSuccessfully added {} as an API key", key);
+    let key = database::create_api_key(db, opts.key, opts.desc).await?;
+    println!("Created api key: {}", key.id);
     Ok(())
 }
 
-#[tracing::instrument]
-async fn list_api_keys(_: ListKeysOpts, conn: &DatabaseConnection) -> Result<(), DbErr> {
-    let mut keys: Vec<_> = api_key::Entity::find()
-        .all(conn)
+async fn list_api_keys(db: &DatabaseConnection) -> Result<(), DbErr> {
+    let mut keys: Vec<_> = database::read_api_keys(db)
         .await?
         .into_iter()
         .map(|x| {
@@ -65,29 +36,20 @@ async fn list_api_keys(_: ListKeysOpts, conn: &DatabaseConnection) -> Result<(),
         .collect();
 
     let headers = vec!["Id".into(), "Key".into(), "Desc".into()];
-    keys.insert(0, headers.clone());
+    keys.insert(0, headers);
 
     table::print_table(keys);
 
     Ok(())
 }
 
-#[tracing::instrument]
 async fn remove_api_key(
-    key: String,
-    conn: &DatabaseConnection,
+    id: &String,
+    db: &DatabaseConnection,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // First find the key, because its a very strange user expierence to see
-    // "key X was successfully removed" when it never existed in the first place.
-    // It means that you can never be quite sure you acomplished what you thought
-    // you did and have to use list-keys to check. This also lets us output
-    // the description before commiting.
-    let Some(result) = api_key::Entity::find()
-        .filter(api_key::Column::Key.eq(&key))
-        .one(conn)
-        .await?
-    else {
-        println!("{} is not a valid key", key);
+    let uuid = Uuid::parse_str(id)?;
+    let Some(key) = database::read_api_key(db, uuid).await? else {
+        println!("{} is not a valid key", id);
         std::process::exit(2);
     };
 
@@ -95,25 +57,110 @@ async fn remove_api_key(
     if std::io::stdin().is_terminal() {
         let should_delete = Confirm::new("Are you sure you want to delete this key?")
             .with_default(false)
-            .with_help_message(format!("key = {}, desc = {:?}", key, result.desc).as_str())
+            .with_help_message(format!("key = {}, desc = {:?}", key.key, key.desc).as_str())
             .prompt()?;
 
         if !should_delete {
-            println!("Aborting key removal");
+            println!("Aborting removal");
             return Ok(());
         }
     }
 
     // Ok now that we're really sure we want to delete this key
-    tracing::info!("Deleting key {}", &key);
-    api_key::Entity::delete_many()
-        .filter(api_key::Column::Key.eq(&key))
-        .exec(conn)
-        .await?;
+    database::delete_api_key(db, key).await?;
 
-    // If we haven't returned already then log it and tell the user
-    tracing::info!("Key {} deleted", &key);
-    println!("Key {} was successfully removed", key);
+    println!("Key {} was successfully removed", id);
+    Ok(())
+}
+
+async fn add_local_blob_store(
+    opts: AddLocalBlobStoreOpts,
+    db: &DatabaseConnection,
+) -> Result<(), Box<dyn std::error::Error>> {
+    tokio::fs::create_dir_all(opts.root.clone()).await?;
+    let store = database::create_local_blob_store(db, opts.root).await?;
+    println!("Created local blob store: {}", store.id);
+    Ok(())
+}
+
+async fn list_local_blob_stores(db: &DatabaseConnection) -> Result<(), DbErr> {
+    let mut stores: Vec<_> = database::read_local_blob_stores(db)
+        .await?
+        .into_iter()
+        .map(|x| vec![format!("{}", x.id), x.root])
+        .collect();
+
+    let headers = vec!["Id".into(), "Root".into()];
+    stores.insert(0, headers);
+
+    table::print_table(stores);
+
+    Ok(())
+}
+
+async fn remove_local_blob_store(
+    id: &String,
+    db: &DatabaseConnection,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let uuid = Uuid::parse_str(id)?;
+    let Some(store) = database::read_local_blob_store(db, uuid).await? else {
+        println!("{} is not a valid local blob store", id);
+        std::process::exit(2);
+    };
+
+    // We only want to prompt the user if the user can type into the terminal
+    if std::io::stdin().is_terminal() {
+        let should_delete = Confirm::new("Are you sure you want to delete this local blob store?")
+            .with_default(false)
+            .with_help_message(format!("id = {}, root = {}", store.id, store.root).as_str())
+            .prompt()?;
+
+        if !should_delete {
+            println!("Aborting removal");
+            return Ok(());
+        }
+    }
+
+    // Try to delete the backing store and fail if it isn't empty
+    let Ok(()) = tokio::fs::remove_dir(store.root.clone()).await else {
+        println!("Local blob store contains blobs so it is not safe to delete it!");
+        std::process::exit(2);
+    };
+
+    // Ok now that we're really sure we want to delete this key
+    database::delete_local_blob_store(db, store).await?;
+
+    println!("Local Blob Store {} was successfully removed", id);
+    Ok(())
+}
+
+async fn remove_all_jobs(db: &DatabaseConnection) -> Result<(), Box<dyn std::error::Error>> {
+    // We only want to prompt the user if the user can type into the terminal
+    if std::io::stdin().is_terminal() {
+        let mut should_delete = Confirm::new("Are you REALLY sure you want to delete ALL jobs?")
+            .with_default(false)
+            .prompt()?;
+
+        if !should_delete {
+            println!("Aborting removal");
+            return Ok(());
+        }
+
+        should_delete =
+            Confirm::new("Last chance: Are you REALLY sure you want to delete ALL jobs?")
+                .with_default(false)
+                .prompt()?;
+
+        if !should_delete {
+            println!("Aborting removal");
+            return Ok(());
+        }
+    }
+
+    // Ok now that we're really sure we want to delete this key
+    database::delete_all_jobs(db).await?;
+
+    println!("All jobs successfully removed");
     Ok(())
 }
 
@@ -139,26 +186,85 @@ struct TopLevel {
     #[arg(help = "Show's the config and then exits", long)]
     show_config: bool,
 
-    // The `command` option will delegate option parsing to the command type,
-    // starting at the first free argument.
     #[command(subcommand)]
-    api_key_command: Option<ApiKey>,
+    db_command: Option<DBCommand>,
 }
 
 #[derive(Debug, Subcommand)]
-enum ApiKey {
-    //#[options(help = "list all api keys in the database")]
-    List(ListKeysOpts),
+enum DBCommand {
+    /// List all models in the database
+    List(ListOpts),
 
-    //#[options(help = "add an api key to the database")]
-    AddKey(AddKeyOpts),
+    /// Add a model to the database
+    Add(AddOpts),
 
-    //#[options(help = "remove an api key from the database")]
-    RemoveKey(RemoveKeyOpts),
+    /// Remove a model from the database
+    Remove(RemoveOpts),
 }
 
 #[derive(Debug, Parser)]
-struct AddKeyOpts {
+struct ListOpts {
+    #[command(subcommand)]
+    db_command: DBModelList,
+}
+
+#[derive(Debug, Parser)]
+struct AddOpts {
+    #[command(subcommand)]
+    db_command: DBModelAdd,
+}
+
+#[derive(Debug, Parser)]
+struct RemoveOpts {
+    #[command(subcommand)]
+    db_command: DBModelRemove,
+}
+
+#[derive(Debug, Subcommand)]
+enum DBModelList {
+    /// List all api keys
+    ApiKey(NullOpts),
+
+    /// List all local blob stores
+    LocalBlobStore(NullOpts),
+}
+
+#[derive(Debug, Subcommand)]
+enum DBModelAdd {
+    /// Add an api key
+    ApiKey(AddApiKeyOpts),
+
+    /// Add a local blob store
+    LocalBlobStore(AddLocalBlobStoreOpts),
+}
+
+#[derive(Debug, Subcommand)]
+enum DBModelRemove {
+    /// Remove an api key
+    ApiKey(RemoveByIdOpts),
+
+    /// Remove a local blob store
+    LocalBlobStore(RemoveByIdOpts),
+
+    /// DANGER Remove all cached jobs
+    DangerJobsAll(NullOpts),
+}
+
+#[derive(Debug, Parser)]
+struct NullOpts {}
+
+#[derive(Debug, Parser)]
+struct RemoveByIdOpts {
+    #[arg(
+        required = true,
+        help = "The id of the model you want to remove",
+        value_name = "ID"
+    )]
+    id: String,
+}
+
+#[derive(Debug, Parser)]
+struct AddApiKeyOpts {
     #[arg(
         help = "If specified this is the key that will be used, otherwise one will be generated",
         value_name = "KEY",
@@ -176,16 +282,14 @@ struct AddKeyOpts {
 }
 
 #[derive(Debug, Parser)]
-struct ListKeysOpts {}
-
-#[derive(Debug, Parser)]
-struct RemoveKeyOpts {
+struct AddLocalBlobStoreOpts {
     #[arg(
         required = true,
-        help = "The key you want to remove",
-        value_name = "KEY"
+        help = "The root directory for the store. Blobs will be saved to this location",
+        value_name = "ROOT",
+        long
     )]
-    key: String,
+    root: String,
 }
 
 #[tokio::main]
@@ -206,8 +310,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // connect to our db
-    let connection = sea_orm::Database::connect(config.database_url).await?;
-    let pending_migrations = Migrator::get_pending_migrations(&connection).await?;
+    let db = sea_orm::Database::connect(config.database_url).await?;
+    let pending_migrations = Migrator::get_pending_migrations(&db).await?;
     if pending_migrations.len() != 0 {
         let err = Error::new(
             ErrorKind::Other,
@@ -220,14 +324,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Err(err)?;
     }
 
-    let Some(api_key_args) = args.api_key_command else {
+    let Some(db_command) = args.db_command else {
         return Ok(());
     };
 
-    match api_key_args {
-        ApiKey::List(args) => list_api_keys(args, &connection).await?,
-        ApiKey::AddKey(args) => add_api_key(args, &connection).await?,
-        ApiKey::RemoveKey(args) => remove_api_key(args.key, &connection).await?,
+    match db_command {
+        // List Commands
+        DBCommand::List(ListOpts {
+            db_command: DBModelList::ApiKey(_),
+        }) => list_api_keys(&db).await?,
+        DBCommand::List(ListOpts {
+            db_command: DBModelList::LocalBlobStore(_),
+        }) => list_local_blob_stores(&db).await?,
+
+        // Add Commands
+        DBCommand::Add(AddOpts {
+            db_command: DBModelAdd::ApiKey(args),
+        }) => add_api_key(args, &db).await?,
+        DBCommand::Add(AddOpts {
+            db_command: DBModelAdd::LocalBlobStore(args),
+        }) => add_local_blob_store(args, &db).await?,
+
+        // Remove Commands
+        DBCommand::Remove(RemoveOpts {
+            db_command: DBModelRemove::ApiKey(args),
+        }) => remove_api_key(&args.id, &db).await?,
+        DBCommand::Remove(RemoveOpts {
+            db_command: DBModelRemove::LocalBlobStore(args),
+        }) => remove_local_blob_store(&args.id, &db).await?,
+        DBCommand::Remove(RemoveOpts {
+            db_command: DBModelRemove::DangerJobsAll(_),
+        }) => remove_all_jobs(&db).await?,
     }
 
     Ok(())

--- a/rust/rsc/src/rsc_tool/table.rs
+++ b/rust/rsc/src/rsc_tool/table.rs
@@ -49,5 +49,5 @@ pub fn print_table(data: Vec<Vec<String>>) {
     let mut dims = SpannedGridDimension::default();
     dims.estimate(&records, &cfg);
     let grid = PeekableGrid::new(&records, &cfg, &dims, NoColors).to_string();
-    print!("{grid}");
+    println!("{grid}");
 }


### PR DESCRIPTION
This is a somewhat chunky refactor of the `rsc_tool` to enable and support various database bootstrapping processes.

An example of a first-time configuration of a new rsc server may look like the following

```sh
$ rsc_tool add api-key --desc "API key for foo.ci.com"
Created api key: 8f0eac7e-edc7-427b-83f9-a4171b722e33
# Copy 8f0eac7e-edc7-427b-83f9-a4171b722e33 over to clients allowed to post jobs to the rsc
$ rsc_tool add local-blob-store --root /some/valid/path
Created local blob store: 94e2f4aa-2188-4368-8d99-c33117762c71
# This will create the store path for you as well
# Copy 94e2f4aa-2188-4368-8d99-c33117762c71 to rsc's .config as the "active store"
# Launch the server 
```

The main goal of rsc_tool is to be used directly by engineering and support teams to spin up and manage the server.

This PR also add `rsc_tool remove danger-jobs-all` which will delete all jobs from the database. It is primarily used as a development tool but in case of an aggressively poisoned cache it may be useful as a parachute. Risk of accidentenal use is low as it has 3 points of "are you sure" (1 in the name, 2 in direct prompts)