### PR TITLE
ci: Include hidden files in the test artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,7 @@ jobs:
           uses: actions/upload-artifact@v3
           with:
             name: tests
+            include-hidden-files: true
             path: tests
             retention-days: 1
 


### PR DESCRIPTION
upload-artificant@v3 silently changed the default to not included hidden files. This broke the release process.

Restores the functionality to just that artifact upload.

See https://github.com/actions/upload-artifact/issues/602 for more details.