### PR TITLE
rsc: Update api types to align with client expectations

### DIFF
--- a/rust/entity/src/job.rs
+++ b/rust/entity/src/job.rs
@@ -7,8 +7,8 @@ use sea_orm::entity::prelude::*;
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
-    #[sea_orm(column_type = "Binary(BlobSize::Blob(None))", unique)]
-    pub hash: Vec<u8>,
+    #[sea_orm(unique)]
+    pub hash: String,
     #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
     pub cmd: Vec<u8>,
     #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]

--- a/rust/entity/src/job.rs
+++ b/rust/entity/src/job.rs
@@ -9,7 +9,8 @@ pub struct Model {
     pub id: Uuid,
     #[sea_orm(column_type = "Binary(BlobSize::Blob(None))", unique)]
     pub hash: Vec<u8>,
-    pub cmd: String,
+    #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
+    pub cmd: Vec<u8>,
     #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
     pub env: Vec<u8>,
     pub cwd: String,

--- a/rust/entity/src/visible_file.rs
+++ b/rust/entity/src/visible_file.rs
@@ -8,8 +8,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
     pub path: String,
-    #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
-    pub hash: Vec<u8>,
+    pub hash: Option<String>,
     pub job_id: Uuid,
     pub created_at: DateTime,
 }

--- a/rust/entity/src/visible_file.rs
+++ b/rust/entity/src/visible_file.rs
@@ -8,7 +8,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
     pub path: String,
-    pub hash: Option<String>,
+    pub hash: String,
     pub job_id: Uuid,
     pub created_at: DateTime,
 }

--- a/rust/migration/src/m20220101_000002_create_table.rs
+++ b/rust/migration/src/m20220101_000002_create_table.rs
@@ -30,7 +30,7 @@ impl MigrationTrait for Migration {
                             .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(Job::Hash).ezblob().unique_key())
-                    .col(ColumnDef::new(Job::Cmd).string().not_null())
+                    .col(ColumnDef::new(Job::Cmd).ezblob().not_null())
                     .col(ColumnDef::new(Job::Env).ezblob())
                     .col(ColumnDef::new(Job::Cwd).string().not_null())
                     .col(ColumnDef::new(Job::Stdin).string().not_null())
@@ -84,7 +84,7 @@ impl MigrationTrait for Migration {
                             .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(VisibleFile::Path).string().not_null())
-                    .col(ColumnDef::new(VisibleFile::Hash).ezblob())
+                    .col(ColumnDef::new(VisibleFile::Hash).string())
                     .col(ColumnDef::new(VisibleFile::JobId).uuid().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()

--- a/rust/migration/src/m20220101_000002_create_table.rs
+++ b/rust/migration/src/m20220101_000002_create_table.rs
@@ -84,7 +84,7 @@ impl MigrationTrait for Migration {
                             .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(VisibleFile::Path).string().not_null())
-                    .col(ColumnDef::new(VisibleFile::Hash).string())
+                    .col(ColumnDef::new(VisibleFile::Hash).string().not_null())
                     .col(ColumnDef::new(VisibleFile::JobId).uuid().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()

--- a/rust/migration/src/m20220101_000002_create_table.rs
+++ b/rust/migration/src/m20220101_000002_create_table.rs
@@ -29,7 +29,7 @@ impl MigrationTrait for Migration {
                             .primary_key()
                             .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
-                    .col(ColumnDef::new(Job::Hash).ezblob().unique_key())
+                    .col(ColumnDef::new(Job::Hash).string().not_null().unique_key())
                     .col(ColumnDef::new(Job::Cmd).ezblob().not_null())
                     .col(ColumnDef::new(Job::Env).ezblob())
                     .col(ColumnDef::new(Job::Cwd).string().not_null())

--- a/rust/rsc/src/rsc/add_job.rs
+++ b/rust/rsc/src/rsc/add_job.rs
@@ -24,7 +24,7 @@ pub async fn add_job(
         created_at: NotSet,
         hash: Set(hash.clone().into()),
         cmd: Set(payload.cmd),
-        env: Set(payload.env.as_bytes().into()),
+        env: Set(payload.env),
         cwd: Set(payload.cwd),
         stdin: Set(payload.stdin),
         is_atty: Set(payload.is_atty),

--- a/rust/rsc/src/rsc/add_job.rs
+++ b/rust/rsc/src/rsc/add_job.rs
@@ -51,7 +51,7 @@ pub async fn add_job(
                     id: NotSet,
                     created_at: NotSet,
                     path: Set(vis_file.path),
-                    hash: Set(vis_file.hash.into()),
+                    hash: Set(vis_file.hash),
                     job_id: Set(job_id),
                 });
 

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -482,8 +482,8 @@ mod tests {
                     .header("Authorization", api_key)
                     .body(Body::from(
                         serde_json::to_vec(&json!({
-                            "cmd": "blarg",
-                            "env":"PATH=/usr/bin",
+                            "cmd": [98, 108, 97, 114, 103], // blarg
+                            "env": [65, 61, 98], // A=b
                             "cwd":"/workspace",
                             "stdin":"",
                             "is_atty": false,
@@ -519,8 +519,8 @@ mod tests {
                     .header("Content-Type", "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&json!({
-                            "cmd": "blrg",
-                            "env":"PATH=/usr/bin",
+                            "cmd": [98, 108, 114, 103], // blrg
+                            "env": [65, 61, 98], // A=b
                             "cwd":"/workspace",
                             "stdin":"",
                             "is_atty": false,
@@ -549,8 +549,8 @@ mod tests {
                     .header("Content-Type", "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&json!({
-                            "cmd": "blarg",
-                            "env":"PATH=/usr/bin",
+                            "cmd": [98, 108, 97, 114, 103], // blarg
+                            "env": [65, 61, 98], // A=b
                             "cwd":"/workspace",
                             "stdin":"",
                             "is_atty": false,

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -482,8 +482,8 @@ mod tests {
                     .header("Authorization", api_key)
                     .body(Body::from(
                         serde_json::to_vec(&json!({
-                            "cmd": [98, 108, 97, 114, 103], // blarg
-                            "env": [65, 61, 98], // A=b
+                            "cmd": b"blarg",
+                            "env": b"PATH=/usr/bin",
                             "cwd":"/workspace",
                             "stdin":"",
                             "is_atty": false,
@@ -519,8 +519,8 @@ mod tests {
                     .header("Content-Type", "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&json!({
-                            "cmd": [98, 108, 114, 103], // blrg
-                            "env": [65, 61, 98], // A=b
+                            "cmd": b"blrg",
+                            "env": b"PATH=/usr/bin",
                             "cwd":"/workspace",
                             "stdin":"",
                             "is_atty": false,
@@ -549,8 +549,8 @@ mod tests {
                     .header("Content-Type", "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&json!({
-                            "cmd": [98, 108, 97, 114, 103], // blarg
-                            "env": [65, 61, 98], // A=b
+                            "cmd": b"blarg",
+                            "env": b"PATH=/usr/bin",
                             "cwd":"/workspace",
                             "stdin":"",
                             "is_atty": false,
@@ -600,16 +600,11 @@ mod tests {
         let blob_id = create_fake_blob(&db, store_id).await.unwrap();
         let conn = Arc::new(db);
 
-        let hash: [u8; 32] = [
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0,
-        ];
-
         // Create a job that is 5 days old
         let insert_job = entity::job::ActiveModel {
             id: NotSet,
             created_at: Set((Utc::now() - Duration::days(5)).naive_utc()),
-            hash: Set(hash.into()),
+            hash: Set("00000000".to_string()),
             cmd: Set("blarg".into()),
             env: Set("PATH=/usr/bin".as_bytes().into()),
             cwd: Set("/workspace".into()),
@@ -628,16 +623,11 @@ mod tests {
 
         insert_job.save(conn.clone().as_ref()).await.unwrap();
 
-        let hash: [u8; 32] = [
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 1,
-        ];
-
         // Create a job that is 1 day old
         let insert_job = entity::job::ActiveModel {
             id: NotSet,
             created_at: Set((Utc::now() - Duration::days(1)).naive_utc()),
-            hash: Set(hash.into()),
+            hash: Set("00000001".to_string()),
             cmd: Set("blarg2".into()),
             env: Set("PATH=/usr/bin".as_bytes().into()),
             cwd: Set("/workspace".into()),

--- a/rust/rsc/src/rsc/types.rs
+++ b/rust/rsc/src/rsc/types.rs
@@ -52,7 +52,7 @@ pub struct AddJobPayload {
 }
 
 impl AddJobPayload {
-    pub fn hash(&self) -> [u8; 32] {
+    pub fn hash(&self) -> String {
         let mut hasher = blake3::Hasher::new();
         hasher.update(&self.cmd.len().to_le_bytes());
         hasher.update(&self.cmd);
@@ -72,7 +72,7 @@ impl AddJobPayload {
             hasher.update(&file.hash.len().to_le_bytes());
             hasher.update(file.hash.as_bytes());
         }
-        hasher.finalize().into()
+        hasher.finalize().to_string()
     }
 }
 
@@ -90,7 +90,7 @@ pub struct ReadJobPayload {
 
 impl ReadJobPayload {
     // TODO: Figure out a way to de-dup this with AddJobPayload somehow
-    pub fn hash(&self) -> [u8; 32] {
+    pub fn hash(&self) -> String {
         let mut hasher = blake3::Hasher::new();
         hasher.update(&self.cmd.len().to_le_bytes());
         hasher.update(&self.cmd);
@@ -110,7 +110,7 @@ impl ReadJobPayload {
             hasher.update(&file.hash.len().to_le_bytes());
             hasher.update(file.hash.as_bytes());
         }
-        hasher.finalize().into()
+        hasher.finalize().to_string()
     }
 }
 

--- a/rust/rsc/src/rsc/types.rs
+++ b/rust/rsc/src/rsc/types.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct VisibleFile {
     pub path: String,
-    pub hash: [u8; 32],
+    pub hash: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -30,8 +30,8 @@ pub struct Symlink {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AddJobPayload {
-    pub cmd: String,
-    pub env: String,
+    pub cmd: Vec<u8>,
+    pub env: Vec<u8>,
     pub cwd: String,
     pub stdin: String,
     pub is_atty: bool,
@@ -55,9 +55,9 @@ impl AddJobPayload {
     pub fn hash(&self) -> [u8; 32] {
         let mut hasher = blake3::Hasher::new();
         hasher.update(&self.cmd.len().to_le_bytes());
-        hasher.update(self.cmd.as_bytes());
+        hasher.update(&self.cmd);
         hasher.update(&self.env.len().to_le_bytes());
-        hasher.update(self.env.as_bytes());
+        hasher.update(&self.env);
         hasher.update(&self.cwd.len().to_le_bytes());
         hasher.update(self.cwd.as_bytes());
         hasher.update(&self.stdin.len().to_le_bytes());
@@ -70,7 +70,7 @@ impl AddJobPayload {
             hasher.update(&file.path.len().to_le_bytes());
             hasher.update(file.path.as_bytes());
             hasher.update(&file.hash.len().to_le_bytes());
-            hasher.update(&file.hash);
+            hasher.update(file.hash.as_bytes());
         }
         hasher.finalize().into()
     }
@@ -78,8 +78,8 @@ impl AddJobPayload {
 
 #[derive(Debug, Deserialize)]
 pub struct ReadJobPayload {
-    pub cmd: String,
-    pub env: String,
+    pub cmd: Vec<u8>,
+    pub env: Vec<u8>,
     pub cwd: String,
     pub stdin: String,
     pub is_atty: bool,
@@ -93,9 +93,9 @@ impl ReadJobPayload {
     pub fn hash(&self) -> [u8; 32] {
         let mut hasher = blake3::Hasher::new();
         hasher.update(&self.cmd.len().to_le_bytes());
-        hasher.update(self.cmd.as_bytes());
+        hasher.update(&self.cmd);
         hasher.update(&self.env.len().to_le_bytes());
-        hasher.update(self.env.as_bytes());
+        hasher.update(&self.env);
         hasher.update(&self.cwd.len().to_le_bytes());
         hasher.update(self.cwd.as_bytes());
         hasher.update(&self.stdin.len().to_le_bytes());
@@ -108,7 +108,7 @@ impl ReadJobPayload {
             hasher.update(&file.path.len().to_le_bytes());
             hasher.update(file.path.as_bytes());
             hasher.update(&file.hash.len().to_le_bytes());
-            hasher.update(&file.hash);
+            hasher.update(file.hash.as_bytes());
         }
         hasher.finalize().into()
     }


### PR DESCRIPTION
- Changes job's `cmd` from a string to a vector of bytes as multipart commands are delimited with `\0` which is not valid in rust strings
- Changes visible_file's `hash` from a vector of bytes to a string as that is a much simpler representation for the client to construct.