### PR TITLE
rsc: Track job label in rsc db

### DIFF
--- a/rust/entity/src/job.rs
+++ b/rust/entity/src/job.rs
@@ -29,6 +29,7 @@ pub struct Model {
     pub i_bytes: i64,
     pub o_bytes: i64,
     pub created_at: DateTime,
+    pub label: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/rust/migration/src/lib.rs
+++ b/rust/migration/src/lib.rs
@@ -7,6 +7,7 @@ mod m20230707_144317_record_uses;
 mod m20231117_162713_add_created_at;
 mod m20231127_232833_drop_use_time;
 mod m20231128_000751_normalize_uses_table;
+mod m20240509_163905_add_label_to_job;
 
 pub struct Migrator;
 
@@ -21,6 +22,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20231117_162713_add_created_at::Migration),
             Box::new(m20231127_232833_drop_use_time::Migration),
             Box::new(m20231128_000751_normalize_uses_table::Migration),
+            Box::new(m20240509_163905_add_label_to_job::Migration),
         ]
     }
 }

--- a/rust/migration/src/m20240509_163905_add_label_to_job.rs
+++ b/rust/migration/src/m20240509_163905_add_label_to_job.rs
@@ -1,0 +1,35 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Job::Table)
+                    .add_column(ColumnDef::new(Job::Label).string().not_null().default(""))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Job::Table)
+                    .drop_column(Job::Label)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+pub enum Job {
+    Table,
+    Label,
+}

--- a/rust/rsc/src/rsc/add_job.rs
+++ b/rust/rsc/src/rsc/add_job.rs
@@ -41,6 +41,7 @@ pub async fn add_job(
         memory: Set(payload.memory as i64),
         i_bytes: Set(payload.ibytes as i64),
         o_bytes: Set(payload.obytes as i64),
+        label: Set(payload.label.unwrap_or("".to_string())),
     };
 
     // Now perform the insert as a single transaction

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -785,6 +785,7 @@ mod tests {
             memory: Set(1000),
             i_bytes: Set(100000),
             o_bytes: Set(1000),
+            label: Set("".to_string()),
         };
 
         insert_job.save(conn.clone().as_ref()).await.unwrap();
@@ -808,6 +809,7 @@ mod tests {
             memory: Set(1000),
             i_bytes: Set(100000),
             o_bytes: Set(1000),
+            label: Set("".to_string()),
         };
 
         insert_job.save(conn.clone().as_ref()).await.unwrap();

--- a/rust/rsc/src/rsc/types.rs
+++ b/rust/rsc/src/rsc/types.rs
@@ -55,7 +55,7 @@ pub struct AddJobPayload {
     pub obytes: u64,
 
     // Label is not part of the job key and is not considered in any caching decisions. It is
-    // strictly use for inspecting the remote cache's database. Left as optional for soft migration
+    // strictly used for inspecting the remote cache's database. Left as optional for soft migration
     // purposes. May become required in the future
     pub label: Option<String>,
 }

--- a/rust/rsc/src/rsc/types.rs
+++ b/rust/rsc/src/rsc/types.rs
@@ -53,6 +53,11 @@ pub struct AddJobPayload {
     pub memory: u64,
     pub ibytes: u64,
     pub obytes: u64,
+
+    // Label is not part of the job key and is not considered in any caching decisions. It is
+    // strictly use for inspecting the remote cache's database. Left as optional for soft migration
+    // purposes. May become required in the future
+    pub label: Option<String>,
 }
 
 impl AddJobPayload {

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -581,7 +581,7 @@ def getCacheSearchRequestJson (req: CacheSearchRequest): JValue =
 def getCachePostRequestJson (req: CachePostRequest): JValue =
     def (
         CachePostRequest
-        _label
+        label
         cmd
         cwd
         env
@@ -640,6 +640,7 @@ def getCachePostRequestJson (req: CachePostRequest): JValue =
         "memory" :-> JInteger memory,
         "ibytes" :-> JInteger ibytes,
         "obytes" :-> JInteger obytes,
+        "label" :-> JString label,
     )
 
 # Makes a CacheSearchResponse from json if possible


### PR DESCRIPTION
A job's label isn't relevant to a job's cachability so it was not previously tracked. However, since things like cmd/env are obscured in the db (due to storage format) it is very difficult to examine a specific job. Adding the label makes it easier to inspect the db so this change adds it as an option field when uploading a job.