### PR TITLE
rsc: Optimize blob eviction query

### DIFF
--- a/rust/rsc/src/database.rs
+++ b/rust/rsc/src/database.rs
@@ -685,12 +685,12 @@ pub async fn delete_unreferenced_blobs<T: ConnectionTrait>(
         r#"
             WITH
             eligible_blob_ids as (
-                SELECT id FROM blob
+                SELECT DISTINCT id FROM blob
                 WHERE updated_at <= $1
                 EXCEPT (
                     SELECT blob_id FROM output_file
-                    UNION SELECT stdout_blob_id FROM job
-                    UNION SELECT stderr_blob_id FROM job
+                    UNION ALL SELECT stdout_blob_id FROM job
+                    UNION ALL SELECT stderr_blob_id FROM job
                 )
                 LIMIT $2
             )


### PR DESCRIPTION
`UNION` requires that duplicate ids be removed which requires a sort + unique linear scan. We were previously doing this on the largest table in the database. Instead its more performant if we move the id deduplication to the last step where the id list is as small as possible. This results in a query plan where the sort + unique linear scan happens on a much smaller set of rows