### PR TITLE
rsc: Don't fail in presence of old hardlink

### DIFF
--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -472,7 +472,7 @@ export def rscApiGetFileBlob ((CacheSearchBlob _ uri): CacheSearchBlob) (path: S
         #    then it needs to be removed so we can complete the atomic mv
         [ '%{path}.rsctmp' -ef '%{path}' ] && rm '%{path}'
         # 5. Atomically move so interruptions don't effect the build.
-        mv -f '%{path}.rsctmp' '%{path}'
+        mv '%{path}.rsctmp' '%{path}'
         """
 
     def job =

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -464,14 +464,16 @@ export def rscApiGetFileBlob ((CacheSearchBlob _ uri): CacheSearchBlob) (path: S
         """
         # 1. No failures are acceptable
         set -e
-        # 2. Hardlink the file to not use 2x disk space
+        # 2. Remove the old rsctmp file if it exists
+        rm -f '%{path}.rsctmp'
+        # 3. Hardlink the file to not use 2x disk space
         cp -l %{downloadPath.getPathName} '%{path}.rsctmp'
-        # 3. Set the permissions as specified
+        # 4. Set the permissions as specified
         chmod %{mode | strOctal} '%{path}.rsctmp'
-        # 4. If the file was previously created with the exact inode by the rsc but not cleaned up
+        # 5. If the file was previously created with the exact inode by the rsc but not cleaned up
         #    then it needs to be removed so we can complete the atomic mv
         [ '%{path}.rsctmp' -ef '%{path}' ] && rm '%{path}'
-        # 5. Atomically move so interruptions don't effect the build.
+        # 6. Atomically move so interruptions don't effect the build.
         mv '%{path}.rsctmp' '%{path}'
         """
 

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -462,11 +462,17 @@ export def rscApiGetFileBlob ((CacheSearchBlob _ uri): CacheSearchBlob) (path: S
 
     def fixupScript =
         """
-        # 1. Hardlink the file to not use 2x disk space
-        # 2. Do all edits to a tmp file then atomically mv so interruptions don't effect the build
+        # 1. No failures are acceptable
+        set -e
+        # 2. Hardlink the file to not use 2x disk space
         cp -l %{downloadPath.getPathName} '%{path}.rsctmp'
+        # 3. Set the permissions as specified
         chmod %{mode | strOctal} '%{path}.rsctmp'
-        mv '%{path}.rsctmp' '%{path}'
+        # 4. If the file was previously created with the exact inode by the rsc but not cleaned up
+        #    then it needs to be removed so we can complete the atomic mv
+        [ '%{path}.rsctmp' -ef '%{path}' ] && rm '%{path}'
+        # 5. Atomically move so interruptions don't effect the build.
+        mv -f '%{path}.rsctmp' '%{path}'
         """
 
     def job =


### PR DESCRIPTION
Certain versions of `mv` will fail when both the `src` and `dst` are hardlinked to the same inode.

Ex:
```
$ echo "foo" > foo.txt
$ ln foo.txt one.txt
$ ln foo.txt two.txt
$ mv two.txt one.txt 
mv: 'two.txt' and 'one.txt' are the same file
```

which can occur if the a build is hydrated from the RSC, then the local db is removed but none of the output files, then the build is again hydrated from the RSC.

`mv` doesn't have a magic `--pls-dont-have-that-behavior` flag and we can't simply skip the `mv` due to atomic permission  requirements so this changes the client to rm the old output file if it is a hardlink to the same inode