### PR TITLE
rsc: Split configs for rsc/rsc_tool

### DIFF
--- a/rust/rsc/src/bin/rsc/config.rs
+++ b/rust/rsc/src/bin/rsc/config.rs
@@ -1,11 +1,6 @@
 use config::{Config, ConfigError, Environment, File};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Default)]
-pub struct RSCConfigOverride {
-    pub active_store: Option<String>,
-}
-
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RSCConfig {
     pub database_url: String,
@@ -14,12 +9,11 @@ pub struct RSCConfig {
 }
 
 impl RSCConfig {
-    pub fn new(overrides: RSCConfigOverride) -> Result<RSCConfig, ConfigError> {
+    pub fn new() -> Result<RSCConfig, ConfigError> {
         // Gather the config
         let config = Config::builder()
             .add_source(Environment::with_prefix("WAKE_RSC_CONFIG"))
-            .add_source(File::with_name(".config").required(false))
-            .set_override_option("active_store", overrides.active_store)?
+            .add_source(File::with_name(".config"))
             .build()?;
 
         config.try_deserialize()

--- a/rust/rsc/src/bin/rsc/config.rs
+++ b/rust/rsc/src/bin/rsc/config.rs
@@ -3,8 +3,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Default)]
 pub struct RSCConfigOverride {
-    pub database_url: Option<String>,
-    pub server_addr: Option<String>,
     pub active_store: Option<String>,
 }
 
@@ -12,7 +10,7 @@ pub struct RSCConfigOverride {
 pub struct RSCConfig {
     pub database_url: String,
     pub server_addr: String,
-    pub active_store: Option<String>,
+    pub active_store: String,
 }
 
 impl RSCConfig {
@@ -21,8 +19,6 @@ impl RSCConfig {
         let config = Config::builder()
             .add_source(Environment::with_prefix("WAKE_RSC_CONFIG"))
             .add_source(File::with_name(".config").required(false))
-            .set_override_option("database_url", overrides.database_url)?
-            .set_override_option("server_addr", overrides.server_addr)?
             .set_override_option("active_store", overrides.active_store)?
             .build()?;
 

--- a/rust/rsc/src/bin/rsc/config.rs
+++ b/rust/rsc/src/bin/rsc/config.rs
@@ -3,21 +3,15 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Default)]
 pub struct RSCConfigOverride {
-    pub config_override: Option<String>,
     pub database_url: Option<String>,
     pub server_addr: Option<String>,
-    pub standalone: Option<bool>,
-    // Active store is specified by setting the UUID of the store
-    // that should be processing uploads.
     pub active_store: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RSCConfig {
     pub database_url: String,
-    // TODO: We should allow setting a domain as well
     pub server_addr: String,
-    pub standalone: bool,
     pub active_store: Option<String>,
 }
 
@@ -25,20 +19,10 @@ impl RSCConfig {
     pub fn new(overrides: RSCConfigOverride) -> Result<RSCConfig, ConfigError> {
         // Gather the config
         let config = Config::builder()
-            .add_source(Environment::with_prefix("WAKE_RSC"))
-            .add_source(
-                File::with_name(
-                    &overrides
-                        .config_override
-                        .as_ref()
-                        .map(|x| x.as_str())
-                        .unwrap_or(".config"),
-                )
-                .required(false),
-            )
+            .add_source(Environment::with_prefix("WAKE_RSC_CONFIG"))
+            .add_source(File::with_name(".config"))
             .set_override_option("database_url", overrides.database_url)?
             .set_override_option("server_addr", overrides.server_addr)?
-            .set_override_option("standalone", overrides.standalone)?
             .set_override_option("active_store", overrides.active_store)?
             .build()?;
 

--- a/rust/rsc/src/bin/rsc/config.rs
+++ b/rust/rsc/src/bin/rsc/config.rs
@@ -20,7 +20,7 @@ impl RSCConfig {
         // Gather the config
         let config = Config::builder()
             .add_source(Environment::with_prefix("WAKE_RSC_CONFIG"))
-            .add_source(File::with_name(".config"))
+            .add_source(File::with_name(".config").required(false))
             .set_override_option("database_url", overrides.database_url)?
             .set_override_option("server_addr", overrides.server_addr)?
             .set_override_option("active_store", overrides.active_store)?

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -319,7 +319,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = ServerOptions::parse();
 
     // Get the configuration
-    let config = config::RSCConfig::new(config::RSCConfigOverride { active_store: None })?;
+    let config = config::RSCConfig::new()?;
     let config = Arc::new(config);
 
     if args.show_config {
@@ -395,10 +395,12 @@ mod tests {
         Ok(inserted.id)
     }
 
-    fn create_config(store_id: Uuid) -> Result<config::RSCConfig, Box<dyn std::error::Error>> {
-        Ok(config::RSCConfig::new(config::RSCConfigOverride {
-            active_store: Some(store_id.to_string()),
-        })?)
+    fn create_config(store_id: Uuid) -> config::RSCConfig {
+        config::RSCConfig {
+            database_url: "test:0000".to_string(),
+            server_addr: "".to_string(),
+            active_store: store_id.to_string(),
+        }
     }
 
     async fn create_fake_blob(
@@ -455,7 +457,7 @@ mod tests {
         let store_id = create_test_store(&db).await.unwrap();
         let api_key = create_insecure_api_key(&db).await.unwrap();
         let blob_id = create_fake_blob(&db, store_id.clone()).await.unwrap();
-        let config = create_config(store_id.clone()).unwrap();
+        let config = create_config(store_id.clone());
         let db = Arc::new(db);
         let stores = activate_stores(db.clone()).await;
         let mut router = create_router(db.clone(), Arc::new(config), &stores);

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -5,15 +5,10 @@ use axum::{
 };
 use chrono::Utc;
 use clap::Parser;
-use data_encoding::HEXLOWER;
 use migration::{Migrator, MigratorTrait};
-use rand_core::{OsRng, RngCore};
 use rlimit::Resource;
-use rsc::{config, database};
-use sea_orm::{
-    prelude::Uuid, ActiveModelTrait, ActiveValue::*, ConnectOptions, ConnectionTrait, Database,
-    DatabaseConnection,
-};
+use rsc::database;
+use sea_orm::{prelude::Uuid, ConnectOptions, Database, DatabaseConnection};
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 use std::sync::Arc;
@@ -24,34 +19,15 @@ mod add_job;
 mod api_key_check;
 mod blob;
 mod blob_store_impls;
+mod config;
 mod dashboard;
 mod read_job;
 mod types;
 
 #[derive(Debug, Parser)]
 struct ServerOptions {
-    #[arg(help = "Specify a config override file", value_name = "CONFIG", long)]
-    config_override: Option<String>,
-
     #[arg(help = "Shows the config and then exits", long)]
     show_config: bool,
-
-    #[arg(
-        help = "Specify an override for the bind address",
-        value_name = "SERVER_IP[:SERVER_PORT]",
-        long
-    )]
-    server_addr: Option<String>,
-
-    #[arg(
-        help = "Specify an override for the database url",
-        value_name = "DATABASE_URL",
-        long
-    )]
-    database_url: Option<String>,
-
-    #[arg(help = "Launches the cache without an external database", long)]
-    standalone: bool,
 }
 
 // Maps databse store uuid -> dyn blob::DebugBlobStore
@@ -215,22 +191,7 @@ fn create_router(
         .route("/version/check", get(check_version))
 }
 
-async fn create_standalone_db() -> Result<DatabaseConnection, sea_orm::DbErr> {
-    let shim_db = Database::connect("postgres://127.0.0.1/shim").await?;
-    let mut buf = [0u8; 24];
-    OsRng.fill_bytes(&mut buf);
-    let rng_str = HEXLOWER.encode(&buf);
-    let db = format!("db_{}", rng_str);
-    shim_db
-        .execute_unprepared(&format!("CREATE DATABASE {}", db))
-        .await?;
-    drop(shim_db);
-    let db = Database::connect(format!("postgres://127.0.0.1/{}", db)).await?;
-    Migrator::up(&db, None).await?;
-    Ok(db)
-}
-
-async fn create_remote_db(
+async fn connect_to_database(
     config: &config::RSCConfig,
 ) -> Result<DatabaseConnection, Box<dyn std::error::Error>> {
     let mut opt = ConnectOptions::new(&config.database_url);
@@ -250,36 +211,6 @@ async fn create_remote_db(
     }
 
     Ok(connection)
-}
-
-async fn create_insecure_api_key(
-    db: &DatabaseConnection,
-) -> Result<String, Box<dyn std::error::Error>> {
-    let active_key = entity::api_key::ActiveModel {
-        id: NotSet,
-        created_at: NotSet,
-        key: Set("InsecureKey".into()),
-        desc: Set("Generated Insecure Key".into()),
-    };
-
-    let inserted_key = active_key.insert(db).await?;
-
-    Ok(inserted_key.key)
-}
-
-async fn connect_to_database(
-    config: &config::RSCConfig,
-) -> Result<DatabaseConnection, Box<dyn std::error::Error>> {
-    if config.standalone {
-        tracing::warn!("Launching rsc in standalone mode, data will not persist.");
-        let db = create_standalone_db().await?;
-        let key = create_insecure_api_key(&db).await?;
-        tracing::info!(key, "Created insecure api key.");
-
-        return Ok(db);
-    }
-
-    create_remote_db(config).await
 }
 
 fn launch_job_eviction(conn: Arc<DatabaseConnection>, tick_interval: u64, ttl: u64) {
@@ -394,14 +325,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Get the configuration
     let config = config::RSCConfig::new(config::RSCConfigOverride {
-        config_override: args.config_override,
-        server_addr: args.server_addr,
-        database_url: args.database_url,
-        standalone: if args.standalone {
-            Some(args.standalone)
-        } else {
-            None
-        },
+        server_addr: None,
+        database_url: None,
         active_store: None,
     })?;
     let config = Arc::new(config);
@@ -446,8 +371,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use data_encoding::HEXLOWER;
     use entity::blob_store;
-    use sea_orm::{prelude::Uuid, ActiveModelTrait, EntityTrait, PaginatorTrait};
+    use rand_core::{OsRng, RngCore};
+    use sea_orm::{
+        prelude::Uuid, ActiveModelTrait, ActiveValue::*, ConnectionTrait, EntityTrait,
+        PaginatorTrait,
+    };
     use std::sync::Arc;
 
     use axum::{
@@ -476,10 +406,8 @@ mod tests {
 
     fn create_config(store_id: Uuid) -> Result<config::RSCConfig, Box<dyn std::error::Error>> {
         Ok(config::RSCConfig::new(config::RSCConfigOverride {
-            config_override: Some("".into()),
             server_addr: Some("test:0000".into()),
             database_url: Some("".into()),
-            standalone: Some(true),
             active_store: Some(store_id.to_string()),
         })?)
     }
@@ -500,6 +428,36 @@ mod tests {
         let inserted_key = active_key.insert(db).await?;
 
         Ok(inserted_key.id)
+    }
+
+    async fn create_insecure_api_key(
+        db: &DatabaseConnection,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let active_key = entity::api_key::ActiveModel {
+            id: NotSet,
+            created_at: NotSet,
+            key: Set("InsecureKey".into()),
+            desc: Set("Generated Insecure Key".into()),
+        };
+
+        let inserted_key = active_key.insert(db).await?;
+
+        Ok(inserted_key.key)
+    }
+
+    async fn create_standalone_db() -> Result<DatabaseConnection, sea_orm::DbErr> {
+        let shim_db = Database::connect("postgres://127.0.0.1/shim").await?;
+        let mut buf = [0u8; 24];
+        OsRng.fill_bytes(&mut buf);
+        let rng_str = HEXLOWER.encode(&buf);
+        let db = format!("db_{}", rng_str);
+        shim_db
+            .execute_unprepared(&format!("CREATE DATABASE {}", db))
+            .await?;
+        drop(shim_db);
+        let db = Database::connect(format!("postgres://127.0.0.1/{}", db)).await?;
+        Migrator::up(&db, None).await?;
+        Ok(db)
     }
 
     #[tokio::test]

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -110,12 +110,7 @@ fn create_router(
     config: Arc<config::RSCConfig>,
     blob_stores: &HashMap<Uuid, Arc<dyn blob::DebugBlobStore + Sync + Send>>,
 ) -> Router {
-    // If we can't create a store, just exit. The config is wrong and must be rectified.
-    let Some(active_store_uuid) = config.active_store.clone() else {
-        panic!("Active store uuid not set in configuration");
-    };
-
-    let Ok(active_store_uuid) = Uuid::parse_str(&active_store_uuid) else {
+    let Ok(active_store_uuid) = Uuid::parse_str(&config.active_store) else {
         panic!("Failed to parse provided active store into uuid");
     };
 
@@ -324,11 +319,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = ServerOptions::parse();
 
     // Get the configuration
-    let config = config::RSCConfig::new(config::RSCConfigOverride {
-        server_addr: None,
-        database_url: None,
-        active_store: None,
-    })?;
+    let config = config::RSCConfig::new(config::RSCConfigOverride { active_store: None })?;
     let config = Arc::new(config);
 
     if args.show_config {
@@ -406,8 +397,6 @@ mod tests {
 
     fn create_config(store_id: Uuid) -> Result<config::RSCConfig, Box<dyn std::error::Error>> {
         Ok(config::RSCConfig::new(config::RSCConfigOverride {
-            server_addr: Some("test:0000".into()),
-            database_url: Some("".into()),
             active_store: Some(store_id.to_string()),
         })?)
     }

--- a/rust/rsc/src/bin/rsc_tool/config.rs
+++ b/rust/rsc/src/bin/rsc_tool/config.rs
@@ -16,7 +16,7 @@ impl RSCToolConfig {
         // Gather the config
         let config = Config::builder()
             .add_source(Environment::with_prefix("WAKE_RSC_CONFIG"))
-            .add_source(File::with_name(".config"))
+            .add_source(File::with_name(".config").required(false))
             .set_override_option("database_url", overrides.database_url)?
             .build()?;
 

--- a/rust/rsc/src/bin/rsc_tool/config.rs
+++ b/rust/rsc/src/bin/rsc_tool/config.rs
@@ -1,0 +1,25 @@
+use config::{Config, ConfigError, Environment, File};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Default)]
+pub struct RSCToolConfigOverride {
+    pub database_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RSCToolConfig {
+    pub database_url: String,
+}
+
+impl RSCToolConfig {
+    pub fn new(overrides: RSCToolConfigOverride) -> Result<RSCToolConfig, ConfigError> {
+        // Gather the config
+        let config = Config::builder()
+            .add_source(Environment::with_prefix("WAKE_RSC_CONFIG"))
+            .add_source(File::with_name(".config"))
+            .set_override_option("database_url", overrides.database_url)?
+            .build()?;
+
+        config.try_deserialize()
+    }
+}

--- a/rust/rsc/src/bin/rsc_tool/main.rs
+++ b/rust/rsc/src/bin/rsc_tool/main.rs
@@ -2,11 +2,12 @@ use clap::{Parser, Subcommand};
 use inquire::{Confirm, Text};
 use is_terminal::IsTerminal;
 use migration::{DbErr, Migrator, MigratorTrait};
-use rsc::{config, database};
+use rsc::database;
 use sea_orm::{prelude::Uuid, DatabaseConnection};
 use std::io::{Error, ErrorKind};
 use tracing;
 
+mod config;
 mod table;
 
 async fn add_api_key(
@@ -243,14 +244,6 @@ async fn bootstrap_db(db: &DatabaseConnection) -> Result<(), Box<dyn std::error:
 #[command(author, version, about, long_about = None)]
 struct TopLevel {
     #[arg(
-        help = "Specify a config override file",
-        value_name = "CONFIG",
-        short,
-        long
-    )]
-    config_override: Option<String>,
-
-    #[arg(
         help = "Specify and override for the database url",
         value_name = "DATABASE_URL",
         long
@@ -396,10 +389,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = TopLevel::parse();
 
     // Gather our config
-    let config = config::RSCConfig::new(config::RSCConfigOverride {
-        config_override: args.config_override,
+    let config = config::RSCToolConfig::new(config::RSCToolConfigOverride {
         database_url: args.database_url,
-        ..Default::default()
     })?;
 
     if args.show_config {

--- a/rust/rsc/src/lib.rs
+++ b/rust/rsc/src/lib.rs
@@ -1,2 +1,1 @@
-pub mod config;
 pub mod database;


### PR DESCRIPTION
This is a simplification and split of the RSC config files in preparation for a larger push for config changes.

Unneeded configs and arg flags were removed and the `rsc` and `rsc_tool` were given dedicated config types