### PR TITLE
Wake db open version error bug fix

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -284,7 +284,7 @@ std::string Database::open(bool wait, bool memory, bool tty) {
 
     // since older wake.db files may not have the header set, we need to check the legacy table,
     // to differentiate between a brand-new DB and an old one.
-    // Todo: remove this check once all wake.db instances have migrated to newer versions.
+    // TODO: remove this check once most wake.db instances have the newer version.
     int legacy_ver = 0;
     if (header_ver == 0) {
       sqlite3_stmt *st = nullptr;
@@ -320,7 +320,7 @@ std::string Database::open(bool wait, bool memory, bool tty) {
       close_db(imp.get());
       return db_ver > atoi(SCHEMA_VERSION)
                  ? "wake.db was created by a newer version of Wake; please upgrade Wake."
-                 : "wake.db was created by an older version of Wake; remove it.";
+                 : "wake.db was created by an older version of Wake; please remove it.";
     }
 
     char *fail = nullptr;
@@ -342,14 +342,14 @@ std::string Database::open(bool wait, bool memory, bool tty) {
           "select (select count(row_id) from entropy), (select max(version) from schema);";
       const char *set_version = "insert or ignore into schema(version) values(" SCHEMA_VERSION ");";
 
-      // TODO: remove this older check once all wake.db instances have migrated to newer versions.
+      // TODO: remove this older check once most wake.db instances have migrated to newer versions.
       ret = sqlite3_exec(imp->db, get_version, &schema_cb, 0, 0);
       if (ret == SQLITE_OK) {
         sqlite3_exec(imp->db, set_version, 0, 0, 0);
         break;
       } else {
         close_db(imp.get());
-        return "produced by an incompatible version of wake; remove it.";
+        return "produced by an incompatible version of wake; please remove it.";
       }
     }
 
@@ -364,7 +364,8 @@ std::string Database::open(bool wait, bool memory, bool tty) {
       if (waiting) {
         std::cerr << std::endl;
       }
-      return out;
+      return "Could not apply schema version " + std::string(SCHEMA_VERSION) +
+             " to the wake.db. Please remove the wake.db and try again: " + out;
     } else {
       if (tty) {
         if (waiting) {


### PR DESCRIPTION
When doing schema updates to the wake.db, we would get a confusing error message like `Failed to open wake.db: no such column: runner_status`. The reason is because wake is doing version checking after applying the schema. This check needs to be done before to get a clear error message - however since we update our version within the schema table this is not possible with the current implementation.

To properly address this, we should start deprecating the schema version table, and instead have the version in our DB header (via `PRAGMA user_version`) for quick access and allows us to check for the version without executing the schema (and without additional locks).