### PR TITLE
rsc: Hidden directories should be returned as cleanable outputs

### DIFF
--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -186,9 +186,16 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
             outputSymlinks
             | map getCacheSearchOutputSymlinkLink
 
-        def resolvedDirectories =
+        def Pair hiddenDirectories publishedDirectories =
             outputDirs
-            | filter (!_.getCacheSearchOutputDirectoryHidden)
+            | splitBy getCacheSearchOutputDirectoryHidden
+
+        def cleanableOutputs =
+            hiddenDirectories
+            | map getCacheSearchOutputDirectoryPath
+
+        def resolvedDirectories =
+            publishedDirectories
             | map getCacheSearchOutputDirectoryPath
 
         def outputs = resolvedOutputs ++ resolvedDirectories ++ resolvedSymlinks
@@ -237,7 +244,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
         #     by the same job. If so, upload the target as a "hidden" output file. On rehydration
         #     retore the file as normal but don't list it in the outputs.
         ## -------------------------------------------------------------------------------------- ##
-        Pass (RunnerOutput inputs outputs Nil predict)
+        Pass (RunnerOutput inputs outputs cleanableOutputs predict)
 
     def run (job: Job) (input: RunnerInput): Result RunnerOutput Error =
         def label = input.getRunnerInputLabel


### PR DESCRIPTION
When rehydrating from the cache, any "hidden" directories should be listed as cleanable outputs since they aren't listed as actual outputs by the runner. If they aren't listed then they won't get cleaned up as expected by `wake --clean`