### PR TITLE
rsc: Don't cache the cache infra jobs

### DIFF
--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -367,6 +367,7 @@ export def rscApiGetFileBlob ((CacheSearchBlob _ uri): CacheSearchBlob) (path: S
     def job =
         makeShellPlan fixupScript (downloadPath, Nil)
         | setPlanLabel "rsc: fixup blob {path} from {downloadPath.getPathName}"
+        | setPlanPersistence Once
         # We need to copy the file over another jobs output space so:
         #   - We must run with the localRunner
         #   - We must lie and say we output nothing

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -122,6 +122,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                     require True =
                         makeExecPlan cmd Nil
                         | setPlanLabel "rsc: mkdir output dir {path}"
+                        | setPlanPersistence Once
                         | runJobWith localRunner
                         | isJobOk
                     else failWithError "rsc: Failed to mkdir output dir: {path}"
@@ -184,6 +185,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                         )
                         Nil
                         | setPlanLabel "rsc: symlink {link} to {path}"
+                        | setPlanPersistence Once
                         | runJobWith localRunner
                         | isJobOk
                     else failWithError "rsc: Failed to link {link} to {path}"
@@ -365,6 +367,7 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
             )
             Nil
             | setPlanLabel "rsc: readlink {link}"
+            | setPlanPersistence Once
             | runJobWith localRunner
             | getJobStdout
 


### PR DESCRIPTION
Since the `localRunner` job don't report their inputs/outputs to the wake runtime they must rerun once any time the are encountered in a given invocation. Otherwise errors can occur where their outputs are missing and wake doesn't know how to recreate them.

Its not possible to teach wake about the inputs/outputs as that would cause the cached jobs to encounter "file output by multiple jobs" error.

However its totally acceptable for these to rerun since they are only requested from the runner when they aren't already in the local `wake.db`. If a job is in the db then wake won't try to reach out to the cache for it so the jobs don't unnecessarily rerun. 