### PR TITLE
rsc: Failing jobs shouldn't be cached

### DIFF
--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -43,6 +43,10 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: Result RunnerIn
         # Run the job to get the results
         require Pass output = baseDoIt job (Pass input)
 
+        # Don't cache failing jobs
+        require True = output.getRunnerOutputUsage.getUsageStatus == 0
+        else Pass output
+
         # If pushing to the cache is not enabled don't bother
         require True = rscApi.getRemoteCacheApiCanPush
         else Pass output


### PR DESCRIPTION
Not sure how I forget this, but we can't cache jobs that fail. It wastes space but more importantly can "lock in" a flow failure for other users/flow runs