### PR TITLE
Update Fuse Client-Daemon linger timeout logic

### DIFF
--- a/src/wakefs/daemon_client.cpp
+++ b/src/wakefs/daemon_client.cpp
@@ -36,11 +36,11 @@
 #include "util/execpath.h"
 #include "util/mkdir_parents.h"
 
-// Time the fuse daemon will wait for a new client before exiting.
-static constexpr int linger_timeout_secs = 60;
+// Default time the fuse daemon will wait for a new client before exiting.
+static constexpr int default_linger_timeout_secs = 2;
 
-// Maximum time to wait for the daemon to start on each retry attempt (linger / 4).
-static constexpr int max_retry_wait_ms = (linger_timeout_secs / 4) * 1000;
+// Maximum time to wait for the daemon to start on each retry attempt.
+static constexpr int max_retry_wait_ms = 30000;
 
 // The user-id and group-id are used so that fuse daemons with different uid:gid pairs
 // running within the same build can co-exist without trying to share. The kernel
@@ -59,7 +59,10 @@ daemon_client::daemon_client(const std::string &base_dir)
       visibles_path(mount_path + "/.i." + std::to_string(getpid())) {}
 
 // The arg 'visible' is destroyed/moved in the interest of performance with large visible lists.
-bool daemon_client::connect(std::vector<std::string> &visible, bool close_live_file) {
+bool daemon_client::connect(std::vector<std::string> &visible, bool close_live_file,
+                            wcl::optional<int> linger_timeout) {
+  int linger_secs = linger_timeout ? *linger_timeout : default_linger_timeout_secs;
+
   int err = mkdir_with_parents(mount_path, 0775);
   if (0 != err) {
     std::cerr << "mkdir_with_parents ('" << mount_path << "'):" << strerror(err) << std::endl;
@@ -76,7 +79,7 @@ bool daemon_client::connect(std::vector<std::string> &visible, bool close_live_f
 
     pid_t pid = fork();
     if (pid == 0) {
-      std::string delayStr = std::to_string(linger_timeout_secs);
+      std::string delayStr = std::to_string(linger_secs);
       const char *env[3] = {"PATH=/usr/bin:/bin:/usr/sbin:/sbin", 0, 0};
       if (getenv("DEBUG_FUSE_WAKE")) env[1] = "DEBUG_FUSE_WAKE=1";
       execle(executable.c_str(), "fuse-waked", mount_path.c_str(), delayStr.c_str(), nullptr, env);

--- a/src/wakefs/daemon_client.cpp
+++ b/src/wakefs/daemon_client.cpp
@@ -26,6 +26,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -34,6 +35,12 @@
 #include "json/json5.h"
 #include "util/execpath.h"
 #include "util/mkdir_parents.h"
+
+// Time the fuse daemon will wait for a new client before exiting.
+static constexpr int linger_timeout_secs = 60;
+
+// Maximum time to wait for the daemon to start on each retry attempt (linger / 4).
+static constexpr int max_retry_wait_ms = (linger_timeout_secs / 4) * 1000;
 
 // The user-id and group-id are used so that fuse daemons with different uid:gid pairs
 // running within the same build can co-exist without trying to share. The kernel
@@ -69,10 +76,7 @@ bool daemon_client::connect(std::vector<std::string> &visible, bool close_live_f
 
     pid_t pid = fork();
     if (pid == 0) {
-      // The daemon should wait at least 4x as long to exit as we wait for it to start.
-      int exit_delay = 4 * delay.tv_sec;
-      if (exit_delay < 2) exit_delay = 2;
-      std::string delayStr = std::to_string(exit_delay);
+      std::string delayStr = std::to_string(linger_timeout_secs);
       const char *env[3] = {"PATH=/usr/bin:/bin:/usr/sbin:/sbin", 0, 0};
       if (getenv("DEBUG_FUSE_WAKE")) env[1] = "DEBUG_FUSE_WAKE=1";
       execle(executable.c_str(), "fuse-waked", mount_path.c_str(), delayStr.c_str(), nullptr, env);
@@ -86,7 +90,7 @@ bool daemon_client::connect(std::vector<std::string> &visible, bool close_live_f
       ok = nanosleep(&delay, &delay);
     } while (ok == -1 && errno == EINTR);
 
-    wait_ms <<= 1;
+    wait_ms = std::min(wait_ms << 1, max_retry_wait_ms);
 
     int status;
     do waitpid(pid, &status, 0);

--- a/src/wakefs/fuse.cpp
+++ b/src/wakefs/fuse.cpp
@@ -65,13 +65,27 @@ bool json_as_struct(const std::string &json, json_args &result) {
   if (timeout_entry.kind == JSON_INTEGER) {
     int timeout = std::stoi(timeout_entry.value);
     if (timeout <= 0) {
-      std::cerr << "timeout must be be an integer value greater than 0" << std::endl;
+      std::cerr << "command-timeout must be an integer value greater than 0" << std::endl;
       return false;
     }
 
     result.command_timeout = wcl::make_some<int>(timeout);
   } else if (timeout_entry.kind != JSON_NULLVAL) {
-    std::cerr << "timeout must be be an integer value greater than 0" << std::endl;
+    std::cerr << "command-timeout must be an integer value greater than 0" << std::endl;
+    return false;
+  }
+
+  JAST linger_entry = jast.get("linger-timeout");
+  if (linger_entry.kind == JSON_INTEGER) {
+    int linger = std::stoi(linger_entry.value);
+    if (linger <= 0) {
+      std::cerr << "linger-timeout must be an integer value greater than 0" << std::endl;
+      return false;
+    }
+
+    result.linger_timeout = wcl::make_some<int>(linger);
+  } else if (linger_entry.kind != JSON_NULLVAL) {
+    std::cerr << "linger-timeout must be an integer value greater than 0" << std::endl;
     return false;
   }
 
@@ -154,7 +168,7 @@ bool run_in_fuse(fuse_args &args, int &status, std::string &result_json) {
     return false;
   }
 
-  if (!args.daemon.connect(args.visible, args.isolate_pids)) return false;
+  if (!args.daemon.connect(args.visible, args.isolate_pids, args.linger_timeout)) return false;
 
   struct timeval start;
   gettimeofday(&start, 0);

--- a/src/wakefs/fuse.h
+++ b/src/wakefs/fuse.h
@@ -45,7 +45,8 @@ struct daemon_client {
 
   daemon_client(const std::string &base_dir);
 
-  bool connect(std::vector<std::string> &visible, bool close_live_file);
+  bool connect(std::vector<std::string> &visible, bool close_live_file,
+               wcl::optional<int> linger_timeout = {});
   bool disconnect(std::string &result);
 
  protected:
@@ -56,6 +57,7 @@ struct daemon_client {
 struct json_args {
   std::vector<std::string> command;
   wcl::optional<int> command_timeout;  // timeout in seconds.
+  wcl::optional<int> linger_timeout;   // fuse daemon linger timeout in seconds.
   std::vector<std::string> environment;
   std::vector<std::string> visible;
   std::string directory;


### PR DESCRIPTION
This inverts the calculation of linger timeout from the retry wait_ms. Instead, the linger timeout is now a constant with a max wait_ms being calculated from that. Each retry will increase its wait up to the max.

The default linger timeout was increased to 60 seconds. 

I thought about exposing `linger_timeout_secs` up to wake runtime config, but it didn't seem straightforward at this time. 