### PR TITLE
rsc: Don't panic on invalid RSC

### DIFF
--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -162,11 +162,13 @@ export def defaultRunner: Runner =
         # consistent place across runs.
         mkJobCacheRunner (\_ Pass "") "/workspace" fuseRunner
 
-    def remoteCacheApi = match (makeRemoteCacheApi config)
-        Pass x -> x
-        Fail (Error why _) -> panic why
+    match (makeRemoteCacheApi config)
+        Pass api -> rscRunner api
+        Fail (Error why _) ->
+            def _ =
+                printlnLevel logError "Remote Cache requested, but unavailable. Continuing anyways. Why: '{why}'"
 
-    rscRunner remoteCacheApi
+            fuseRunner
 
 # A plan describing how to construct a JSONRunner
 # RawScript: the path to the script to run jobs with


### PR DESCRIPTION
Previously I just `panic`ed with the RSC config was invalid. At the time this was more reasonable because 1) it was only invalid when the config had a typo and 2) I (incorrectly) assumed it would only apply to the wake bootstrap build. 

With both of those no longer true, the `panic` needs to be replaced with a fallback to the non-cache runner