### PR TITLE
rsc: Delete multiple blob files per task by config

### DIFF
--- a/rust/rsc/.config.json
+++ b/rust/rsc/.config.json
@@ -8,7 +8,8 @@
   "blob_eviction": {
     "tick_rate": 60,
     "ttl": 3600,
-    "chunk_size": 16000
+    "chunk_size": 16000,
+    "file_chunk_size": 100
   },
   "job_eviction": {
     "ttl": {

--- a/rust/rsc/src/bin/rsc/config.rs
+++ b/rust/rsc/src/bin/rsc/config.rs
@@ -25,7 +25,7 @@ pub struct RSCBlobTTLConfig {
     pub tick_rate: u64,
     // How long an object is allowed to live
     pub ttl: u64,
-    // Maximum number of objects to delete from the db at a time. Must be 1 >= x <= 16000
+    // Maximum number of blobs to delete from the db at a time. Must be 1 >= x <= 64000
     pub chunk_size: u32,
     // Maximum number of files to delete from the disk per task
     pub file_chunk_size: usize,

--- a/rust/rsc/src/bin/rsc/config.rs
+++ b/rust/rsc/src/bin/rsc/config.rs
@@ -15,8 +15,20 @@ pub struct RSCTTLConfig {
     pub tick_rate: u64,
     // How long an object is allowed to live
     pub ttl: u64,
-    // Maximum number of objects to delete at a time. Must be 1 >= x <= 16000
+    // Maximum number of objects to delete from the db at a time. Must be 1 >= x <= 16000
     pub chunk_size: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RSCBlobTTLConfig {
+    // How often to run the eviction check in seconds
+    pub tick_rate: u64,
+    // How long an object is allowed to live
+    pub ttl: u64,
+    // Maximum number of objects to delete from the db at a time. Must be 1 >= x <= 16000
+    pub chunk_size: u32,
+    // Maximum number of files to delete from the disk per task
+    pub file_chunk_size: usize,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -62,7 +74,7 @@ pub struct RSCConfig {
     // The directory that server logs should be written to. If None logs are written to stdout
     pub log_directory: Option<String>,
     // The config to control blob eviction
-    pub blob_eviction: RSCTTLConfig,
+    pub blob_eviction: RSCBlobTTLConfig,
     // The config to control job eviction
     pub job_eviction: RSCJobEvictionConfig,
     // The config to control job size calculation

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use itertools::Itertools;
 use migration::{Migrator, MigratorTrait};
 use rlimit::Resource;
-use rsc::database::{self, DeletedBlob};
+use rsc::database;
 use sea_orm::{prelude::Uuid, ConnectOptions, Database, DatabaseConnection};
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
@@ -280,7 +280,7 @@ fn launch_blob_eviction(
             tracing::info!(%deleted, "N blobs deleted for eviction");
 
             // Delete blobs from blob store
-            let chunked: Vec<Vec<DeletedBlob>> = blobs
+            let chunked: Vec<Vec<database::DeletedBlob>> = blobs
                 .into_iter()
                 .chunks(config.blob_eviction.file_chunk_size)
                 .into_iter()

--- a/rust/rsc/src/bin/rsc/types.rs
+++ b/rust/rsc/src/bin/rsc/types.rs
@@ -58,11 +58,6 @@ pub struct File {
 pub struct Dir {
     pub path: String,
     pub mode: i32,
-<<<<<<< Updated upstream
-=======
-    // Optional member to allow for soft migration
-    pub hidden: Option<bool>,
->>>>>>> Stashed changes
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/rust/rsc/src/bin/rsc/types.rs
+++ b/rust/rsc/src/bin/rsc/types.rs
@@ -58,6 +58,11 @@ pub struct File {
 pub struct Dir {
     pub path: String,
     pub mode: i32,
+<<<<<<< Updated upstream
+=======
+    // Optional member to allow for soft migration
+    pub hidden: Option<bool>,
+>>>>>>> Stashed changes
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Blob file deletion previously launched a task per file. This has significant overhead when deleting 100s of thousands of files. 

This change allows the config to specify how many files should be deleted per task