### PR TITLE
rsc: Chunk insert_many to avoid max param count

### DIFF
--- a/rust/rsc/Cargo.lock
+++ b/rust/rsc/Cargo.lock
@@ -1395,6 +1395,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,6 +2266,7 @@ dependencies = [
  "hyper",
  "inquire",
  "is-terminal",
+ "itertools 0.12.1",
  "migration",
  "papergrid",
  "rand_core",
@@ -2757,7 +2767,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "nom",
  "unicode_categories",
 ]

--- a/rust/rsc/Cargo.toml
+++ b/rust/rsc/Cargo.toml
@@ -38,3 +38,4 @@ serde_json = "1.0.100"
 clap = { version = "4.3.23", features = ["derive"] }
 is-terminal = "0.4.9"
 async-trait = "0.1.74"
+itertools = "0.12.1"

--- a/rust/rsc/src/rsc/add_job.rs
+++ b/rust/rsc/src/rsc/add_job.rs
@@ -9,6 +9,9 @@ use sea_orm::{
 use std::sync::Arc;
 use tracing;
 
+// The actual max is 65536, but adding an arbritrary buffer of 36 for any incidental parameters
+const MAX_SQLX_PARAMS: usize = 65500;
+
 #[tracing::instrument]
 pub async fn add_job(
     Json(payload): Json<AddJobPayload>,
@@ -59,7 +62,7 @@ pub async fn add_job(
                         hash: Set(vis_file.hash),
                         job_id: Set(job_id),
                     })
-                    .chunks(65500 / 5)
+                    .chunks(MAX_SQLX_PARAMS / 5)
                     .into_iter()
                     .map(|chunk| chunk.collect())
                     .collect();
@@ -83,7 +86,7 @@ pub async fn add_job(
                         job_id: Set(job_id),
                         blob_id: Set(out_file.blob_id),
                     })
-                    .chunks(65500 / 6)
+                    .chunks(MAX_SQLX_PARAMS / 6)
                     .into_iter()
                     .map(|chunk| chunk.collect())
                     .collect();
@@ -107,7 +110,7 @@ pub async fn add_job(
                             link: Set(out_symlink.link),
                             job_id: Set(job_id),
                         })
-                        .chunks(65500 / 5)
+                        .chunks(MAX_SQLX_PARAMS / 5)
                         .into_iter()
                         .map(|chunk| chunk.collect())
                         .collect();
@@ -130,7 +133,7 @@ pub async fn add_job(
                         mode: Set(dir.mode),
                         job_id: Set(job_id),
                     })
-                    .chunks(65500 / 5)
+                    .chunks(MAX_SQLX_PARAMS / 5)
                     .into_iter()
                     .map(|chunk| chunk.collect())
                     .collect();

--- a/rust/rsc/src/rsc/add_job.rs
+++ b/rust/rsc/src/rsc/add_job.rs
@@ -2,6 +2,7 @@ use crate::types::AddJobPayload;
 use axum::{http::StatusCode, Json};
 use entity::prelude::{OutputDir, OutputFile, OutputSymlink, VisibleFile};
 use entity::{job, output_dir, output_file, output_symlink, visible_file};
+use itertools::Itertools;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::*, DatabaseConnection, DbErr, EntityTrait, TransactionTrait,
 };
@@ -47,20 +48,32 @@ pub async fn add_job(
                 let job = insert_job.save(txn).await?;
                 let job_id = job.id.unwrap();
 
-                let visible_files = vis.into_iter().map(|vis_file| visible_file::ActiveModel {
-                    id: NotSet,
-                    created_at: NotSet,
-                    path: Set(vis_file.path),
-                    hash: Set(vis_file.hash),
-                    job_id: Set(job_id),
-                });
+                // sqlx only allows 65635 sql parameters per query and each visible file accounts
+                // for 5 parameters so we can only insert 65635/5 visible files per query
+                let chunked_visible_files: Vec<Vec<visible_file::ActiveModel>> = vis
+                    .into_iter()
+                    .map(|vis_file| visible_file::ActiveModel {
+                        id: NotSet,
+                        created_at: NotSet,
+                        path: Set(vis_file.path),
+                        hash: Set(vis_file.hash),
+                        job_id: Set(job_id),
+                    })
+                    .chunks(65635 / 5)
+                    .into_iter()
+                    .map(|chunk| chunk.collect())
+                    .collect();
 
-                VisibleFile::insert_many(visible_files)
-                    .on_empty_do_nothing()
-                    .exec(txn)
-                    .await?;
+                for chunk in chunked_visible_files {
+                    VisibleFile::insert_many(chunk)
+                        .on_empty_do_nothing()
+                        .exec(txn)
+                        .await?;
+                }
 
-                let out_files = output_files
+                // sqlx only allows 65635 sql parameters per query and each output file accounts
+                // for 6 parameters so we can only insert 65635/6 visible files per query
+                let chunked_output_files: Vec<Vec<output_file::ActiveModel>> = output_files
                     .into_iter()
                     .map(|out_file| output_file::ActiveModel {
                         id: NotSet,
@@ -69,14 +82,22 @@ pub async fn add_job(
                         mode: Set(out_file.mode),
                         job_id: Set(job_id),
                         blob_id: Set(out_file.blob_id),
-                    });
+                    })
+                    .chunks(65635 / 6)
+                    .into_iter()
+                    .map(|chunk| chunk.collect())
+                    .collect();
 
-                OutputFile::insert_many(out_files)
-                    .on_empty_do_nothing()
-                    .exec(txn)
-                    .await?;
+                for chunk in chunked_output_files {
+                    OutputFile::insert_many(chunk)
+                        .on_empty_do_nothing()
+                        .exec(txn)
+                        .await?;
+                }
 
-                let out_symlinks =
+                // sqlx only allows 65635 sql parameters per query and each output symlink accounts
+                // for 5 parameters so we can only insert 65635/5 visible files per query
+                let chunked_output_symlinks: Vec<Vec<output_symlink::ActiveModel>> =
                     output_symlinks
                         .into_iter()
                         .map(|out_symlink| output_symlink::ActiveModel {
@@ -85,25 +106,41 @@ pub async fn add_job(
                             path: Set(out_symlink.path),
                             link: Set(out_symlink.link),
                             job_id: Set(job_id),
-                        });
+                        })
+                        .chunks(65635 / 5)
+                        .into_iter()
+                        .map(|chunk| chunk.collect())
+                        .collect();
 
-                OutputSymlink::insert_many(out_symlinks)
-                    .on_empty_do_nothing()
-                    .exec(txn)
-                    .await?;
+                for chunk in chunked_output_symlinks {
+                    OutputSymlink::insert_many(chunk)
+                        .on_empty_do_nothing()
+                        .exec(txn)
+                        .await?;
+                }
 
-                let dirs = output_dirs.into_iter().map(|dir| output_dir::ActiveModel {
-                    id: NotSet,
-                    created_at: NotSet,
-                    path: Set(dir.path),
-                    mode: Set(dir.mode),
-                    job_id: Set(job_id),
-                });
+                // sqlx only allows 65635 sql parameters per query and each output dir accounts
+                // for 5 parameters so we can only insert 65635/5 visible files per query
+                let chunked_output_dirs: Vec<Vec<output_dir::ActiveModel>> = output_dirs
+                    .into_iter()
+                    .map(|dir| output_dir::ActiveModel {
+                        id: NotSet,
+                        created_at: NotSet,
+                        path: Set(dir.path),
+                        mode: Set(dir.mode),
+                        job_id: Set(job_id),
+                    })
+                    .chunks(65635 / 5)
+                    .into_iter()
+                    .map(|chunk| chunk.collect())
+                    .collect();
 
-                OutputDir::insert_many(dirs)
-                    .on_empty_do_nothing()
-                    .exec(txn)
-                    .await?;
+                for chunk in chunked_output_dirs {
+                    OutputDir::insert_many(chunk)
+                        .on_empty_do_nothing()
+                        .exec(txn)
+                        .await?;
+                }
 
                 Ok(())
             })

--- a/rust/rsc/src/rsc/add_job.rs
+++ b/rust/rsc/src/rsc/add_job.rs
@@ -48,8 +48,8 @@ pub async fn add_job(
                 let job = insert_job.save(txn).await?;
                 let job_id = job.id.unwrap();
 
-                // sqlx only allows 65635 sql parameters per query and each visible file accounts
-                // for 5 parameters so we can only insert 65635/5 visible files per query
+                // sqlx only allows 65536 sql parameters per query and each visible file accounts
+                // for 5 parameters so we can only insert 65536/5 visible files per query
                 let chunked_visible_files: Vec<Vec<visible_file::ActiveModel>> = vis
                     .into_iter()
                     .map(|vis_file| visible_file::ActiveModel {
@@ -59,7 +59,7 @@ pub async fn add_job(
                         hash: Set(vis_file.hash),
                         job_id: Set(job_id),
                     })
-                    .chunks(65635 / 5)
+                    .chunks(65500 / 5)
                     .into_iter()
                     .map(|chunk| chunk.collect())
                     .collect();
@@ -71,8 +71,8 @@ pub async fn add_job(
                         .await?;
                 }
 
-                // sqlx only allows 65635 sql parameters per query and each output file accounts
-                // for 6 parameters so we can only insert 65635/6 visible files per query
+                // sqlx only allows 65536 sql parameters per query and each output file accounts
+                // for 6 parameters so we can only insert 65536/6 visible files per query
                 let chunked_output_files: Vec<Vec<output_file::ActiveModel>> = output_files
                     .into_iter()
                     .map(|out_file| output_file::ActiveModel {
@@ -83,7 +83,7 @@ pub async fn add_job(
                         job_id: Set(job_id),
                         blob_id: Set(out_file.blob_id),
                     })
-                    .chunks(65635 / 6)
+                    .chunks(65500 / 6)
                     .into_iter()
                     .map(|chunk| chunk.collect())
                     .collect();
@@ -95,8 +95,8 @@ pub async fn add_job(
                         .await?;
                 }
 
-                // sqlx only allows 65635 sql parameters per query and each output symlink accounts
-                // for 5 parameters so we can only insert 65635/5 visible files per query
+                // sqlx only allows 65536 sql parameters per query and each output symlink accounts
+                // for 5 parameters so we can only insert 65536/5 visible files per query
                 let chunked_output_symlinks: Vec<Vec<output_symlink::ActiveModel>> =
                     output_symlinks
                         .into_iter()
@@ -107,7 +107,7 @@ pub async fn add_job(
                             link: Set(out_symlink.link),
                             job_id: Set(job_id),
                         })
-                        .chunks(65635 / 5)
+                        .chunks(65500 / 5)
                         .into_iter()
                         .map(|chunk| chunk.collect())
                         .collect();
@@ -119,8 +119,8 @@ pub async fn add_job(
                         .await?;
                 }
 
-                // sqlx only allows 65635 sql parameters per query and each output dir accounts
-                // for 5 parameters so we can only insert 65635/5 visible files per query
+                // sqlx only allows 65536 sql parameters per query and each output dir accounts
+                // for 5 parameters so we can only insert 65536/5 visible files per query
                 let chunked_output_dirs: Vec<Vec<output_dir::ActiveModel>> = output_dirs
                     .into_iter()
                     .map(|dir| output_dir::ActiveModel {
@@ -130,7 +130,7 @@ pub async fn add_job(
                         mode: Set(dir.mode),
                         job_id: Set(job_id),
                     })
-                    .chunks(65635 / 5)
+                    .chunks(65500 / 5)
                     .into_iter()
                     .map(|chunk| chunk.collect())
                     .collect();


### PR DESCRIPTION
The version of `sqlx` we depend on has a max of 65536 parameters. When calling `insert_many` each model contributes several parameters (5-6). In cases of very large jobs we need to split the `insert_many` into several queries to stay under the max.