### PR TITLE
rsc: Add client-server compatibility check

### DIFF
--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -125,8 +125,8 @@ struct VersionCheck {
 }
 
 async fn check_version(check: axum::extract::Query<VersionCheck>) -> axum::http::StatusCode {
-    println!("{:?}", check.version);
-    if check.version != "sifive/wake/41.1.1" {
+    // During development, declare all version as compatible
+    if !check.version.starts_with("sifive/wake/") {
         return axum::http::StatusCode::FORBIDDEN;
     }
 
@@ -729,6 +729,34 @@ mod tests {
             .unwrap();
 
         assert_eq!(res.status(), StatusCode::OK);
+
+        // Allowed version should should 200
+        let res = router
+            .call(
+                Request::builder()
+                    .uri("/version/check?version=sifive/wake/1.2.3")
+                    .method(http::Method::GET)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Disallowed version should should 403
+        let res = router
+            .call(
+                Request::builder()
+                    .uri("/version/check?version=sifive/foo/1.2.3")
+                    .method(http::Method::GET)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -119,6 +119,20 @@ async fn activate_stores(
     return active_stores;
 }
 
+#[derive(serde::Deserialize)]
+struct VersionCheck {
+    version: String,
+}
+
+async fn check_version(check: axum::extract::Query<VersionCheck>) -> axum::http::StatusCode {
+    println!("{:?}", check.version);
+    if check.version != "sifive/wake/41.1.1" {
+        return axum::http::StatusCode::FORBIDDEN;
+    }
+
+    return axum::http::StatusCode::OK;
+}
+
 fn create_router(
     conn: Arc<DatabaseConnection>,
     config: Arc<config::RSCConfig>,
@@ -195,6 +209,7 @@ fn create_router(
                 move || blob::get_upload_url(config.server_addr.clone())
             }),
         )
+        .route("/version/check", get(check_version))
 }
 
 async fn create_standalone_db() -> Result<DatabaseConnection, sea_orm::DbErr> {

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -201,7 +201,24 @@ export def makeRemoteCacheApi (config: String): Result RemoteCacheApi Error =
     def auth = if authStr ==* "" then None else Some authStr
     def api = RemoteCacheApi domain port auth
 
-    # TODO: check for compatable wake version
+    # When in debug mode, allow server incompatible version.
+    def overrideOnDebugCache check =
+        require Fail err = check
+        else check
+
+        require Some _ = getenv "DEBUG_WAKE_SHARED_CACHE"
+        else check
+
+        printlnLevel
+        logWarning
+        "RSC client is incompatable with server but continuing due to DEBUG enabled. Reason: {format err}"
+        | Pass
+
+    # If the client isn't compatiable with the server then give up on the cache
+    require Pass Unit =
+        api
+        | rscApiCheckClientVersion "sifive/wake/{version}"
+        | overrideOnDebugCache
 
     # If auth is not set we are done. Just return the api
     require Some _ = auth
@@ -333,6 +350,23 @@ export def rscApiFindMatchingJob (req: CacheSearchRequest) (api: RemoteCacheApi)
         | addErrorContext "rsc: http body contains invalid JSON"
 
     mkCacheSearchResponse json
+
+# rscApiCheckClientVersion: Checks if the client version is compatiable with the server. 
+#
+# ```
+#  api | rscApiCheckClientVersion "sifive/wake/1.2.3 = Pass Unit
+# ```
+export def rscApiCheckClientVersion (version: String) (api: RemoteCacheApi): Result Unit Error =
+    require Pass response =
+        makeRoute api "version/check?version={version}"
+        | buildHttpRequest
+        | setMethod HttpMethodGet
+        | makeRequest
+
+    match response.getHttpResponseStatusCode
+        Some 200 -> Pass Unit
+        Some x -> failWithError "Incompatiable client. Status code: {str x}"
+        None -> failWithError "Incompatiable client. Unable to determine status code"
 
 # rscApiCheckAuthorization: Checks if the provided authorization key is valid.
 #


### PR DESCRIPTION
Creates `GET /version/check` which a client can use to see if the server declares compatibility with the it. The server doesn't enforce anything based on the result but a client should expect issues if it continues to interact with the server when incompatible. 