### PR TITLE
rsc: Emit debug information when env set

### DIFF
--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -31,6 +31,8 @@ export tuple RemoteCacheApi =
 
 # A request to the remote server to check if a job is cached
 tuple CacheSearchRequest =
+    # The label for the job. Not part of the key, used only for inspection
+    Label: String
     # The command line of the job
     Cmd: List String
     # The directory of the job
@@ -53,7 +55,7 @@ tuple CacheSearchBlob =
     # The uri where the blob may be downloaded from. Not guaranteed to be http/https
     Uri: String
 
-# A single file backed by a blob that a cached job created
+# A file backed by a blob that a cached job created
 tuple CacheSearchOutputFile =
     # The path on disk of the file
     Path: String
@@ -96,7 +98,7 @@ data CacheSearchResponse =
 
 ## --- POST /job types ---
 
-# A single file uploaded to the server for the owning job
+# A file created by a job and uploaded to the server as a blob
 tuple CachePostRequestOutputFile =
     # The path on disk of the file
     Path: String
@@ -107,6 +109,8 @@ tuple CachePostRequestOutputFile =
 
 # A request to the remote server to cache a job
 tuple CachePostRequest =
+    # The label for the job. Not part of the key, used only for inspection
+    Label: String
     # The command line of the job
     Cmd: List String
     # The directory of the job
@@ -214,6 +218,14 @@ export def rscApiPostJob (req: CachePostRequest) (api: RemoteCacheApi): Result U
         | getCachePostRequestJson
         | formatJSON
 
+    def _ =
+        require True = shouldDebugRemoteCache Unit
+
+        def _ =
+            writeTempFile "remote.cache.api.postJob.req" "label: {req.getCachePostRequestLabel}\nreq: {jsonStr}"
+
+        True
+
     require Pass response =
         makeRoute api "job"
         | buildHttpRequest
@@ -222,6 +234,16 @@ export def rscApiPostJob (req: CachePostRequest) (api: RemoteCacheApi): Result U
         | addAuthorizationHeader auth
         | setBody jsonStr
         | makeRequest
+
+    def _ =
+        require True = shouldDebugRemoteCache Unit
+
+        def _ =
+            writeTempFile
+            "remote.cache.api.postJob.res.{response.getHttpResponseStatusCode | format}"
+            "label: {req.getCachePostRequestLabel}\nres: {response | format}"
+
+        True
 
     require (Some 200) = response.getHttpResponseStatusCode
     else failWithError "rsc: post job failed with code {response.getHttpResponseStatusCode | format}"
@@ -241,6 +263,16 @@ export def rscApiFindMatchingJob (req: CacheSearchRequest) (api: RemoteCacheApi)
         | getCacheSearchRequestJson
         | formatJSON
 
+    def _ =
+        require True = shouldDebugRemoteCache Unit
+
+        def _ =
+            writeTempFile
+            "remote.cache.api.findJob.req"
+            "label: {req.getCacheSearchRequestLabel}\nreq: {jsonStr}"
+
+        True
+
     require Pass response =
         makeRoute api "job/matching"
         | buildHttpRequest
@@ -248,6 +280,16 @@ export def rscApiFindMatchingJob (req: CacheSearchRequest) (api: RemoteCacheApi)
         | addContentTypeJsonHeader
         | setBody jsonStr
         | makeRequest
+
+    def _ =
+        require True = shouldDebugRemoteCache Unit
+
+        def _ =
+            writeTempFile
+            "remote.cache.api.findJob.res.{response.getHttpResponseStatusCode | format}"
+            "label: {req.getCacheSearchRequestLabel}\nres: {response | format}"
+
+        True
 
     require Pass json =
         response.getHttpResponseBody.parseJSONBody
@@ -381,7 +423,7 @@ def uploadBlobRequest (api: RemoteCacheApi) (setBlob: HttpRequest => HttpRequest
 
 # Converts a CacheSearchRequest to JSON
 def getCacheSearchRequestJson (req: CacheSearchRequest): JValue =
-    def (CacheSearchRequest cmd cwd env hiddenInfo isAtty stdin visibleFiles) = req
+    def (CacheSearchRequest _label cmd cwd env hiddenInfo isAtty stdin visibleFiles) = req
 
     JObject (
         "cmd" :-> JArray (cmd.asBytesDelimedByNull | map JInteger),
@@ -397,6 +439,7 @@ def getCacheSearchRequestJson (req: CacheSearchRequest): JValue =
 def getCachePostRequestJson (req: CachePostRequest): JValue =
     def (
         CachePostRequest
+        _label
         cmd
         cwd
         env
@@ -419,7 +462,7 @@ def getCachePostRequestJson (req: CachePostRequest): JValue =
         obytes
     ) = req
 
-    def mkOutputFileJson ((CachePostRequestOutputFile path mode blobId): CachePostRequestOutputFile): JValue =
+    def mkOutputFileJson (CachePostRequestOutputFile path mode blobId) =
         JObject (
             "path" :-> JString path,
             "mode" :-> JInteger mode,

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -52,12 +52,26 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
             # -------------------------------------
 
             # Search the cache for a match
-            require Pass response =
+            def requestTask =
                 rscApi
                 | rscApiFindMatchingJob (mkSearchRequest input hashKey)
+
+            require Pass response = requestTask
             else
-                # Leave a breadcrumb and fallback to the base runner if the cache fails to respond
+                require Fail err = requestTask
+                else unreachable "Result must be either Pass or Fail"
+
+                # Always leave a breadcrumb since this should be a rare error.
                 def _ = breadcrumb "{label}: Failed to search for job in the cache"
+
+                # Leave detailed info if debugging is enabled
+                def _ =
+                    require True = shouldDebugRemoteCache Unit
+
+                    def _ =
+                        writeTempFile "remote.cache.lookup.fail" "label: {input.getRunnerInputLabel}\nerror: {err | format}"
+
+                    True
 
                 # This job isn't getting cached. That's probably preferable since the server
                 # request failed but good to keep in mind.
@@ -69,7 +83,15 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                 require (Match details) = response
                 else unreachable "two-constructor tuple must have one value"
 
-                def _ = breadcrumb "{label}: Found a match in the cache"
+                def _ =
+                    require True = shouldDebugRemoteCache Unit
+
+                    def _ = breadcrumb "{label}: Found a match in the cache"
+
+                    def _ =
+                        writeTempFile "remote.cache.lookup.hit" "label: {input.getRunnerInputLabel}"
+
+                    True
 
                 def (
                     CacheSearchResponseMatch
@@ -122,7 +144,15 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
 
                 Pass (RunnerOutput inputs outputs predict)
 
-            def _ = breadcrumb "{label}: Did not find a match"
+            def _ =
+                require True = shouldDebugRemoteCache Unit
+
+                def _ = breadcrumb "{label}: Did not find a match"
+
+                def _ =
+                    writeTempFile "remote.cache.lookup.miss" "label: {input.getRunnerInputLabel}"
+
+                True
 
             # -------------------------------------
             # --- Insert the job into the cache ---
@@ -143,14 +173,15 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
 ## --- Helper functions ---
 
 # Creates a CacheSearchRequest from the various inputs to a runner
-def mkSearchRequest ((RunnerInput _label cmd vis env dir stdin _res _prefix _usage isAtty): RunnerInput) (hidden: String) =
-    CacheSearchRequest cmd dir env hidden isAtty stdin vis
+def mkSearchRequest ((RunnerInput label cmd vis env dir stdin _res _prefix _usage isAtty): RunnerInput) (hidden: String) =
+    CacheSearchRequest label cmd dir env hidden isAtty stdin vis
 
 # Creates a CachePostJobRequest from the various inputs and outputs of a runner
-def mkPostJobRequest ((RunnerInput _label cmd vis env dir stdin _res _prefix _ isAtty): RunnerInput) (output: RunnerOutput) (hidden: String) (stdoutBlobId: String) (stderrBlobId: String) (files: List CachePostRequestOutputFile) =
+def mkPostJobRequest ((RunnerInput label cmd vis env dir stdin _res _prefix _ isAtty): RunnerInput) (output: RunnerOutput) (hidden: String) (stdoutBlobId: String) (stderrBlobId: String) (files: List CachePostRequestOutputFile) =
     def Usage status runtime cputime mem ibytes obytes = output.getRunnerOutputUsage
 
     CachePostRequest
+    label
     cmd
     dir
     env
@@ -212,3 +243,7 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
     rscApi
     | rscApiPostJob req
 
+# Determines if the user has requested that debug info be emitted from the cache
+target shouldDebugRemoteCache Unit: Boolean = match (getenv "DEBUG_WAKE_REMOTE_CACHE")
+    Some _ -> True
+    None -> False


### PR DESCRIPTION
Setting `DEBUG_WAKE_REMOTE_CACHE` env var now emits debug information to `wake.log` and `<wakeroot>/.build/tmp/writes` to more easily debug and inspect the client side of the cache interactions.