### PR TITLE
highlight: Add missing regex syntax in emacs

### DIFF
--- a/share/doc/wake/syntax/emacs/wake-mode.el
+++ b/share/doc/wake/syntax/emacs/wake-mode.el
@@ -171,6 +171,7 @@ repeated key presses."
     (modify-syntax-entry ?\' "|" table)
     (modify-syntax-entry ?\{ "|" table)
     (modify-syntax-entry ?\} "|" table)
+    (modify-syntax-entry ?` "\"`" table)
     table))
 
 ;;;###autoload


### PR DESCRIPTION
Fix a bug in syntax highlighting for regular expressions.  These are put in backticks.  However, this was not specified in the syntax table. Therefore, any quote in a regex would kick syntax highlighting into "string mode" and likely mess up highlighting in the rest of the file.