### PR TITLE
Avoid exposing the hash file at the top dir

### DIFF
--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -180,7 +180,7 @@ def computeHashes (prefix: String) (files: List String): List String =
 
     def hashPlan cmd vis =
         Plan
-        "<hash>"
+        "hash: #{prefix}"
         cmd
         vis
         Nil
@@ -196,7 +196,7 @@ def computeHashes (prefix: String) (files: List String): List String =
         identity
         False
 
-    def stdin_file_path = "to_hash.{prefix}.stdin"
+    def stdin_file_path = ".build/tmp/to_hash.{prefix}.stdin"
 
     # We construct a different plan depending on if we could use command line arguments or not
     require Pass plan = match use_file


### PR DESCRIPTION
The internal `to_hash.{prefix}.stdin` files can show up in the workspace root directory in very rare circumstances -- likely they need Wake to be aborted at exactly the wrong time (in the brief span before it's removed), on a fallback branch which is itself rarely hit (requiring a Job to output either 12k files or 1.9MB of filenames).  Still, there's no reason not to tuck the files away within the `.build/` directory to avoid any chance of random exposure; that directory's already going to have been added to users' gitignore, etc.

Testing this is a bit of a hassle.  I had to set the thresholds for `use_file` very low manually (unconditionally True sends it into an infinite loop, presumably when `write` tries to hash its output in turn), but I was eventually able to see it run successfully:

```shellsession
sammay:[...]/wake$ ./bin/wake --label 'hash: *' | grep -B1 -A1 @
# hash: #479 (489) [inspect.visibility=hidden,]
$ [...]/wake/bin/../lib/wake/wake-hash @
f4ad7f19c03ca5b0f7b46138e41f456391437c826d84faaff183e3e2e0974aa2
```

This also demonstrates the updated job label, which matches the format used by `hashcode` and `markFileCleanable` rather than the old, undifferentiated `<hash>` -- unlike those other two Jobs we don't have easy access to the file being hashed here (since there may be multiple), so I used the job ID whose outputs are being hashed:

```shellsession
sammay@[...]/wake$ ./bin/wake --metadata --job 479
Job 479 (lemon: src/parser/parser.y):
  Command-line: vendor/lemon/lemon.native-c11-release -Tvendor/lemon/lempar.c src/parser/parser.y
  Environment:
    PATH=/usr/lib64/ccache:/usr/bin:/bin
    TERM=xterm-256color
  Directory:     .
  Built:         2025-10-09 16:02:47
  Runtime:       0.066709
  CPUtime:       0.025014
  Mem bytes:     4014080
  In  bytes:     333291
  Out bytes:     996089
  Status:        0
  Runner Status: 0
  Stdin:         /dev/null
Inputs:
  38e577ca src/parser/parser.y
  a9c7477a vendor/lemon/lemon.native-c11-release
  064ed987 vendor/lemon/lempar.c
Outputs:
  f4ad7f19 src/parser/parser.cpp
  4c76bff4 src/parser/parser.h
  34b93768 src/parser/parser.out
```

For completeness, I compared those output hashes to the ones produced with the input file in its old location, and all three fingerprints are identical.