### PR TITLE
makeBinaryRequest: mkdir http dir for curl request

### DIFF
--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -334,7 +334,10 @@ export def makeBinaryRequest (request: HttpRequest): Result Path Error =
     # always rerun and we'd want to replace the file incase it changed on the remote.
     # Per-process directory avoids conflicts when multiple wake processes share a workspace.
     def wakePid: Integer = prim "pid"
-    def httpDir = ".build/wake-{str wakePid}/stdlib/http/"
+    def httpDir = ".build/wake-{str wakePid}/stdlib/http"
+
+    require Pass httpDirPath = mkdir httpDir
+
     def destination = "{httpDir}/binary.{request | format | hashString}"
 
     require Pass cmd = makeCurlCmd request ("--output", destination, Nil)
@@ -369,7 +372,7 @@ export def makeBinaryRequest (request: HttpRequest): Result Path Error =
         """
 
     def cleanupJob =
-        makeShellPlan cleanupScript Nil
+        makeShellPlan cleanupScript (httpDirPath, Nil)
         | setPlanLabel "http: rm {destination}"
         | setPlanStdout logNever
         | setPlanStderr logNever


### PR DESCRIPTION
https://github.com/sifiveinc/wake/pull/1777 introduced a bug that caused RSC rehydration to fail.

This PR dropped a `mkdir` that was very much necessary otherwise the curl command will fail as the target directory doesn't exist. This was silently failing.

I also believe (but didn't test) that the original [change](https://github.com/sifiveinc/wake/pull/1729) to move to fuse runner would have introduced the same bug as the directory would be created, but wouldn't be in the wakebox command.

I have updated the code to create the dir and ties it to the job, even though it's a localRunner. 
