### PR TITLE
rsc: Add updated_at to blob

### DIFF
--- a/rust/entity/src/blob.rs
+++ b/rust/entity/src/blob.rs
@@ -11,6 +11,7 @@ pub struct Model {
     pub store_id: Uuid,
     pub size: i64,
     pub created_at: DateTime,
+    pub updated_at: DateTime,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/rust/migration/src/lib.rs
+++ b/rust/migration/src/lib.rs
@@ -8,6 +8,7 @@ mod m20231117_162713_add_created_at;
 mod m20231127_232833_drop_use_time;
 mod m20231128_000751_normalize_uses_table;
 mod m20240509_163905_add_label_to_job;
+mod m20240517_195757_add_updated_at_to_blob;
 
 pub struct Migrator;
 
@@ -23,6 +24,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20231127_232833_drop_use_time::Migration),
             Box::new(m20231128_000751_normalize_uses_table::Migration),
             Box::new(m20240509_163905_add_label_to_job::Migration),
+            Box::new(m20240517_195757_add_updated_at_to_blob::Migration),
         ]
     }
 }

--- a/rust/migration/src/m20240517_195757_add_updated_at_to_blob.rs
+++ b/rust/migration/src/m20240517_195757_add_updated_at_to_blob.rs
@@ -1,0 +1,40 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Blob::Table)
+                    .add_column(
+                        ColumnDef::new(Blob::UpdatedAt)
+                            .timestamp()
+                            .not_null()
+                            .default(SimpleExpr::Keyword(Keyword::CurrentTimestamp)),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Blob::Table)
+                    .drop_column(Blob::UpdatedAt)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Blob {
+    Table,
+    UpdatedAt,
+}

--- a/rust/rsc/.config.json
+++ b/rust/rsc/.config.json
@@ -2,5 +2,5 @@
   "database_url": "postgres://localhost:5433/test",
   "server_addr": "0.0.0.0:3002",
   "standalone": false,
-  "active_store": "1918d654-b381-49dd-a50e-e8625a672575"
+  "active_store": "7b725898-3f53-4711-8a82-e95bb9dc6a55"
 }

--- a/rust/rsc/src/common/database.rs
+++ b/rust/rsc/src/common/database.rs
@@ -390,7 +390,7 @@ pub async fn upsert_blob<T: ConnectionTrait>(
     let result = blob::Entity::insert(blob)
         .on_conflict(
             OnConflict::columns(vec![blob::Column::Key, blob::Column::StoreId])
-                .update_column(blob::Column::CreatedAt)
+                .update_column(blob::Column::UpdatedAt)
                 .to_owned(),
         )
         .exec(db)
@@ -421,7 +421,7 @@ pub async fn read_unreferenced_blobs<T: ConnectionTrait>(
             DbBackend::Postgres,
             r#"
             SELECT * FROM blob
-            WHERE created_at <= $1
+            WHERE updated_at <= $1
             AND id IN
             (
                 SELECT id FROM blob

--- a/rust/rsc/src/rsc/blob.rs
+++ b/rust/rsc/src/rsc/blob.rs
@@ -80,6 +80,7 @@ pub async fn create_blob(
         let active_blob = blob::ActiveModel {
             id: NotSet,
             created_at: NotSet,
+            updated_at: NotSet,
             key: Set(blob_key),
             size: Set(blob_size),
             store_id: Set(store.id()),

--- a/rust/rsc/src/rsc/main.rs
+++ b/rust/rsc/src/rsc/main.rs
@@ -492,6 +492,7 @@ mod tests {
         let active_key = entity::blob::ActiveModel {
             id: NotSet,
             created_at: Set((Utc::now() - Duration::days(5)).naive_utc()),
+            updated_at: Set((Utc::now() - Duration::days(5)).naive_utc()),
             key: Set("InsecureKey".into()),
             size: Set(11),
             store_id: Set(store_id),


### PR DESCRIPTION
Adds an `update_at` column to Blob to track when updated. Blob eviction TTL now uses updated_at instead of created_at