### PR TITLE
rsc: Tier blobs into nested dirs to avoid file limits

### DIFF
--- a/rust/rsc/.config.json
+++ b/rust/rsc/.config.json
@@ -3,7 +3,7 @@
   "server_address": "0.0.0.0:3002",
   "connection_pool_timeout": 60,
   "standalone": false,
-  "active_store": "3446d287-1d6f-439f-bc8a-9e73ab34065d",
+  "active_store": "e9c2dac1-3882-442f-b8a4-1fc04582a003",
   "log_directory": null,
   "blob_eviction": {
     "tick_rate": 60,

--- a/rust/rsc/src/bin/rsc/blob_store_impls.rs
+++ b/rust/rsc/src/bin/rsc/blob_store_impls.rs
@@ -11,14 +11,25 @@ use tokio_util::bytes::Bytes;
 use tokio_util::io::StreamReader;
 
 fn create_random_blob_path() -> std::path::PathBuf {
-    let mut parts = [0u8; 32];
+    // 2 deep @ 8 bytes wide
+    let mut parts = [0u8; 10];
     OsRng.fill_bytes(&mut parts);
+
     let mut buf = std::path::PathBuf::from("");
-    for part in parts {
+
+    // First 2 bytes represent the containing directories
+    for i in 0..2 {
         let mut s = String::new();
-        write!(&mut s, "{:02X}", part).unwrap();
+        write!(&mut s, "{:02X}", parts[i]).unwrap();
         buf.push(s);
     }
+
+    // Next 8 bytes represent the file name
+    let mut s = String::new();
+    for i in 2..10 {
+        write!(&mut s, "{:02X}", parts[i]).unwrap();
+    }
+    buf.push(s);
 
     return buf;
 }

--- a/rust/rsc/src/bin/rsc/blob_store_impls.rs
+++ b/rust/rsc/src/bin/rsc/blob_store_impls.rs
@@ -70,7 +70,7 @@ impl BlobStore for LocalBlobStore {
 
         let key = match rel_path.into_os_string().into_string() {
             Err(path) => {
-                tracing::error!("Cannot convert path to string, returning loosy path instead");
+                tracing::error!("Cannot convert path to string, returning lossy path instead");
                 path.to_string_lossy().to_string()
             }
             Ok(s) => s,


### PR DESCRIPTION
Instead of dumping all blobs into the root of the local blob store, nest them into sub folders to avoid hitting files limits