### PR TITLE
rsc: Reenable minified version of trace logging

### DIFF
--- a/rust/rsc/src/rsc/add_job.rs
+++ b/rust/rsc/src/rsc/add_job.rs
@@ -17,7 +17,7 @@ pub async fn add_job(
 ) -> StatusCode {
     // First construct all the job details as an ActiveModel for insert
     let hash = payload.hash();
-    tracing::info!(hash, "Add Request Hash");
+    tracing::info!(hash);
 
     let vis = payload.visible_files;
     let output_files = payload.output_files;

--- a/rust/rsc/src/rsc/add_job.rs
+++ b/rust/rsc/src/rsc/add_job.rs
@@ -10,13 +10,15 @@ use tracing;
 #[path = "../common/database.rs"]
 mod database;
 
-#[tracing::instrument]
+#[tracing::instrument(skip_all)]
 pub async fn add_job(
     Json(payload): Json<AddJobPayload>,
     conn: Arc<DatabaseConnection>,
 ) -> StatusCode {
     // First construct all the job details as an ActiveModel for insert
     let hash = payload.hash();
+    tracing::info!(hash, "Add Request Hash");
+
     let vis = payload.visible_files;
     let output_files = payload.output_files;
     let output_symlinks = payload.output_symlinks;

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -24,13 +24,13 @@ pub trait BlobStore {
 
 pub trait DebugBlobStore: BlobStore + std::fmt::Debug {}
 
-#[tracing::instrument]
+#[tracing::instrument(skip_all)]
 pub async fn get_upload_url(server_addr: String) -> Json<GetUploadUrlResponse> {
     let url = server_addr + "/blob";
     Json(GetUploadUrlResponse { url })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(skip_all)]
 pub async fn create_blob(
     mut multipart: Multipart,
     db: Arc<DatabaseConnection>,

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 use tracing;
 
 use sea_orm::{
-    prelude::Uuid, ActiveModelTrait, ActiveValue::*, ColumnTrait, ConnectionTrait, Database,
-    DatabaseConnection, EntityTrait, QueryFilter,
+    prelude::Uuid, ActiveModelTrait, ActiveValue::*, ColumnTrait, ConnectOptions, ConnectionTrait,
+    Database, DatabaseConnection, EntityTrait, QueryFilter,
 };
 
 use chrono::Utc;
@@ -215,7 +215,9 @@ async fn create_standalone_db() -> Result<DatabaseConnection, sea_orm::DbErr> {
 async fn create_remote_db(
     config: &config::RSCConfig,
 ) -> Result<DatabaseConnection, Box<dyn std::error::Error>> {
-    let connection = Database::connect(&config.database_url).await?;
+    let mut opt = ConnectOptions::new(&config.database_url);
+    opt.sqlx_logging_level(tracing::log::LevelFilter::Debug);
+    let connection = Database::connect(opt).await?;
     let pending_migrations = Migrator::get_pending_migrations(&connection).await?;
     if pending_migrations.len() != 0 {
         let err = Error::new(
@@ -353,10 +355,8 @@ fn launch_blob_eviction(
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // setup a subscriber for logging
-    // TODO: The logging is incredibly spammy right now and causes significant slow down.
-    //       for now, logging is disabled but this should be turned back on once logging is pruned.
-    // let subscriber = tracing_subscriber::FmtSubscriber::new();
-    // tracing::subscriber::set_global_default(subscriber)?;
+    let subscriber = tracing_subscriber::FmtSubscriber::new();
+    tracing::subscriber::set_global_default(subscriber)?;
 
     // Parse the arguments
     let args = ServerOptions::parse();

--- a/rust/rsc/src/rsc/read_job.rs
+++ b/rust/rsc/src/rsc/read_job.rs
@@ -51,7 +51,7 @@ pub async fn read_job(
     blob_stores: HashMap<Uuid, Arc<dyn blob::DebugBlobStore + Sync + Send>>,
 ) -> (StatusCode, Json<ReadJobResponse>) {
     let hash = payload.hash();
-    tracing::info!(hash, "Add Request Hash");
+    tracing::info!(hash);
 
     // TODO: This transaction is quite large with a bunch of "serialized" queries. If read_job
     // becomes a bottleneck it should be rewritten such that joining on promises is delayed for as


### PR DESCRIPTION
Reenables tracing logs for the RSC. It does this by moving (and thus omitting) the spammy `sqx` logs and completely removing the very spammy parameter logs. 

This isn't as useful as the super spammy logs for debugging but its significantly better than the nothing we have right now.

In the long term, I'd like to see about writing the logs to a file, or more interestingly, writing the logs back into the postgres database so we can do structured analysis on them.