### PR TITLE
rsc: Allow blob stores to dedup blobs

### DIFF
--- a/rust/migration/src/m20220101_000001_create_blob_tables.rs
+++ b/rust/migration/src/m20220101_000001_create_blob_tables.rs
@@ -51,6 +51,18 @@ impl MigrationTrait for Migration {
             .await?;
 
         manager
+            .create_index(
+                Index::create()
+                    .name("idx-key-store_id-unq")
+                    .table(Blob::Table)
+                    .col(Blob::Key)
+                    .col(Blob::StoreId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
             .create_table(
                 Table::create()
                     .table(LocalBlobStore::Table)

--- a/rust/rsc/.config.json
+++ b/rust/rsc/.config.json
@@ -2,5 +2,5 @@
   "database_url": "postgres://localhost:5433/test",
   "server_addr": "0.0.0.0:3002",
   "standalone": false,
-  "active_store": "940f57d5-fcbc-41eb-977c-ae150faa7d3f"
+  "active_store": "5fbe75c0-b7e1-4d33-86a4-c142e1a54513"
 }

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -1,3 +1,4 @@
+use crate::database;
 use crate::types::{GetUploadUrlResponse, PostBlobResponse, PostBlobResponsePart};
 use async_trait::async_trait;
 use axum::{extract::Multipart, http::StatusCode, Json};
@@ -81,7 +82,7 @@ pub async fn create_blob(
             store_id: Set(store.id()),
         };
 
-        match active_blob.insert(db.as_ref()).await {
+        match database::upsert_blob(db.as_ref(), active_blob).await {
             Err(msg) => {
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -90,7 +91,7 @@ pub async fn create_blob(
                     }),
                 )
             }
-            Ok(blob) => parts.push(PostBlobResponsePart { id: blob.id, name }),
+            Ok(id) => parts.push(PostBlobResponsePart { id, name }),
         }
     }
 


### PR DESCRIPTION
The dbonly blob store was creating hundreds of rows for the empty string blob. In solving this a more general implementation arose.

A blob store is now allowed to de-duplicate a blob by returning a previously return key. The database will automatically flatten that into one entry in the db (and update the TTL for blob eviction)

The uniqueness requirement is set for store id+key pair so two different stores are allowed to return the same key without issues