### PR TITLE
--history: show run status, end time, and duration 

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -425,7 +425,8 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   const char *sql_tag_job = "insert into tags(job_id, uri, content) values(?, ?, ?)";
   const char *sql_get_tags = "select job_id, uri, content from tags where job_id=?";
   const char *sql_get_all_tags = "select job_id, uri, content from tags";
-  const char *sql_get_all_runs = "select run_id, time, cmdline from runs order by time ASC";
+  const char *sql_get_all_runs =
+      "select run_id, time, end_time, cmdline from runs order by time ASC";
   const char *sql_get_edges =
       "select distinct user.job_id as user, used.job_id as used"
       "  from filetree user, filetree used"
@@ -2000,8 +2001,13 @@ std::vector<RunReflection> Database::get_runs() const {
   while (sqlite3_step(imp->get_all_runs) == SQLITE_ROW) {
     RunReflection run;
     run.id = sqlite3_column_int(imp->get_all_runs, 0);
-    run.time = Time(sqlite3_column_int64(imp->get_all_runs, 1));
-    run.cmdline = rip_column(imp->get_all_runs, 2);
+    run.start_time = Time(sqlite3_column_int64(imp->get_all_runs, 1));
+    if (sqlite3_column_type(imp->get_all_runs, 2) == SQLITE_NULL) {
+      run.end_time = std::nullopt;
+    } else {
+      run.end_time = sqlite3_column_int64(imp->get_all_runs, 2);
+    }
+    run.cmdline = rip_column(imp->get_all_runs, 3);
     out.emplace_back(run);
   }
   finish_stmt("Could not retrieve runs", imp->get_all_runs, imp->debugdb);

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -75,11 +75,10 @@ struct Time {
 
 struct RunReflection {
   int id;
-  Time time;
+  Time start_time;
+  std::optional<int64_t> end_time;  // nullopt=running, >0=completed, -1=reaped
   std::string cmdline;
   RunReflection() = default;
-  RunReflection(int id_, int64_t time_, std::string cmdline_)
-      : id(id_), time(time_), cmdline(cmdline_) {}
 };
 
 struct JobReflection {

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -172,10 +172,38 @@ void hide_internal_jobs(std::vector<std::vector<std::string>> &out) {
   out.push_back({"tags NOT LIKE '%<d>inspect.visibility=hidden<d>%'", "tags IS NULL"});
 }
 
+static std::string format_duration(int64_t nanos) {
+  using namespace std::chrono;
+  auto total = duration_cast<seconds>(nanoseconds(nanos));
+
+  auto h = duration_cast<hours>(total);
+  auto m = duration_cast<minutes>(total) % 60;
+  auto s = total % 60;
+
+  int64_t days = h.count() / 24;
+  int64_t hrs = h.count() % 24;
+
+  if (days > 0) return std::to_string(days) + "d" + std::to_string(hrs) + "h";
+  if (hrs > 0) return std::to_string(hrs) + "h" + std::to_string(m.count()) + "m";
+  if (m.count() > 0) return std::to_string(m.count()) + "m" + std::to_string(s.count()) + "s";
+  return std::to_string(s.count()) + "s";
+}
+
 void query_runs(Database &db) {
   const auto runs = db.get_runs();
   for (const auto &run : runs) {
-    std::cout << run.time.as_string() << " " << run.cmdline << std::endl;
+    std::cout << run.start_time.as_string() << " → ";
+    if (!run.end_time) {
+      std::cout << "...                  [running]  ";
+    } else if (*run.end_time < 0) {
+      std::cout << "???                  [crashed]  ";
+    } else {
+      Time end(*run.end_time);
+      int64_t duration = *run.end_time - run.start_time.as_int64();
+      std::cout << end.as_string() << "  " << std::setw(9) << std::left
+                << ("[" + format_duration(duration) + "]") << "  ";
+    }
+    std::cout << run.cmdline << std::endl;
   }
 }
 


### PR DESCRIPTION
Display whether each run is running, crashed, or duration.
Adds end_time to RunReflection.
Migrated runs show 0s since we lack their actual end time.
