### PR TITLE
Use simpler string syntax table in Emacs

### DIFF
--- a/share/doc/wake/syntax/emacs/wake-mode.el
+++ b/share/doc/wake/syntax/emacs/wake-mode.el
@@ -167,10 +167,8 @@ repeated key presses."
     (modify-syntax-entry ?\) ")(" table)
     (modify-syntax-entry ?_ "w" table)
     (modify-syntax-entry ?\\ "\\" table)
-    (modify-syntax-entry ?\" "|" table)
-    (modify-syntax-entry ?\' "|" table)
-    (modify-syntax-entry ?\{ "|" table)
-    (modify-syntax-entry ?\} "|" table)
+    (modify-syntax-entry ?\" "\"" table)
+    (modify-syntax-entry ?\' "\"" table)
     (modify-syntax-entry ?` "\"`" table)
     table))
 


### PR DESCRIPTION
This minimally fixes a bug at the cost of slightly worse syntax highlighting for strings.  The bug is that, as written, any of `"`, `'`, `{`, or `}` are treated as the `|` (generic string delimiter) syntax class.  This means that these act like "string toggles".  This has the benefit of allowing things like string interpolation to work:

    "foo{bar}"
    ^   ^   ^^
    |   |   ||
    |   |   |End string
    |   |   Start string
    |   End string
    Start string

However, this creates problems if the strings are ever unbalanced.  E.g., the following is mis-highlighted without this patch:

    "foo'bar"
    ^   ^   ^
    |   |   |
    |   |   |
    |   |   Start string
    |   End string
    Start string

Avoid all this by just forcing `'` and `"` to make everything inside them strings.  This loses the syntax highlighting for string interpolation. However, this seems like a win overall as some internal Wake files run into this bug and I'm seeing the entire file show up as a string.