### PR TITLE
rsc: Add json route that returns stats

### DIFF
--- a/rust/rsc/src/bin/rsc/dashboard.rs
+++ b/rust/rsc/src/bin/rsc/dashboard.rs
@@ -1,4 +1,7 @@
-use crate::types::{DashboardStatsMostReusedJob, DashboardStatsOldestJob, DashboardStatsResponse};
+use crate::types::{
+    DashboardStatsLostOpportunityJob, DashboardStatsMostReusedJob, DashboardStatsOldestJob,
+    DashboardStatsResponse, DashboardStatsSizeRuntimeValueJob,
+};
 use axum::Json;
 use rsc::database;
 use sea_orm::DatabaseConnection;
@@ -13,6 +16,9 @@ pub async fn stats(db: Arc<DatabaseConnection>) -> Json<DashboardStatsResponse> 
         savings: 0,
         oldest_jobs: Vec::new(),
         most_reused_jobs: Vec::new(),
+        lost_opportunity_jobs: Vec::new(),
+        most_space_efficient_jobs: Vec::new(),
+        most_space_use_jobs: Vec::new(),
     };
 
     let job_count = match database::count_jobs(db.as_ref()).await {
@@ -92,6 +98,64 @@ pub async fn stats(db: Arc<DatabaseConnection>) -> Json<DashboardStatsResponse> 
         }
     };
 
+    let lost_opportunity_jobs = match database::lost_opportuinty_jobs(db.as_ref()).await {
+        Ok(items) => {
+            let mut out = Vec::new();
+            for item in items {
+                out.push(DashboardStatsLostOpportunityJob {
+                    label: item.label,
+                    reuses: item.reuses,
+                    misses: item.misses,
+                    real_savings: item.real_savings,
+                    potential_savings: item.potential_savings,
+                });
+            }
+            out
+        }
+        Err(err) => {
+            tracing::error! {%err, "Failed to lookup lost opportunity jobs"};
+            return Json(empty);
+        }
+    };
+
+    let most_space_efficient_jobs = match database::most_space_efficient_jobs(db.as_ref()).await {
+        Ok(items) => {
+            let mut out = Vec::new();
+            for item in items {
+                out.push(DashboardStatsSizeRuntimeValueJob {
+                    label: item.label,
+                    runtime: item.runtime,
+                    disk_usage: item.disk_usage,
+                    ms_saved_per_byte: item.ms_saved_per_byte,
+                });
+            }
+            out
+        }
+        Err(err) => {
+            tracing::error! {%err, "Failed to lookup most space efficient jobs"};
+            return Json(empty);
+        }
+    };
+
+    let most_space_use_jobs = match database::most_space_use_jobs(db.as_ref()).await {
+        Ok(items) => {
+            let mut out = Vec::new();
+            for item in items {
+                out.push(DashboardStatsSizeRuntimeValueJob {
+                    label: item.label,
+                    runtime: item.runtime,
+                    disk_usage: item.disk_usage,
+                    ms_saved_per_byte: item.ms_saved_per_byte,
+                });
+            }
+            out
+        }
+        Err(err) => {
+            tracing::error! {%err, "Failed to lookup most space use jobs"};
+            return Json(empty);
+        }
+    };
+
     Json(DashboardStatsResponse {
         job_count,
         blob_count,
@@ -99,5 +163,8 @@ pub async fn stats(db: Arc<DatabaseConnection>) -> Json<DashboardStatsResponse> 
         savings,
         oldest_jobs,
         most_reused_jobs,
+        lost_opportunity_jobs,
+        most_space_efficient_jobs,
+        most_space_use_jobs,
     })
 }

--- a/rust/rsc/src/bin/rsc/dashboard.rs
+++ b/rust/rsc/src/bin/rsc/dashboard.rs
@@ -62,6 +62,7 @@ pub async fn stats(db: Arc<DatabaseConnection>) -> Json<DashboardStatsResponse> 
                 out.push(DashboardStatsOldestJob {
                     label: item.label,
                     created_at: item.created_at,
+                    reuses: item.reuses,
                     savings: item.savings,
                 });
             }

--- a/rust/rsc/src/bin/rsc/dashboard.rs
+++ b/rust/rsc/src/bin/rsc/dashboard.rs
@@ -1,0 +1,102 @@
+use crate::types::{DashboardStatsMostReusedJob, DashboardStatsOldestJob, DashboardStatsResponse};
+use axum::Json;
+use rsc::database;
+use sea_orm::DatabaseConnection;
+use std::sync::Arc;
+
+#[tracing::instrument(skip_all)]
+pub async fn stats(db: Arc<DatabaseConnection>) -> Json<DashboardStatsResponse> {
+    let empty = DashboardStatsResponse {
+        job_count: 0,
+        blob_count: 0,
+        size: 0,
+        savings: 0,
+        oldest_jobs: Vec::new(),
+        most_reused_jobs: Vec::new(),
+    };
+
+    let job_count = match database::count_jobs(db.as_ref()).await {
+        Ok(res) => res,
+        Err(err) => {
+            tracing::error! {%err, "Failed to lookup job count"};
+            return Json(empty);
+        }
+    };
+
+    let blob_count = match database::count_blobs(db.as_ref()).await {
+        Ok(res) => res,
+        Err(err) => {
+            tracing::error! {%err, "Failed to lookup blob count"};
+            return Json(empty);
+        }
+    };
+
+    let size = match database::total_blob_size(db.as_ref()).await {
+        Ok(Some(res)) => res.size,
+        Ok(None) => {
+            tracing::error! {"Failed to lookup total blob size"};
+            return Json(empty);
+        }
+        Err(err) => {
+            tracing::error! {%err, "Failed to lookup total blob size"};
+            return Json(empty);
+        }
+    };
+
+    let savings = match database::time_saved(db.as_ref()).await {
+        Ok(Some(res)) => res.savings,
+        Ok(None) => {
+            tracing::error! {"Failed to lookup cache savings"};
+            return Json(empty);
+        }
+        Err(err) => {
+            tracing::error! {%err, "Failed to lookup cache savings"};
+            return Json(empty);
+        }
+    };
+
+    let oldest_jobs = match database::oldest_jobs(db.as_ref()).await {
+        Ok(items) => {
+            let mut out = Vec::new();
+            for item in items {
+                out.push(DashboardStatsOldestJob {
+                    label: item.label,
+                    created_at: item.created_at,
+                    savings: item.savings,
+                });
+            }
+            out
+        }
+        Err(err) => {
+            tracing::error! {%err, "Failed to lookup oldest jobs"};
+            return Json(empty);
+        }
+    };
+
+    let most_reused_jobs = match database::most_reused_jobs(db.as_ref()).await {
+        Ok(items) => {
+            let mut out = Vec::new();
+            for item in items {
+                out.push(DashboardStatsMostReusedJob {
+                    label: item.label,
+                    reuses: item.reuses,
+                    savings: item.savings,
+                });
+            }
+            out
+        }
+        Err(err) => {
+            tracing::error! {%err, "Failed to lookup most reused jobs"};
+            return Json(empty);
+        }
+    };
+
+    Json(DashboardStatsResponse {
+        job_count,
+        blob_count,
+        size,
+        savings,
+        oldest_jobs,
+        most_reused_jobs,
+    })
+}

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -24,6 +24,7 @@ mod add_job;
 mod api_key_check;
 mod blob;
 mod blob_store_impls;
+mod dashboard;
 mod read_job;
 mod types;
 
@@ -188,6 +189,13 @@ fn create_router(
             })),
         )
         // Unauthorized Routes
+        .route(
+            "/dashboard",
+            get({
+                let conn = conn.clone();
+                move || dashboard::stats(conn)
+            }),
+        )
         .route(
             "/job/matching",
             post({

--- a/rust/rsc/src/bin/rsc/types.rs
+++ b/rust/rsc/src/bin/rsc/types.rs
@@ -178,6 +178,7 @@ pub struct GetUploadUrlResponse {
 pub struct DashboardStatsOldestJob {
     pub label: String,
     pub created_at: DateTime,
+    pub reuses: i32,
     pub savings: i64,
 }
 

--- a/rust/rsc/src/bin/rsc/types.rs
+++ b/rust/rsc/src/bin/rsc/types.rs
@@ -1,4 +1,5 @@
 use blake3;
+use sea_orm::prelude::DateTime;
 use sea_orm::prelude::Uuid;
 use serde::{Deserialize, Serialize};
 
@@ -171,4 +172,28 @@ pub enum ReadJobResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetUploadUrlResponse {
     pub url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DashboardStatsOldestJob {
+    pub label: String,
+    pub created_at: DateTime,
+    pub savings: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DashboardStatsMostReusedJob {
+    pub label: String,
+    pub reuses: i32,
+    pub savings: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DashboardStatsResponse {
+    pub job_count: u64,
+    pub blob_count: u64,
+    pub size: i64,
+    pub savings: i64,
+    pub oldest_jobs: Vec<DashboardStatsOldestJob>,
+    pub most_reused_jobs: Vec<DashboardStatsMostReusedJob>,
 }

--- a/rust/rsc/src/bin/rsc/types.rs
+++ b/rust/rsc/src/bin/rsc/types.rs
@@ -190,6 +190,23 @@ pub struct DashboardStatsMostReusedJob {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct DashboardStatsLostOpportunityJob {
+    pub label: String,
+    pub reuses: i32,
+    pub misses: i32,
+    pub real_savings: i64,
+    pub potential_savings: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DashboardStatsSizeRuntimeValueJob {
+    pub label: String,
+    pub runtime: i64,
+    pub disk_usage: i64,
+    pub ms_saved_per_byte: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DashboardStatsResponse {
     pub job_count: u64,
     pub blob_count: u64,
@@ -197,4 +214,7 @@ pub struct DashboardStatsResponse {
     pub savings: i64,
     pub oldest_jobs: Vec<DashboardStatsOldestJob>,
     pub most_reused_jobs: Vec<DashboardStatsMostReusedJob>,
+    pub lost_opportunity_jobs: Vec<DashboardStatsLostOpportunityJob>,
+    pub most_space_efficient_jobs: Vec<DashboardStatsSizeRuntimeValueJob>,
+    pub most_space_use_jobs: Vec<DashboardStatsSizeRuntimeValueJob>,
 }

--- a/rust/rsc/src/database.rs
+++ b/rust/rsc/src/database.rs
@@ -340,9 +340,9 @@ pub async fn most_space_efficient_jobs<T: ConnectionTrait>(
         INNER JOIN job j
         ON j.id = b.job_id
         INNER JOIN blob stdout
-        ON j.stdout_blob_id= stdout.id
+        ON j.stdout_blob_id = stdout.id
         INNER JOIN blob stderr
-        ON j.stderr_blob_id= stderr.id
+        ON j.stderr_blob_id = stderr.id
         ORDER BY ms_saved_per_byte DESC
         LIMIT 30;
         "#,
@@ -372,9 +372,9 @@ pub async fn most_space_use_jobs<T: ConnectionTrait>(
         INNER JOIN job j
         ON j.id = b.job_id
         INNER JOIN blob stdout
-        ON j.stdout_blob_id= stdout.id
+        ON j.stdout_blob_id = stdout.id
         INNER JOIN blob stderr
-        ON j.stderr_blob_id= stderr.id
+        ON j.stderr_blob_id = stderr.id
         ORDER BY disk_usage DESC
         LIMIT 30;
         "#,


### PR DESCRIPTION
This PR adds another route to the rsc `GET /dashboard` which returns a json object summarizing basic stats about the cache. 

A follow up PR will be added that renders it (somewhat) nicely as an HTML page

Example response:

```json
{
  "job_count": 1234,
  "blob_count": 9999,
  "size": 1000000000,
  "savings": 5432,
  "oldest_jobs": [
    {
      "label": "echo foo",
      "created_at": "2024-07-16T18:02:01.083651",
      "savings": 5
    }
  ],
  "most_reused_jobs": [
    {
      "label": "echo foo",
      "reuses": 2,
      "savings": 5
    }
  ],
  "most_space_efficient_jobs": [
    {
      "label": "foo bar",
      "runtime": 1,
      "disk_usage": 50,
      "ms_saved_per_byte": 50
    }
  ],
  "most_space_use_jobs": [
    {
      "label": "foo bar",
      "runtime": 1,
      "disk_usage": 50,
      "ms_saved_per_byte": 50
    }
  ],
  "lost_opportunity_jobs": [
    {
      "label": "foo bar",
      "reuses": 1,
      "misses": 50,
      "real_savings": 1,
      "potential_savings": 51
    }
  ]
}
```