### PR TITLE
rsc: Only check auth/version once per wake invocation

### DIFF
--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -358,7 +358,9 @@ export def rscApiFindMatchingJob (req: CacheSearchRequest) (api: RemoteCacheApi)
 # ```
 #  api | rscApiCheckClientVersion "sifive/wake/1.2.3 = Pass Unit
 # ```
-export def rscApiCheckClientVersion (version: String) (api: RemoteCacheApi): Result Unit Error =
+export target rscApiCheckClientVersion (version: String) (api: RemoteCacheApi): Result Unit Error =
+    def _ = printlnLevel logError "batfoo"
+
     require Pass response =
         makeRoute api "version/check?version={version}"
         | buildHttpRequest
@@ -375,9 +377,11 @@ export def rscApiCheckClientVersion (version: String) (api: RemoteCacheApi): Res
 # ```
 #  api | rscApiCheckAuthorization = Pass Unit
 # ```
-export def rscApiCheckAuthorization (api: RemoteCacheApi): Result Unit Error =
+export target rscApiCheckAuthorization (api: RemoteCacheApi): Result Unit Error =
     require Some auth = api.getRemoteCacheApiAuthorization
     else failWithError "rsc: Checking authorization requires authorization but none was provided"
+
+    def _ = printlnLevel logError "foobat"
 
     require Pass response =
         makeRoute api "auth/check"

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -359,8 +359,6 @@ export def rscApiFindMatchingJob (req: CacheSearchRequest) (api: RemoteCacheApi)
 #  api | rscApiCheckClientVersion "sifive/wake/1.2.3 = Pass Unit
 # ```
 export target rscApiCheckClientVersion (version: String) (api: RemoteCacheApi): Result Unit Error =
-    def _ = printlnLevel logError "batfoo"
-
     require Pass response =
         makeRoute api "version/check?version={version}"
         | buildHttpRequest
@@ -380,8 +378,6 @@ export target rscApiCheckClientVersion (version: String) (api: RemoteCacheApi): 
 export target rscApiCheckAuthorization (api: RemoteCacheApi): Result Unit Error =
     require Some auth = api.getRemoteCacheApiAuthorization
     else failWithError "rsc: Checking authorization requires authorization but none was provided"
-
-    def _ = printlnLevel logError "foobat"
 
     require Pass response =
         makeRoute api "auth/check"


### PR DESCRIPTION
The `auth` and `version` checks were getting triggered far more than expected. This change makes them `target`s so they are only triggered once per wake invocation.