### PR TITLE
rsc: Add support for output directories and symlinks

### DIFF
--- a/rust/entity/src/output_symlink.rs
+++ b/rust/entity/src/output_symlink.rs
@@ -8,8 +8,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
     pub path: String,
-    #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
-    pub content: Vec<u8>,
+    pub link: String,
     pub job_id: Uuid,
     pub created_at: DateTime,
 }

--- a/rust/migration/src/m20220101_000002_create_table.rs
+++ b/rust/migration/src/m20220101_000002_create_table.rs
@@ -150,7 +150,7 @@ impl MigrationTrait for Migration {
                             .default(SimpleExpr::FunctionCall(PgFunc::gen_random_uuid())),
                     )
                     .col(ColumnDef::new(OutputSymlink::Path).string().not_null())
-                    .col(ColumnDef::new(OutputSymlink::Content).ezblob())
+                    .col(ColumnDef::new(OutputSymlink::Link).string().not_null())
                     .col(ColumnDef::new(OutputSymlink::JobId).uuid().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
@@ -237,7 +237,7 @@ enum OutputSymlink {
     Table,
     Id,
     Path,
-    Content,
+    Link,
     JobId,
 }
 

--- a/rust/rsc/src/rsc/add_job.rs
+++ b/rust/rsc/src/rsc/add_job.rs
@@ -83,7 +83,7 @@ pub async fn add_job(
                             id: NotSet,
                             created_at: NotSet,
                             path: Set(out_symlink.path),
-                            content: Set(out_symlink.content),
+                            link: Set(out_symlink.link),
                             job_id: Set(job_id),
                         });
 

--- a/rust/rsc/src/rsc/read_job.rs
+++ b/rust/rsc/src/rsc/read_job.rs
@@ -105,7 +105,7 @@ pub async fn read_job(
                     .into_iter()
                     .map(|m| Symlink {
                         path: m.path,
-                        content: m.content,
+                        link: m.link,
                     })
                     .collect();
 

--- a/rust/rsc/src/rsc/types.rs
+++ b/rust/rsc/src/rsc/types.rs
@@ -24,8 +24,7 @@ pub struct Dir {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Symlink {
     pub path: String,
-    #[serde(with = "serde_bytes")]
-    pub content: Vec<u8>,
+    pub link: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -64,12 +64,26 @@ tuple CacheSearchOutputFile =
     # The description of how to download the files contents
     Blob: CacheSearchBlob
 
+# A directory created by a cached job
+tuple CacheSearchOutputDirectory =
+    # The path on disk of the directory
+    Path: String
+    # The mode on disk of the directory
+    Mode: Integer
+
+# A symlink created by a cached job
+tuple CacheSearchOutputSymlink =
+    # The path on disk of the symlink
+    Path: String
+    # The file being link to
+    Link: String
+
 # A match response from the server. Specifies all details of a cached job
 tuple CacheSearchResponseMatch =
     # The symlinks that were output by the job
-    OutputSymlinks: List String
+    OutputSymlinks: List CacheSearchOutputSymlink
     # The directories that were output by the job
-    OutputDirs: List String
+    OutputDirs: List CacheSearchOutputDirectory
     # The files that were output by the job
     OutputFiles: List CacheSearchOutputFile
     # The stdout of the job
@@ -107,6 +121,20 @@ tuple CachePostRequestOutputFile =
     # The blob id returned by the server from the blob upload
     BlobId: String
 
+# A directory created by a job
+tuple CachePostRequestOutputDirectory =
+    # The path on disk of the directory
+    Path: String
+    # The mode on disk of the directory
+    Mode: Integer
+
+# A symlink created by a job
+tuple CachePostRequestOutputSymlink =
+    # The path on disk of the symlink
+    Path: String
+    # The file being link to
+    Link: String
+
 # A request to the remote server to cache a job
 tuple CachePostRequest =
     # The label for the job. Not part of the key, used only for inspection
@@ -126,9 +154,9 @@ tuple CachePostRequest =
     # The list of files the job is allowed to read in the sandbox
     VisibleFiles: List Path
     # The directories that were output by the job
-    OutputDirs: List Integer
+    OutputDirs: List CachePostRequestOutputDirectory
     # The symlinks that were output by the job
-    OutputSymlinks: List Integer
+    OutputSymlinks: List CachePostRequestOutputSymlink
     # The files that were output by the job
     OutputFiles: List CachePostRequestOutputFile
     # The blob id returned from the server for the stdout of the job
@@ -447,10 +475,8 @@ def getCachePostRequestJson (req: CachePostRequest): JValue =
         isAtty
         stdin
         visibleFiles
-        # TODO: these two are just being ignored right now
-        # That is probably not right
-        _outputDirs
-        _outputSymlinks
+        outputDirs
+        outputSymlinks
         outputFiles
         stdoutBlobId
         stderrBlobId
@@ -469,6 +495,18 @@ def getCachePostRequestJson (req: CachePostRequest): JValue =
             "blob_id" :-> JString blobId,
         )
 
+    def mkOutputDirJson (CachePostRequestOutputDirectory path mode) =
+        JObject (
+            "path" :-> JString path,
+            "mode" :-> JInteger mode,
+        )
+
+    def mkOutputSymlinkJson (CachePostRequestOutputSymlink path link) =
+        JObject (
+            "path" :-> JString path,
+            "link" :-> JString link,
+        )
+
     JObject (
         "cmd" :-> JArray (cmd.asBytesDelimedByNull | map JInteger),
         "cwd" :-> JString cwd,
@@ -477,8 +515,8 @@ def getCachePostRequestJson (req: CachePostRequest): JValue =
         "is_atty" :-> JBoolean isAtty,
         "stdin" :-> JString stdin,
         "visible_files" :-> JArray (visibleFiles | map getPathAsJson),
-        "output_dirs" :-> JArray Nil,
-        "output_symlinks" :-> JArray Nil,
+        "output_dirs" :-> JArray (outputDirs | map mkOutputDirJson),
+        "output_symlinks" :-> JArray (outputSymlinks | map mkOutputSymlinkJson),
         "output_files" :-> JArray (outputFiles | map mkOutputFileJson),
         "stdout_blob_id" :-> JString stdoutBlobId,
         "stderr_blob_id" :-> JString stderrBlobId,
@@ -538,7 +576,39 @@ def mkCacheSearchResponse (json: JValue): Result CacheSearchResponse Error =
     require Pass (JArray outputFiles) = jField json "output_files"
     else failWithError "rsc: JSON response has incorrect schema. Must have array key 'output_files'"
 
-    # TODO: Decode output_dirs and output_symlinks
+    require Pass (JArray outputSymlinks) = jField json "output_symlinks"
+    else failWithError "rsc: JSON response has incorrect schema. Must have array key 'output_symlinks'"
+
+    require Pass (JArray outputDirectories) = jField json "output_dirs"
+    else failWithError "rsc: JSON response has incorrect schema. Must have array key 'output_dirs'"
+
+    def mkOutputSymlink (v: JValue): Result CacheSearchOutputSymlink Error =
+        require Pass (JString path) = jField v "path"
+        else
+            failWithError
+            "rsc: JSON response has incorrect schema. output_symlinks[x] must have string key 'path'"
+
+        require Pass (JString link) = jField v "link"
+        else
+            failWithError
+            "rsc: JSON response has incorrect schema. output_symlinks[x] must have string key 'link'"
+
+        CacheSearchOutputSymlink path link
+        | Pass
+
+    def mkOutputDirectory (v: JValue): Result CacheSearchOutputDirectory Error =
+        require Pass (JString path) = jField v "path"
+        else
+            failWithError
+            "rsc: JSON response has incorrect schema. output_directories[x] must have string key 'path'"
+
+        require Pass (JInteger mode) = jField v "mode"
+        else
+            failWithError
+            "rsc: JSON response has incorrect schema. output_directories[x] must have integer key 'mode'"
+
+        CacheSearchOutputDirectory path mode
+        | Pass
 
     def mkOutputFile (v: JValue): Result CacheSearchOutputFile Error =
         require Pass (JString path) = jField v "path"
@@ -561,15 +631,25 @@ def mkCacheSearchResponse (json: JValue): Result CacheSearchResponse Error =
         CacheSearchOutputFile path mode blob
         | Pass
 
-    require Pass csofs =
+    require Pass csOutputFiles =
         outputFiles
         | map mkOutputFile
         | findFail
 
+    require Pass csOutputSymlinks =
+        outputSymlinks
+        | map mkOutputSymlink
+        | findFail
+
+    require Pass csOutputDirectories =
+        outputDirectories
+        | map mkOutputDirectory
+        | findFail
+
     CacheSearchResponseMatch
-    Nil
-    Nil
-    csofs
+    csOutputSymlinks
+    csOutputDirectories
+    csOutputFiles
     stdoutBlob
     stderrBlob
     status

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -75,7 +75,7 @@ tuple CacheSearchOutputDirectory =
 tuple CacheSearchOutputSymlink =
     # The path on disk of the symlink
     Path: String
-    # The file being link to
+    # The file being linked to
     Link: String
 
 # A match response from the server. Specifies all details of a cached job
@@ -132,7 +132,7 @@ tuple CachePostRequestOutputDirectory =
 tuple CachePostRequestOutputSymlink =
     # The path on disk of the symlink
     Path: String
-    # The file being link to
+    # The file being linked to
     Link: String
 
 # A request to the remote server to cache a job

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -108,15 +108,95 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                     obytes
                 ) = details
 
+                # Start these downloads now since they aren't written to disk
+                def stdoutDownload = rscApiGetStringBlob stdoutBlob
+                def stderrDownload = rscApiGetStringBlob stderrBlob
+
+                # TODO: mode must be used here for this to be fully correct
+                def doMakeDirectory (CacheSearchOutputDirectory path mode) =
+                    require True =
+                        makeExecPlan
+                        (
+                            "mkdir",
+                            "-p",
+                            path,
+                        )
+                        Nil
+                        | setPlanLabel "rsc: mkdir output dir {path}"
+                        | runJobWith localRunner
+                        | isJobOk
+                    else failWithError "rsc: Failed to mkdir output dir: {path}"
+
+                    Pass Unit
+
+                # We need to create directories from shortest to longest, each directory along the
+                # chain may have a different permission set and by creating short dirs first we
+                # ensure they don't incorrectly inheret the permissions of a subdir. This required
+                # ordering significantly decreases parallism, however this is mitigated by the fact
+                # that most outputs are files, not dirs.
+                def dirLoop (dirs: List CacheSearchOutputDirectory) = match dirs
+                    Nil -> Pass Nil
+                    h, t ->
+                        require Pass dir = doMakeDirectory h
+                        require Pass rest = dirLoop t
+
+                        Pass (dir, rest)
+
+                def lenOrder lhs rhs =
+                    def lhsLen = lhs.getCacheSearchOutputDirectoryPath.strlen
+                    def rhsLen = rhs.getCacheSearchOutputDirectoryPath.strlen
+
+                    if lhsLen == rhsLen then
+                        EQ
+                    else if lhsLen < rhsLen then
+                        LT
+                    else
+                        GT
+
+                def orderedDirs =
+                    outputDirs
+                    | sortBy lenOrder
+
+                # We don't actually care about the result here but we need to ensure that all
+                # directories are created before potentially downloading files into them.
+                require Pass _ = dirLoop orderedDirs
+                else failWithError "rsc: Failed to make output directory"
+
                 def doDownload (CacheSearchOutputFile path mode blob) =
                     rscApiGetFileBlob blob "{input.getRunnerInputDirectory}/{path}" mode
 
-                def blobDownloads =
+                # We don't actually care about the result here but we need to ensure that all
+                # downloads have completed and succeeded before we attempt any symlinks/continue.
+                require Pass _ =
                     outputFiles
                     | map doDownload
+                    | findFail
+                    | addErrorContext "rsc: Failed to download a blob"
 
-                def stdoutDownload = rscApiGetStringBlob stdoutBlob
-                def stderrDownload = rscApiGetStringBlob stderrBlob
+                # TODO: These probably need to be wakeroot relative
+                # Link must point to dest. We do the reverse here of what is done for posting a job
+                def doMakeSymlink (CacheSearchOutputSymlink dest link) =
+                    require True =
+                        makeExecPlan
+                        (
+                            "ln",
+                            "-s",
+                            dest,
+                            link,
+                        )
+                        Nil
+                        | setPlanLabel "rsc: symlink {link} to {dest}"
+                        | runJobWith localRunner
+                        | isJobOk
+                    else failWithError "rsc: Failed to link {link} to {dest}"
+
+                    Pass Unit
+
+                require Pass _ =
+                    outputSymlinks
+                    | map doMakeSymlink
+                    | findFail
+                    | addErrorContext "rsc: Failed to create a symlink"
 
                 require Pass stdout =
                     stdoutDownload
@@ -126,18 +206,19 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                     stderrDownload
                     | addErrorContext "rsc: Failed to download stderr for '{label}'"
 
-                # We don't actually care about the result here but we do need to ensure that all
-                # downloads have completed and succeeded before we continue on.
-                require Pass _ =
-                    blobDownloads
-                    | findFail
-                    | addErrorContext "rsc: Failed to download a blob for '{label}'"
-
                 def resolvedOutputs =
                     outputFiles
-                    | map (_.getCacheSearchOutputFilePath)
+                    | map getCacheSearchOutputFilePath
 
-                def outputs = resolvedOutputs ++ outputDirs ++ outputSymlinks
+                def resolvedSymlinks =
+                    outputSymlinks
+                    | map getCacheSearchOutputSymlinkPath
+
+                def resolvedDirectories =
+                    outputDirs
+                    | map getCacheSearchOutputDirectoryPath
+
+                def outputs = resolvedOutputs ++ resolvedDirectories ++ resolvedSymlinks
                 def predict = Usage status runtime cputime mem ibytes obytes
                 def _ = virtual job stdout stderr status runtime cputime mem ibytes obytes
                 def inputs = map getPathName (input.getRunnerInputVisible)
@@ -177,7 +258,7 @@ def mkSearchRequest ((RunnerInput label cmd vis env dir stdin _res _prefix _usag
     CacheSearchRequest label cmd dir env hidden isAtty stdin vis
 
 # Creates a CachePostJobRequest from the various inputs and outputs of a runner
-def mkPostJobRequest ((RunnerInput label cmd vis env dir stdin _res _prefix _ isAtty): RunnerInput) (output: RunnerOutput) (hidden: String) (stdoutBlobId: String) (stderrBlobId: String) (files: List CachePostRequestOutputFile) =
+def mkPostJobRequest ((RunnerInput label cmd vis env dir stdin _res _prefix _ isAtty): RunnerInput) (output: RunnerOutput) (hidden: String) (stdoutBlobId: String) (stderrBlobId: String) (files: List CachePostRequestOutputFile) (directories: List CachePostRequestOutputDirectory) (symlinks: List CachePostRequestOutputSymlink) =
     def Usage status runtime cputime mem ibytes obytes = output.getRunnerOutputUsage
 
     CachePostRequest
@@ -189,8 +270,8 @@ def mkPostJobRequest ((RunnerInput label cmd vis env dir stdin _res _prefix _ is
     isAtty
     stdin
     vis
-    Nil
-    Nil
+    directories
+    symlinks
     files
     stdoutBlobId
     stderrBlobId
@@ -201,27 +282,92 @@ def mkPostJobRequest ((RunnerInput label cmd vis env dir stdin _res _prefix _ is
     ibytes
     obytes
 
+export def thirdBy (acceptFn: a => Integer): (list: List a) => Triple (one: List a) (two: List a) (three: List a) =
+    def loop list = match list
+        Nil -> Triple Nil Nil Nil
+        h, t ->
+            # don't wait on f to process tail:
+            def Triple x y z = loop t
+
+            match (acceptFn h)
+                1 -> Triple (h, x) y z
+                2 -> Triple x (h, y) z
+                3 -> Triple x y (h, z)
+                _ -> Triple x y z
+
+    loop
+
 # Posts a completed job to the remote cache
 def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: String) (input: RunnerInput) (output: RunnerOutput): Result Unit Error =
     require Pass stdout = job.getJobFailedStdoutRaw
     require Pass stderr = job.getJobFailedStderrRaw
 
-    def uploadFileAndCollect path =
+    def allOutputs = output.getRunnerOutputOutputs
+
+    def rmapStat path = match (unsafe_stat path)
+        Fail x -> Fail x
+        Pass x -> Pass (Pair path x)
+
+    require Pass outputsStat =
+        allOutputs
+        | map rmapStat
+        | findFail
+        | addErrorContext "rsc: Failed to stat files to upload"
+
+    def statToGroup (Stat t _ _) = match t
+        PathTypeRegularFile -> 1
+        PathTypeDirectory -> 2
+        PathTypeSymlink -> 3
+        _ -> panic "unsuported filetype for rsc"
+
+    def (Triple regFiles directories symlinks) =
+        outputsStat
+        | thirdBy (\x x.getPairSecond.statToGroup)
+
+    def uploadAndMakeFile (Pair path (Stat _ mode _)) =
         def doUpload =
             rscApi
             | rscApiPostFileBlob path path
 
-        def doStat = unsafe_stat path
-
         require Pass id = doUpload
-        require Pass (Stat _ mode _) = doStat
 
         CachePostRequestOutputFile path (mode | mode2bits) id
         | Pass
 
+    # TODO: readlink may need to be a PRIM for performance reasons
+    # The path output by the job itself is the created symlink. The contents of the symlink
+    # is the original file on disk. This is reversed when downloading a job.
+    def makeSymlink (Pair link _) =
+        require Pass dest =
+            makeExecPlan
+            (
+                "readlink",
+                "-n",
+                link,
+            )
+            Nil
+            | setPlanLabel "rsc: readlink {link}"
+            | runJobWith localRunner
+            | getJobStdout
+
+        # TODO: Pretty sure this needs to be wakeroot relative
+        CachePostRequestOutputSymlink dest link
+        | Pass
+
+    def makeDirectory (Pair path (Stat _ mode _)) =
+        CachePostRequestOutputDirectory path (mode | mode2bits)
+
     def fileUploads =
-        output.getRunnerOutputOutputs
-        | map uploadFileAndCollect
+        regFiles
+        | map uploadAndMakeFile
+
+    def symlinksUpload =
+        symlinks
+        | map makeSymlink
+
+    def directoriesUpload =
+        directories
+        | map makeDirectory
 
     def stdoutUpload =
         rscApi
@@ -237,8 +383,15 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
     require Pass uploads =
         fileUploads
         | findFail
+        | addErrorContext "rsc: Failed to upload file"
 
-    def req = mkPostJobRequest input output hidden stdoutId stderrId uploads
+    require Pass resolvedLinks =
+        symlinksUpload
+        | findFail
+        | addErrorContext "rsc: Failed to resolve symlink"
+
+    def req =
+        mkPostJobRequest input output hidden stdoutId stderrId uploads directoriesUpload resolvedLinks
 
     rscApi
     | rscApiPostJob req

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -112,16 +112,15 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                 def stdoutDownload = rscApiGetStringBlob stdoutBlob
                 def stderrDownload = rscApiGetStringBlob stderrBlob
 
-                # TODO: mode must be used here for this to be fully correct
                 def doMakeDirectory (CacheSearchOutputDirectory path mode) =
+                    # wake-format off
+                    def cmd =
+                        "mkdir",
+                        "-m", "{strOctal mode}",
+                        "-p", path,
+
                     require True =
-                        makeExecPlan
-                        (
-                            "mkdir",
-                            "-p",
-                            path,
-                        )
-                        Nil
+                        makeExecPlan cmd Nil
                         | setPlanLabel "rsc: mkdir output dir {path}"
                         | runJobWith localRunner
                         | isJobOk

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -116,7 +116,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                     # wake-format off
                     def cmd =
                         "mkdir",
-                        "-m", "{strOctal mode}",
+                        "-m", mode.strOctal,
                         "-p", path,
 
                     require True =
@@ -128,7 +128,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
 
                     Pass Unit
 
-                # We need to create directories from shortest to longest, each directory along the
+                # We need to create directories from shallowest to deepest, each directory along the
                 # chain may have a different permission set and by creating short dirs first we
                 # ensure they don't incorrectly inheret the permissions of a subdir. This required
                 # ordering significantly decreases parallism, however this is mitigated by the fact
@@ -281,18 +281,22 @@ def mkPostJobRequest ((RunnerInput label cmd vis env dir stdin _res _prefix _ is
     ibytes
     obytes
 
-export def thirdBy (acceptFn: a => Integer): (list: List a) => Triple (one: List a) (two: List a) (three: List a) =
+data ThirdByGroup =
+    ThirdByGroupFirst
+    ThirdByGroupSecond
+    ThirdByGroupThird
+
+def thirdBy (acceptFn: a => ThirdByGroup): (list: List a) => Triple (one: List a) (two: List a) (three: List a) =
     def loop list = match list
         Nil -> Triple Nil Nil Nil
         h, t ->
-            # don't wait on f to process tail:
+            # don't wait on acceptFn to process tail:
             def Triple x y z = loop t
 
             match (acceptFn h)
-                1 -> Triple (h, x) y z
-                2 -> Triple x (h, y) z
-                3 -> Triple x y (h, z)
-                _ -> Triple x y z
+                ThirdByGroupFirst -> Triple (h, x) y z
+                ThirdByGroupSecond -> Triple x (h, y) z
+                ThirdByGroupThird -> Triple x y (h, z)
 
     loop
 
@@ -314,10 +318,10 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
         | addErrorContext "rsc: Failed to stat files to upload"
 
     def statToGroup (Stat t _ _) = match t
-        PathTypeRegularFile -> 1
-        PathTypeDirectory -> 2
-        PathTypeSymlink -> 3
-        _ -> panic "unsuported filetype for rsc"
+        PathTypeRegularFile -> ThirdByGroupFirst
+        PathTypeDirectory -> ThirdByGroupSecond
+        PathTypeSymlink -> ThirdByGroupThird
+        _ -> panic "rsc: unsuported filetype: {format t}"
 
     def (Triple regFiles directories symlinks) =
         outputsStat


### PR DESCRIPTION
This PR adds support for jobs that output directories or symlinks which is necessary to support much more complex builds than what the wake repo itself tests.

Now when a job creates a symlink, the output pulled back out of the cache will be put back on disk as a symlink. 

This change forces more ordering (and thus less parallelism) as a directory needs to be created before any output files are put into it and a symlink needs be created after all files have been saved to disk in case the symlink references a file output by the job