### PR TITLE
updated github actions for docs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -241,7 +241,7 @@ jobs:
           run: touch .nojekyll
 
         - name: Upload
-          uses: actions/upload-pages-artifact@v1
+          uses: actions/upload-pages-artifact@v3
           with:
             path: .
 
@@ -263,7 +263,7 @@ jobs:
       steps:
         - name: Deploy
           id: deployment
-          uses: actions/deploy-pages@v1
+          uses: actions/deploy-pages@v4
 
     release:
       # Only run the 'release' job if this workflow was triggered by the creation of a tag


### PR DESCRIPTION
Updating github actions for docs was missed. According to https://github.com/actions/upload-pages-artifact/releases , we should update `actions/upload-pages-artifact` to the latest `v3` and update `actions/deploy-pages` to `v4`