### PR TITLE
rsc: Update the tool to fully bootstrap a fresh db from one command

### DIFF
--- a/rust/rsc/src/common/database.rs
+++ b/rust/rsc/src/common/database.rs
@@ -115,6 +115,38 @@ pub async fn delete_local_blob_store(
 }
 
 // --------------------------------------------------
+// ----------       DbOnly Blob Store       ----------
+// --------------------------------------------------
+// ----------            Create            ----------
+pub async fn create_dbonly_blob_store(db: &DatabaseConnection) -> Result<blob_store::Model, DbErr> {
+    let active_blob_store = blob_store::ActiveModel {
+        id: Set(read_dbonly_blob_store_id()),
+        r#type: Set("DbOnlyBlobStore".to_string()),
+    };
+
+    active_blob_store.insert(db).await
+}
+
+// ----------             Read             ----------
+// This creates a single source of truth for the DbOnly Blob Store id in case it ever needs to
+// change. Unwrap is safe here since the string being parsed is static.
+pub fn read_dbonly_blob_store_id() -> Uuid {
+    Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()
+}
+
+pub async fn read_dbonly_blob_store(
+    db: &DatabaseConnection,
+) -> Result<Option<blob_store::Model>, DbErr> {
+    blob_store::Entity::find_by_id(read_dbonly_blob_store_id())
+        .one(db)
+        .await
+}
+
+// ----------            Update            ----------
+
+// ----------            Delete            ----------
+
+// --------------------------------------------------
 // ----------             Job              ----------
 // --------------------------------------------------
 

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -30,6 +30,8 @@ mod types;
 
 #[path = "../common/config.rs"]
 mod config;
+#[path = "../common/database.rs"]
+mod database;
 
 #[derive(Debug, Parser)]
 struct ServerOptions {
@@ -101,10 +103,18 @@ async fn activate_stores(
     }
 
     // ---    Activate DBOnly Store   ---
-    let dbonly_id = Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap();
+    let dbonly_store = match database::read_dbonly_blob_store(&conn).await {
+        Ok(Some(store)) => store,
+        Ok(None) => {
+            panic!("Database is not configured with a DbOnly store. Please bootstrap the db")
+        }
+        Err(_) => panic!("Failed to load DbOnly store from database. Unable to continue"),
+    };
     active_stores.insert(
-        dbonly_id,
-        Arc::new(blob_store_impls::DbOnlyBlobStore { id: dbonly_id }),
+        dbonly_store.id,
+        Arc::new(blob_store_impls::DbOnlyBlobStore {
+            id: dbonly_store.id,
+        }),
     );
 
     return active_stores;
@@ -128,7 +138,7 @@ fn create_router(
         panic!("UUID for active store not in database");
     };
 
-    let dbonly_uuid = Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap();
+    let dbonly_uuid = database::read_dbonly_blob_store_id();
     let Some(dbonly_store) = blob_stores.get(&dbonly_uuid).clone() else {
         panic!("UUID for db store not in database");
     };

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -417,6 +417,8 @@ mod tests {
     async fn create_test_store(
         db: &DatabaseConnection,
     ) -> Result<Uuid, Box<dyn std::error::Error>> {
+        database::create_dbonly_blob_store(db).await?;
+
         let test_store = blob_store::ActiveModel {
             id: NotSet,
             r#type: Set("TestBlobStore".into()),

--- a/rust/rsc/src/rsc_tool/main.rs
+++ b/rust/rsc/src/rsc_tool/main.rs
@@ -189,7 +189,7 @@ async fn bootstrap_db(db: &DatabaseConnection) -> Result<(), Box<dyn std::error:
     // Create the local blob store
     add_local_blob_store(local_store_root, db).await?;
 
-    // Create "DBOnly blob store"
+    // Create DbOnly blob store
     database::create_dbonly_blob_store(db).await?;
 
     println!("");

--- a/rust/rsc/src/rsc_tool/main.rs
+++ b/rust/rsc/src/rsc_tool/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use inquire::Confirm;
+use inquire::{Confirm, Text};
 use is_terminal::IsTerminal;
 use migration::{DbErr, Migrator, MigratorTrait};
 use sea_orm::{prelude::Uuid, DatabaseConnection};
@@ -14,11 +14,14 @@ mod config;
 mod database;
 
 async fn add_api_key(
-    opts: AddApiKeyOpts,
+    key: Option<String>,
+    desc: String,
     db: &DatabaseConnection,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let key = database::create_api_key(db, opts.key, opts.desc).await?;
-    println!("Created api key: {}", key.id);
+    let key = database::create_api_key(db, key, desc).await?;
+    println!("Created api key:");
+    println!("  Id: {}", key.id);
+    println!("  Key: {}", key.key);
     Ok(())
 }
 
@@ -74,12 +77,13 @@ async fn remove_api_key(
 }
 
 async fn add_local_blob_store(
-    opts: AddLocalBlobStoreOpts,
+    root: String,
     db: &DatabaseConnection,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    tokio::fs::create_dir_all(opts.root.clone()).await?;
-    let store = database::create_local_blob_store(db, opts.root).await?;
-    println!("Created local blob store: {}", store.id);
+    tokio::fs::create_dir_all(root.clone()).await?;
+    let store = database::create_local_blob_store(db, root).await?;
+    println!("Created local blob store:");
+    println!("  Id: {}", store.id);
     Ok(())
 }
 
@@ -166,6 +170,33 @@ async fn remove_all_jobs(db: &DatabaseConnection) -> Result<(), Box<dyn std::err
     Ok(())
 }
 
+async fn bootstrap_db(db: &DatabaseConnection) -> Result<(), Box<dyn std::error::Error>> {
+    // Get all the info from the user
+    let use_dev_key = Confirm::new("Create a test API key? (development only!)")
+        .with_default(false)
+        .prompt()?;
+    let key_desc = Text::new("What is the key used for?").prompt()?;
+    let local_store_root = Text::new("Where should local blobs be saved?").prompt()?;
+
+    // Create the API key
+    let key = if use_dev_key {
+        Some("InsecureKey".into())
+    } else {
+        None
+    };
+    add_api_key(key, key_desc, db).await?;
+
+    // Create the local blob store
+    add_local_blob_store(local_store_root, db).await?;
+
+    // Create "DBOnly blob store"
+    database::create_dbonly_blob_store(db).await?;
+
+    println!("");
+    println!("Done! Use the store id to set the active store and share the key as appropiate.");
+    Ok(())
+}
+
 // Define all of our top level commands
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -185,8 +216,11 @@ struct TopLevel {
     )]
     database_url: Option<String>,
 
-    #[arg(help = "Show's the config and then exits", long)]
+    #[arg(help = "Shows the config and then exits", long)]
     show_config: bool,
+
+    #[arg(help = "Bootstraps the database with minimal configs", long)]
+    bootstrap: bool,
 
     #[command(subcommand)]
     db_command: Option<DBCommand>,
@@ -326,6 +360,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Err(err)?;
     }
 
+    if args.bootstrap {
+        bootstrap_db(&db).await?;
+        return Ok(());
+    }
+
     let Some(db_command) = args.db_command else {
         return Ok(());
     };
@@ -342,10 +381,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Add Commands
         DBCommand::Add(AddOpts {
             db_command: DBModelAdd::ApiKey(args),
-        }) => add_api_key(args, &db).await?,
+        }) => add_api_key(args.key, args.desc, &db).await?,
         DBCommand::Add(AddOpts {
             db_command: DBModelAdd::LocalBlobStore(args),
-        }) => add_local_blob_store(args, &db).await?,
+        }) => add_local_blob_store(args.root, &db).await?,
 
         // Remove Commands
         DBCommand::Remove(RemoveOpts {


### PR DESCRIPTION
`rsc_tool --bootstrap` now completes all tasks needed to bootstrap an empty but migrated postgres database. This includes supporting DbOnly Blob Store which was previously under supported. There is now only one place where the DbOnly Blob Store id is hard coded.