### PR TITLE
lsc: Fix incomplete capture of job output

### DIFF
--- a/share/wake/lib/system/job_cache_runner.wake
+++ b/share/wake/lib/system/job_cache_runner.wake
@@ -199,8 +199,8 @@ export def mkJobCacheRunner (hashFn: Result RunnerInput Error => Result String E
 
                 JArray (map mkVisJson readPaths)
 
-            require Pass stdout = getJobFailedStdout job
-            require Pass stderr = getJobFailedStderr job
+            require Pass stdout = job.getJobFailedStdoutRaw
+            require Pass stderr = job.getJobFailedStderrRaw
 
             def jobCacheAddJson =
                 prettyJSON


### PR DESCRIPTION
The jobCacheRunner was caching the filtered output when writing to the cache, it should instead be caching the raw output. This PR fixes that.