### PR TITLE
multi-wake: remove .wake-build-lock mechanism

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -210,13 +210,6 @@ Database::~Database() { close(); }
 std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   if (imp->db) return "";
 
-  // Try to acquire build lock for write operations
-  if (!readonly) {
-    if (!try_acquire_build_lock(wait, tty)) {
-      return "Failed to acquire build lock";
-    }
-  }
-
   int flags = readonly ? SQLITE_OPEN_READONLY : SQLITE_OPEN_READWRITE;
 
   WaitingIndicator indicator(tty);
@@ -599,77 +592,6 @@ void Database::close() {
   imp->run_lock.reset();
 
   close_db(this);
-  release_build_lock();
-}
-
-bool Database::try_acquire_build_lock(bool wait, bool tty) {
-  const char *lock_file = ".wake-build-lock";
-  WaitingIndicator indicator(tty);
-
-  while (true) {
-    int fd = ::open(lock_file, O_CREAT | O_EXCL | O_WRONLY, 0644);
-
-    if (fd != -1) {
-      // Successfully acquired lock
-      char pid_str[32];
-      snprintf(pid_str, sizeof(pid_str), "%d\n", getpid());
-      ssize_t written = ::write(fd, pid_str, strlen(pid_str));
-      ::close(fd);
-
-      if (written < (ssize_t)strlen(pid_str)) {
-        std::cerr << "Failed to create build lock: "
-                  << (written < 0 ? strerror(errno) : "incomplete pid written") << std::endl;
-        unlink(lock_file);
-        return false;
-      }
-
-      indicator.finish();
-      build_lock_acquired = true;
-      return true;
-    }
-
-    if (errno != EEXIST) {
-      std::cerr << "Failed to create build lock: " << strerror(errno) << std::endl;
-      return false;
-    }
-
-    // Lock exists - check if process is still alive
-    if (!is_lock_valid(lock_file)) {
-      unlink(lock_file);  // Stale lock, remove and retry
-      continue;
-    }
-
-    if (!wait) {
-      std::cerr << "Another wake target is running. Exiting early because of '--no-wait' argument."
-                << std::endl;
-      return false;
-    }
-
-    indicator.show_waiting("Another wake target is running; waiting");
-    sleep(1);
-  }
-}
-
-void Database::release_build_lock() {
-  if (build_lock_acquired) {
-    unlink(".wake-build-lock");
-    build_lock_acquired = false;
-  }
-}
-
-bool Database::is_lock_valid(const char *lock_file) {
-  FILE *f = fopen(lock_file, "r");
-  if (!f) return false;
-
-  int pid;
-  if (fscanf(f, "%d", &pid) != 1) {
-    fclose(f);
-    return false;
-  }
-  fclose(f);
-
-  // Check if process exists
-  return kill(pid, 0) == 0;
 }
 
 static void finish_stmt(const char *why, sqlite3_stmt *stmt, bool debug) {

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -222,17 +222,11 @@ struct Database {
   // bool=true if error present, false if NULL
   std::pair<bool, std::string> get_runner_status(long job_id);
 
-  // Build locking for non-inspection commands
-  bool try_acquire_build_lock(bool wait, bool tty);
-  void release_build_lock();
-
  private:
   void begin_ro_txn() const;
   void begin_rw_txn() const;
   void end_txn() const;
 
-  bool is_lock_valid(const char *lock_file);
-  bool build_lock_acquired = false;
   int checkpoint_interval;
 };
 

--- a/src/runtime/schema.h
+++ b/src/runtime/schema.h
@@ -29,7 +29,6 @@ inline const char *getWakeSchemaSQLTxn() {
          "create table if not exists entropy("
          "  row_id integer primary key autoincrement,"
          "  seed   integer not null);"
-         "update entropy set seed=0 where 0;"  // "write" to acquire exclusive lock
          "create table if not exists schema("
          "  version integer primary key);"
          "create table if not exists runs("


### PR DESCRIPTION
The file-based build lock prevented concurrent wake invocations.
This is no longer needed, remove it!

Remove entropy table exclusive lock in schema.

---------

Should land at least after #1760 .