### PR TITLE
Add builtin type Time

### DIFF
--- a/.wakemanifest
+++ b/.wakemanifest
@@ -35,6 +35,7 @@ share/wake/lib/system/runner.wake
 share/wake/lib/system/remote_cache_api.wake
 share/wake/lib/system/remote_cache_runner.wake
 share/wake/lib/system/sources.wake
+share/wake/lib/system/time.wake
 src/compat/compat.wake
 src/dst/dst.wake
 src/json/json.wake

--- a/share/wake/lib/core/types.wake
+++ b/share/wake/lib/core/types.wake
@@ -78,3 +78,13 @@ from builtin export type RegExp
 #
 # Jobs are created via the `runJob` API.
 from builtin export type Job
+
+# The Time type is a builtin of the wake language itself.
+#
+# A Time object represents a point in time with nanosecond
+# precision, stored as nanoseconds since the Unix epoch
+# (January 1, 1970 00:00:00 UTC).
+#
+# Time values are created via the `getTime` API and can be
+# formatted using `formatTime`.
+from builtin export type Time

--- a/share/wake/lib/system/time.wake
+++ b/share/wake/lib/system/time.wake
@@ -1,0 +1,200 @@
+# Copyright 2026 SiFive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You should have received a copy of LICENSE.Apache2 along with
+# this software. If not, you may obtain a copy at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package wake
+
+# Time Library
+#
+# The Time type is a built-in type representing a point in time with nanosecond
+# precision. Internally, it stores nanoseconds since the Unix epoch (1970-01-01
+# 00:00:00 UTC).
+
+# getTime: Get the current system time.
+#
+# Returns a Time value representing the current time with nanosecond precision.
+# This function observes the system clock and is marked as ORDERED to ensure
+# proper sequencing in the build system.
+#
+# Example:
+#   def now = getTime Unit
+export def getTime (_: a): Time =
+    prim "get_time"
+
+# formatTime: Format a Time value as a string in UTC.
+#
+# Converts a Time value to a human-readable string using strftime format
+# specifiers. The output is always in UTC.
+#
+# Arguments:
+#   format - strftime format string
+#   time   - Time value to format
+#
+# Example:
+#   def now = getTime Unit
+#   formatTime "%Y-%m-%d" now                    # "2026-03-10"
+#   formatTime "%A, %B %d, %Y" now               # "Monday, March 10, 2026"
+#   formatTime "%Y-%m-%d %H:%M:%S" now           # "2026-03-10 08:15:07"
+export def formatTime (format: String) (time: Time): String =
+    (\f \t prim "format_time") format time
+
+# formatTimeTZ: Format a Time value as a string in a specific timezone.
+#
+# Converts a Time value to a human-readable string using strftime format
+# specifiers in the specified timezone.
+#
+# Arguments:
+#   format   - strftime format string
+#   timezone - IANA timezone name (e.g., "America/Los_Angeles", "UTC", "PST8PDT")
+#   time     - Time value to format
+#
+# Example:
+#   def now = getTime Unit
+#   formatTimeTZ "%Y-%m-%d %H:%M:%S" "UTC" now                    # "2026-03-10 08:15:07"
+#   formatTimeTZ "%Y-%m-%d %H:%M:%S" "America/Los_Angeles" now    # "2026-03-10 00:15:07"
+#   formatTimeTZ "%Y-%m-%d %H:%M:%S %Z" "America/New_York" now    # "2026-03-10 03:15:07 EST"
+export def formatTimeTZ (format: String) (timezone: String) (time: Time): String =
+    (\f \tz \t prim "format_time_tz") format timezone time
+
+# parseTime: Parse a time string into a Time value.
+#
+# Parses a time string according to a strptime format string and returns a
+# Time value. Parsing is done in UTC. If the format string doesn't specify
+# all fields, missing fields default to epoch values (1970-01-01 00:00:00).
+#
+# Arguments:
+#   format  - strptime format string
+#   timestr - String to parse
+#
+# Example:
+#   parseTime "%Y-%m-%d" "2020-01-01"                    # 2020-01-01 00:00:00 UTC
+#   parseTime "%Y-%m-%d %H:%M:%S" "2020-06-15 14:30:00"  # 2020-06-15 14:30:00 UTC
+export def parseTime (format: String) (timestr: String): Time =
+    (\f \t prim "parse_time") format timestr
+
+# formatDate: Format the current date/time in UTC.
+#
+# Convenience function that gets the current time and formats it in one step.
+# Equivalent to: formatTime format (getTime Unit)
+#
+# Arguments:
+#   format - strftime format string
+#
+# Example:
+#   formatDate "%Y-%m-%d"              # "2026-03-10"
+#   formatDate "%Y-%m-%d %H:%M:%S"     # "2026-03-10 08:15:07"
+export def formatDate (format: String): String =
+    formatTime format (getTime Unit)
+
+# formatDateTZ: Format the current date/time in a specific timezone.
+#
+# Convenience function that gets the current time and formats it in a specific
+# timezone in one step.
+# Equivalent to: formatTimeTZ format timezone (getTime Unit)
+#
+# Arguments:
+#   format   - strftime format string
+#   timezone - IANA timezone name (e.g., "America/Los_Angeles", "UTC", "PST8PDT")
+#
+# Example:
+#   formatDateTZ "%Y-%m-%d %H:%M:%S" "UTC"                    # "2026-03-10 08:15:07"
+#   formatDateTZ "%Y-%m-%d %H:%M:%S" "America/Los_Angeles"    # "2026-03-10 00:15:07"
+#   formatDateTZ "%Y-%m-%d %H:%M:%S %Z" "America/New_York"    # "2026-03-10 03:15:07 EST"
+export def formatDateTZ (format: String) (timezone: String): String =
+    formatTimeTZ format timezone (getTime Unit)
+
+# tsub: Subtract two Time values
+#
+# Computes the difference between two Time values using type-safe chrono
+# arithmetic. Returns an Integer representing the number of nanoseconds
+# between the two times (t1 - t2).
+#
+# Arguments:
+#   t1 - First time (minuend)
+#   t2 - Second time (subtrahend)
+#
+# Returns:
+#   Integer nanoseconds (positive if t1 > t2, negative if t1 < t2)
+#
+# Example:
+#   def start = getTime Unit
+#   # ... do work ...
+#   def end = getTime Unit
+#   def elapsedNanos = tsub end start
+#   def elapsedSeconds = elapsedNanos / 1000000000
+#   println "Elapsed: {str elapsedSeconds} seconds"
+export def tsub (t1: Time) (t2: Time): Integer =
+    (\a \b prim "time_sub") t1 t2
+
+# tadd: Add nanoseconds to a Time value, returning a new Time.
+#
+# Adds an Integer number of nanoseconds to a Time value using type-safe
+# chrono arithmetic. Returns a new Time value.
+#
+# Arguments:
+#   time  - Base time
+#   nanos - Nanoseconds to add (can be negative to subtract)
+#
+# Returns:
+#   New Time value
+#
+# Example:
+#   def now = getTime Unit
+#   def oneHourLater = tadd now 3600000000000  # Add 1 hour (3600 * 10^9 ns)
+#   def oneMinuteAgo = tadd now (-60000000000) # Subtract 1 minute
+export def tadd (time: Time) (nanos: Integer): Time =
+    (\t \n prim "time_add") time nanos
+
+# Compare two Time values for Order.
+# tcmp t1 t2 = LT  # if t1 < t2
+# tcmp t1 t2 = EQ  # if t1 == t2
+# tcmp t1 t2 = GT  # if t1 > t2
+export def tcmp (x: Time) (y: Time): Order =
+    (\a \b prim "time_cmp") x y
+
+# Binary three-way comparison operator for Time values.
+# Returns LT if x < y, EQ if x == y, GT if x > y.
+# t1 <=>$ t2 = LT  # if t1 < t2
+export def (x: Time) <=>$ (y: Time): Order =
+    tcmp x y
+
+# Binary Less-Than operator for Time values.
+# parseTime "%Y-%m-%d" "2020-01-01" <$ parseTime "%Y-%m-%d" "2020-01-02"  # True
+export def (x: Time) <$ (y: Time): Boolean =
+    isLT (x <=>$ y)
+
+# Binary Greater-Than operator for Time values.
+# parseTime "%Y-%m-%d" "2020-01-02" >$ parseTime "%Y-%m-%d" "2020-01-01"  # True
+export def (x: Time) >$ (y: Time): Boolean =
+    isGT (x <=>$ y)
+
+# Binary Greater-Or-Equal operator for Time values.
+# parseTime "%Y-%m-%d" "2020-01-02" >=$ parseTime "%Y-%m-%d" "2020-01-01"  # True
+export def (x: Time) >=$ (y: Time): Boolean =
+    isGE (x <=>$ y)
+
+# Binary Less-Or-Equal operator for Time values.
+# parseTime "%Y-%m-%d" "2020-01-01" <=$ parseTime "%Y-%m-%d" "2020-01-02"  # True
+export def (x: Time) <=$ (y: Time): Boolean =
+    isLE (x <=>$ y)
+
+# Binary Is-Equal operator for Time values.
+# parseTime "%Y-%m-%d" "2020-01-01" ==$ parseTime "%Y-%m-%d" "2020-01-01"  # True
+export def (x: Time) ==$ (y: Time): Boolean =
+    isEQ (x <=>$ y)
+
+# Binary Not-Equal operator for Time values.
+# parseTime "%Y-%m-%d" "2020-01-01" !=$ parseTime "%Y-%m-%d" "2020-01-02"  # True
+export def (x: Time) !=$ (y: Time): Boolean =
+    isNE (x <=>$ y)

--- a/src/dst/expr.cpp
+++ b/src/dst/expr.cpp
@@ -70,6 +70,8 @@ Top::Top() : packages(), globals(), def_package(nullptr) {
       std::make_pair("Array", SymbolSource(FRAGMENT_CPP_LINE, "Array@builtin", SYM_LEAF)));
   builtin->package.types.insert(
       std::make_pair("Job", SymbolSource(FRAGMENT_CPP_LINE, "Job@builtin", SYM_LEAF)));
+  builtin->package.types.insert(
+      std::make_pair("Time", SymbolSource(FRAGMENT_CPP_LINE, "Time@builtin", SYM_LEAF)));
   builtin->exports = builtin->package;
 }
 

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1279,7 +1279,7 @@ static std::vector<std::string> chop_null(const std::string &str) {
   return out;
 }
 
-std::string Time::as_string() const {
+std::string DBTime::as_string() const {
   char buf[100];
   struct tm tm;
   time_t time = t / 1000000000;
@@ -1521,10 +1521,10 @@ static JobReflection find_one(const Database *db, sqlite3_stmt *query) {
   desc.environment = chop_null(rip_column(query, 4));
   desc.stack = rip_column(query, 5);
   desc.stdin_file = rip_column(query, 6);
-  desc.starttime = Time(sqlite3_column_int64(query, 7));
-  desc.endtime = Time(sqlite3_column_int64(query, 8));
+  desc.starttime = DBTime(sqlite3_column_int64(query, 7));
+  desc.endtime = DBTime(sqlite3_column_int64(query, 8));
   desc.stale = sqlite3_column_int64(query, 9) != 0;
-  desc.wake_start = Time(sqlite3_column_int64(query, 10));
+  desc.wake_start = DBTime(sqlite3_column_int64(query, 10));
   desc.wake_cmdline = rip_column(query, 11);
   desc.usage.status = sqlite3_column_int64(query, 12);
   desc.usage.runtime = sqlite3_column_double(query, 13);
@@ -1869,7 +1869,7 @@ std::vector<RunReflection> Database::get_runs() const {
   while (sqlite3_step(imp->get_all_runs) == SQLITE_ROW) {
     RunReflection run;
     run.id = sqlite3_column_int(imp->get_all_runs, 0);
-    run.time = Time(sqlite3_column_int64(imp->get_all_runs, 1));
+    run.time = DBTime(sqlite3_column_int64(imp->get_all_runs, 1));
     run.cmdline = rip_column(imp->get_all_runs, 2);
     out.emplace_back(run);
   }

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -53,17 +53,17 @@ struct JobTag {
       : job(job_), uri(std::move(uri_)), content(std::move(content_)) {}
 };
 
-struct Time {
+struct DBTime {
   int64_t t;
-  Time() : t(0) {}
-  explicit Time(int64_t _t) : t(_t) {}
+  DBTime() : t(0) {}
+  explicit DBTime(int64_t _t) : t(_t) {}
   int64_t as_int64() const { return t; }
   std::string as_string() const;
 };
 
 struct RunReflection {
   int id;
-  Time time;
+  DBTime time;
   std::string cmdline;
   RunReflection() = default;
   RunReflection(int id_, int64_t time_, std::string cmdline_)
@@ -79,9 +79,9 @@ struct JobReflection {
   std::vector<std::string> environment;
   std::string stack;
   std::string stdin_file;
-  Time starttime;
-  Time endtime;
-  Time wake_start;
+  DBTime starttime;
+  DBTime endtime;
+  DBTime wake_start;
   std::string wake_cmdline;
   // List of interleaved writes to (1) stdout, (2) stderr, (3) runner output, and (4) runner errors
   std::vector<std::pair<std::string, int>> std_writes;

--- a/src/runtime/prim.cpp
+++ b/src/runtime/prim.cpp
@@ -200,5 +200,6 @@ PrimMap prim_register_all(StringInfo *info, JobTable *jobtable) {
   prim_register_json(pmap);
   prim_register_job(jobtable, pmap);
   prim_register_sources(pmap);
+  prim_register_time(pmap);
   return pmap;
 }

--- a/src/runtime/prim.h
+++ b/src/runtime/prim.h
@@ -144,6 +144,7 @@ void prim_register_target(PrimMap &pmap);
 void prim_register_json(PrimMap &pmap);
 void prim_register_job(JobTable *jobtable, PrimMap &pmap);
 void prim_register_sources(PrimMap &pmap);
+void prim_register_time(PrimMap &pmap);
 
 PrimMap prim_register_all(StringInfo *info, JobTable *jobtable);
 

--- a/src/runtime/time.cpp
+++ b/src/runtime/time.cpp
@@ -107,7 +107,15 @@ static PRIMFN(prim_format_time_tz) {
   }
 
   // Set the requested timezone
-  setenv("TZ", timezone->c_str(), 1);
+  // If timezone is empty, unset TZ to use system default
+  // Otherwise, set TZ to the requested timezone
+  if (timezone->c_str()[0] == '\0') {
+    // Empty string means use system default - unset TZ
+    unsetenv("TZ");
+  } else {
+    // Non-empty string - set TZ to the requested timezone
+    setenv("TZ", timezone->c_str(), 1);
+  }
   tzset();
 
   // Use localtime_r with the new timezone

--- a/src/runtime/time.cpp
+++ b/src/runtime/time.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Open Group Base Specifications Issue 7
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
+
+#include <gmp.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <string>
+
+#include "prim.h"
+#include "types/data.h"
+#include "types/internal.h"
+#include "types/type.h"
+#include "value.h"
+
+// Get current time in nanoseconds since Unix epoch using chrono
+static PRIMFN(prim_get_time) {
+  EXPECT(0);
+
+  // Use chrono to get current time with nanosecond precision
+  auto now = std::chrono::system_clock::now();
+  auto duration = now.time_since_epoch();
+  auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
+
+  RETURN(Time::alloc(runtime.heap, nanos.count()));
+}
+
+static PRIMTYPE(type_get_time) { return args.size() == 0 && out->unify(Data::typeTime); }
+
+// Format a Time value using chrono and strftime (UTC)
+static PRIMFN(prim_format_time) {
+  EXPECT(2);
+  STRING(format, 0);
+
+  HeapObject *time_obj = args[1];
+  REQUIRE(typeid(*time_obj) == typeid(Time));
+  Time *time = static_cast<Time *>(time_obj);
+
+  // Convert nanoseconds to chrono time_point
+  std::chrono::nanoseconds nanos_duration(time->nanoseconds);
+  std::chrono::system_clock::time_point tp(
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(nanos_duration));
+
+  // Convert to time_t for strftime
+  time_t seconds = std::chrono::system_clock::to_time_t(tp);
+
+  struct tm tm_info;
+  gmtime_r(&seconds, &tm_info);
+
+  char buffer[256];
+  size_t len = strftime(buffer, sizeof(buffer), format->c_str(), &tm_info);
+
+  RETURN(String::alloc(runtime.heap, buffer, len));
+}
+
+static PRIMTYPE(type_format_time) {
+  return args.size() == 2 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeTime) &&
+         out->unify(Data::typeString);
+}
+
+// Format a Time value using chrono and strftime with timezone support
+static PRIMFN(prim_format_time_tz) {
+  EXPECT(3);
+  STRING(format, 0);
+  STRING(timezone, 1);
+
+  HeapObject *time_obj = args[2];
+  REQUIRE(typeid(*time_obj) == typeid(Time));
+  Time *time = static_cast<Time *>(time_obj);
+
+  // Convert nanoseconds to chrono time_point
+  std::chrono::nanoseconds nanos_duration(time->nanoseconds);
+  std::chrono::system_clock::time_point tp(
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(nanos_duration));
+
+  // Convert to time_t for strftime
+  time_t seconds = std::chrono::system_clock::to_time_t(tp);
+
+  struct tm tm_info;
+
+  // Save current TZ environment variable
+  char *old_tz = getenv("TZ");
+  std::string saved_tz;
+  bool had_tz = (old_tz != nullptr);
+  if (had_tz) {
+    saved_tz = old_tz;
+  }
+
+  // Set the requested timezone
+  setenv("TZ", timezone->c_str(), 1);
+  tzset();
+
+  // Use localtime_r with the new timezone
+  localtime_r(&seconds, &tm_info);
+
+  char buffer[256];
+  size_t len = strftime(buffer, sizeof(buffer), format->c_str(), &tm_info);
+
+  // Restore original TZ environment variable
+  if (had_tz) {
+    setenv("TZ", saved_tz.c_str(), 1);
+  } else {
+    unsetenv("TZ");
+  }
+  tzset();
+
+  RETURN(String::alloc(runtime.heap, buffer, len));
+}
+
+static PRIMTYPE(type_format_time_tz) {
+  return args.size() == 3 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeString) &&
+         args[2]->unify(Data::typeTime) && out->unify(Data::typeString);
+}
+
+// Parse a time string using strptime and convert to chrono time_point
+static PRIMFN(prim_parse_time) {
+  EXPECT(2);
+  STRING(format, 0);
+  STRING(timestr, 1);
+
+  struct tm tm_info;
+  memset(&tm_info, 0, sizeof(tm_info));
+
+  char *result = strptime(timestr->c_str(), format->c_str(), &tm_info);
+
+  // Check if parsing was successful
+  REQUIRE(result != nullptr && *result == '\0');
+
+  // Convert to time_t (assumes UTC)
+  time_t seconds = timegm(&tm_info);
+  REQUIRE(seconds != -1);
+
+  // Convert to chrono time_point, then to nanoseconds
+  auto tp = std::chrono::system_clock::from_time_t(seconds);
+  auto duration = tp.time_since_epoch();
+  auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
+
+  RETURN(Time::alloc(runtime.heap, nanos.count()));
+}
+
+static PRIMTYPE(type_parse_time) {
+  return args.size() == 2 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeString) &&
+         out->unify(Data::typeTime);
+}
+
+// Subtract two Time values using chrono, return Integer nanoseconds
+static PRIMFN(prim_time_sub) {
+  EXPECT(2);
+
+  HeapObject *time1_obj = args[0];
+  HeapObject *time2_obj = args[1];
+  REQUIRE(typeid(*time1_obj) == typeid(Time));
+  REQUIRE(typeid(*time2_obj) == typeid(Time));
+
+  Time *time1 = static_cast<Time *>(time1_obj);
+  Time *time2 = static_cast<Time *>(time2_obj);
+
+  // Use chrono for type-safe arithmetic
+  std::chrono::nanoseconds nanos1(time1->nanoseconds);
+  std::chrono::nanoseconds nanos2(time2->nanoseconds);
+  auto diff = nanos1 - nanos2;
+
+  MPZ result;
+  mpz_set_si(result.value, diff.count());
+
+  RETURN(Integer::alloc(runtime.heap, result));
+}
+
+static PRIMTYPE(type_time_sub) {
+  return args.size() == 2 && args[0]->unify(Data::typeTime) && args[1]->unify(Data::typeTime) &&
+         out->unify(Data::typeInteger);
+}
+
+// Add Integer nanoseconds to a Time value using chrono, return new Time
+static PRIMFN(prim_time_add) {
+  EXPECT(2);
+
+  HeapObject *time_obj = args[0];
+  REQUIRE(typeid(*time_obj) == typeid(Time));
+  Time *time = static_cast<Time *>(time_obj);
+
+  INTEGER_MPZ(nanos_to_add, 1);
+
+  // Convert to int64_t
+  int64_t add_value = 0;
+  if (mpz_fits_slong_p(nanos_to_add)) {
+    add_value = mpz_get_si(nanos_to_add);
+  }
+
+  // Use chrono for type-safe arithmetic
+  std::chrono::nanoseconds time_nanos(time->nanoseconds);
+  std::chrono::nanoseconds add_nanos(add_value);
+  auto result = time_nanos + add_nanos;
+
+  RETURN(Time::alloc(runtime.heap, result.count()));
+}
+
+static PRIMTYPE(type_time_add) {
+  return args.size() == 2 && args[0]->unify(Data::typeTime) && args[1]->unify(Data::typeInteger) &&
+         out->unify(Data::typeTime);
+}
+
+// Compare two Time values, return Order (LT/EQ/GT)
+static PRIMFN(prim_time_cmp) {
+  EXPECT(2);
+
+  HeapObject *time1_obj = args[0];
+  HeapObject *time2_obj = args[1];
+  REQUIRE(typeid(*time1_obj) == typeid(Time));
+  REQUIRE(typeid(*time2_obj) == typeid(Time));
+
+  Time *time1 = static_cast<Time *>(time1_obj);
+  Time *time2 = static_cast<Time *>(time2_obj);
+
+  int cmp = 0;
+  if (time1->nanoseconds < time2->nanoseconds)
+    cmp = -1;
+  else if (time1->nanoseconds > time2->nanoseconds)
+    cmp = 1;
+
+  RETURN(alloc_order(runtime.heap, cmp));
+}
+
+static PRIMTYPE(type_time_cmp) {
+  return args.size() == 2 && args[0]->unify(Data::typeTime) && args[1]->unify(Data::typeTime) &&
+         out->unify(Data::typeOrder);
+}
+
+void prim_register_time(PrimMap &pmap) {
+  prim_register(pmap, "get_time", prim_get_time, type_get_time, PRIM_ORDERED);
+  prim_register(pmap, "format_time", prim_format_time, type_format_time, PRIM_PURE);
+  prim_register(pmap, "format_time_tz", prim_format_time_tz, type_format_time_tz, PRIM_PURE);
+  prim_register(pmap, "parse_time", prim_parse_time, type_parse_time, PRIM_PURE);
+  prim_register(pmap, "time_sub", prim_time_sub, type_time_sub, PRIM_PURE);
+  prim_register(pmap, "time_add", prim_time_add, type_time_add, PRIM_PURE);
+  prim_register(pmap, "time_cmp", prim_time_cmp, type_time_cmp, PRIM_PURE);
+}

--- a/src/runtime/value.cpp
+++ b/src/runtime/value.cpp
@@ -26,6 +26,8 @@
 #include <string.h>
 
 #include <algorithm>
+#include <chrono>
+#include <iomanip>
 #include <sstream>
 
 #include "optimizer/ssa.h"
@@ -275,6 +277,51 @@ std::string Double::str(int format, int precision) const {
       return out;
     }
   }
+  return s.str();
+}
+
+Time *Time::claim(Heap &h, int64_t nanos) {
+  Time *out = new (h.claim(reserve())) Time(nanos);
+  HeapAgeTracker::setAge(out, 0);
+  return out;
+}
+
+Time *Time::alloc(Heap &h, int64_t nanos) {
+  Time *out = new (h.alloc(reserve())) Time(nanos);
+  HeapAgeTracker::setAge(out, 0);
+  return out;
+}
+
+RootPointer<Time> Time::literal(Heap &h, int64_t nanos) {
+  h.guarantee(reserve());
+  Time *out = claim(h, nanos);
+  return h.root(out);
+}
+
+void Time::format(std::ostream &os, FormatState &state) const { os << str(); }
+
+Hash Time::shallow_hash() const { return Hash(&nanoseconds, sizeof(nanoseconds)) ^ TYPE_TIME; }
+
+std::string Time::str() const {
+  std::stringstream s;
+  s << nanoseconds;
+  return s.str();
+}
+
+std::string Time::str(const char *format) const {
+  std::chrono::nanoseconds nanos_duration(nanoseconds);
+  std::chrono::system_clock::time_point tp(
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(nanos_duration));
+
+  // Convert to time_t for formatting
+  std::time_t time = std::chrono::system_clock::to_time_t(tp);
+
+  // Format using std::put_time (C++11)
+  std::tm tm_buf;
+  std::tm *tm_ptr = gmtime_r(&time, &tm_buf);
+
+  std::stringstream s;
+  s << std::put_time(tm_ptr, format);
   return s.str();
 }
 

--- a/src/runtime/value.h
+++ b/src/runtime/value.h
@@ -45,6 +45,7 @@ class StringPiece;
 #define TYPE_RECORD 7
 #define TYPE_SCOPE 8
 #define TYPE_TARGET 9
+#define TYPE_TIME 10
 
 /* Values */
 
@@ -209,6 +210,24 @@ struct Double final : public GCObject<Double, Value> {
 
   // Never call this during runtime! It can invalidate the heap.
   static RootPointer<Double> literal(Heap &h, const char *str);
+};
+
+struct Time final : public GCObject<Time, Value> {
+  typedef GCObject<Time, Value> Parent;
+  int64_t nanoseconds;
+
+  Time(int64_t nanos_ = 0) : nanoseconds(nanos_) {}
+
+  std::string str() const;
+  std::string str(const char *format) const;
+  void format(std::ostream &os, FormatState &state) const override;
+  Hash shallow_hash() const override;
+
+  static Time *claim(Heap &h, int64_t nanos);
+  static Time *alloc(Heap &h, int64_t nanos);
+
+  // Never call this during runtime! It can invalidate the heap.
+  static RootPointer<Time> literal(Heap &h, int64_t nanos);
 };
 
 struct RegExp final : public GCObject<RegExp, DestroyableObject> {

--- a/src/types/data.cpp
+++ b/src/types/data.cpp
@@ -27,6 +27,7 @@ TypeVar Data::typeDouble("Double@builtin", 0);
 TypeVar Data::typeRegExp("RegExp@builtin", 0);
 TypeVar Data::typeJob("Job@builtin", 0);
 TypeVar Data::typeTarget("Target@builtin", 0);
+TypeVar Data::typeTime("Time@builtin", 0);
 
 TypeVar Data::typeBoolean("Boolean@wake", 0);
 TypeVar Data::typeOrder("Order@wake", 0);

--- a/src/types/data.h
+++ b/src/types/data.h
@@ -28,6 +28,7 @@ struct Data {
   static TypeVar typeRegExp;
   static TypeVar typeJob;
   static TypeVar typeTarget;
+  static TypeVar typeTime;
   // standard library supplied
   static TypeVar typeBoolean;
   static TypeVar typeOrder;

--- a/tests/standard-library/time/.wakeroot
+++ b/tests/standard-library/time/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/standard-library/time/pass.sh
+++ b/tests/standard-library/time/pass.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+set -e
+WAKE="${1:+$1/wake}"
+
+"${WAKE:-wake}" --stdout=warning,report testTimeLibrary
+"${WAKE:-wake}" --stdout=warning,report testTimeComparison

--- a/tests/standard-library/time/test.wake
+++ b/tests/standard-library/time/test.wake
@@ -1,0 +1,100 @@
+# Test basic time library functionality
+export def testTimeLibrary _ =
+    # Test parsing and formatting a specific date/time
+    def testTime = parseTime '%Y-%m-%d %H:%M:%S' '2020-06-15 14:30:00'
+    def testFormatted = formatTime '%Y-%m-%d %H:%M:%S' testTime
+    require '2020-06-15 14:30:00' = testFormatted
+    else False
+
+    # Test time subtraction (2020-01-02 - 2020-01-01 = 86400 seconds)
+    def t1 = parseTime '%Y-%m-%d' '2020-01-01'
+    def t2 = parseTime '%Y-%m-%d' '2020-01-02'
+    def diff = tsub t2 t1
+    require 86400000000000 = diff  # 86400 seconds in nanoseconds
+    else False
+
+    # Test time addition (add 1 hour = 3600 seconds)
+    def t3 = parseTime '%Y-%m-%d %H:%M:%S' '2020-01-01 12:00:00'
+    def oneHour = 3600000000000  # 3600 seconds in nanoseconds
+    def t4 = tadd t3 oneHour
+    def t4Formatted = formatTime '%Y-%m-%d %H:%M:%S' t4
+    require '2020-01-01 13:00:00' = t4Formatted
+    else False
+
+    # Test invalid date normalization (Feb 30 → Mar 1)
+    def invalidDate = parseTime '%Y-%m-%d' '2020-02-30'
+    def invalidFormatted = formatTime '%Y-%m-%d' invalidDate
+    require '2020-03-01' = invalidFormatted
+    else False
+
+    # Test negative time difference (earlier - later = negative)
+    def t1 = parseTime '%Y-%m-%d' '2020-01-01'
+    def t2 = parseTime '%Y-%m-%d' '2020-01-02'
+    def negDiff = tsub t1 t2
+    def expectedNeg = 0 - 86400000000000
+    require True = (negDiff == expectedNeg)
+    else False
+
+    # Use a fixed time for testing: 2020-06-15 12:00:00 UTC (during PDT, not PST)
+    def testTime = parseTime '%Y-%m-%d %H:%M:%S' '2020-06-15 12:00:00'
+
+    # Format in UTC
+    def utcFormatted = formatTimeTZ '%Y-%m-%d %H:%M:%S' 'UTC' testTime
+    require '2020-06-15 12:00:00' = utcFormatted
+    else False
+
+    # Format in America/Los_Angeles (PDT in summer, UTC-7)
+    # 12:00 UTC = 05:00 PDT (UTC-7)
+    def pstFormatted = formatTimeTZ '%Y-%m-%d %H:%M:%S' 'America/Los_Angeles' testTime
+    require '2020-06-15 05:00:00' = pstFormatted
+    else False
+
+    True
+
+# Test comparison operators
+export def testTimeComparison _ =
+    def t1 = parseTime '%Y-%m-%d' '2020-01-01'
+    def t2 = parseTime '%Y-%m-%d' '2020-01-02'
+    def t3 = parseTime '%Y-%m-%d' '2020-01-01'  # Same as t1
+
+    # Test tcmp function returns LT when t1 < t2
+    require True = isLT (tcmp t1 t2)
+    else False
+
+    # Test tcmp function returns GT when t2 > t1
+    require True = isGT (tcmp t2 t1)
+    else False
+
+    # Test tcmp function returns EQ when t1 == t3
+    require True = isEQ (tcmp t1 t3)
+    else False
+
+    # Test <$ operator (less than)
+    require True = (t1 <$ t2)
+    else False
+
+    # Test >$ operator (greater than)
+    require True = (t2 >$ t1)
+    else False
+
+    # Test <=$ operator (less than or equal)
+    require True = (t1 <=$ t3)
+    else False
+
+    # Test >=$ operator (greater than or equal)
+    require True = (t2 >=$ t1)
+    else False
+
+    # Test ==$ operator (equality)
+    require True = (t1 ==$ t3)
+    else False
+
+    # Test !=$ operator (inequality)
+    require True = (t1 !=$ t2)
+    else False
+
+    # Test !=$ operator returns False for equal times
+    require False = (t1 !=$ t3)
+    else False
+
+    True


### PR DESCRIPTION
Creates a builtin type `Time` for the main purpose of handling timestamps. 

Time is stored as a unit of nanoseconds. 

This adds functional support for adding, subtracting, comparing, parsing, and formatting time. Default functions for getting the date appear in UTC, but there is support for requesting date in specific TimeZones.

This uses the `chrono` library to help safely handle time. Since we are using c++17, I'm still using `strftime` to format the string.

I did rename the database `Time` struct to `DBTime` to avoid conflicts. 