### PR TITLE
stdlib: Add unsafe_stat and writeTempFile to io.wake

### DIFF
--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -195,11 +195,11 @@ export def write (path: String) (content: String): Result Path Error =
 
 # Writes a string to an intermediate file that will not conflict with other files.
 #
-# Idential prefix+files will be automatically deduplicated
+# Identical prefix+files will be automatically deduplicated
 export def writeTempFile (prefix: String) (content: String): Result Path Error =
     def name = "{prefix}.{hashString content}"
 
-    require Pass dir = mkdir "build/.temp"
+    require Pass dir = mkdir ".build/tmp/writes"
 
     writeIn dir 0644 name content
 

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -106,10 +106,16 @@ def statTypeNumberToPathType (inodeType: Integer): PathType = match inodeType
 
 # Returns the system Stat for a given path
 export target stat (path: Path): Result Stat Error =
+    unsafe_stat path.getPathName
+
+# Returns the system Stat for a given path string. Prefer stat instead
+#
+# Should only be used in rare cases where wake invariants are upheld by the caller
+export target unsafe_stat (path: String): Result Stat Error =
     def imp p = prim "stat"
 
     require Pass (Pair size (Pair inodeType mode)) =
-        imp path.getPathName
+        imp path
         | rmapError makeError
 
     Stat (statTypeNumberToPathType inodeType) (bits2mode mode) size
@@ -186,6 +192,16 @@ export def write (path: String) (content: String): Result Path Error =
         | mkdir
 
     writeImp (parent, Nil) 0644 spath content
+
+# Writes a string to an intermediate file that will not conflict with other files.
+#
+# Idential prefix+files will be automatically deduplicated
+export def writeTempFile (prefix: String) (content: String): Result Path Error =
+    def name = "{prefix}.{hashString content}"
+
+    require Pass dir = mkdir "build/.temp"
+
+    writeIn dir 0644 name content
 
 # Create a file with the given mode in the specified directory
 export def writeIn (parent: Path) (mode: Integer) (name: String) (content: String): Result Path Error =


### PR DESCRIPTION
`unsafe_stat`: `stat` but doesn't require path. Needed by the cacheRunner to stat a file before it can be elevated into a Path

`writeTempFile`: writes a file from a string. Useful for jobs/tools that require a file as input. Filenames are generated from the hash of the content and duplicate content is de-duplicated therefore guarantees to never raise the `file output by multiple jobs` error