### PR TITLE
db: Use tags instead of magic to hide internal jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ all:		wake.db
 	$(WAKE_ENV) BOOTSTRAP_WAKE=true ./bin/wake build default
 
 clean:
-	rm -f .build/* bin/* lib/wake/* */*.o */*/*.o src/json/jlexer.cpp src/parser/lexer.cpp src/parser/parser.cpp src/parser/parser.h src/version.h wake.db
+	rm -rf .build/* bin/* lib/wake/* */*.o */*/*.o src/json/jlexer.cpp src/parser/lexer.cpp src/parser/parser.cpp src/parser/parser.h src/version.h wake.db
 	touch bin/stamp lib/wake/stamp
 
 wake.db:	bin/wake bin/wakebox lib/wake/fuse-waked lib/wake/shim-wake lib/wake/wake-hash

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -261,6 +261,7 @@ export def makeRequest (request: HttpRequest): Result HttpResponse Error =
         | runJobWith localRunner
         | setJobTag "http.method" "{method | methodToString}"
         | setJobTag "http.url" url
+        | setJobInspectVisibilityHidden
         | getJobStdout
 
     parseCurlResponse stdout
@@ -312,6 +313,7 @@ export def makeBinaryRequest (request: HttpRequest): Result Path Error =
         | runJobWith localRunner
         | setJobTag "http.method" methodStr
         | setJobTag "http.url" url
+        | setJobInspectVisibilityHidden
 
     require True = job.isJobOk
     else failWithError "Failed attempting to write binary file to {destination}"

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -179,6 +179,7 @@ target writeImp inputs mode path content =
     | setPlanOnce False
     | setPlanEnvironment Nil
     | runJobWith writeRunner
+    | setJobInspectVisibilityHidden
     | getJobOutput
 
 # Create all directories and the named file. The `content` string is written verbatim with no
@@ -277,6 +278,7 @@ def mkdirImp inputs mode path =
     | setPlanKeep False
     | setPlanEnvironment Nil
     | runJobWith mkdirRunner
+    | setJobInspectVisibilityHidden
     | getJobOutput
 
 # Create a directory in the parent

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -156,6 +156,11 @@ export def setJobTag (key: String) (value: String) (job: Job): Job =
 
     job
 
+# Set a special tag to tell db inspection that this job shouldn't be shown by default
+export def setJobInspectVisibilityHidden (job: Job): Job =
+    job
+    | setJobTag "inspect.visibility" "hidden"
+
 def toUsage (Pair (Pair status runtime) (Pair (Pair cputime membytes) (Pair ibytes obytes))) =
     Usage status runtime cputime membytes ibytes obytes
 

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -211,7 +211,10 @@ def computeHashes (prefix: String) (files: List String): List String =
             | Pass
     else mergeSelect which_files_to_hash (map (add _ "BadHash") to_hash) not_to_hash
 
-    def job = runJobWith localRunner plan
+    def job =
+        plan
+        | runJobWith localRunner
+        | setJobTag "inspect.visibility" "hidden"
 
     require Exited 0 = getJobStatus job
     else mergeSelect which_files_to_hash (map (add _ "BadHash") to_hash) not_to_hash
@@ -261,6 +264,7 @@ target hashcode (f: String): String =
             hashPlan ("<hash>", f, Nil)
             | setPlanLabel "hash: {f}"
             | runJobWith localRunner
+            | setJobTag "inspect.visibility" "hidden"
 
         def hash =
             job.getJobStdout
@@ -281,6 +285,7 @@ export target markFileCleanable (filepath: String): Result Unit Error =
         | setPlanLabel "hash: {filepath}"
         | setPlanFnOutputs (\_ filepath, Nil)
         | runJobWith localRunner
+        | setJobTag "inspect.visibility" "hidden"
 
     if job.isJobOk then
         Pass Unit

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -214,7 +214,7 @@ def computeHashes (prefix: String) (files: List String): List String =
     def job =
         plan
         | runJobWith localRunner
-        | setJobTag "inspect.visibility" "hidden"
+        | setJobInspectVisibilityHidden
 
     require Exited 0 = getJobStatus job
     else mergeSelect which_files_to_hash (map (add _ "BadHash") to_hash) not_to_hash
@@ -264,7 +264,7 @@ target hashcode (f: String): String =
             hashPlan ("<hash>", f, Nil)
             | setPlanLabel "hash: {f}"
             | runJobWith localRunner
-            | setJobTag "inspect.visibility" "hidden"
+            | setJobInspectVisibilityHidden
 
         def hash =
             job.getJobStdout
@@ -285,7 +285,7 @@ export target markFileCleanable (filepath: String): Result Unit Error =
         | setPlanLabel "hash: {filepath}"
         | setPlanFnOutputs (\_ filepath, Nil)
         | runJobWith localRunner
-        | setJobTag "inspect.visibility" "hidden"
+        | setJobInspectVisibilityHidden
 
     if job.isJobOk then
         Pass Unit

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -487,6 +487,7 @@ export def rscApiGetFileBlob ((CacheSearchBlob _ uri): CacheSearchBlob) (path: S
         #   - The *path* must be listed as another jobs output to be available to the system 
         | setPlanFnOutputs (\_ Nil)
         | runJobWith localRunner
+        | setJobInspectVisibilityHidden
 
     require True = job.isJobOk
     else failWithError "Failed to cleanup downloaded file {path} from {downloadPath.getPathName}"

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -124,6 +124,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                         | setPlanLabel "rsc: mkdir output dir {path}"
                         | setPlanPersistence Once
                         | runJobWith localRunner
+                        | setJobInspectVisibilityHidden
                         | isJobOk
                     else failWithError "rsc: Failed to mkdir output dir: {path}"
 
@@ -187,6 +188,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
                         | setPlanLabel "rsc: symlink {link} to {path}"
                         | setPlanPersistence Once
                         | runJobWith localRunner
+                        | setJobInspectVisibilityHidden
                         | isJobOk
                     else failWithError "rsc: Failed to link {link} to {path}"
 
@@ -369,6 +371,7 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
             | setPlanLabel "rsc: readlink {link}"
             | setPlanPersistence Once
             | runJobWith localRunner
+            | setJobInspectVisibilityHidden
             | getJobStdout
 
         CachePostRequestOutputSymlink path link

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -52,6 +52,7 @@ def raw_source file =
         | setPlanEnvironment Nil
         | setPlanFnOutputs (file, _)
         | runJobWith virtualRunner
+        | setJobInspectVisibilityHidden
         | getJobOutput
 
 export def source (file: String): Result Path Error =
@@ -104,6 +105,7 @@ export def claim (file: String): Result Path Error =
             | setPlanEnvironment Nil
             | setPlanFnOutputs (file, _)
             | runJobWith virtualRunner
+            | setJobInspectVisibilityHidden
             | getJobOutput
 
     # Compute the relative path in simplest form

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -157,8 +157,7 @@ void make_and_group(const std::vector<std::vector<std::string>> &query, const st
 }
 
 void hide_internal_jobs(std::vector<std::vector<std::string>> &out) {
-  out.push_back({"substr(cast(commandline as text),1,1) <> '<'"});
-  out.push_back({"label <> '<hash>'"});
+  out.push_back({"tags NOT LIKE '%<d>inspect.visibility=hidden<d>%'", "tags IS NULL"});
 }
 
 void inspect_database(const CommandLineOptions &clo, Database &db, const std::string &wake_cwd) {


### PR DESCRIPTION
Manually and directly tag jobs as hidden then filter those jobs out from inspection instead of relying on magic character in the jobs commandline/label