### PR TITLE
database: add lock files for dead run detection

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -39,6 +39,7 @@
 
 #include "schema.h"
 #include "status.h"
+#include "util/mkdir_parents.h"
 #include "wcl/iterator.h"
 
 #define VISIBLE 0
@@ -96,9 +97,11 @@ struct Database::detail {
   sqlite3_stmt *insert_run_job;
   sqlite3_stmt *get_gc_watermark;
   sqlite3_stmt *set_run_end_time;
+  sqlite3_stmt *get_incomplete_runs;
 
   long run_id;
   long gc_watermark;
+  int run_lock_fd;
   detail(bool debugdb_)
       : debugdb(debugdb_),
         db(0),
@@ -144,8 +147,10 @@ struct Database::detail {
         insert_run_job(0),
         get_gc_watermark(0),
         set_run_end_time(0),
+        get_incomplete_runs(0),
         run_id(0),
-        gc_watermark(0) {}
+        gc_watermark(0),
+        run_lock_fd(-1) {}
 };
 
 class WaitingIndicator {
@@ -459,6 +464,7 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   const char *sql_insert_run_job = "insert or ignore into run_jobs(run_id, job_id) values(?, ?)";
   const char *sql_get_gc_watermark = "select min(run_id) - 1 from runs where end_time is null";
   const char *sql_set_run_end_time = "update runs set end_time = ? where run_id = ?";
+  const char *sql_get_incomplete_runs = "select run_id, time from runs where end_time is null";
 
 #define PREPARE(sql, member)                                                                     \
   ret = sqlite3_prepare_v2(imp->db, sql, -1, &imp->member, 0);                                   \
@@ -515,6 +521,7 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   PREPARE(sql_insert_run_job, insert_run_job);
   PREPARE(sql_get_gc_watermark, get_gc_watermark);
   PREPARE(sql_set_run_end_time, set_run_end_time);
+  PREPARE(sql_get_incomplete_runs, get_incomplete_runs);
 
   return "";
 }
@@ -580,6 +587,14 @@ void Database::close() {
   FINALIZE(insert_run_job);
   FINALIZE(get_gc_watermark);
   FINALIZE(set_run_end_time);
+  FINALIZE(get_incomplete_runs);
+
+  // Close run lock file if held
+  if (imp->run_lock_fd >= 0) {
+    ::close(imp->run_lock_fd);
+    imp->run_lock_fd = -1;
+  }
+
   close_db(this);
   release_build_lock();
 }
@@ -808,6 +823,31 @@ void Database::entropy(uint64_t *key, int words) {
   end_txn();
 }
 
+static std::string run_lock_path(long run_id) {
+  return ".wake/locks/run_" + std::to_string(run_id) + ".lock";
+}
+
+// Returns true if lock acquired, false otherwise (sets errno).
+static bool acquire_lock(int fd, bool wait) {
+  struct flock fl;
+  memset(&fl, 0, sizeof(fl));
+  fl.l_type = F_WRLCK;
+  fl.l_whence = SEEK_SET;
+  fl.l_start = 0;
+  fl.l_len = 0;  // 0 = entire file
+  return fcntl(fd, wait ? F_SETLKW : F_SETLK, &fl) == 0;
+}
+
+static void release_lock(int fd) {
+  struct flock fl;
+  memset(&fl, 0, sizeof(fl));
+  fl.l_type = F_UNLCK;
+  fl.l_whence = SEEK_SET;
+  fl.l_start = 0;
+  fl.l_len = 0;
+  fcntl(fd, F_SETLK, &fl);
+}
+
 void Database::prepare(const std::string &cmdline) {
   struct timespec now;
   clock_gettime(CLOCK_REALTIME, &now);
@@ -820,6 +860,81 @@ void Database::prepare(const std::string &cmdline) {
   single_step(why, imp->add_run, imp->debugdb);
   imp->run_id = sqlite3_last_insert_rowid(imp->db);
 
+  mkdir_with_parents(".wake/locks", 0755);
+
+  // Acquire lock before committing, so we never appear incomplete without one.
+  std::string our_lock_path = run_lock_path(imp->run_id);
+  imp->run_lock_fd = ::open(our_lock_path.c_str(), O_CREAT | O_CLOEXEC | O_RDWR, 0644);
+  if (imp->run_lock_fd < 0) {
+    std::cerr << "error: failed to create run lock '" << our_lock_path << "': " << strerror(errno)
+              << std::endl;
+    exit(1);
+  }
+  if (!acquire_lock(imp->run_lock_fd, true)) {
+    std::cerr << "error: failed to acquire run lock: " << strerror(errno) << std::endl;
+    unlink(our_lock_path.c_str());
+    exit(1);
+  }
+  end_txn();
+
+  // Query incomplete runs (separate txn; snapshot doesn't need to match above).
+  why = "Could not query incomplete runs";
+  std::vector<std::pair<long, int64_t>> incomplete_runs;  // (run_id, start_time)
+  begin_ro_txn();
+  while (sqlite3_step(imp->get_incomplete_runs) == SQLITE_ROW) {
+    long run_id = sqlite3_column_int64(imp->get_incomplete_runs, 0);
+    int64_t start_time = sqlite3_column_int64(imp->get_incomplete_runs, 1);
+    if (run_id != imp->run_id) {
+      incomplete_runs.emplace_back(run_id, start_time);
+    }
+  }
+  finish_stmt(why, imp->get_incomplete_runs, imp->debugdb);
+  end_txn();
+
+  // Probe locks outside any transaction to avoid blocking DB during IO.
+  // If we can acquire a run's lock, that process is dead.
+  std::vector<long> dead_runs;
+  for (const auto &[run_id, start_time] : incomplete_runs) {
+    std::string lock_path = run_lock_path(run_id);
+    int fd = ::open(lock_path.c_str(), O_RDWR);
+    if (fd < 0) {
+      if (errno == ENOENT) {
+        // No lock file! Conservatively keep if started < 24h ago.
+        constexpr int64_t dead_threshold_ns = 24LL * 60 * 60 * 1000000000LL;
+        if (ts - start_time > dead_threshold_ns) {
+          dead_runs.push_back(run_id);
+        }
+      } else {
+        std::cerr << "warning: failed to open run lock " << run_id << ": " << strerror(errno)
+                  << std::endl;
+      }
+      continue;
+    }
+
+    if (acquire_lock(fd, false)) {
+      dead_runs.push_back(run_id);
+      unlink(lock_path.c_str());  // remove while locked
+      release_lock(fd);
+    } else if (errno != EAGAIN && errno != EACCES) {
+      std::cerr << "warning: failed to probe run lock " << run_id << ": " << strerror(errno)
+                << std::endl;
+    }
+    ::close(fd);
+  }
+
+  // Mark dead runs as reaped (end_time := -1).
+  if (!dead_runs.empty()) {
+    begin_rw_txn();
+    why = "Could not reap dead run";
+    for (long dead_run : dead_runs) {
+      bind_integer(why, imp->set_run_end_time, 1, static_cast<int64_t>(-1));
+      bind_integer(why, imp->set_run_end_time, 2, dead_run);
+      single_step(why, imp->set_run_end_time, imp->debugdb);
+    }
+    end_txn();
+  }
+
+  begin_ro_txn();
   why = "Could not compute GC watermark";
   if (sqlite3_step(imp->get_gc_watermark) == SQLITE_ROW) {
     imp->gc_watermark = sqlite3_column_int64(imp->get_gc_watermark, 0);
@@ -843,6 +958,11 @@ void Database::finish_run() {
   bind_integer(why, imp->set_run_end_time, 2, imp->run_id);
   single_step(why, imp->set_run_end_time, imp->debugdb);
   end_txn();
+
+  // Remove our own lock file - we're done with this run
+  if (imp->run_lock_fd >= 0) {
+    unlink(run_lock_path(imp->run_id).c_str());
+  }
 }
 
 void Database::clean() {

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -906,8 +906,43 @@ void Database::prepare(const std::string &cmdline) {
   }
   end_txn();
 
-  // Query incomplete runs (separate txn; snapshot doesn't need to match above).
-  why = "Could not query incomplete runs";
+  // Reap any dead runs (our run_id is automatically excluded).
+  reap_dead_runs();
+
+  begin_ro_txn();
+  why = "Could not compute GC watermark";
+  if (sqlite3_step(imp->get_gc_watermark) == SQLITE_ROW) {
+    imp->gc_watermark = sqlite3_column_int64(imp->get_gc_watermark, 0);
+  } else {
+    std::cerr << "warning: unable to compute GC watermark" << std::endl;
+    imp->gc_watermark = 0;
+  }
+  finish_stmt(why, imp->get_gc_watermark, imp->debugdb);
+
+  end_txn();
+}
+
+void Database::finish_run() {
+  auto ts = gettime_ns();
+
+  const char *why = "Could not set run end_time";
+  begin_rw_txn();
+  bind_integer(why, imp->set_run_end_time, 1, ts);
+  bind_integer(why, imp->set_run_end_time, 2, imp->run_id);
+  single_step(why, imp->set_run_end_time, imp->debugdb);
+  end_txn();
+
+  // Remove our own lock file - we're done with this run
+  if (imp->run_lock_fd >= 0) {
+    unlink(run_lock_path(imp->run_id).c_str());
+  }
+}
+
+void Database::reap_dead_runs() {
+  auto ts = gettime_ns();
+
+  // Query incomplete runs, excluding our own (imp->run_id is 0 if no run).
+  auto *why = "Could not query incomplete runs";
   std::vector<std::pair<long, int64_t>> incomplete_runs;  // (run_id, start_time)
   begin_ro_txn();
   while (sqlite3_step(imp->get_incomplete_runs) == SQLITE_ROW) {
@@ -961,34 +996,6 @@ void Database::prepare(const std::string &cmdline) {
       single_step(why, imp->set_run_end_time, imp->debugdb);
     }
     end_txn();
-  }
-
-  begin_ro_txn();
-  why = "Could not compute GC watermark";
-  if (sqlite3_step(imp->get_gc_watermark) == SQLITE_ROW) {
-    imp->gc_watermark = sqlite3_column_int64(imp->get_gc_watermark, 0);
-  } else {
-    std::cerr << "warning: unable to compute GC watermark" << std::endl;
-    imp->gc_watermark = 0;
-  }
-  finish_stmt(why, imp->get_gc_watermark, imp->debugdb);
-
-  end_txn();
-}
-
-void Database::finish_run() {
-  auto ts = gettime_ns();
-
-  const char *why = "Could not set run end_time";
-  begin_rw_txn();
-  bind_integer(why, imp->set_run_end_time, 1, ts);
-  bind_integer(why, imp->set_run_end_time, 2, imp->run_id);
-  single_step(why, imp->set_run_end_time, imp->debugdb);
-  end_txn();
-
-  // Remove our own lock file - we're done with this run
-  if (imp->run_lock_fd >= 0) {
-    unlink(run_lock_path(imp->run_id).c_str());
   }
 }
 

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -848,6 +848,24 @@ static void release_lock(int fd) {
   fcntl(fd, F_SETLK, &fl);
 }
 
+static bool write_pid_fd(int fd) {
+  static_assert(sizeof(pid_t) <= sizeof(long), "pid_t must fit in long");
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%ld\n", (long)getpid());
+  if (len <= 0 || len >= (int)sizeof(buf)) {
+    return false;
+  }
+  for (int off = 0; off < len;) {
+    auto n = write(fd, buf + off, len - off);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    off += n;
+  }
+  return true;
+}
+
 void Database::prepare(const std::string &cmdline) {
   struct timespec now;
   clock_gettime(CLOCK_REALTIME, &now);
@@ -870,6 +888,12 @@ void Database::prepare(const std::string &cmdline) {
               << std::endl;
     exit(1);
   }
+  if (!write_pid_fd(imp->run_lock_fd)) {
+    std::cerr << "error: failed to write pid to run lock '" << our_lock_path
+              << "': " << strerror(errno) << std::endl;
+    exit(1);
+  }
+
   if (!acquire_lock(imp->run_lock_fd, true)) {
     std::cerr << "error: failed to acquire run lock: " << strerror(errno) << std::endl;
     unlink(our_lock_path.c_str());

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -38,6 +38,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "run_lock.h"
 #include "schema.h"
 #include "status.h"
 #include "util/mkdir_parents.h"
@@ -102,7 +103,7 @@ struct Database::detail {
 
   long run_id;
   long gc_watermark;
-  int run_lock_fd;
+  std::optional<RunLock> run_lock;
   detail(bool debugdb_)
       : debugdb(debugdb_),
         db(0),
@@ -150,8 +151,7 @@ struct Database::detail {
         set_run_end_time(0),
         get_incomplete_runs(0),
         run_id(0),
-        gc_watermark(0),
-        run_lock_fd(-1) {}
+        gc_watermark(0) {}
 };
 
 class WaitingIndicator {
@@ -596,11 +596,7 @@ void Database::close() {
   FINALIZE(set_run_end_time);
   FINALIZE(get_incomplete_runs);
 
-  // Close run lock file if held
-  if (imp->run_lock_fd >= 0) {
-    ::close(imp->run_lock_fd);
-    imp->run_lock_fd = -1;
-  }
+  imp->run_lock.reset();
 
   close_db(this);
   release_build_lock();
@@ -830,49 +826,6 @@ void Database::entropy(uint64_t *key, int words) {
   end_txn();
 }
 
-static std::string run_lock_path(long run_id) {
-  return ".wake/locks/run_" + std::to_string(run_id) + ".lock";
-}
-
-// Returns true if lock acquired, false otherwise (sets errno).
-static bool acquire_lock(int fd, bool wait) {
-  struct flock fl;
-  memset(&fl, 0, sizeof(fl));
-  fl.l_type = F_WRLCK;
-  fl.l_whence = SEEK_SET;
-  fl.l_start = 0;
-  fl.l_len = 0;  // 0 = entire file
-  return fcntl(fd, wait ? F_SETLKW : F_SETLK, &fl) == 0;
-}
-
-static void release_lock(int fd) {
-  struct flock fl;
-  memset(&fl, 0, sizeof(fl));
-  fl.l_type = F_UNLCK;
-  fl.l_whence = SEEK_SET;
-  fl.l_start = 0;
-  fl.l_len = 0;
-  fcntl(fd, F_SETLK, &fl);
-}
-
-static bool write_pid_fd(int fd) {
-  static_assert(sizeof(pid_t) <= sizeof(long), "pid_t must fit in long");
-  char buf[32];
-  int len = snprintf(buf, sizeof(buf), "%ld\n", (long)getpid());
-  if (len <= 0 || len >= (int)sizeof(buf)) {
-    return false;
-  }
-  for (int off = 0; off < len;) {
-    auto n = write(fd, buf + off, len - off);
-    if (n < 0) {
-      if (errno == EINTR) continue;
-      return false;
-    }
-    off += n;
-  }
-  return true;
-}
-
 void Database::prepare(const std::string &cmdline) {
   auto ts = gettime_ns();
 
@@ -883,27 +836,13 @@ void Database::prepare(const std::string &cmdline) {
   single_step(why, imp->add_run, imp->debugdb);
   imp->run_id = sqlite3_last_insert_rowid(imp->db);
 
-  mkdir_with_parents(".wake/locks", 0755);
-
   // Acquire lock before committing, so we never appear incomplete without one.
-  std::string our_lock_path = run_lock_path(imp->run_id);
-  imp->run_lock_fd = ::open(our_lock_path.c_str(), O_CREAT | O_CLOEXEC | O_RDWR, 0644);
-  if (imp->run_lock_fd < 0) {
-    std::cerr << "error: failed to create run lock '" << our_lock_path << "': " << strerror(errno)
-              << std::endl;
+  auto lock = RunLock::create_and_acquire(imp->run_id, true);
+  if (!lock) {
+    std::cerr << "error: " << lock.error() << std::endl;
     exit(1);
   }
-  if (!write_pid_fd(imp->run_lock_fd)) {
-    std::cerr << "error: failed to write pid to run lock '" << our_lock_path
-              << "': " << strerror(errno) << std::endl;
-    exit(1);
-  }
-
-  if (!acquire_lock(imp->run_lock_fd, true)) {
-    std::cerr << "error: failed to acquire run lock: " << strerror(errno) << std::endl;
-    unlink(our_lock_path.c_str());
-    exit(1);
-  }
+  imp->run_lock = std::move(*lock);
   end_txn();
 
   // Reap any dead runs (our run_id is automatically excluded).
@@ -933,8 +872,8 @@ void Database::finish_run() {
   end_txn();
 
   // Remove our own lock file - we're done with this run
-  if (imp->run_lock_fd >= 0) {
-    unlink(run_lock_path(imp->run_id).c_str());
+  if (imp->run_lock) {
+    imp->run_lock->unlink_file();
   }
 }
 
@@ -959,31 +898,12 @@ void Database::reap_dead_runs() {
   // If we can acquire a run's lock, that process is dead.
   std::vector<long> dead_runs;
   for (const auto &[run_id, start_time] : incomplete_runs) {
-    std::string lock_path = run_lock_path(run_id);
-    int fd = ::open(lock_path.c_str(), O_RDWR);
-    if (fd < 0) {
-      if (errno == ENOENT) {
-        // No lock file! Conservatively keep if started < 24h ago.
-        constexpr int64_t dead_threshold_ns = 24LL * 60 * 60 * 1000000000LL;
-        if (ts - start_time > dead_threshold_ns) {
-          dead_runs.push_back(run_id);
-        }
-      } else {
-        std::cerr << "warning: failed to open run lock " << run_id << ": " << strerror(errno)
-                  << std::endl;
-      }
-      continue;
-    }
-
-    if (acquire_lock(fd, false)) {
+    auto result = RunLockProbe::probe_and_cleanup_if_dead(run_id, start_time, ts);
+    if (!result) {
+      std::cerr << "warning: " << result.error() << std::endl;
+    } else if (*result) {
       dead_runs.push_back(run_id);
-      unlink(lock_path.c_str());  // remove while locked
-      release_lock(fd);
-    } else if (errno != EAGAIN && errno != EACCES) {
-      std::cerr << "warning: failed to probe run lock " << run_id << ": " << strerror(errno)
-                << std::endl;
     }
-    ::close(fd);
   }
 
   // Mark dead runs as reaped (end_time := -1).

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -29,6 +29,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <set>
@@ -181,6 +182,12 @@ class WaitingIndicator {
 
   ~WaitingIndicator() { finish(); }
 };
+
+static int64_t gettime_ns() {
+  using namespace std::chrono;
+  auto now = system_clock::now();
+  return duration_cast<nanoseconds>(now.time_since_epoch()).count();
+}
 
 static void close_db(Database *db) {
   if (!db || !db->imp || !db->imp->db) {
@@ -867,9 +874,7 @@ static bool write_pid_fd(int fd) {
 }
 
 void Database::prepare(const std::string &cmdline) {
-  struct timespec now;
-  clock_gettime(CLOCK_REALTIME, &now);
-  int64_t ts = static_cast<int64_t>(now.tv_sec) * 1000000000 + now.tv_nsec;
+  auto ts = gettime_ns();
 
   const char *why = "Could not insert run";
   begin_rw_txn();
@@ -972,9 +977,7 @@ void Database::prepare(const std::string &cmdline) {
 }
 
 void Database::finish_run() {
-  struct timespec now;
-  clock_gettime(CLOCK_REALTIME, &now);
-  int64_t ts = static_cast<int64_t>(now.tv_sec) * 1000000000 + now.tv_nsec;
+  auto ts = gettime_ns();
 
   const char *why = "Could not set run end_time";
   begin_rw_txn();

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -19,12 +19,14 @@
 #define DATABASE_H
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
 
 #include "json/json5.h"
+#include "run_lock.h"
 
 struct FileReflection {
   std::string path;

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -135,6 +135,10 @@ struct Database {
   void finish_run();                         // mark run as complete (sets end_time)
   void clean();                              // finished execution; sweep stale jobs
 
+  // Reap dead runs: probe lock files and mark crashed runs as reaped.
+  // Automatically excludes our own run_id if prepare() was called.
+  void reap_dead_runs();
+
   // Reclaim space on disk from deleted records.
   // If not incremental, will lock DB exclusively for duration.
   // Recommend a blocking checkpoint after full.

--- a/src/runtime/run_lock.cpp
+++ b/src/runtime/run_lock.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Open Group Base Specifications Issue 7
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
+
+#include "run_lock.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <iostream>
+#include <sstream>
+
+#include "util/mkdir_parents.h"
+
+// Generate lock file path for a given run_id.
+static std::string run_lock_path(long run_id) {
+  return ".wake/locks/run_" + std::to_string(run_id) + ".lock";
+}
+
+// Returns true if lock acquired, false otherwise (sets errno).
+static bool acquire_lock(int fd, bool wait) {
+  struct flock fl;
+  memset(&fl, 0, sizeof(fl));
+  fl.l_type = F_WRLCK;
+  fl.l_whence = SEEK_SET;
+  fl.l_start = 0;
+  fl.l_len = 0;  // 0 = entire file
+  return fcntl(fd, wait ? F_SETLKW : F_SETLK, &fl) == 0;
+}
+
+// Release fcntl lock on file descriptor
+static void release_lock(int fd) {
+  struct flock fl;
+  memset(&fl, 0, sizeof(fl));
+  fl.l_type = F_UNLCK;
+  fl.l_whence = SEEK_SET;
+  fl.l_start = 0;
+  fl.l_len = 0;
+  fcntl(fd, F_SETLK, &fl);
+}
+
+// Write current PID to file descriptor
+static bool write_pid_fd(int fd) {
+  static_assert(sizeof(pid_t) <= sizeof(long), "pid_t must fit in long");
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%ld\n", (long)getpid());
+  if (len <= 0 || len >= (int)sizeof(buf)) {
+    return false;
+  }
+  for (int off = 0; off < len;) {
+    auto n = write(fd, buf + off, len - off);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    off += n;
+  }
+  return true;
+}
+
+template <typename R = RunLock, typename... Args>
+static auto make_error(Args&&... args) {
+  std::stringstream ss;
+  (ss << ... << std::forward<Args>(args));
+
+  return wcl::make_error<R, std::string>(ss.str());
+}
+
+template <typename R = RunLock, typename... Args>
+static auto make_errno(Args&... args) {
+  return make_error<R>(std::forward<Args>(args)..., ": ", strerror(errno));
+}
+
+// RunLock implementation
+
+RunLock::RunLock(wcl::unique_fd&& fd, std::string path)
+    : fd(std::move(fd)), path(std::move(path)) {}
+
+RunLock::LockAcquireRetTy RunLock::create_and_acquire(long run_id, bool wait) {
+  // Ensure lock directory exists
+  mkdir_with_parents(".wake/locks", 0755);
+
+  std::string lock_path = run_lock_path(run_id);
+  auto fd = wcl::unique_fd::open(lock_path.c_str(), O_CREAT | O_CLOEXEC | O_RDWR, 0644);
+  if (!fd) {
+    errno = fd.error();
+    return make_errno("failed to create run lock '", lock_path, "'");
+  }
+
+  if (!write_pid_fd(fd->get())) {
+    auto err = make_errno("failed to write pid to run lock '", lock_path, "'");
+    fd->close();
+    return err;
+  }
+
+  if (!acquire_lock(fd->get(), wait)) {
+    int saved_errno = errno;
+    fd->close();
+    unlink(lock_path.c_str());
+    errno = saved_errno;
+    return make_errno("failed to acquire own run lock '", lock_path, "'");
+  }
+
+  return wcl::result_value<std::string>(RunLock{std::move(*fd), std::move(lock_path)});
+}
+
+void RunLock::unlink_file() { ::unlink(path.c_str()); }
+
+// RunLockProbe implementation
+
+namespace RunLockProbe {
+
+wcl::result<bool, std::string> probe_and_cleanup_if_dead(long run_id, int64_t start_time,
+                                                         int64_t current_time) {
+  std::string lock_path = run_lock_path(run_id);
+  int fd = ::open(lock_path.c_str(), O_RDWR | O_CLOEXEC);
+
+  if (fd < 0) {
+    if (errno == ENOENT) {
+      // No lock file! Conservatively consider dead only if started > 24h ago.
+      constexpr int64_t dead_threshold_ns = 24LL * 60 * 60 * 1000000000LL;
+      return wcl::result_value<std::string>(current_time - start_time > dead_threshold_ns);
+    }
+    return make_errno<bool>("failed to open run lock ", run_id);
+  }
+
+  // Try to acquire the lock non-blocking
+  if (acquire_lock(fd, false)) {
+    // Lock acquired - process is dead
+    unlink(lock_path.c_str());  // remove while locked
+    release_lock(fd);
+    ::close(fd);
+    return wcl::result_value<std::string>(true);
+  }
+  if (errno != EAGAIN && errno != EACCES) {
+    ::close(fd);
+    return make_errno<bool>("failed to probe run lock ", run_id);
+  }
+
+  ::close(fd);
+  return wcl::result_value<std::string>(false);
+}
+
+}  // namespace RunLockProbe

--- a/src/runtime/run_lock.h
+++ b/src/runtime/run_lock.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RUN_LOCK_H
+#define RUN_LOCK_H
+
+#include <string>
+
+#include "wcl/result.h"
+#include "wcl/unique_fd.h"
+
+// RAII wrapper for run lock files.
+// Runs keep write lock on these while live.
+class RunLock {
+ public:
+  using LockAcquireRetTy = wcl::result<RunLock, std::string>;
+
+  // Create and acquire a lock for the given run_id.
+  static LockAcquireRetTy create_and_acquire(long run_id, bool wait);
+
+  // Move-only
+  RunLock(RunLock&& other) noexcept = default;
+  RunLock& operator=(RunLock&& other) noexcept = default;
+  RunLock(const RunLock&) = delete;
+  RunLock& operator=(const RunLock&) = delete;
+
+  // Close the file descriptor for this lock.
+  // Use unlink_file() to remove it on graceful exit path.
+  ~RunLock() = default;
+
+  // Explicitly unlink the lock file (call on successful run completion)
+  void unlink_file();
+
+ private:
+  RunLock(wcl::unique_fd&& fd, std::string path);
+
+  wcl::unique_fd fd;
+  std::string path;
+};
+
+// Utility functions for probing other processes' run locks
+namespace RunLockProbe {
+// Check if a run's lock is held by a live process.
+// Returns true if dead, false if alive.
+// On error, return string message.  Consider alive.
+// If dead and the lock file exists, it will be cleaned up.
+wcl::result<bool, std::string> probe_and_cleanup_if_dead(long run_id, int64_t start_time,
+                                                         int64_t current_time);
+}  // namespace RunLockProbe
+
+#endif

--- a/src/wcl/unique_fd.h
+++ b/src/wcl/unique_fd.h
@@ -44,12 +44,12 @@ class unique_fd {
   unique_fd(const unique_fd&) = delete;
   explicit unique_fd(int fd) : fd(fd) {}
 
-  unique_fd& operator=(unique_fd&& f) {
+  unique_fd& operator=(unique_fd&& f) noexcept {
     fd = f.fd;
     f.fd = -1;
     return *this;
   }
-  unique_fd(unique_fd&& f) : fd(f.fd) { f.fd = -1; }
+  unique_fd(unique_fd&& f) noexcept : fd(f.fd) { f.fd = -1; }
 
   ~unique_fd() {
     // We can't actully handle the error here because


### PR DESCRIPTION
Use per-run lock files (.wake/locks/run_N.lock) to detect dead wake
processes.  Each wake process creates and holds an exclusive fcntl
lock on its lock file for the duration of the run.  On startup, probe
lock files of incomplete runs -- if we can acquire the lock, the
original process is dead and we mark it as reaped (end_time == -1).

Additionally:
If for whatever reason lock files are missing, to avoid blocking
GC watermark indefinitely assumes such runs are dead if they
started more than 24 hours ago.
This is mostly to cover a strange case that shouldn't happen,
not a part of anyone's normal flow.