### PR TITLE
rsc: Refine curl escape

### DIFF
--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -196,8 +196,8 @@ def makeCurlCmd ((HttpRequest url method headers body formData): HttpRequest) (e
     def headerToCurlFlag (HttpHeader name value) = "--header", "{name}:{value}", Nil
 
     def formDataToCurlFlag (HttpFormData name file contentType) = match contentType
-        Some ct -> "--form", "'{name}=@\"{file}\";type={ct}'", Nil
-        None -> "--form", "'{name}=@\"{file}\"'", Nil
+        Some ct -> "--form", "{name}=@\"{file}\";type={ct}", Nil
+        None -> "--form", "{name}=@\"{file}\"", Nil
 
     def bodyToCurlFlag body =
         require True = body.strlen >= 5000


### PR DESCRIPTION
The previous escape changes regressed small blob handling. This PR refines the escape so that it works for both small/blob and files with `,` in them