### PR TITLE
rsc: Decrease job TTL

### DIFF
--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -416,8 +416,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let one_min_in_seconds = 60 * 1;
     let ten_mins_in_seconds = one_min_in_seconds * 10;
     let one_hour_in_seconds = one_min_in_seconds * 60;
-    let one_week_in_seconds = one_hour_in_seconds * 24 * 7;
-    launch_job_eviction(connection.clone(), ten_mins_in_seconds, one_week_in_seconds);
+    let one_day_in_seconds = one_hour_in_seconds * 24 * 1;
+    launch_job_eviction(connection.clone(), ten_mins_in_seconds, one_day_in_seconds);
     launch_blob_eviction(
         connection.clone(),
         one_min_in_seconds,


### PR DESCRIPTION
Out of an abundance of caution, this PR dials the job TTL down to 24 hours. As a fairly quick followup this will be changed into a config variable but for now I'd like to lean on the conservative side for the reason we are making later today