### PR TITLE
rsc: Move client code to dedicated package

### DIFF
--- a/rust/rsc/.config.json
+++ b/rust/rsc/.config.json
@@ -2,5 +2,5 @@
   "database_url": "postgres://localhost:5433/test",
   "server_addr": "0.0.0.0:3002",
   "standalone": false,
-  "active_store": "7b725898-3f53-4711-8a82-e95bb9dc6a55"
+  "active_store": "bfa63b02-d41f-4eff-b0e3-f42bafb33a3d"
 }

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: change this to package remote_cache and deal with all the churn
-package wake
+package remote_cache
 
 from http import _
+from wake import _
 
 # RSC Policy on engaging with the cache. Can be configured to only push to the cache, only pull from
 # the cache, or both. Pushing requires an authorization key.
@@ -543,6 +543,16 @@ export def rscApiGetFileBlob ((CacheSearchBlob _ uri): CacheSearchBlob) (path: S
     Pass path
 
 ## --- Helper functions ---
+# TODO: Delete these once new json API is added to wake repo
+def jField (jvalue: JValue) (key: String) =
+    require JObject obj = jvalue
+    else failWithError "not an object"
+
+    require Some (Pair (Pair _ value) _) = find (_.getPairFirst ==~ key) obj
+    else failWithError "key '{key}' not found"
+
+    Pass value
+
 
 # strToBytes "foo" = (13, 14, 15, Nil)
 def strToBytes (str: String): List Integer =
@@ -561,10 +571,10 @@ def asBytesDelimedByNull (parts: List String): List Integer =
     | listFlattenWithNull
 
 # getPathAsJson (Path "foo" "asdf") = (JObject ...)
-def getPathAsJson (Path path hash) =
+def getPathAsJson path =
     JObject (
-        "path" :-> JString path,
-        "hash" :-> JString hash,
+        "path" :-> JString path.getPathName,
+        "hash" :-> JString path.getPathHash,
     )
 
 # Helper function for building the route for the resource

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -553,7 +553,6 @@ def jField (jvalue: JValue) (key: String) =
 
     Pass value
 
-
 # strToBytes "foo" = (13, 14, 15, Nil)
 def strToBytes (str: String): List Integer =
     str

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package wake
+package remote_cache
+
+from wake import _
 
 # rscRunner: Creates a remote cache runner for a given api config
 #

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -15,6 +15,8 @@
 
 package wake
 
+from remote_cache import rscRunner makeRemoteCacheApi
+
 export tuple Usage = # Unknown quantities are 0
     export Status: Integer
     export Runtime: Double


### PR DESCRIPTION
Moves all of the RSC client code into the `remote_cache` package for better isolation and deals with the associated fallout 