### PR TITLE
rsc: Fix dashboard for jobs with no file outputs

### DIFF
--- a/rust/rsc/src/database.rs
+++ b/rust/rsc/src/database.rs
@@ -410,7 +410,7 @@ pub async fn most_space_efficient_jobs<T: ConnectionTrait>(
             j.size as disk_usage,
             CAST(round(j.runtime / (j.size) * 1000000000) as BIGINT) as ns_saved_per_byte
         FROM job j
-        WHERE size IS NOT NULL
+        WHERE size IS NOT NULL AND size > 0
         ORDER BY ns_saved_per_byte DESC
         LIMIT 30;
         "#,
@@ -431,7 +431,7 @@ pub async fn most_space_use_jobs<T: ConnectionTrait>(
             j.size as disk_usage,
             CAST(round(j.runtime / (j.size) * 1000000000) as BIGINT) as ns_saved_per_byte
         FROM job j
-        WHERE size IS NOT NULL
+        WHERE size IS NOT NULL AND size > 0
         ORDER BY disk_usage DESC
         LIMIT 30;
         "#,


### PR DESCRIPTION
Some jobs don't have any stdout/stderr/file outputs which causes divide by zero bugs in the dashboard. This PR fixes some of those cases