### PR TITLE
rsc: Fix type for hidden_info

### DIFF
--- a/rust/entity/src/job.rs
+++ b/rust/entity/src/job.rs
@@ -16,8 +16,7 @@ pub struct Model {
     pub cwd: String,
     pub stdin: String,
     pub is_atty: bool,
-    #[sea_orm(column_type = "Binary(BlobSize::Blob(None))")]
-    pub hidden_info: Vec<u8>,
+    pub hidden_info: String,
     pub stdout_blob_id: Uuid,
     pub stderr_blob_id: Uuid,
     pub status: i32,

--- a/rust/migration/src/m20220101_000002_create_table.rs
+++ b/rust/migration/src/m20220101_000002_create_table.rs
@@ -35,7 +35,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Job::Cwd).string().not_null())
                     .col(ColumnDef::new(Job::Stdin).string().not_null())
                     .col(ColumnDef::new(Job::IsAtty).boolean().not_null())
-                    .col(ColumnDef::new(Job::HiddenInfo).ezblob())
+                    .col(ColumnDef::new(Job::HiddenInfo).string().not_null())
                     .col(ColumnDef::new(Job::StdoutBlobId).uuid().not_null())
                     .col(ColumnDef::new(Job::StderrBlobId).uuid().not_null())
                     .col(ColumnDef::new(Job::Status).integer().not_null())

--- a/rust/rsc/.config.json
+++ b/rust/rsc/.config.json
@@ -3,7 +3,7 @@
   "server_address": "0.0.0.0:3002",
   "connection_pool_timeout": 60,
   "standalone": false,
-  "active_store": "3446d287-1d6f-439f-bc8a-9e73ab34065d",
+  "active_store": "6716a342-e800-40f8-a1c4-03f520fd64ff",
   "log_directory": null,
   "blob_eviction": {
     "tick_rate": 60,

--- a/rust/rsc/src/bin/rsc/types.rs
+++ b/rust/rsc/src/bin/rsc/types.rs
@@ -40,8 +40,7 @@ pub struct AddJobPayload {
     pub cwd: String,
     pub stdin: String,
     pub is_atty: bool,
-    #[serde(with = "serde_bytes")]
-    pub hidden_info: Vec<u8>,
+    pub hidden_info: String,
     pub visible_files: Vec<VisibleFile>,
     pub output_dirs: Vec<Dir>,
     pub output_symlinks: Vec<Symlink>,
@@ -73,7 +72,7 @@ impl AddJobPayload {
         hasher.update(&self.stdin.len().to_le_bytes());
         hasher.update(self.stdin.as_bytes());
         hasher.update(&self.hidden_info.len().to_le_bytes());
-        hasher.update(self.hidden_info.as_slice());
+        hasher.update(self.hidden_info.as_bytes());
         hasher.update(&[self.is_atty as u8]);
         hasher.update(&self.visible_files.len().to_le_bytes());
         for file in &self.visible_files {
@@ -93,8 +92,7 @@ pub struct ReadJobPayload {
     pub cwd: String,
     pub stdin: String,
     pub is_atty: bool,
-    #[serde(with = "serde_bytes")]
-    pub hidden_info: Vec<u8>,
+    pub hidden_info: String,
     pub visible_files: Vec<VisibleFile>,
 }
 
@@ -111,7 +109,7 @@ impl ReadJobPayload {
         hasher.update(&self.stdin.len().to_le_bytes());
         hasher.update(self.stdin.as_bytes());
         hasher.update(&self.hidden_info.len().to_le_bytes());
-        hasher.update(self.hidden_info.as_slice());
+        hasher.update(self.hidden_info.as_bytes());
         hasher.update(&[self.is_atty as u8]);
         hasher.update(&self.visible_files.len().to_le_bytes());
         for file in &self.visible_files {


### PR DESCRIPTION
Hidden info was suppose to be a `string` not an `ezblob`. It wasn't really hurting anything besides using more space but since db breaking changes are going in anyways it should be fixed