### PR TITLE
rsc: Use a singular env var to debug shared caches

### DIFF
--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -206,7 +206,7 @@ export def makeRemoteCacheApi (config: String): Result RemoteCacheApi Error =
         require Fail err = check
         else check
 
-        require Some _ = getenv "DEBUG_WAKE_SHARED_CACHE"
+        require True = shouldDebugRemoteCache Unit
         else check
 
         printlnLevel

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -417,6 +417,14 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
     | rscApiPostJob req
 
 # Determines if the user has requested that debug info be emitted from the cache
-target shouldDebugRemoteCache Unit: Boolean = match (getenv "DEBUG_WAKE_REMOTE_CACHE")
-    Some _ -> True
-    None -> False
+target shouldDebugRemoteCache Unit: Boolean =
+    match (Pair (getenv "DEBUG_WAKE_REMOTE_CACHE") (getenv "DEBUG_WAKE_SHARED_CACHE"))
+        Pair None None -> False
+        Pair (Some _) None ->
+            def _ =
+                printlnLevel
+                logWarning
+                "DEBUG_WAKE_REMOTE_CACHE is depreciated. Use DEBUG_WAKE_SHARED_CACHE instead"
+
+            True
+        _ -> True


### PR DESCRIPTION
I unnecessarily introduced a new env var for debugging the remote cache. This complicated things without actually having an real value. This change makes the old env var the standard and warns when the new one is being used.