### PR TITLE
rsc: Fix large uploads and unescaped paths

### DIFF
--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -140,6 +140,7 @@ fn create_router(
                 let conn = conn.clone();
                 move |body| add_job::add_job(body, conn)
             })
+            .layer(DefaultBodyLimit::disable()),
             .layer(axum::middleware::from_fn({
                 let conn = conn.clone();
                 move |req, next| api_key_check::api_key_check_middleware(req, next, conn.clone())
@@ -151,7 +152,8 @@ fn create_router(
                 let conn = conn.clone();
                 let blob_stores = blob_stores.clone();
                 move |body| read_job::read_job(body, conn, blob_stores)
-            }),
+            })
+            .layer(DefaultBodyLimit::disable()),
         )
         .route(
             "/blob",

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -140,7 +140,7 @@ fn create_router(
                 let conn = conn.clone();
                 move |body| add_job::add_job(body, conn)
             })
-            .layer(DefaultBodyLimit::disable()),
+            .layer(DefaultBodyLimit::disable())
             .layer(axum::middleware::from_fn({
                 let conn = conn.clone();
                 move |req, next| api_key_check::api_key_check_middleware(req, next, conn.clone())

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -192,14 +192,28 @@ def methodToString = match _
 # helper function for building up the curl cmd representing a request
 def makeCurlCmd ((HttpRequest url method headers body formData): HttpRequest) (extraFlags: List String): Result (List String) Error =
     def headerToCurlFlag (HttpHeader name value) = "--header", "{name}:{value}", Nil
-    def bodyToCurlFlag body = "--data", body, Nil
     def formDataToCurlFlag (HttpFormData name file) = "--form", "{name}=@{file}", Nil
+
+    def bodyToCurlFlag body =
+        require True = body.strlen >= 5000
+        else
+            ("--data", body, Nil)
+            | Pass
+
+        require Pass path = writeTempFile "curl.long.body" body
+
+        ("--data", "@{path.getPathName}", Nil)
+        | Pass
 
     require False = body.isSome && formData.isSome
     else failWithError "Request Body and FormData are both set. This is not allowed."
 
+    require Pass bodyFlags = match body
+        Some x -> bodyToCurlFlag x
+        None -> Pass Nil
+
     # Curl does a preflight check before sending the request if it is large. In core use cases
-    # this requres a clunky retry of the request. For now we accpt the tradeoff of wasting time
+    # this requres a clunky retry of the request. For now we accept the tradeoff of wasting time
     # uploading a reject file to not muddy the api. Setting 'Expect' to empty disables the check.
     # See https://everything.curl.dev/http/post/expect100 for more details.
     def heads = (HttpHeader "Expect" ""), headers
@@ -211,7 +225,7 @@ def makeCurlCmd ((HttpRequest url method headers body formData): HttpRequest) (e
         "--url",
         url,
         (heads | mapFlat headerToCurlFlag) ++
-        (body | omap bodyToCurlFlag | optionToList | flatten) ++
+        bodyFlags ++
         (formData | omap (mapFlat formDataToCurlFlag) | optionToList | flatten) ++
         extraFlags
     )

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -290,8 +290,8 @@ export def rscApiGetFileBlob ((CacheSearchBlob _ uri): CacheSearchBlob) (path: S
     # TODO: I should probably mv instead of cp since this will be very space expensive
     def fixupScript =
         """
-        cp %{downloadPath.getPathName} %{path} 
-        chmod %{mode | strOctal} %{path} 
+        cp %{downloadPath.getPathName} '%{path}'
+        chmod %{mode | strOctal} '%{path}'
         """
 
     def job =


### PR DESCRIPTION
Fixes a few small rsc bugs:
- Large JSON body requests would fail to launch from the client due to linux's max character len for a command
- Large requests would fail to be accepted by the server due to max request size limits
- Filenames were not shell escaped and so things like `$` would be incorrectly resolved to shell values