### PR TITLE
Create autofs-resolve mount option to pre-resolve paths before mounting a namespace

### DIFF
--- a/src/wakefs/fuse.cpp
+++ b/src/wakefs/fuse.cpp
@@ -161,7 +161,23 @@ static bool resolve_autofs_mounts(const std::vector<mount_op> &mount_ops) {
   // Sort by path depth as we want parent paths resolved first for nested autofs situations
   std::sort(autofs_paths.begin(), autofs_paths.end(),
             [](const std::string &a, const std::string &b) {
-              return std::count(a.begin(), a.end(), '/') < std::count(b.begin(), b.end(), '/');
+              auto count_directories = [](const std::string &path) {
+                if (path.empty() || path == "/") return 0;
+
+                std::vector<std::string> directories;
+                std::stringstream ss(path);
+                std::string directory;
+
+                while (std::getline(ss, directory, '/')) {
+                  if (!directory.empty()) {  // Skip slashes
+                    directories.push_back(directory);
+                  }
+                }
+
+                return static_cast<int>(directories.size());
+              };
+
+              return count_directories(a) < count_directories(b);
             });
 
   for (const auto &path : autofs_paths) {

--- a/src/wakefs/fuse.cpp
+++ b/src/wakefs/fuse.cpp
@@ -22,7 +22,6 @@
 
 #include "fuse.h"
 
-#include <algorithm>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
@@ -34,6 +33,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -151,7 +151,6 @@ static bool collect_result_metadata(const std::string daemon_output, const struc
 
 // Pre-resolve autofs paths through stating the paths on host machine
 static bool resolve_autofs_mounts(const std::vector<mount_op> &mount_ops) {
-
   std::vector<std::string> autofs_paths;
   for (const auto &op : mount_ops) {
     if (op.type == "autofs-resolve") {
@@ -161,16 +160,17 @@ static bool resolve_autofs_mounts(const std::vector<mount_op> &mount_ops) {
 
   // Sort by path depth as we want parent paths resolved first for nested autofs situations
   std::sort(autofs_paths.begin(), autofs_paths.end(),
-    [](const std::string &a, const std::string &b) {
-      return std::count(a.begin(), a.end(), '/') < std::count(b.begin(), b.end(), '/');
-    });
+            [](const std::string &a, const std::string &b) {
+              return std::count(a.begin(), a.end(), '/') < std::count(b.begin(), b.end(), '/');
+            });
 
   for (const auto &path : autofs_paths) {
     struct stat st;
     if (stat(path.c_str(), &st) == 0) {
       std::cerr << "Pre-resolved autofs path: " << path << std::endl;
     } else {
-      std::cerr << "Failed to resolve autofs path: " << path << " - " << strerror(errno) << std::endl;
+      std::cerr << "Failed to resolve autofs path: " << path << " - " << strerror(errno)
+                << std::endl;
     }
   }
   return true;
@@ -198,7 +198,7 @@ bool run_in_fuse(fuse_args &args, int &status, std::string &result_json) {
       exit(1);
     }
 
-    //trigger autofs paths on host before entering namespace
+    // trigger autofs paths on host before entering namespace
     resolve_autofs_mounts(args.mount_ops);
 
     if (!setup_user_namespaces(args.userid, args.groupid, args.isolate_network, args.hostname,


### PR DESCRIPTION
**Problem**
Wakebox jobs fail when trying to bind mount autofs paths  with "Too many levels of symbolic links" errors. This occurs because autofs resolution doesn't work inside user namespaces - as that is [unsupported](https://bugzilla.redhat.com/show_bug.cgi?id=1569146) without proper mount propagation (which we don't want inorder to maintain our isolated namespace).

**Solution**
Add a new `autofs-resolve` mount operation type that pre-resolves autofs paths in the host namespace before entering the user namespace. This allows wakebox to trigger autofs mounts while still in the host namespace and having mounted filesystems before entering the isolated namespace where bind mounts can succeed.