### PR TITLE
rsc: Add route to check for valid api key

### DIFF
--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -325,6 +325,27 @@ export def rscApiFindMatchingJob (req: CacheSearchRequest) (api: RemoteCacheApi)
 
     mkCacheSearchResponse json
 
+# rscApiCheckAuthorization: Checks if the provided authorization key is valid. 
+#
+# ```
+#  api | rscApiCheckAuthorization = Pass Unit
+# ```
+export def rscApiCheckAuthorization (api: RemoteCacheApi): Result Unit Error =
+    require Some auth = api.getRemoteCacheApiAuthorization
+    else failWithError "rsc: Checking authorization requires authorization but none was provided"
+
+    require Pass response =
+        makeRoute api "auth/check"
+        | buildHttpRequest
+        | setMethod HttpMethodPost
+        | addAuthorizationHeader auth
+        | makeRequest
+
+    match response.getHttpResponseStatusCode
+        Some 200 -> Pass Unit
+        Some x -> failWithError "Invalid auth key. Status code: {str x}"
+        None -> failWithError "Invalid auth key. Unable to determine statuc code"
+
 # rscApiGetStringBlob: Downloads a blob and returns the contents as a string 
 #
 # ```

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -199,9 +199,18 @@ export def makeRemoteCacheApi (config: String): Result RemoteCacheApi Error =
     else failWithError "Remote cache config was set with non-integer port. Saw: {portStr}"
 
     def auth = if authStr ==* "" then None else Some authStr
+    def api = RemoteCacheApi domain port auth
 
-    RemoteCacheApi domain port auth
-    | Pass
+    # TODO: check for compatable wake version
+
+    # If auth is not set we are done. Just return the api
+    require Some _ = auth
+    else Pass api
+
+    # Auth was set so it must be validated.
+    api
+    | rscApiCheckAuthorization
+    | rmapPass (\_ Pass api)
 
 # rscApiPostStringBlob: Posts a named string as a blob to the remote server defined by *api*
 #                       then returns the id associated to the blob. Requires authorization.

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -334,7 +334,7 @@ export def rscApiFindMatchingJob (req: CacheSearchRequest) (api: RemoteCacheApi)
 
     mkCacheSearchResponse json
 
-# rscApiCheckAuthorization: Checks if the provided authorization key is valid. 
+# rscApiCheckAuthorization: Checks if the provided authorization key is valid.
 #
 # ```
 #  api | rscApiCheckAuthorization = Pass Unit

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -210,7 +210,7 @@ export def makeRemoteCacheApi (config: String): Result RemoteCacheApi Error =
     # Auth was set so it must be validated.
     api
     | rscApiCheckAuthorization
-    | rmapPass (\_ Pass api)
+    | rmap (\_ api)
 
 # rscApiPostStringBlob: Posts a named string as a blob to the remote server defined by *api*
 #                       then returns the id associated to the blob. Requires authorization.

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -344,7 +344,7 @@ export def rscApiCheckAuthorization (api: RemoteCacheApi): Result Unit Error =
     match response.getHttpResponseStatusCode
         Some 200 -> Pass Unit
         Some x -> failWithError "Invalid auth key. Status code: {str x}"
-        None -> failWithError "Invalid auth key. Unable to determine statuc code"
+        None -> failWithError "Invalid auth key. Unable to determine status code"
 
 # rscApiGetStringBlob: Downloads a blob and returns the contents as a string 
 #


### PR DESCRIPTION
Add the route `POST /auth/check` which returns `200` on valid auth key and `401` on invalid auth key. It will be used as an early warning to actors they they may have incorrectly specified their auth key when connecting to the rsc