### PR TITLE
rsc: Page delete-all-jobs query for interruptable progress

### DIFF
--- a/rust/rsc/src/common/database.rs
+++ b/rust/rsc/src/common/database.rs
@@ -219,7 +219,7 @@ pub async fn delete_all_jobs<T: ConnectionTrait>(db: &T, chunk_size: u16) -> Res
         affected += exec.rows_affected();
         tracing::info!(%affected, %total, "Jobs deleted");
 
-        if exec.rows_affected() == 0 {
+        if exec.rows_affected() <= chunk_size.into() {
             break Ok(affected);
         }
     }

--- a/rust/rsc/src/common/database.rs
+++ b/rust/rsc/src/common/database.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use data_encoding::BASE64;
 use entity::prelude::{
-    Blob, BlobStore, LocalBlobStore, OutputDir, OutputFile, OutputSymlink, VisibleFile,
+    Blob, BlobStore, Job, LocalBlobStore, OutputDir, OutputFile, OutputSymlink, VisibleFile,
 };
 use entity::{
     api_key, blob, blob_store, job, local_blob_store, output_dir, output_file, output_symlink,
@@ -9,9 +9,10 @@ use entity::{
 };
 use itertools::Itertools;
 use rand_core::{OsRng, RngCore};
+use sea_orm::ExecResult;
 use sea_orm::{
     prelude::Uuid, ActiveModelTrait, ActiveValue::*, ColumnTrait, ConnectionTrait, DbBackend,
-    DbErr, DeleteResult, EntityTrait, QueryFilter, Statement,
+    DbErr, DeleteResult, EntityTrait, PaginatorTrait, QueryFilter, QuerySelect, Statement,
 };
 use tracing;
 
@@ -190,9 +191,38 @@ pub async fn read_dbonly_blob_store<T: ConnectionTrait>(
 // ----------            Update            ----------
 
 // ----------            Delete            ----------
-pub async fn delete_all_jobs<T: ConnectionTrait>(db: &T) -> Result<DeleteResult, DbErr> {
+pub async fn delete_all_jobs<T: ConnectionTrait>(db: &T, chunk_size: u16) -> Result<u64, DbErr> {
     tracing::info!("Deleting ALL jobs");
-    job::Entity::delete_many().exec(db).await
+
+    if chunk_size == 0 {
+        panic!("Chunk size must be larger than zero");
+    }
+
+    let total = entity::job::Entity::find().count(db).await?;
+    let mut affected = 0;
+
+    loop {
+        let exec: ExecResult = db
+            .execute(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                r#"
+                DELETE FROM job
+                WHERE id IN
+                (
+                    SELECT id FROM job
+                    LIMIT $1
+                )
+                "#,
+                [chunk_size.into()],
+            ))
+            .await?;
+        affected += exec.rows_affected();
+        tracing::info!(%affected, %total, "Jobs deleted");
+
+        if exec.rows_affected() == 0 {
+            break Ok(affected);
+        }
+    }
 }
 
 // --------------------------------------------------


### PR DESCRIPTION
Running `rsc_tool danger-delete-all-jobs` on large databases takes a very long time and can peg the postgres processes at 100% for several hours. This seems to be a common postgres issue when issuing very large deletes.

Being a very rare thing we would do, its fine that the process is slow but we need to be able to interrupt the project if the machine is under heavy load however interrupting the process doesn't actually stop postgres from maxing out the cores.

To avoid this issue, the delete is issued in batches so when it is interrupted only the last (much smaller) batch needs to complete before postgres chills out.

As a bonus, this also gives some level of progress through the delete instead of hanging for a long time