### PR TITLE
rsc: Join chunked futures into single await

### DIFF
--- a/rust/rsc/src/common/database.rs
+++ b/rust/rsc/src/common/database.rs
@@ -7,7 +7,6 @@ use entity::{
     api_key, blob, blob_store, job, local_blob_store, output_dir, output_file, output_symlink,
     visible_file,
 };
-use futures::future::join_all;
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use itertools::Itertools;
@@ -16,7 +15,7 @@ use sea_orm::ExecResult;
 use sea_orm::{
     prelude::Uuid, ActiveModelTrait, ActiveValue::*, ColumnTrait, ConnectionTrait, DbBackend,
     DbErr, DeleteResult, EntityTrait, InsertResult, PaginatorTrait, QueryFilter, QueryOrder,
-    QuerySelect, Statement,
+    Statement,
 };
 use tracing;
 


### PR DESCRIPTION
Joining all the futures before awaiting them gives a small but noticeable performance improvement without much cost to code readability.
 
Going to move forward with this change and keep a close eye on it. This is something worth deeper profiling later but for now still provides a net win.