### PR TITLE
rsc: Track blob size in database

### DIFF
--- a/rust/entity/src/blob.rs
+++ b/rust/entity/src/blob.rs
@@ -9,6 +9,7 @@ pub struct Model {
     pub id: Uuid,
     pub key: String,
     pub store_id: Uuid,
+    pub size: i64,
     pub created_at: DateTime,
 }
 

--- a/rust/migration/src/m20220101_000001_create_blob_tables.rs
+++ b/rust/migration/src/m20220101_000001_create_blob_tables.rs
@@ -35,6 +35,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(ColumnDef::new(Blob::Key).string().not_null())
                     .col(ColumnDef::new(Blob::StoreId).uuid().not_null())
+                    .col(ColumnDef::new(Blob::Size).big_integer().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
                             .name("fk-store_id-blob_store")
@@ -121,6 +122,7 @@ enum Blob {
     Id,
     Key,
     StoreId,
+    Size,
 }
 
 #[derive(DeriveIden)]

--- a/rust/migration/src/m20220101_000001_create_blob_tables.rs
+++ b/rust/migration/src/m20220101_000001_create_blob_tables.rs
@@ -51,6 +51,18 @@ impl MigrationTrait for Migration {
             .await?;
 
         manager
+            .create_index(
+                Index::create()
+                    .name("idx-key-store_id-unq")
+                    .table(Blob::Table)
+                    .col(Blob::Key)
+                    .col(Blob::StoreId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
             .create_table(
                 Table::create()
                     .table(LocalBlobStore::Table)

--- a/rust/rsc/.config.json
+++ b/rust/rsc/.config.json
@@ -2,5 +2,5 @@
   "database_url": "postgres://localhost:5433/test",
   "server_addr": "0.0.0.0:3002",
   "standalone": false,
-  "active_store": "940f57d5-fcbc-41eb-977c-ae150faa7d3f"
+  "active_store": "5fbe75c0-b7e1-4d33-86a4-c142e1a54513"
 }

--- a/rust/rsc/.config.json
+++ b/rust/rsc/.config.json
@@ -2,5 +2,5 @@
   "database_url": "postgres://localhost:5433/test",
   "server_addr": "0.0.0.0:3002",
   "standalone": false,
-  "active_store": "5fbe75c0-b7e1-4d33-86a4-c142e1a54513"
+  "active_store": "1918d654-b381-49dd-a50e-e8625a672575"
 }

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -1,3 +1,4 @@
+use crate::database;
 use crate::types::{GetUploadUrlResponse, PostBlobResponse, PostBlobResponsePart};
 use async_trait::async_trait;
 use axum::{extract::Multipart, http::StatusCode, Json};
@@ -81,7 +82,7 @@ pub async fn create_blob(
             store_id: Set(store.id()),
         };
 
-        match active_blob.insert(db.as_ref()).await {
+        match database::upsert_blob(db.as_ref(), active_blob).await {
             Err(msg) => {
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -90,7 +91,7 @@ pub async fn create_blob(
                     }),
                 )
             }
-            Ok(blob) => parts.push(PostBlobResponsePart { id: blob.id, name }),
+            Ok(id) => parts.push(PostBlobResponsePart { id, name }),
         }
     }
 

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -17,7 +17,7 @@ pub trait BlobStore {
     async fn stream<'a>(
         &self,
         stream: BoxStream<'a, Result<Bytes, std::io::Error>>,
-    ) -> Result<String, std::io::Error>;
+    ) -> Result<(String, i64), std::io::Error>;
 
     async fn download_url(&self, key: String) -> String;
     async fn delete_key(&self, key: String) -> Result<(), std::io::Error>;
@@ -75,10 +75,13 @@ pub async fn create_blob(
             );
         }
 
+        let (blob_key, blob_size) = result.unwrap();
+
         let active_blob = blob::ActiveModel {
             id: NotSet,
             created_at: NotSet,
-            key: Set(result.unwrap()),
+            key: Set(blob_key),
+            size: Set(blob_size),
             store_id: Set(store.id()),
         };
 

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -493,6 +493,7 @@ mod tests {
             id: NotSet,
             created_at: Set((Utc::now() - Duration::days(5)).naive_utc()),
             key: Set("InsecureKey".into()),
+            size: Set(11),
             store_id: Set(store_id),
         };
 


### PR DESCRIPTION
Blob size will be needed eventually for more complex eviction algorithms and is useful now for analyzing usage stats of given jobs.

This change adds sizes to blobs and requires the BlobStore to report the size used for an uploaded blob. 