### PR TITLE
rsc: Support database backed blobs

### DIFF
--- a/rust/rsc/src/rsc/read_job.rs
+++ b/rust/rsc/src/rsc/read_job.rs
@@ -178,9 +178,12 @@ pub async fn read_job(
         Err(cause) => {
             tracing::error! {
               %cause,
-              "failed to add job"
+              "failed to read job"
             };
-            (StatusCode::NOT_FOUND, Json(ReadJobResponse::NoMatch))
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ReadJobResponse::NoMatch),
+            )
         }
     }
 }


### PR DESCRIPTION
For small enough blobs, the overhead of writing out to disk/a second provider isn't worth it. This PR allows the client to opt in to storing certain blobs directly in the database. This is primarily useful for the empty blob but will also be useful for other small blobs.

Clients can opt in by setting the content type of the mutipart part to `"blob/small"`. Right now only blobs up to 100 bytes are allowed but there isn't a strong reason (other than de-duplication) to let the client arbitrarily defined what small is.

When a small blob is resolved by the server, its contents are directly returned as the blob url using standard `%BYTE%BYTE` url encoding. the schema `db://` can be used to detect this.