### PR TITLE
[result] Fix documentation for getWhenFail and getWhenPass methods.

### DIFF
--- a/share/wake/lib/core/result.wake
+++ b/share/wake/lib/core/result.wake
@@ -73,15 +73,15 @@ export def getFail: Result a b => Option b = match _
 # getWhenFail: retrieve the Pass value, using a default value for Fail
 #
 #   getWhenFail 42 (Pass 123) = 123
-#   getWhenFail 42 (Pass 123) = 42
+#   getWhenFail 42 (Fail "fail") = 42
 export def getWhenFail (default: pass): Result pass fail => pass = match _
     Pass a -> a
     Fail _ -> default
 
 # getWhenPass: retrieve the Fail value, using a default value for Pass
 #
-#   getWhenPass 42 (Pass 123) = 42
-#   getWhenPass 42 (Pass 123) = 123
+#   getWhenPass 42 (Pass "pass") = 42
+#   getWhenPass 42 (Fail 123) = 123
 export def getWhenPass (default: fail): Result pass fail => fail = match _
     Pass _ -> default
     Fail f -> f


### PR DESCRIPTION
The examples in the documentation showed passing the same arguments and getting different results. The examples are incorrect because they forgot to change the arguments to demonstrate the other case. This fixes the examples and also replaces the type of the other case to more clearly indicate that it is totally unused.