### PR TITLE
database: optimize delete_jobs query.

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -378,9 +378,10 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
       "j2.job_id<>?2)";
   const char *sql_fetch_hash = "select hash from files where path=? and modified=?";
   const char *sql_delete_jobs =
-      "delete from jobs where job_id in"
-      " (select job_id from jobs where keep=0 and use_id<>? except select job_id from filetree "
-      "where access=2)";
+      " delete from jobs where keep=0 and use_id<>? "
+      " and not exists (select 1 from filetree where "
+      "                 filetree.job_id=jobs.job_id and "
+      "                 filetree.access=2)";
   const char *sql_delete_dups =
       "delete from stats where stat_id in"
       " (select stat_id from (select hashcode, count(*) as num, max(stat_id) as keep from stats "


### PR DESCRIPTION
Used in Database::clean, profiling using a trivial run shows across a selection of large wake databases this is where time is spent before returning user control after a run finishes.  Non-trivial runs likely have other bottlenecks, but also will include the cost of this query.

On the largest DB considered, 37GB, this query takes 22s before and 1.9s afterwards!

A few things were improved, especially enabling the use of an index over the filetree table, as well as exists to skip after first:

```
QUERY PLAN
|--SCAN TABLE jobs
|--SCALAR SUBQUERY
|  `--SEARCH TABLE runs
`--CORRELATED SCALAR SUBQUERY
   `--SEARCH TABLE filetree USING COVERING INDEX sqlite_autoindex_filetree_1 (job_id=? AND access=?)
```

Today we have, for comparison:

```
QUERY PLAN
|--SEARCH TABLE jobs USING INTEGER PRIMARY KEY (rowid=?)
`--LIST SUBQUERY
   `--COMPOUND QUERY
      |--LEFT-MOST SUBQUERY
      |  `--SCAN TABLE jobs
      `--EXCEPT USING TEMP B-TREE
         `--SCAN TABLE filetree
```

Both still scan the full jobs table, due to lack of an index covering 'keep'. Adding this index reduces the query from 1.89s -> 1.58s.

At the time this doesn't seem worth adding due to costs.