### PR TITLE
Add debug statments capturing error message from client mount connection

### DIFF
--- a/src/wakefs/daemon_client.cpp
+++ b/src/wakefs/daemon_client.cpp
@@ -67,8 +67,8 @@ bool daemon_client::connect(std::vector<std::string> &visible, bool close_live_f
        ++retry) {
     int open_errno = errno;
     if (debug_fuse) {
-      std::cerr << "[fuse_client] connect retry=" << retry
-                << " errno=" << open_errno << " (" << strerror(open_errno) << ")" << std::endl;
+      std::cerr << "[fuse_client] connect retry=" << retry << " errno=" << open_errno << " ("
+                << strerror(open_errno) << ")" << std::endl;
     }
 
     struct timespec delay;
@@ -105,8 +105,8 @@ bool daemon_client::connect(std::vector<std::string> &visible, bool close_live_f
     int final_errno = errno;
     std::cerr << "[fuse_client] Could not contact FUSE daemon" << std::endl;
     if (debug_fuse) {
-      std::cerr << "[fuse_client] errno=" << final_errno
-                << " (" << strerror(final_errno) << ")" << std::endl;
+      std::cerr << "[fuse_client] errno=" << final_errno << " (" << strerror(final_errno) << ")"
+                << std::endl;
     }
     return false;
   }


### PR DESCRIPTION
In order to help with debugging `Could not contact FUSE daemon` issues, this adds some debug logging in the client daemon connect loop based on the DEBUG_FUSE_WAKE env var.

When enabled, it will now print the attempt number and then `open()` call error code/str.
In the message, I include the `[fuse_client]` prefix to identify where its coming from. I updated the `Could not contact FUSE daemon` to include it as well. 