### PR TITLE
rsc: Add config var for max number of pool connections

### DIFF
--- a/rust/rsc/.config.json
+++ b/rust/rsc/.config.json
@@ -1,6 +1,7 @@
 {
   "database_url": "postgres://localhost:5433/test",
   "server_address": "0.0.0.0:3002",
+  "connection_pool_max_connect": 90,
   "connection_pool_timeout": 60,
   "standalone": false,
   "active_store": "5eed6ba4-d65f-46ca-b4a6-eff98b00857d",

--- a/rust/rsc/src/bin/rsc/config.rs
+++ b/rust/rsc/src/bin/rsc/config.rs
@@ -67,6 +67,9 @@ pub struct RSCConfig {
     pub database_url: String,
     // The address the that server should bind to
     pub server_address: String,
+    // The max number of connnections to open in the connection pool. Value must consider the
+    // postgres server max
+    pub connection_pool_max_connect: u32,
     // The amount of time a query should wait for a connection before timing out in seconds
     pub connection_pool_timeout: u64,
     // The blob store that new blobs should be written into

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -204,7 +204,8 @@ async fn connect_to_database(
     let timeout = config.connection_pool_timeout;
     let mut opt = ConnectOptions::new(&config.database_url);
     opt.sqlx_logging_level(tracing::log::LevelFilter::Debug)
-        .acquire_timeout(std::time::Duration::from_secs(timeout));
+        .acquire_timeout(std::time::Duration::from_secs(timeout))
+        .max_connections(config.connection_pool_max_connect);
 
     tracing::info!(%timeout, "Max seconds to wait for connection from pool");
 
@@ -491,6 +492,7 @@ mod tests {
             database_url: "test:0000".to_string(),
             server_address: "".to_string(),
             active_store: store_id.to_string(),
+            connection_pool_max_connect: 10,
             connection_pool_timeout: 10,
             log_directory: None,
             blob_eviction: config::RSCBlobTTLConfig {

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -202,12 +202,14 @@ async fn connect_to_database(
     config: &config::RSCConfig,
 ) -> Result<DatabaseConnection, Box<dyn std::error::Error>> {
     let timeout = config.connection_pool_timeout;
+    let max_connect = config.connection_pool_max_connect;
     let mut opt = ConnectOptions::new(&config.database_url);
     opt.sqlx_logging_level(tracing::log::LevelFilter::Debug)
         .acquire_timeout(std::time::Duration::from_secs(timeout))
-        .max_connections(config.connection_pool_max_connect);
+        .max_connections(max_connect);
 
     tracing::info!(%timeout, "Max seconds to wait for connection from pool");
+    tracing::info!(%max_connect, "Max number of connections in pool");
 
     let connection = Database::connect(opt).await?;
     let pending_migrations = Migrator::get_pending_migrations(&connection).await?;


### PR DESCRIPTION
Adds a new config var `connection_pool_max_connect` which is used to determine the max number of connections the server will make to the database server