### PR TITLE
Filter out introspection hidden jobs from database queries and logEcho

### DIFF
--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -297,6 +297,7 @@ export def makeRequest (request: HttpRequest): Result HttpResponse Error =
         | setPlanFnOutputs (\_ Nil)
         # Curl jobs don't use many resources, most time is spent waiting for a response
         | setPlanUsage (Usage 0 0.0 0.1 0 0 0)
+        | setPlanEcho logDebug
         | runJobWith localRunner
         | setJobTag "http.method" "{method | methodToString}"
         | setJobTag "http.url" url
@@ -375,6 +376,7 @@ export def makeBinaryRequest (request: HttpRequest): Result Path Error =
         | setPlanFnOutputs (\_ Nil)
         # Cleanup doesn't use many resources but isn't reused so wake never learns that
         | setPlanUsage (Usage 0 0.0 0.002 0 0 0)
+        | setPlanEcho logDebug
         | runJobWith localRunner
         | setJobTag "http.cleanup" destination
         | setJobInspectVisibilityHidden
@@ -395,6 +397,7 @@ export def makeBinaryRequest (request: HttpRequest): Result Path Error =
         | setPlanFnOutputs (\_ destination, Nil)
         # Curl jobs don't use many resources, most time is spent waiting for a response
         | setPlanUsage (Usage 0 0.0 0.1 0 0 0)
+        | setPlanEcho logDebug
         | runJobWith localRunner
         | setJobTag "http.method" methodStr
         | setJobTag "http.url" url

--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -213,6 +213,7 @@ target writeImp inputs mode path content =
     | setPlanLabel "write: {path} 0{strOctal mode}"
     | setPlanOnce False
     | setPlanEnvironment Nil
+    | setPlanEcho logDebug
     | runJobWith (writeRunner content)
     | setJobInspectVisibilityHidden
     | getJobOutput
@@ -336,6 +337,7 @@ def mkdirImp inputs mode path =
     | setPlanLabel "mkdir: {path} 0{strOctal mode}"
     | setPlanKeep False
     | setPlanEnvironment Nil
+    | setPlanEcho logDebug
     | runJobWith mkdirRunner
     | setJobInspectVisibilityHidden
     | getJobOutput

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -213,6 +213,7 @@ def computeHashes (prefix: String) (files: List String): List String =
 
     def job =
         plan
+        | setPlanEcho logDebug
         | runJobWith localRunner
         | setJobInspectVisibilityHidden
 
@@ -263,6 +264,7 @@ target hashcode (f: String): String =
         def job =
             hashPlan ("<hash>", f, Nil)
             | setPlanLabel "hash: {f}"
+            | setPlanEcho logDebug
             | runJobWith localRunner
             | setJobInspectVisibilityHidden
 
@@ -284,6 +286,7 @@ export target markFileCleanable (filepath: String): Result Unit Error =
         hashPlan ("<hash>", filepath, Nil)
         | setPlanLabel "hash: {filepath}"
         | setPlanFnOutputs (\_ filepath, Nil)
+        | setPlanEcho logDebug
         | runJobWith localRunner
         | setJobInspectVisibilityHidden
 

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -719,6 +719,7 @@ export def rscApiGetFileBlob ((CacheSearchBlob blobId uri contentHash): CacheSea
         #   - We must lie and say we output nothing
         #   - The *path* must be listed as another jobs output to be available to the system
         | setPlanFnOutputs (\_ Nil)
+        | setPlanEcho logDebug
         | runJobWith localRunner
         | setJobInspectVisibilityHidden
 
@@ -744,6 +745,7 @@ def generateUUID Unit: Result String Error =
         makeExecPlan ("date", "+%s%N", Nil) Nil
         | setPlanLabel "rsc: generate client uuid"
         | setPlanPersistence Once # Exactly one UUID per wake invocation
+        | setPlanEcho logDebug
         | runJobWith localRunner
         | setJobInspectVisibilityHidden
 
@@ -1148,6 +1150,7 @@ def rscHashFile (file: String): Result String Error =
     def hashJob =
         hashPlan ("<hash>", file, Nil)
         | setPlanLabel "rsc: compute hash for {file}"
+        | setPlanEcho logDebug
         | runJobWith localRunner
         | setJobInspectVisibilityHidden
 

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -102,6 +102,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
                 makeExecPlan cmd Nil
                 | setPlanLabel "rsc: mkdir output dir {path}"
                 | setPlanPersistence Once
+                | setPlanEcho logDebug
                 | runJobWith localRunner
                 | setJobInspectVisibilityHidden
                 | isJobOk
@@ -165,6 +166,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
                 Nil
                 | setPlanLabel "rsc: symlink {link} to {path}"
                 | setPlanPersistence Once
+                | setPlanEcho logDebug
                 | runJobWith localRunner
                 | setJobInspectVisibilityHidden
                 | isJobOk
@@ -409,6 +411,7 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
             Nil
             | setPlanLabel "rsc: readlink {link}"
             | setPlanPersistence Once
+            | setPlanEcho logDebug
             | runJobWith localRunner
             | setJobInspectVisibilityHidden
             | getJobStdout

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -51,6 +51,7 @@ def raw_source file =
         | setPlanEcho logDebug
         | setPlanEnvironment Nil
         | setPlanFnOutputs (file, _)
+        | setPlanEcho logDebug
         | runJobWith virtualRunner
         | setJobInspectVisibilityHidden
         | getJobOutput
@@ -104,6 +105,7 @@ export def claim (file: String): Result Path Error =
             | setPlanEcho logDebug
             | setPlanEnvironment Nil
             | setPlanFnOutputs (file, _)
+            | setPlanEcho logDebug
             | runJobWith virtualRunner
             | setJobInspectVisibilityHidden
             | getJobOutput

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -63,6 +63,7 @@ struct CommandLineOptions {
   bool canceled;
   bool clean;
   bool list_outputs;
+  bool include_hidden;
   wcl::optional<bool> log_header_align;
   wcl::optional<bool> cache_miss_on_failure;
 
@@ -176,6 +177,7 @@ struct CommandLineOptions {
       {0, "no-cache-miss-on-failure", GOPT_ARGUMENT_FORBIDDEN},
       {0, "user-config", GOPT_ARGUMENT_REQUIRED},
       {':', "shebang", GOPT_ARGUMENT_REQUIRED},
+      {0, "include-hidden", GOPT_ARGUMENT_FORBIDDEN},
       {0, 0, GOPT_LAST}
     };
     // clang-format on
@@ -218,6 +220,7 @@ struct CommandLineOptions {
     canceled = arg(options, "canceled")->count;
     clean = arg(options, "clean")->count;
     list_outputs = arg(options, "list-outputs")->count;
+    include_hidden = arg(options, "include-hidden")->count;
 
     percent_str = arg(options, "percent")->argument;
     jobs_str = arg(options, "jobs")->argument;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -198,13 +198,11 @@ void query_jobs(const CommandLineOptions &clo, Database &db) {
   // --last-exe
   if (clo.last_exe) {
     collect_ands.push_back({"run_id == (select max(run_id) from jobs)"});
-    hide_internal_jobs(collect_ands);
   }
 
   // --last-use
   if (clo.last_use) {
     collect_ands.push_back({"use_id == (select max(run_id) from jobs)"});
-    hide_internal_jobs(collect_ands);
   }
 
   // --failed
@@ -215,6 +213,11 @@ void query_jobs(const CommandLineOptions &clo, Database &db) {
   // --canceled
   if (clo.canceled) {
     collect_ands.push_back({"endtime = 0"});
+  }
+
+  // Hide introspection jobs by default unless --include-hidden is specified
+  if (!clo.include_hidden) {
+    hide_internal_jobs(collect_ands);
   }
 
   auto matching_jobs = db.matching(collect_ands, collect_input_ands, collect_output_ands);
@@ -292,6 +295,7 @@ void print_help(const char *argv0) {
     << "    --debug    -d      Report stack frame of captured jobs"                        << std::endl
     << "    --simple           Report only label, cmdline, and tags of captured jobs"      << std::endl
     << "    --script   -s      Format captured jobs as an executable shell script"         << std::endl
+    << "    --include-hidden   Include hidden introspection jobs in query results"         << std::endl
     << std::endl
     << "  Help functions:" << std::endl
     << "    --version          Print the version of wake on standard output"               << std::endl


### PR DESCRIPTION
This PR addresses the issue of `inspect.visibility=hidden` tagged jobs populating our introspection queries, by filtering them out and including a new CLI query `--include-hidden` to optionally include them if needed. As a part of this PR, I also address, as recently exposed by a [bug](https://github.com/sifiveinc/wake/pull/1725), the fact that these hidden jobs populate any tee'd or piped file when running wake with the `--verbose` flag, these jobs should rather only be exposed on `LogDebug` (running with -d), and not the default LogEcho (which shows up in -v). 