### PR TITLE
rsc: Support dbonly small blobs on the client

### DIFF
--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -31,6 +31,8 @@ tuple HttpFormData =
     # in the fullness of time it should be converted to a Path. This library is careful to not
     # claim or otherwise convert it to a Path as it should be done by the caller when possible
     File: String
+    # The optional Content-Type field of the specific form entry. The field is not set when None
+    ContentType: Option String
 
 # The description of a http request to send to a web server.
 tuple HttpRequest =
@@ -104,15 +106,15 @@ export def setBody (body: String): HttpRequest => HttpRequest =
     setHttpRequestBody (Some body)
 
 # Adds a named file to the requests form data.
-export def addFormData (name: String) (value: Path): HttpRequest => HttpRequest =
-    unsafe_addFormData name value.getPathName
+export def addFormData (name: String) (value: Path) (contentType: Option String): HttpRequest => HttpRequest =
+    unsafe_addFormData name value.getPathName contentType
 
 # Adds a named file to the request's form data from an unhashed file.
 #
 # This is a restricted function and should be reserved for advanced use only
-export def unsafe_addFormData (name: String) (value: String): HttpRequest => HttpRequest =
+export def unsafe_addFormData (name: String) (value: String) (contentType: Option String): HttpRequest => HttpRequest =
     def setOrAppend field =
-        def entry = HttpFormData name value
+        def entry = HttpFormData name value contentType
 
         match field
             Some formDatas -> Some (entry, formDatas)
@@ -192,7 +194,10 @@ def methodToString = match _
 # helper function for building up the curl cmd representing a request
 def makeCurlCmd ((HttpRequest url method headers body formData): HttpRequest) (extraFlags: List String): Result (List String) Error =
     def headerToCurlFlag (HttpHeader name value) = "--header", "{name}:{value}", Nil
-    def formDataToCurlFlag (HttpFormData name file) = "--form", "{name}=@{file}", Nil
+
+    def formDataToCurlFlag (HttpFormData name file contentType) = match contentType
+        Some ct -> "--form", "{name}=@{file};type={ct}", Nil
+        None -> "--form", "{name}=@{file}", Nil
 
     def bodyToCurlFlag body =
         require True = body.strlen >= 5000

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -334,7 +334,7 @@ export def rscApiFindMatchingJob (req: CacheSearchRequest) (api: RemoteCacheApi)
 # ```
 export def rscApiGetStringBlob ((CacheSearchBlob _ uri): CacheSearchBlob): Result String Error =
     require scheme, path, Nil = extract `([a-zA-Z][a-zA-Z0-9+.-]*)://(.*)` uri
-    else failWithError "rsc: uri has too many components: '{uri}'"
+    else failWithError "rsc: uri has unexpected format: '{uri}'"
 
     # maps path = "%46%6F%6F" to content = "foo"
     def dbScheme _scheme path =
@@ -342,11 +342,11 @@ export def rscApiGetStringBlob ((CacheSearchBlob _ uri): CacheSearchBlob): Resul
         require True = path.strlen > 0
         else Pass ""
 
-        # If not empty then it must as lease be %00
+        # If not empty then it must as least be %00
         require True = path.strlen > 3
         else failWithError "rsc: Invalid db path: '{path}'"
 
-        require _empty, byteStrs = tokenize `%` path
+        require "", byteStrs = tokenize `%` path
         else failWithError "rsc: Failed to extract bytes from db path: '{path}'"
 
         require Some bytes =

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -343,7 +343,7 @@ export def rscApiGetStringBlob ((CacheSearchBlob _ uri): CacheSearchBlob): Resul
         else Pass ""
 
         # If not empty then it must as least be %00
-        require True = path.strlen > 3
+        require True = path.strlen >= 3
         else failWithError "rsc: Invalid db path: '{path}'"
 
         require "", byteStrs = tokenize `%` path

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -212,7 +212,7 @@ export def makeRemoteCacheApi (config: String): Result RemoteCacheApi Error =
 # ```
 export def rscApiPostStringBlob (name: String) (value: String) (api: RemoteCacheApi): Result String Error =
     def contentType =
-        if value.strlen < 75 then
+        if value.strlen < 95 then
             Some "blob/small"
         else
             None

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -211,13 +211,15 @@ export def makeRemoteCacheApi (config: String): Result RemoteCacheApi Error =
 #  (RemoteCacheApi "foo" 1 None) | rscApiPostStringBlob "foo" "my foo contents" = Fail "authorization required"
 # ```
 export def rscApiPostStringBlob (name: String) (value: String) (api: RemoteCacheApi): Result String Error =
-    # TODO: use "small blob" for this
-    # require False = value ==* ""
-    # else Pass "00000000-0000-0000-0000-000000000000"
+    def contentType =
+        if value.strlen < 75 then
+            Some "blob/small"
+        else
+            None
 
     require Pass temp = writeTempFile name value
 
-    uploadBlobRequest api (addFormData name temp)
+    uploadBlobRequest api (addFormData name temp contentType)
 
 # rscApiPostFileBlob: Posts a named file on disk to the remote server defined by *api*
 #                     then returns the id associated to the blob. Requires authorization.
@@ -229,7 +231,7 @@ export def rscApiPostStringBlob (name: String) (value: String) (api: RemoteCache
 export def rscApiPostFileBlob (name: String) (file: String) (api: RemoteCacheApi): Result String Error =
     # We must use unsafe here since we cannot elevate *file* to a Path without either copying it
     # or triggering the 'job output by multiple files' error.
-    uploadBlobRequest api (unsafe_addFormData name file)
+    uploadBlobRequest api (unsafe_addFormData name file None)
 
 # rscApiPostJob: Posts a job defined by *req* to the remote cache server. Requires authorization.
 #
@@ -331,16 +333,53 @@ export def rscApiFindMatchingJob (req: CacheSearchRequest) (api: RemoteCacheApi)
 #  rscApiGetStringBlob (RemoteCacheBlob "asdf" "https://...") = Pass "foo\nbar\nbat" 
 # ```
 export def rscApiGetStringBlob ((CacheSearchBlob _ uri): CacheSearchBlob): Result String Error =
-    # TODO: use "small blob" for this and also parse the schema out
-    # require False = id ==* "00000000-0000-0000-0000-000000000000"
-    # else Pass  ""
+    require scheme, path, Nil = extract `([a-zA-Z][a-zA-Z0-9+.-]*)://(.*)` uri
+    else failWithError "rsc: uri has too many components: '{uri}'"
 
-    require Pass response =
-        buildHttpRequest uri
-        | setMethod HttpMethodGet
-        | makeRequest
+    # maps path = "%46%6F%6F" to content = "foo"
+    def dbScheme _scheme path =
+        # If path is empty we have the empty string
+        require True = path.strlen > 0
+        else Pass ""
 
-    Pass response.getHttpResponseBody
+        # If not empty then it must as lease be %00
+        require True = path.strlen > 3
+        else failWithError "rsc: Invalid db path: '{path}'"
+
+        require _empty, byteStrs = tokenize `%` path
+        else failWithError "rsc: Failed to extract bytes from db path: '{path}'"
+
+        require Some bytes =
+            byteStrs
+            | map (intbase 16)
+            | findNone
+        else failWithError "rsc: Failed to parse bytes strings into bytes from db path: '{path}'"
+
+        bytes
+        # TODO: this only supports ASCII, not unicode. This needs to be enforced somewhere.
+        | map integerToByte
+        | cat
+        | Pass
+
+    def fileScheme scheme path =
+        require Pass response =
+            buildHttpRequest "{scheme}://{path}"
+            | setMethod HttpMethodGet
+            | makeRequest
+
+        Pass response.getHttpResponseBody
+
+    def unsupportedScheme scheme path =
+        failWithError "rsc: scheme '{scheme}' from uri '{uri}' is not supported"
+
+    def schemeFn = match scheme
+        "db" -> dbScheme
+        "file" -> fileScheme
+        "http" -> fileScheme
+        "https" -> fileScheme
+        _ -> unsupportedScheme
+
+    schemeFn scheme path
 
 # rscApiGetFileBlob: Downloads a blob to *path* with *mode* permisssions and return *path*
 #


### PR DESCRIPTION
This change updates it so that `stdout` and `stderr` are optimized when small. It'll decrease the number of blobs stored externally, and the number of jobs needed to fetch those blobs.

Right now only `stdout`/`stderr` are supported but with careful consideration there is no reason generic blobs can't be supported.

The server still needs a change to dedup duplicate "small blobs" but that is a transparent change to the client that can be done later