### PR TITLE
db: Add simple timeline rendering

### DIFF
--- a/share/wake/html/timeline_main.js
+++ b/share/wake/html/timeline_main.js
@@ -312,11 +312,6 @@ timeline.on('click', function (properties) {
     }
     let job = jobMap.get(parseInt(properties.item)).job;
     document.getElementById("job").innerHTML = job.job
-    if (job.usage.charAt(8) === '0') {
-        document.getElementById("job").style.color = "green";
-    } else {
-        document.getElementById("job").style.color = "red";
-    }
     document.getElementById("stale").innerHTML = job.stale ? "true" : "false";
     document.getElementById("label").innerHTML = job.label;
     document.getElementById("directory").innerHTML = job.directory;

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1177,6 +1177,24 @@ std::string Time::as_string() const {
   return buf;
 }
 
+JAST JobReflection::to_simple_json() const {
+  JAST json(JSON_OBJECT);
+  json.add("job", job);
+  json.add("label", label.c_str());
+
+  std::stringstream commandline_stream;
+  for (const std::string &line : commandline) {
+    commandline_stream << line << " ";
+  }
+  json.add("commandline", commandline_stream.str());
+
+  json.add("starttime", starttime.as_int64());
+  json.add("endtime", endtime.as_int64());
+  json.add("wake_start", wake_start.as_int64());
+
+  return json;
+}
+
 JAST JobReflection::to_json() const {
   JAST json(JSON_OBJECT);
   json.add("job", job);

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1192,6 +1192,15 @@ JAST JobReflection::to_simple_json() const {
   json.add("endtime", endtime.as_int64());
   json.add("wake_start", wake_start.as_int64());
 
+  std::stringstream tags_stream;
+  for (const auto &tag : tags) {
+    tags_stream << "{<br>"
+                << "  job: " << tag.job << ",<br>"
+                << "  uri: " << tag.uri << ",<br>"
+                << "  content: " << tag.content << "<br>},<br>";
+  }
+  json.add("tags", tags_stream.str());
+
   return json;
 }
 

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -82,6 +82,7 @@ struct JobReflection {
   std::vector<JobTag> tags;
 
   JAST to_json() const;
+  JAST to_simple_json() const;
 };
 
 struct JobEdge {

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -55,6 +55,7 @@ struct CommandLineOptions {
   bool optim;
   bool exports;
   bool timeline;
+  bool simple_timeline;
   bool simple;
   bool clean;
   bool list_outputs;
@@ -139,6 +140,7 @@ struct CommandLineOptions {
       {'e', "exports", GOPT_ARGUMENT_FORBIDDEN},
       {0, "html", GOPT_ARGUMENT_FORBIDDEN},
       {0, "timeline", GOPT_ARGUMENT_OPTIONAL},
+      {0, "simple-timeline", GOPT_ARGUMENT_OPTIONAL},
       {0, "simple", GOPT_ARGUMENT_OPTIONAL},
       {'h', "help", GOPT_ARGUMENT_FORBIDDEN},
       {0, "config", GOPT_ARGUMENT_FORBIDDEN},
@@ -200,6 +202,7 @@ struct CommandLineOptions {
     optim = !arg(options, "no-optimize")->count;
     exports = arg(options, "exports")->count;
     timeline = arg(options, "timeline")->count;
+    simple_timeline = arg(options, "simple-timeline")->count;
     simple = arg(options, "simple")->count;
     clean = arg(options, "clean")->count;
     list_outputs = arg(options, "list-outputs")->count;

--- a/tools/wake/describe.h
+++ b/tools/wake/describe.h
@@ -24,7 +24,17 @@
 #include "runtime/database.h"
 
 struct DescribePolicy {
-  enum type { TAG_URI, SCRIPT, HUMAN, METADATA, DEBUG, VERBOSE, TIMELINE, SIMPLE } type;
+  enum type {
+    TAG_URI,
+    SCRIPT,
+    HUMAN,
+    METADATA,
+    DEBUG,
+    VERBOSE,
+    TIMELINE,
+    SIMPLE,
+    SIMPLE_TIMELINE
+  } type;
   union {
     const char *tag;
   };
@@ -75,6 +85,12 @@ struct DescribePolicy {
   static DescribePolicy simple() {
     DescribePolicy policy;
     policy.type = SIMPLE;
+    return policy;
+  }
+
+  static DescribePolicy simple_timeline() {
+    DescribePolicy policy;
+    policy.type = SIMPLE_TIMELINE;
     return policy;
   }
 };

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -136,6 +136,10 @@ DescribePolicy get_describe_policy(const CommandLineOptions &clo) {
     return DescribePolicy::timeline();
   }
 
+  if (clo.simple_timeline) {
+    return DescribePolicy::simple_timeline();
+  }
+
   if (clo.simple) {
     return DescribePolicy::simple();
   }
@@ -281,6 +285,7 @@ void print_help(const char *argv0) {
     << "    --failed   -f    Capture jobs which failed last build"                       << std::endl
     << "    --tag    KEY=VAL Capture jobs which are tagged, matching KEY and VAL globs"  << std::endl
     << "    --timeline       Report timeline of captured jobs as HTML"                   << std::endl
+    << "    --simple-timeline       Report timeline of captured jobs as HTML"            << std::endl
     << "    --verbose  -v    Report metadata, stdout and stderr of captured jobs"        << std::endl
     << "    --metadata       Report metadata of captured jobs"                           << std::endl
     << "    --debug    -d    Report stack frame of captured jobs"                        << std::endl
@@ -426,7 +431,7 @@ int main(int argc, char **argv) {
   bool is_db_inspection = !clo.job_ids.empty() || !clo.output_files.empty() ||
                           !clo.input_files.empty() || !clo.labels.empty() || !clo.tags.empty() ||
                           clo.last_use || clo.last_exe || clo.failed || clo.tagdag ||
-                          clo.timeline || clo.taguri;
+                          clo.timeline || clo.taguri || clo.simple || clo.simple_timeline;
   // Arguments are forbidden with these options
   bool noargs =
       is_db_inspection || clo.init || clo.html || clo.global || clo.exports || clo.api || clo.exec;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -251,54 +251,54 @@ void print_help(const char *argv0) {
     << "Usage in script: #! /usr/bin/env wake [OPTIONS] -:target" << std::endl
     << std::endl
     << "  Flags affecting build execution:" << std::endl
-    << "    --jobs=N   -jN   Schedule local jobs for N cores or N% of CPU (default 90%)" << std::endl
-    << "    --memory=M -mM   Schedule local jobs for M bytes or M% of RAM (default 90%)" << std::endl
-    << "    --check    -c    Rerun all jobs and confirm their output is reproducible"    << std::endl
-    << "    --verbose  -v    Report hash progress and result expression types"           << std::endl
-    << "    --debug    -d    Report stack frame information for exceptions and closures" << std::endl
-    << "    --quiet    -q    Surpress report of launched jobs and final expressions"     << std::endl
-    << "    --no-tty         Surpress interactive build progress interface"              << std::endl
-    << "    --no-wait        Do not wait to obtain database lock; fail immediately"      << std::endl
-    << "    --no-workspace   Do not open a database or scan for sources files"           << std::endl
-    << "    --fatal-warnings Do not execute if there are any warnings"                   << std::endl
-    << "    --heap-factor X  Heap-size is X * live data after the last GC (default 4.0)" << std::endl
-    << "    --profile-heap   Report memory consumption on every garbage collection"      << std::endl
-    << "    --profile  FILE  Report runtime breakdown by stack trace to HTML/JSON file"  << std::endl
-    << "    --chdir -C PATH  Locate database and default package starting from PATH"     << std::endl
-    << "    --in       PKG   Evaluate command-line in package PKG (default is chdir)"    << std::endl
-    << "    --exec -x  EXPR  Execute expression EXPR instead of a target function"       << std::endl
-    << "    --stdout   EXPR  Send specified log levels to stdout (FD 1)"                 << std::endl
-    << "    --stderr   EXPR  Send specified log levels to stderr (FD 2)"                 << std::endl
-    << "    --fd:3     EXPR  Send specified log levels to FD 3. Same for --fd:4, --fd:5" << std::endl
+    << "    --jobs=N   -jN     Schedule local jobs for N cores or N% of CPU (default 90%)" << std::endl
+    << "    --memory=M -mM     Schedule local jobs for M bytes or M% of RAM (default 90%)" << std::endl
+    << "    --check    -c      Rerun all jobs and confirm their output is reproducible"    << std::endl
+    << "    --verbose  -v      Report hash progress and result expression types"           << std::endl
+    << "    --debug    -d      Report stack frame information for exceptions and closures" << std::endl
+    << "    --quiet    -q      Surpress report of launched jobs and final expressions"     << std::endl
+    << "    --no-tty           Surpress interactive build progress interface"              << std::endl
+    << "    --no-wait          Do not wait to obtain database lock; fail immediately"      << std::endl
+    << "    --no-workspace     Do not open a database or scan for sources files"           << std::endl
+    << "    --fatal-warnings   Do not execute if there are any warnings"                   << std::endl
+    << "    --heap-factor X    Heap-size is X * live data after the last GC (default 4.0)" << std::endl
+    << "    --profile-heap     Report memory consumption on every garbage collection"      << std::endl
+    << "    --profile     FILE Report runtime breakdown by stack trace to HTML/JSON file"  << std::endl
+    << "    --chdir    -C PATH Locate database and default package starting from PATH"     << std::endl
+    << "    --in          PKG  Evaluate command-line in package PKG (default is chdir)"    << std::endl
+    << "    --exec     -x EXPR Execute expression EXPR instead of a target function"       << std::endl
+    << "    --stdout      EXPR Send specified log levels to stdout (FD 1)"                 << std::endl
+    << "    --stderr      EXPR Send specified log levels to stderr (FD 2)"                 << std::endl
+    << "    --fd:3        EXPR Send specified log levels to FD 3. Same for --fd:4, --fd:5" << std::endl
     << std::endl
     << "  Database commands:" << std::endl
-    << "    --init      DIR  Create or replace a wake.db in the specified directory"     << std::endl
-    << "    --list-outputs   List all job outputs"                                       << std::endl
-    << "    --clean          Delete all job outputs"                                     << std::endl
-    << "    --input  -i FILE Capture jobs which read FILE. (repeat for multiple files)"  << std::endl
-    << "    --output -o FILE Capture jobs which wrote FILE. (repeat for multiple files)" << std::endl
-    << "    --label     GLOB Capture jobs where label matches GLOB"                      << std::endl
-    << "    --job       JOB  Capture the job with the specified job id"                  << std::endl
-    << "    --last     -l    See --last-used"                                            << std::endl
-    << "    --last-used      Capture all jobs used by last build. Regardless of cache"   << std::endl
-    << "    --last-executed  Capture all jobs executed by the last build. Skips cache"   << std::endl
-    << "    --failed   -f    Capture jobs which failed last build"                       << std::endl
-    << "    --tag    KEY=VAL Capture jobs which are tagged, matching KEY and VAL globs"  << std::endl
-    << "    --timeline       Report timeline of captured jobs as HTML"                   << std::endl
-    << "    --simple-timeline       Report timeline of captured jobs as HTML"            << std::endl
-    << "    --verbose  -v    Report metadata, stdout and stderr of captured jobs"        << std::endl
-    << "    --metadata       Report metadata of captured jobs"                           << std::endl
-    << "    --debug    -d    Report stack frame of captured jobs"                        << std::endl
-    << "    --simple         Report only label, cmdline, and tags of captured jobs"      << std::endl
-    << "    --script   -s    Format captured jobs as an executable shell script"         << std::endl
+    << "    --init        DIR  Create or replace a wake.db in the specified directory"     << std::endl
+    << "    --list-outputs     List all job outputs"                                       << std::endl
+    << "    --clean            Delete all job outputs"                                     << std::endl
+    << "    --input    -i FILE Capture jobs which read FILE. (repeat for multiple files)"  << std::endl
+    << "    --output   -o FILE Capture jobs which wrote FILE. (repeat for multiple files)" << std::endl
+    << "    --label       GLOB Capture jobs where label matches GLOB"                      << std::endl
+    << "    --job         JOB  Capture the job with the specified job id"                  << std::endl
+    << "    --last     -l      See --last-used"                                            << std::endl
+    << "    --last-used        Capture all jobs used by last build. Regardless of cache"   << std::endl
+    << "    --last-executed    Capture all jobs executed by the last build. Skips cache"   << std::endl
+    << "    --failed   -f      Capture jobs which failed last build"                       << std::endl
+    << "    --tag      KEY=VAL Capture jobs which are tagged, matching KEY and VAL globs"  << std::endl
+    << "    --timeline         Report timeline of captured jobs as HTML"                   << std::endl
+    << "    --simple-timeline  Report simplified timeline of captured jobs as HTML"        << std::endl
+    << "    --verbose  -v      Report metadata, stdout and stderr of captured jobs"        << std::endl
+    << "    --metadata         Report metadata of captured jobs"                           << std::endl
+    << "    --debug    -d      Report stack frame of captured jobs"                        << std::endl
+    << "    --simple           Report only label, cmdline, and tags of captured jobs"      << std::endl
+    << "    --script   -s      Format captured jobs as an executable shell script"         << std::endl
     << std::endl
     << "  Help functions:" << std::endl
-    << "    --version        Print the version of wake on standard output"               << std::endl
-    << "    --html           Print all wake source files as cross-referenced HTML"       << std::endl
-    << "    --globals -g     Print global symbols made available to all wake files"      << std::endl
-    << "    --exports -e     Print symbols exported by the selected package (see --in)"  << std::endl
-    << "    --config         Print the configuration parsed from wakeroot and wakerc"    << std::endl
-    << "    --help    -h     Print this help message and exit"                           << std::endl
+    << "    --version          Print the version of wake on standard output"               << std::endl
+    << "    --html             Print all wake source files as cross-referenced HTML"       << std::endl
+    << "    --globals  -g      Print global symbols made available to all wake files"      << std::endl
+    << "    --exports  -e      Print symbols exported by the selected package (see --in)"  << std::endl
+    << "    --config           Print the configuration parsed from wakeroot and wakerc"    << std::endl
+    << "    --help     -h      Print this help message and exit"                           << std::endl
     << std::endl;
     // debug-db, no-optimize, stop-after-* are secret undocumented options
   // clang-format on


### PR DESCRIPTION
Adds a `--simple-timeline` flag similar to `--timeline` with  most of the data removed to generate a much smaller timeline file.

Keeps cmdline, label, job id, start time, and end time. All other info should be pulled from more targeted/filtered timeline files