### PR TITLE
db: Fix mem overflow during inspection

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1408,17 +1408,17 @@ std::vector<JobReflection> Database::matching(
   //
   // The subtable is constructed by joining the jobs table with the minimal set of other dependent
   // tables with the following extra processing excluding input_files and output_files which are
-  // too expensive to inlude.
+  // too expensive to include.
   // 1. tags are flattened from two columns (uri, content) to one column (tags) with a = separator
   // 2. tags are group_concat'd into a single row per job. <d> is
-  //    used as a deliminator between each value. The deliminator is also places at the beginning
+  //    used as a deliminator between each value. The deliminator is also placed at the beginning
   //    and end of each row so that queries don't need to special case the first/last entry.
   //
   // Any inspection flag/user code may add any WHERE expression conditions to the main query using
   // the columns of the subtable for fine grain filters.
   //
-  // For example, the query below will return all jobs that exited with status code 0 and output at
-  // least one .o file.
+  // For example, the query below will return all jobs that exited with status code 0 and were
+  // tagged with key = foo, value = var
   //   SELECT job_id FROM **SUBTABLE**
   //   WHERE status = 0 AND tags like '%<d>foo=bar<d>%'
   std::string core_table = R"delim(        (

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1417,7 +1417,7 @@ std::vector<JobReflection> Database::matching(
   // Any inspection flag/user code may add any WHERE expression conditions to the main query using
   // the columns of the subtable for fine grain filters.
   //
-  // For example, the query below will return all jobs that exited with status code 0 and were
+  // For example, the query below will return all jobs that exited with status code 0 and where
   // tagged with key = foo, value = var
   //   SELECT job_id FROM **SUBTABLE**
   //   WHERE status = 0 AND tags like '%<d>foo=bar<d>%'

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1339,7 +1339,7 @@ std::string collapse_or(const std::vector<std::string> &ors) {
   return out;
 }
 
-std::string collapse_and(const std::vector<std::vector<std::string>> &ands) {
+std::string collapse_and(const std::vector<std::vector<std::string>> &ands, int nest) {
   if (ands.empty()) {
     return "";
   }
@@ -1350,8 +1350,14 @@ std::string collapse_and(const std::vector<std::vector<std::string>> &ands) {
 
   std::string out = "";
 
+  std::string indent = "";
+  for (int i = 0; i < nest; i++) {
+    indent += "    ";
+  }
+  std::string query_indent = indent + "    ";
+
   for (std::vector<std::vector<std::string>>::size_type i = 0; i < ands.size() - 1; i++) {
-    out += collapse_or(ands[i]) + "\nAND\n\t";
+    out += collapse_or(ands[i]) + "\n" + indent + "AND\n" + query_indent;
   }
 
   out += collapse_or(ands.back());
@@ -1360,21 +1366,51 @@ std::string collapse_and(const std::vector<std::vector<std::string>> &ands) {
 }
 
 std::vector<JobReflection> Database::matching(
-    const std::vector<std::vector<std::string>> &and_or_filters) {
+    const std::vector<std::vector<std::string>> &core_filters,
+    std::vector<std::vector<std::string>> input_file_filters,
+    std::vector<std::vector<std::string>> output_file_filters) {
+  std::string input_file_join = "";
+  if (!input_file_filters.empty()) {
+    input_file_filters.push_back({"access = 1"});
+    std::string conds = collapse_and(input_file_filters, 3);
+    input_file_join =
+        "        INNER JOIN (\n"
+        "            SELECT filetree.job_id FROM filetree\n"
+        "            INNER JOIN files\n"
+        "            ON filetree.file_id=files.file_id\n"
+        "            WHERE\n"
+        "                " +
+        conds + "\n" + "        ) ft_input ON core.job_id = ft_input.job_id\n";
+  }
+
+  std::string output_file_join = "";
+  if (!output_file_filters.empty()) {
+    output_file_filters.push_back({"access = 2"});
+    std::string conds = collapse_and(output_file_filters, 3);
+    output_file_join =
+        "        INNER JOIN (\n"
+        "            SELECT filetree.job_id FROM filetree\n"
+        "            INNER JOIN files\n"
+        "            ON filetree.file_id=files.file_id\n"
+        "            WHERE\n"
+        "                " +
+        conds + "\n" + "        ) ft_output ON core.job_id = ft_output.job_id\n";
+  }
+
   // This query creates a subtable of the following shape:
   //
   // clang-format off
-  // | job_id | label | run_id | use_id | endtime | commandline | status | runtime |       input_files   |   output_files  |       tags       |
-  // --------------------------------------------------------------------------------------------------------------------------------
-  // |    1   |  foo  |   1    |    1   |  1234   | ls lah .    |   0    |   2.8   | <d>a.txt<d>b.txt<d> | <d>c.o<d>d.o<d> | <d>a=b<d>c=d<d>  |
-  // |    2   |  bar  |   1    |    1   |  0000   | cat f.txt   |   0    |   0.0   |       null          |      null       |      null        |
+  // | job_id | label | run_id | use_id | endtime | commandline | status | runtime |       tags       |
+  // --------------------------------------------------------------------------------------------------
+  // |    1   |  foo  |   1    |    1   |  1234   | ls lah .    |   0    |   2.8   | <d>a=b<d>c=d<d>  |
+  // |    2   |  bar  |   1    |    1   |  0000   | cat f.txt   |   0    |   0.0   |      null        |
   // clang-format on
   //
   // The subtable is constructed by joining the jobs table with the minimal set of other dependent
-  // tables with the following extra processing.
-  // 1. files table is split into 2 columns, input_files & output_files
-  // 2. tags are flattened from two columns (uri, content) to one column (tags) with a = separator
-  // 3. input_files, output_files, and tags are group_concat'd into a single row per job. <d> is
+  // tables with the following extra processing excluding input_files and output_files which are
+  // too expensive to inlude.
+  // 1. tags are flattened from two columns (uri, content) to one column (tags) with a = separator
+  // 2. tags are group_concat'd into a single row per job. <d> is
   //    used as a deliminator between each value. The deliminator is also places at the beginning
   //    and end of each row so that queries don't need to special case the first/last entry.
   //
@@ -1384,50 +1420,48 @@ std::vector<JobReflection> Database::matching(
   // For example, the query below will return all jobs that exited with status code 0 and output at
   // least one .o file.
   //   SELECT job_id FROM **SUBTABLE**
-  //   WHERE status = 0 AND output_files like '%<d>%.o<d>%'
-  std::string subtable = R"delim(
-          SELECT 
-              j.job_id, 
-              j.label, 
-              j.run_id, 
-              j.use_id, 
-              j.endtime, 
-              j.commandline, 
-              s.status, 
-              s.runtime,
-              '<d>' || group_concat(ft_input.path, '<d>') || '<d>' input_files, 
-              '<d>' || group_concat(ft_output.path,'<d>') || '<d>' output_files, 
-              '<d>' || group_concat(t.tag, '<d>') || '<d>' tags
-          FROM jobs j
-          LEFT JOIN (
-              SELECT stat_id, status, runtime FROM stats
-          ) s
-          ON j.stat_id=s.stat_id
-          LEFT JOIN (
-              SELECT job_id, uri || '=' || content tag FROM tags
-          ) t
-          ON j.job_id = t.job_id
-          LEFT JOIN (
-              SELECT filetree.job_id, files.path FROM filetree
-              INNER JOIN files
-              ON filetree.file_id=files.file_id
-              WHERE access = 1
-          ) ft_input
-          ON j.job_id=ft_input.job_id
-          LEFT JOIN (
-              SELECT filetree.job_id, files.path FROM filetree
-              INNER JOIN files
-              ON filetree.file_id=files.file_id
-              WHERE access = 2
-          ) ft_output
-          ON j.job_id=ft_output.job_id
-          GROUP BY
-              j.job_id
+  //   WHERE status = 0 AND tags like '%<d>foo=bar<d>%'
+  std::string core_table = R"delim(        (
+            SELECT
+                j.job_id,
+                j.label,
+                j.run_id,
+                j.use_id,
+                j.endtime,
+                j.commandline,
+                s.status,
+                s.runtime,
+                '<d>' || group_concat(t.tag, '<d>') || '<d>' tags
+            FROM jobs j
+            LEFT JOIN (
+                SELECT stat_id, status, runtime FROM stats
+            ) s
+            ON j.stat_id=s.stat_id
+            LEFT JOIN (
+                SELECT job_id, uri || '=' || content tag FROM tags
+            ) t
+            ON j.job_id = t.job_id
+            GROUP BY
+                j.job_id
+        ) core
 )delim";
 
+  std::string subtable = core_table + input_file_join + output_file_join;
+
   // This query wraps the subtable, applies the requested filters, and returns the matching jobs
-  std::string id_query = "SELECT job_id\nFROM (\n" + subtable + ")\nWHERE\n\t";
-  id_query += collapse_and(and_or_filters);
+  std::string id_query =
+      "    SELECT core.job_id\n"
+      "    FROM\n"
+      "    (\n" +
+      subtable + "    )";
+
+  if (!core_filters.empty()) {
+    id_query +=
+        "\n"
+        "    WHERE\n"
+        "        " +
+        collapse_and(core_filters, 1);
+  }
 
   // Adapts the id_query to match the columns needed to create a JobReflection
   std::string query =
@@ -1441,7 +1475,7 @@ std::vector<JobReflection> Database::matching(
       "ON j.run_id=r.run_id\n"
       "WHERE j.job_id IN (\n" +
       id_query +
-      ")"
+      "\n)\n"
       "ORDER BY j.job_id";
 
   sqlite3_stmt *stmt;

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -158,7 +158,9 @@ struct Database {
 
   std::string get_hash(const std::string &file, long modified);
 
-  // Outer is a set of filters to be AND'd together, inner is a set of queries to be OR'd together
+  // In core_filters, the outer vec is a set of filters to be AND'd together, inner vec is a set of
+  // queries to be OR'd together. This holds for input_file_filters and output_file_filters as well
+  // but is less useful as its retricted to the column 'path' in the files table.
   std::vector<JobReflection> matching(const std::vector<std::vector<std::string>> &core_filters,
                                       std::vector<std::vector<std::string>> input_file_filters,
                                       std::vector<std::vector<std::string>> output_file_filters);

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -160,7 +160,7 @@ struct Database {
 
   // In core_filters, the outer vec is a set of filters to be AND'd together, inner vec is a set of
   // queries to be OR'd together. This holds for input_file_filters and output_file_filters as well
-  // but is less useful as its retricted to the column 'path' in the files table.
+  // but is less useful as its restricted to the column 'path' in the files table.
   std::vector<JobReflection> matching(const std::vector<std::vector<std::string>> &core_filters,
                                       std::vector<std::vector<std::string>> input_file_filters,
                                       std::vector<std::vector<std::string>> output_file_filters);

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -159,7 +159,9 @@ struct Database {
   std::string get_hash(const std::string &file, long modified);
 
   // Outer is a set of filters to be AND'd together, inner is a set of queries to be OR'd together
-  std::vector<JobReflection> matching(const std::vector<std::vector<std::string>> &and_or_filters);
+  std::vector<JobReflection> matching(const std::vector<std::vector<std::string>> &core_filters,
+                                      std::vector<std::vector<std::string>> input_file_filters,
+                                      std::vector<std::vector<std::string>> output_file_filters);
 
   std::vector<JobEdge> get_edges();
   std::vector<JobTag> get_tags();

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -407,10 +407,18 @@ int main(int argc, char **argv) {
     clo.argv[1] = clo.shebang;
   }
 
-  bool is_db_inspection =
-      !clo.job_ids.empty() || !clo.output_files.empty() || !clo.input_files.empty() ||
-      !clo.labels.empty() || !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
-      clo.tagdag || clo.timeline || clo.taguri || clo.simple || clo.simple_timeline || clo.canceled;
+  bool is_db_inspect_capture = !clo.job_ids.empty() || !clo.output_files.empty() ||
+                               !clo.input_files.empty() || !clo.labels.empty() ||
+                               !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
+                               clo.tagdag || clo.canceled;
+
+  // DescribePolicy::human() is the default and doesn't have a flag.
+  // DescribePolicy::debug() is overloaded and can't be marked as a db flag
+  // DescribePolicy::verbose() is overloaded and can't be marked as a db flag
+  bool is_db_inspect_render =
+      clo.taguri || clo.script || clo.metadata || clo.timeline || clo.simple || clo.simple_timeline;
+
+  bool is_db_inspection = is_db_inspect_capture || is_db_inspect_render;
 
   // Arguments are forbidden with these options
   bool noargs =

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -170,6 +170,8 @@ void inspect_database(const CommandLineOptions &clo, Database &db, const std::st
   }
 
   std::vector<std::vector<std::string>> collect_ands = {};
+  std::vector<std::vector<std::string>> collect_input_ands = {};
+  std::vector<std::vector<std::string>> collect_output_ands = {};
 
   // Process --job
   make_and_group(clo.job_ids, "cast(job_id as TEXT)", "", collect_ands);
@@ -178,10 +180,10 @@ void inspect_database(const CommandLineOptions &clo, Database &db, const std::st
   make_and_group(clo.labels, "label", "", collect_ands);
 
   // --input
-  make_and_group(clo.input_files, "input_files", "<d>", collect_ands);
+  make_and_group(clo.input_files, "path", "", collect_input_ands);
 
   // --output
-  make_and_group(clo.output_files, "output_files", "<d>", collect_ands);
+  make_and_group(clo.output_files, "path", "", collect_output_ands);
 
   // --tag
   make_and_group(clo.tags, "tags", "<d>", collect_ands);
@@ -208,13 +210,7 @@ void inspect_database(const CommandLineOptions &clo, Database &db, const std::st
     collect_ands.push_back({"endtime = 0"});
   }
 
-  // Convert the collected parts into a meaningful query
-  if (collect_ands.empty()) {
-    std::cerr << "No filters were applied" << std::endl;
-    exit(1);
-  }
-
-  auto matching_jobs = db.matching(collect_ands);
+  auto matching_jobs = db.matching(collect_ands, collect_input_ands, collect_output_ands);
 
   if (matching_jobs.empty()) {
     std::cerr << "No jobs matched query" << std::endl;


### PR DESCRIPTION
It was discovered that really long input/output file lists will overflow sqlite3's max column memory after releasing the previous version of wake.

The input/output file part of the query have been moved into a seperate join in order to maintain the nicety of a single generated sql query per inspection. This is _nearly_ identical to the previous inspection query and all previous commands still work as expected however input/output files are now special cased an non-orthogonal. This means any future inspection command has to consider them specifically and also when`--sql` is implemented queries involving input/output files may not be specified in the sql

<details>
  <summary>Examples of the Generated SQL</summary>

```
wake --last
SELECT j.job_id, j.label, j.directory, j.commandline, j.environment, j.stack, j.stdin, j.starttime, j.endtime, j.stale, r.time, r.cmdline, s.status, s.runtime, s.cputime, s.membytes, s.ibytes, s.obytes
FROM jobs j
LEFT JOIN stats s
ON j.stat_id=s.stat_id
LEFT JOIN runs r
ON j.run_id=r.run_id
WHERE j.job_id IN (
    SELECT core.job_id
    FROM
    (
        (
            SELECT
                j.job_id,
                j.label,
                j.run_id,
                j.use_id,
                j.endtime,
                j.commandline,
                s.status,
                s.runtime,
                '<d>' || group_concat(t.tag, '<d>') || '<d>' tags
            FROM jobs j
            LEFT JOIN (
                SELECT stat_id, status, runtime FROM stats
            ) s
            ON j.stat_id=s.stat_id
            LEFT JOIN (
                SELECT job_id, uri || '=' || content tag FROM tags
            ) t
            ON j.job_id = t.job_id
            GROUP BY
                j.job_id
        ) core
    )
    WHERE
        use_id == (select max(run_id) from jobs)
    AND
        (tags NOT LIKE '%<d>inspect.visibility=hidden<d>%' OR tags IS NULL)
)
ORDER BY j.job_id
```

```
wake --last --input '*.c'
SELECT j.job_id, j.label, j.directory, j.commandline, j.environment, j.stack, j.stdin, j.starttime, j.endtime, j.stale, r.time, r.cmdline, s.status, s.runtime, s.cputime, s.membytes, s.ibytes, s.obytes
FROM jobs j
LEFT JOIN stats s
ON j.stat_id=s.stat_id
LEFT JOIN runs r
ON j.run_id=r.run_id
WHERE j.job_id IN (
    SELECT core.job_id
    FROM
    (
        (
            SELECT
                j.job_id,
                j.label,
                j.run_id,
                j.use_id,
                j.endtime,
                j.commandline,
                s.status,
                s.runtime,
                '<d>' || group_concat(t.tag, '<d>') || '<d>' tags
            FROM jobs j
            LEFT JOIN (
                SELECT stat_id, status, runtime FROM stats
            ) s
            ON j.stat_id=s.stat_id
            LEFT JOIN (
                SELECT job_id, uri || '=' || content tag FROM tags
            ) t
            ON j.job_id = t.job_id
            GROUP BY
                j.job_id
        ) core
        INNER JOIN (
            SELECT filetree.job_id FROM filetree
            INNER JOIN files
            ON filetree.file_id=files.file_id
            WHERE
                path like '%.c'
            AND
                access = 1
        ) ft_input ON core.job_id = ft_input.job_id
    )
    WHERE
        use_id == (select max(run_id) from jobs)
    AND
        (tags NOT LIKE '%<d>inspect.visibility=hidden<d>%' OR tags IS NULL)
)
ORDER BY j.job_id
```

```
wake --last --output '*.c'
SELECT j.job_id, j.label, j.directory, j.commandline, j.environment, j.stack, j.stdin, j.starttime, j.endtime, j.stale, r.time, r.cmdline, s.status, s.runtime, s.cputime, s.membytes, s.ibytes, s.obytes
FROM jobs j
LEFT JOIN stats s
ON j.stat_id=s.stat_id
LEFT JOIN runs r
ON j.run_id=r.run_id
WHERE j.job_id IN (
    SELECT core.job_id
    FROM
    (
        (
            SELECT
                j.job_id,
                j.label,
                j.run_id,
                j.use_id,
                j.endtime,
                j.commandline,
                s.status,
                s.runtime,
                '<d>' || group_concat(t.tag, '<d>') || '<d>' tags
            FROM jobs j
            LEFT JOIN (
                SELECT stat_id, status, runtime FROM stats
            ) s
            ON j.stat_id=s.stat_id
            LEFT JOIN (
                SELECT job_id, uri || '=' || content tag FROM tags
            ) t
            ON j.job_id = t.job_id
            GROUP BY
                j.job_id
        ) core
        INNER JOIN (
            SELECT filetree.job_id FROM filetree
            INNER JOIN files
            ON filetree.file_id=files.file_id
            WHERE
                path like '%.c'
            AND
                access = 2
        ) ft_output ON core.job_id = ft_output.job_id
    )
    WHERE
        use_id == (select max(run_id) from jobs)
    AND
        (tags NOT LIKE '%<d>inspect.visibility=hidden<d>%' OR tags IS NULL)
)
ORDER BY j.job_id
```

```
wake --last --input '*.c, *.o' --input '*w*,*a*' --output '*.o' --output '*.json'
SELECT j.job_id, j.label, j.directory, j.commandline, j.environment, j.stack, j.stdin, j.starttime, j.endtime, j.stale, r.time, r.cmdline, s.status, s.runtime, s.cputime, s.membytes, s.ibytes, s.obytes
FROM jobs j
LEFT JOIN stats s
ON j.stat_id=s.stat_id
LEFT JOIN runs r
ON j.run_id=r.run_id
WHERE j.job_id IN (
    SELECT core.job_id
    FROM
    (
        (
            SELECT
                j.job_id,
                j.label,
                j.run_id,
                j.use_id,
                j.endtime,
                j.commandline,
                s.status,
                s.runtime,
                '<d>' || group_concat(t.tag, '<d>') || '<d>' tags
            FROM jobs j
            LEFT JOIN (
                SELECT stat_id, status, runtime FROM stats
            ) s
            ON j.stat_id=s.stat_id
            LEFT JOIN (
                SELECT job_id, uri || '=' || content tag FROM tags
            ) t
            ON j.job_id = t.job_id
            GROUP BY
                j.job_id
        ) core
        INNER JOIN (
            SELECT filetree.job_id FROM filetree
            INNER JOIN files
            ON filetree.file_id=files.file_id
            WHERE
                (path like '%.c' OR path like ' %.o')
            AND
                (path like '%w%' OR path like '%a%')
            AND
                access = 1
        ) ft_input ON core.job_id = ft_input.job_id
        INNER JOIN (
            SELECT filetree.job_id FROM filetree
            INNER JOIN files
            ON filetree.file_id=files.file_id
            WHERE
                path like '%.o'
            AND
                path like '%.json'
            AND
                access = 2
        ) ft_output ON core.job_id = ft_output.job_id
    )
    WHERE
        use_id == (select max(run_id) from jobs)
    AND
        (tags NOT LIKE '%<d>inspect.visibility=hidden<d>%' OR tags IS NULL)
)
ORDER BY j.job_id
```

```
wake --input '*.c'
SELECT j.job_id, j.label, j.directory, j.commandline, j.environment, j.stack, j.stdin, j.starttime, j.endtime, j.stale, r.time, r.cmdline, s.status, s.runtime, s.cputime, s.membytes, s.ibytes, s.obytes
FROM jobs j
LEFT JOIN stats s
ON j.stat_id=s.stat_id
LEFT JOIN runs r
ON j.run_id=r.run_id
WHERE j.job_id IN (
    SELECT core.job_id
    FROM
    (
        (
            SELECT
                j.job_id,
                j.label,
                j.run_id,
                j.use_id,
                j.endtime,
                j.commandline,
                s.status,
                s.runtime,
                '<d>' || group_concat(t.tag, '<d>') || '<d>' tags
            FROM jobs j
            LEFT JOIN (
                SELECT stat_id, status, runtime FROM stats
            ) s
            ON j.stat_id=s.stat_id
            LEFT JOIN (
                SELECT job_id, uri || '=' || content tag FROM tags
            ) t
            ON j.job_id = t.job_id
            GROUP BY
                j.job_id
        ) core
        INNER JOIN (
            SELECT filetree.job_id FROM filetree
            INNER JOIN files
            ON filetree.file_id=files.file_id
            WHERE
                path like '%.c'
            AND
                access = 1
        ) ft_input ON core.job_id = ft_input.job_id
    )
)
ORDER BY j.job_id
```
</details>