### PR TITLE
Add compose function

### DIFF
--- a/share/wake/lib/core/syntax.wake
+++ b/share/wake/lib/core/syntax.wake
@@ -37,6 +37,11 @@ export def (dollarFn: a => b) $ (argument: a): b =
 export def (f: b => c) ∘ (g: a => b): a => c =
     \x f (g x)
 
+# Function composition.
+# (compose f g) x = f (g x)
+export def compose (f: b => c) (g: a => b): a => c =
+    \x f (g x)
+
 # Allows flipping the parameters of a function.
 # icmp.flip 4 5 = GT
 # icmp.flip 5 4 = LT


### PR DESCRIPTION
(compose f g) x = f (g x)

Useful for those who prefer not to use symbolic operators or write it themselves `(g _ | f)`