### PR TITLE
rsc: Add config var for min runtime to cache

### DIFF
--- a/rust/rsc/.config.json
+++ b/rust/rsc/.config.json
@@ -23,6 +23,7 @@
   },
   "load_shed": {
     "tick_rate": 30,
-    "target": 16.0
+    "target": 16.0,
+    "min_runtime": 0.1
   }
 }

--- a/rust/rsc/src/bin/rsc/config.rs
+++ b/rust/rsc/src/bin/rsc/config.rs
@@ -45,6 +45,8 @@ pub struct RSCLoadShedConfig {
     pub tick_rate: u64,
     // Load value after which load should be statistically shed
     pub target: f64,
+    // The minimum amount of time a job must take to complete in order to be cached
+    pub min_runtime: f64,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -182,7 +182,8 @@ fn create_router(
             post({
                 let conn = conn.clone();
                 let target = config.load_shed.target.clone();
-                move |body| read_job::allow_job(body, conn, target, system_load)
+                let min_runtime = config.load_shed.min_runtime.clone();
+                move |body| read_job::allow_job(body, conn, target, system_load, min_runtime)
             })
             .layer(DefaultBodyLimit::disable()),
         )

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -498,6 +498,7 @@ mod tests {
             load_shed: config::RSCLoadShedConfig {
                 tick_rate: 10,
                 target: 10.0,
+                min_runtime: 0.5,
             },
         }
     }

--- a/rust/rsc/src/bin/rsc/read_job.rs
+++ b/rust/rsc/src/bin/rsc/read_job.rs
@@ -214,9 +214,10 @@ pub async fn allow_job(
     conn: Arc<DatabaseConnection>,
     target_load: f64,
     system_load: Arc<RwLock<f64>>,
+    min_runtime: f64,
 ) -> StatusCode {
     // Reject a subset of jobs that are never worth caching
-    if payload.runtime < 0.1 {
+    if payload.runtime < min_runtime {
         return StatusCode::NOT_ACCEPTABLE;
     }
 


### PR DESCRIPTION
Allows the config to specify what the minimum runtime should be for a cache job. Any job that completes faster than that runtime isn't worth caching due to various overheads