### PR TITLE
rsc: Optimize blob eviction deletion

### DIFF
--- a/rust/migration/src/lib.rs
+++ b/rust/migration/src/lib.rs
@@ -10,6 +10,7 @@ mod m20231128_000751_normalize_uses_table;
 mod m20240509_163905_add_label_to_job;
 mod m20240517_195757_add_updated_at_to_blob;
 mod m20240522_185420_create_job_history;
+mod m20240731_201632_create_job_blob_timestamp_index;
 
 pub struct Migrator;
 
@@ -27,6 +28,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240509_163905_add_label_to_job::Migration),
             Box::new(m20240517_195757_add_updated_at_to_blob::Migration),
             Box::new(m20240522_185420_create_job_history::Migration),
+            Box::new(m20240731_201632_create_job_blob_timestamp_index::Migration),
         ]
     }
 }

--- a/rust/migration/src/m20240731_201632_create_job_blob_timestamp_index.rs
+++ b/rust/migration/src/m20240731_201632_create_job_blob_timestamp_index.rs
@@ -1,0 +1,53 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+            CREATE INDEX IF NOT EXISTS blob_updated_at_idx
+            ON blob(updated_at)
+            ",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+            CREATE INDEX IF NOT EXISTS job_created_at_idx
+            ON job(created_at)
+            ",
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+            DROP INDEX IF EXISTS job_created_at_idx
+            ",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+            DROP INDEX IF EXISTS blob_updated_at_idx 
+            ",
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/rust/migration/src/m20240731_201632_create_job_blob_timestamp_index.rs
+++ b/rust/migration/src/m20240731_201632_create_job_blob_timestamp_index.rs
@@ -10,9 +10,9 @@ impl MigrationTrait for Migration {
             .get_connection()
             .execute_unprepared(
                 "
-            CREATE INDEX IF NOT EXISTS blob_updated_at_idx
-            ON blob(updated_at)
-            ",
+                CREATE INDEX IF NOT EXISTS blob_updated_at_idx
+                ON blob(updated_at)
+                ",
             )
             .await?;
 
@@ -20,9 +20,9 @@ impl MigrationTrait for Migration {
             .get_connection()
             .execute_unprepared(
                 "
-            CREATE INDEX IF NOT EXISTS job_created_at_idx
-            ON job(created_at)
-            ",
+                CREATE INDEX IF NOT EXISTS job_created_at_idx
+                ON job(created_at)
+                ",
             )
             .await?;
 
@@ -34,8 +34,8 @@ impl MigrationTrait for Migration {
             .get_connection()
             .execute_unprepared(
                 "
-            DROP INDEX IF EXISTS job_created_at_idx
-            ",
+                DROP INDEX IF EXISTS job_created_at_idx
+                ",
             )
             .await?;
 
@@ -43,8 +43,8 @@ impl MigrationTrait for Migration {
             .get_connection()
             .execute_unprepared(
                 "
-            DROP INDEX IF EXISTS blob_updated_at_idx 
-            ",
+                DROP INDEX IF EXISTS blob_updated_at_idx
+                ",
             )
             .await?;
 

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -249,7 +249,7 @@ fn launch_blob_eviction(
             // This gives clients time to reference a blob before it gets evicted.
             let ttl = (Utc::now() - Duration::from_secs(config.blob_eviction.ttl)).naive_utc();
 
-            let blobs = match database::read_unreferenced_blobs(
+            let blobs = match database::delete_unreferenced_blobs(
                 conn.as_ref(),
                 ttl,
                 config.blob_eviction.chunk_size,
@@ -258,29 +258,17 @@ fn launch_blob_eviction(
             {
                 Ok(b) => b,
                 Err(err) => {
-                    tracing::error!(%err, "Failed to fetch blobs for eviction");
+                    tracing::error!(%err, "Failed to delete blobs for eviction");
                     should_sleep = true;
                     continue; // Try again on the next tick
                 }
             };
 
-            let blob_ids: Vec<Uuid> = blobs.iter().map(|blob| blob.id).collect();
-            let eligible = blob_ids.len();
-            should_sleep = eligible == 0;
+            let deleted = blobs.len();
 
-            tracing::info!(%eligible, "At least N blobs eligible for eviction");
+            should_sleep = deleted == 0;
 
-            // Delete blobs from database
-            match database::delete_blobs_by_ids(conn.as_ref(), blob_ids).await {
-                Ok(deleted) => tracing::info!(%deleted, "Deleted blobs from database"),
-                Err(err) => {
-                    tracing::error!(%err, "Failed to delete blobs from db for eviction");
-                    should_sleep = true;
-                    continue; // Try again on the next tick
-                }
-            };
-
-            tracing::info!("Spawning blob deletion from stores");
+            tracing::info!(%deleted, "N blobs deleted for eviction");
 
             // Delete blobs from blob store
             for blob in blobs {
@@ -288,7 +276,7 @@ fn launch_blob_eviction(
                     Some(s) => s.clone(),
                     None => {
                         let blob = blob.clone();
-                        tracing::info!(%blob.id, %blob.store_id, %blob.key, "Blob has been orphaned!");
+                        tracing::info!(%blob.store_id, %blob.key, "Blob has been orphaned!");
                         tracing::error!(%blob.store_id, "Blob's store id missing from activated stores");
                         continue;
                     }
@@ -297,7 +285,7 @@ fn launch_blob_eviction(
                 tokio::spawn(async move {
                     store.delete_key(blob.key.clone()).await.unwrap_or_else(|err| {
                         let blob = blob.clone();
-                        tracing::info!(%blob.id, %blob.store_id, %blob.key, "Blob has been orphaned!");
+                        tracing::info!(%blob.store_id, %blob.key, "Blob has been orphaned!");
                         tracing::error!(%err, "Failed to delete blob from store for eviction. See above for blob info");
                     });
                 });


### PR DESCRIPTION
- Adds index to blob(updated_at) which speeds up the TTL check for old blobs
- Completes the blob eviction lookup and delete in one query to not waste time repeating work.
- Makes delete query much more static instead of passing in 16k variables