### PR TITLE
Fix pid_namespace bug introudced in PR 1693

### DIFF
--- a/src/wakefs/namespace.cpp
+++ b/src/wakefs/namespace.cpp
@@ -517,7 +517,7 @@ bool setup_user_namespaces(int id_user, int id_group, bool isolate_network,
   }
 
   int user_cmd_status;
-  waitpid(0, &user_cmd_status, 0);
+  waitpid(pid, &user_cmd_status, 0);
 
   // Wait for child processes, we are init(1) in this PID namespace.
   int child_status;


### PR DESCRIPTION
Addresses a bug introduce in https://github.com/sifiveinc/wake/pull/1693  where waitpid was hardcoded to `waitpid(0` instead of `waitpid(pid,..) as given by the `fork()`. The intent still remains the same of grabbing the first child process exit status.

Waitpid(0,...) means it will wait on any child process with matching groupid. 

