### PR TITLE
ci: Don't test alpine builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,7 +101,7 @@ jobs:
               extra_docker_build_args: ''
               extra_docker_run_args: ''
               build_cmd: make -C wake-* static
-              test_cmd: tar xvJf wake-*/wake-static_* && cd tests && ../wake-*/bin/wake runTests
+              test_cmd: tar xvJf wake-*/wake-static_* && cd tests && ../wake-*/bin/wake -x Unit
               install_src_glob: build/wake-*/wake-static_*
 
             - target: centos_7_6


### PR DESCRIPTION
This PR disables the now failing alpine test. For now we will continue to ensure that it builds.

This is not a change in policy as alpine has not been officially supported or released for over 1.5 years. See: https://github.com/sifive/wake/releases/tag/v0.28.5