### PR TITLE
http: Set job cpu time

### DIFF
--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -257,6 +257,8 @@ export def makeRequest (request: HttpRequest): Result HttpResponse Error =
         # Web is unreliable and should never be reused
         | setPlanPersistence ReRun
         | setPlanFnOutputs (\_ Nil)
+        # Curl jobs don't use many resources, most time is spent waiting for a response
+        | setPlanUsage (Usage 0 0.0 0.1 0 0 0)
         | runJobWith localRunner
         | setJobTag "http.method" "{method | methodToString}"
         | setJobTag "http.url" url
@@ -320,6 +322,8 @@ export def makeBinaryRequest (request: HttpRequest): Result Path Error =
         # Match persistence of curl job below
         | setPlanPersistence Once
         | setPlanFnOutputs (\_ Nil)
+        # Cleanup doesn't use many resources but isn't reused so wake never learns that
+        | setPlanUsage (Usage 0 0.0 0.002 0 0 0)
         | runJobWith localRunner
         | setJobTag "http.cleanup" destination
         | setJobInspectVisibilityHidden
@@ -338,6 +342,8 @@ export def makeBinaryRequest (request: HttpRequest): Result Path Error =
         # the same request is made twice in the same invocation
         | setPlanPersistence Once
         | setPlanFnOutputs (\_ destination, Nil)
+        # Curl jobs don't use many resources, most time is spent waiting for a response
+        | setPlanUsage (Usage 0 0.0 0.1 0 0 0)
         | runJobWith localRunner
         | setJobTag "http.method" methodStr
         | setJobTag "http.url" url


### PR DESCRIPTION
Sets Usage to observation based values. Lets more requests run in parallel on a limited set of cores