### PR TITLE
rsc: Add blob_id indexes for fks

### DIFF
--- a/rust/migration/src/lib.rs
+++ b/rust/migration/src/lib.rs
@@ -12,6 +12,7 @@ mod m20240517_195757_add_updated_at_to_blob;
 mod m20240522_185420_create_job_history;
 mod m20240731_152842_create_job_size_proc;
 mod m20240731_201632_create_job_blob_timestamp_index;
+mod m20240805_163520_create_blob_id_fk_indexes;
 
 pub struct Migrator;
 
@@ -31,6 +32,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240522_185420_create_job_history::Migration),
             Box::new(m20240731_152842_create_job_size_proc::Migration),
             Box::new(m20240731_201632_create_job_blob_timestamp_index::Migration),
+            Box::new(m20240805_163520_create_blob_id_fk_indexes::Migration),
         ]
     }
 }

--- a/rust/migration/src/m20240805_163520_create_blob_id_fk_indexes.rs
+++ b/rust/migration/src/m20240805_163520_create_blob_id_fk_indexes.rs
@@ -1,0 +1,72 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                CREATE INDEX IF NOT EXISTS output_file_blob_id_idx
+                ON output_file(blob_id)
+                ",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                CREATE INDEX IF NOT EXISTS job_stdout_blob_id_idx
+                ON job(stdout_blob_id)
+                ",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                CREATE INDEX IF NOT EXISTS job_stderr_blob_id_idx
+                ON job(stderr_blob_id)
+                ",
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                DROP INDEX IF EXISTS output_file_blob_id_idx
+                ",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                DROP INDEX IF EXISTS job_stdout_blob_id_idx
+                ",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                DROP INDEX IF EXISTS job_stderr_blob_id_idx
+                ",
+            )
+            .await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Blob eviction queries were running unacceptably slow. This is because the FK checker had to linear search over the very large `output_file` table to ensure a deleted job wasn't reference. Adding an index converts the linear search into a much faster index lookup