### PR TITLE
rsc: Implement several bug fixes

### DIFF
--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -333,8 +333,10 @@ fn launch_blob_eviction(
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // setup a subscriber for logging
-    let subscriber = tracing_subscriber::FmtSubscriber::new();
-    tracing::subscriber::set_global_default(subscriber)?;
+    // TODO: The logging is incredibly spammy right now and causes significant slow down.
+    //       for now, logging is disabled but this should be turned back on once logging is pruned.
+    // let subscriber = tracing_subscriber::FmtSubscriber::new();
+    // tracing::subscriber::set_global_default(subscriber)?;
 
     // Parse the arguments
     let args = ServerOptions::parse();

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -162,40 +162,55 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                 else failWithError "rsc: Failed to make output directory"
 
                 def doDownload (CacheSearchOutputFile path mode blob) =
-                    rscApiGetFileBlob blob "{input.getRunnerInputDirectory}/{path}" mode
+                    rscApiGetFileBlob blob path mode
 
-                # We don't actually care about the result here but we need to ensure that all
-                # downloads have completed and succeeded before we attempt any symlinks/continue.
-                require Pass _ =
-                    outputFiles
-                    | map doDownload
-                    | findFail
-                    | addErrorContext "rsc: Failed to download a blob"
-
-                # TODO: These probably need to be wakeroot relative
-                # Link must point to dest. We do the reverse here of what is done for posting a job
-                def doMakeSymlink (CacheSearchOutputSymlink dest link) =
+                # Link must point to path. We do the reverse here of what is done for posting a job
+                def doMakeSymlink (CacheSearchOutputSymlink path link) =
                     require True =
                         makeExecPlan
                         (
                             "ln",
+                            # create symbolic link
                             "-s",
-                            dest,
+                            # overwrite <link> on disk if a file already exists at that path.
+                            # Ideally, we could just fail but its very common to delete wake.db
+                            # without cleaning all the outputs. This causes problems since the link
+                            # would already exist on disk
+                            "-f",
+                            path,
                             link,
                         )
                         Nil
-                        | setPlanLabel "rsc: symlink {link} to {dest}"
+                        | setPlanLabel "rsc: symlink {link} to {path}"
                         | runJobWith localRunner
                         | isJobOk
-                    else failWithError "rsc: Failed to link {link} to {dest}"
+                    else failWithError "rsc: Failed to link {link} to {path}"
 
                     Pass Unit
 
-                require Pass _ =
+                def outputFilesDownload =
+                    outputFiles
+                    | map doDownload
+
+                # Symlinks don't need to wait for files, the symlinks will just momentarily be invalid if created first
+                def outputSymlinksDownload =
                     outputSymlinks
                     | map doMakeSymlink
-                    | findFail
-                    | addErrorContext "rsc: Failed to create a symlink"
+
+                def resolvedOutputs =
+                    outputFiles
+                    | map getCacheSearchOutputFilePath
+
+                def resolvedSymlinks =
+                    outputSymlinks
+                    | map getCacheSearchOutputSymlinkLink
+
+                def resolvedDirectories =
+                    outputDirs
+                    | map getCacheSearchOutputDirectoryPath
+
+                def outputs = resolvedOutputs ++ resolvedDirectories ++ resolvedSymlinks
+                def predict = Usage status runtime cputime mem ibytes obytes
 
                 require Pass stdout =
                     stdoutDownload
@@ -205,22 +220,20 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                     stderrDownload
                     | addErrorContext "rsc: Failed to download stderr for '{label}'"
 
-                def resolvedOutputs =
-                    outputFiles
-                    | map getCacheSearchOutputFilePath
-
-                def resolvedSymlinks =
-                    outputSymlinks
-                    | map getCacheSearchOutputSymlinkPath
-
-                def resolvedDirectories =
-                    outputDirs
-                    | map getCacheSearchOutputDirectoryPath
-
-                def outputs = resolvedOutputs ++ resolvedDirectories ++ resolvedSymlinks
-                def predict = Usage status runtime cputime mem ibytes obytes
                 def _ = virtual job stdout stderr status runtime cputime mem ibytes obytes
                 def inputs = map getPathName (input.getRunnerInputVisible)
+
+                # We don't actually care about the result here but we need to ensure that all
+                # downloads have completed before returning.
+                require Pass _ =
+                    outputFilesDownload
+                    | findFail
+                    | addErrorContext "rsc: Failed to download a blob"
+
+                require Pass _ =
+                    outputSymlinksDownload
+                    | findFail
+                    | addErrorContext "rsc: Failed to create a symlink"
 
                 Pass (RunnerOutput inputs outputs predict)
 
@@ -341,7 +354,7 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
     # The path output by the job itself is the created symlink. The contents of the symlink
     # is the original file on disk. This is reversed when downloading a job.
     def makeSymlink (Pair link _) =
-        require Pass dest =
+        require Pass path =
             makeExecPlan
             (
                 "readlink",
@@ -353,8 +366,7 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
             | runJobWith localRunner
             | getJobStdout
 
-        # TODO: Pretty sure this needs to be wakeroot relative
-        CachePostRequestOutputSymlink dest link
+        CachePostRequestOutputSymlink path link
         | Pass
 
     def makeDirectory (Pair path (Stat _ mode _)) =

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -161,6 +161,8 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                 require Pass _ = dirLoop orderedDirs
                 else failWithError "rsc: Failed to make output directory"
 
+                # The path is downloaded directly, as is, because it is relative to the workspace.
+                # Everything besides Command is stored in the server as workspace relative
                 def doDownload (CacheSearchOutputFile path mode blob) =
                     rscApiGetFileBlob blob path mode
 


### PR DESCRIPTION
The following bugs are fixed in this PR

- Logging is temporarily disabled due to spammy logs creating a 2x slowdown
- Output files were previously being written to the wrong location when the Plan directory was changed
- Symlink content is now entirely defined by the content of the link, not a vague notion of the source path
- Symlinks would fail if a symlink was left on disk from a previous build
- The source path of the symlink was being returned as the output instead of the symlink itself
- Symlinks no longer wait for all files to download as it's not necessary

With these changes larger internal builds will complete successfully 