### PR TITLE
Bugfix: Make sync() handle pipes, sockets, and tty correctly

### DIFF
--- a/src/util/term.cpp
+++ b/src/util/term.cpp
@@ -448,7 +448,7 @@ int FdBuf::overflow(int c) {
 
 int FdBuf::sync() {
   int ret = fsync(fd);
-  // fsync fails on pipes, sockets, and TTYs with EINVAL as they are not storage devices,
+  // fsync fails on pipes, sockets, and TTYs with EINVAL as they don't support synchronization,
   // proceed normally
   if (ret == -1 && errno == EINVAL) {
     return 0;


### PR DESCRIPTION
This PR addresses a bug where users are not able to tee a file and see the outputs of a job when a user does `printlnLevel logInfo job.getJobStdout`. The reason why this was happening was when we flush a buffer to a stream, we call fsync() which does not work for pipes, sockets, or tty as they [do not support synchronization](https://man7.org/linux/man-pages/man2/fsync.2.html), causing the stream to break and output to be ignored.