### PR TITLE
Add builtin type Time

### DIFF
--- a/.wakemanifest
+++ b/.wakemanifest
@@ -37,6 +37,7 @@ share/wake/lib/system/remote_cache_api.wake
 share/wake/lib/system/remote_cache_runner.wake
 share/wake/lib/system/sources.wake
 share/wake/lib/system/staging_outputs.wake
+share/wake/lib/system/time.wake
 src/cas/cas.wake
 src/compat/compat.wake
 src/dst/dst.wake

--- a/share/wake/lib/core/types.wake
+++ b/share/wake/lib/core/types.wake
@@ -78,3 +78,11 @@ from builtin export type RegExp
 #
 # Jobs are created via the `runJob` API.
 from builtin export type Job
+
+# The Time type is a builtin of the wake language itself.
+#
+# A Time object represents a point in time with nanosecond
+# precision, stored as nanoseconds since the Unix epoch
+# (January 1, 1970 00:00:00 UTC).
+#
+from builtin export type Time

--- a/share/wake/lib/system/time.wake
+++ b/share/wake/lib/system/time.wake
@@ -1,0 +1,129 @@
+# Copyright 2026 SiFive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You should have received a copy of LICENSE.Apache2 along with
+# this software. If not, you may obtain a copy at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package time
+
+# Time Library
+#
+# The Time type is a built-in type representing a point in time since the Unix epoch
+# with nanosecond precision.
+#
+# Format strings use strftime syntax with additional sub-second specifiers:
+#   %f     - nanoseconds since last whole second (9 digits, zero-padded)
+#   %.f    - decimal fraction with leading dot, trailing zeros trimmed
+#   %.Nf   - decimal fraction with leading dot, fixed N digits (N = 1-9)
+#   %Nf    - fractional digits without dot, fixed N digits (N = 1-9)
+#
+# Examples:
+#   "%H:%M:%S%.3f"  => "08:15:07.026"    (milliseconds)
+#   "%H:%M:%S%.6f"  => "08:15:07.026490" (microseconds)
+#   "%H:%M:%S%3f"   => "08:15:07026"     (millis, no dot)
+#   "%H:%M:%S%.f"   => "08:15:07.02649"  (trimmed)
+
+# getTime: Get the current system time.
+#
+# Returns a Time value representing the current time since the Unix epoch
+# with nanosecond precision.
+#
+# Example:
+#   def now = getTime Unit
+export def getTime (_: a): Time =
+    prim "get_time"
+
+# formatTime: Format a Time value as a string in UTC.
+#
+# Converts a Time value to a human-readable string using strftime format
+# specifiers with sub-second support as %f. The output is always in UTC.
+#
+# Arguments:
+#   format - strftime format string
+#   time   - Time value to format
+#
+# Example:
+#   def now = getTime Unit
+#   formatTime "%Y-%m-%d" now                    # "2026-03-10"
+#   formatTime "%Y-%m-%d %H:%M:%S" now           # "2026-03-10 08:15:07"
+#   formatTime "%Y-%m-%d %H:%M:%S.%.3f" now      # "2026-03-10 08:15:07.026"
+export def formatTime (format: String) (time: Time): String =
+    (\f \t prim "format_time") format time
+
+# getTimeISO: Get the current time as an ISO 8601 string in UTC.
+#
+# Example:
+#   getTimeISO Unit  # "2026-03-10T08:15:07Z"
+export def getTimeISO (_: a): String =
+    formatTime '%Y-%m-%dT%H:%M:%SZ' (getTime Unit)
+
+# timeToNanoseconds: Convert a Time to nanoseconds since the Unix epoch.
+#
+# Example:
+#   def nanos = timeToNanoseconds (getTime Unit)
+export def timeToNanoseconds (time: Time): Integer =
+    (\t prim "time_to_nanos") time
+
+# timeToMilliseconds: Convert a Time to milliseconds since the Unix epoch.
+#
+# Example:
+#   def millis = timeToMilliseconds (getTime Unit)
+export def timeToMilliseconds (time: Time): Double =
+    dint (timeToNanoseconds time) /. 1.0e6
+
+# timeToSeconds: Convert a Time to seconds since the Unix epoch.
+#
+# Example:
+#   def secs = timeToSeconds (getTime Unit)
+export def timeToSeconds (time: Time): Double =
+    dint (timeToNanoseconds time) /. 1.0e9
+
+# printTimeLnLevel: Print a message with a timestamp prefix at a given log level.
+#
+# The timestamp is formatted using strftime format specifiers in the specified
+# timezone. Use "UTC" for UTC output, or an IANA timezone name. Empty string
+# uses the local machine timezone.
+#
+# Arguments:
+#   format   - strftime format string for the timestamp
+#   timezone - IANA timezone name (e.g., "UTC", "America/Los_Angeles")
+#   time     - Time value to format
+#   logLevel - LogLevel to print at
+#   message  - message to print
+#
+# Example:
+#   printTimeLnLevel "%H:%M:%S" "UTC" (getTime Unit) logWarning "something happened"
+#   printTimeLnLevel "%H:%M:%S" "America/Los_Angeles" (getTime Unit) logReport "hello"
+export def printTimeLnLevel (format: String) (timezone: String) (time: Time) (logLevel: LogLevel) (message: String): Unit =
+    def LogLevel name = logLevel
+
+    (\f \tz \t \s \m prim "time_print") format timezone time name "{message}\n"
+
+# printTsLn: Print a local-timezone ISO 8601 timestamped message at report level.
+#
+# Output: [2026-04-07T01:15:07-0700] message
+#
+# Example:
+#   printTsLn (getTime Unit) "build started"
+export def printTsLn (time: Time) (message: String): Unit =
+    printTimeLnLevel '[%Y-%m-%dT%H:%M:%S%.3f%z]' '' time logReport message
+
+# printCurrentTsLn: Print a local-timezone ISO 8601 timestamped message at report level.
+# Automatically captures the current time.
+#
+# Output: [2026-04-07T01:15:07-0700] message
+#
+# Example:
+#   printCurrentTsLn "build started"
+export def printCurrentTsLn (message: String): Unit =
+    printTsLn (getTime Unit) message
+

--- a/share/wake/lib/system/time.wake
+++ b/share/wake/lib/system/time.wake
@@ -101,22 +101,20 @@ export def printTimeLnLevel (format: String) (time: Time) (logLevel: LogLevel) (
 
     (\f \t \s \m prim "time_print") format time name "{message}\n"
 
-# printTsLn: Print a local-timezone ISO 8601 timestamped message at report level.
+# printTimeLn: Print a ISO 8601 timestamped message at report level.
 #
 # Output: [2026-04-07T01:15:07-0700] message
 #
 # Example:
-#   printTsLn (getTime Unit) "build started"
-export def printTsLn (time: Time) (message: String): Unit =
+#   printTimeLn (getTime Unit) "build started"
+export def printTimeLn (time: Time) (message: String): Unit =
     printTimeLnLevel '[%Y-%m-%dT%H:%M:%S%.3f%z]' time logReport message
 
-# printCurrentTsLn: Print a local-timezone ISO 8601 timestamped message at report level.
-# Automatically captures the current time.
+# printCurrentTimeLn: Print an ISO 8601 timestamped message at report level using the current time.
 #
 # Output: [2026-04-07T01:15:07-0700] message
 #
 # Example:
-#   printCurrentTsLn "build started"
-export def printCurrentTsLn (message: String): Unit =
-    printTsLn (getTime Unit) message
-
+#   printCurrentTimeLn "build started"
+export def printCurrentTimeLn (message: String): Unit =
+    printTimeLn (getTime Unit) message

--- a/share/wake/lib/system/time.wake
+++ b/share/wake/lib/system/time.wake
@@ -19,18 +19,6 @@ package time
 #
 # The Time type is a built-in type representing a point in time since the Unix epoch
 # with nanosecond precision.
-#
-# Format strings use strftime syntax with additional sub-second specifiers:
-#   %f     - nanoseconds since last whole second (9 digits, zero-padded)
-#   %.f    - decimal fraction with leading dot, trailing zeros trimmed
-#   %.Nf   - decimal fraction with leading dot, fixed N digits (N = 1-9)
-#   %Nf    - fractional digits without dot, fixed N digits (N = 1-9)
-#
-# Examples:
-#   "%H:%M:%S%.3f"  => "08:15:07.026"    (milliseconds)
-#   "%H:%M:%S%.6f"  => "08:15:07.026490" (microseconds)
-#   "%H:%M:%S%3f"   => "08:15:07026"     (millis, no dot)
-#   "%H:%M:%S%.f"   => "08:15:07.02649"  (trimmed)
 
 # getTime: Get the current system time.
 #
@@ -42,20 +30,28 @@ package time
 export def getTime (_: a): Time =
     prim "get_time"
 
-# formatTime: Format a Time value as a string in UTC.
+# formatTime: Format a Time value as a string in UTC
 #
-# Converts a Time value to a human-readable string using strftime format
-# specifiers with sub-second support as %f. The output is always in UTC.
+# Converts a Time value to a human-readable string using strftime format specifiers
+# with an additional sub-second specifier %f. The output is always in UTC.
+#
+# Sub-second format specifiers:
+#   %f    - nanoseconds since last whole second (9 digits, zero-padded)
+#   %.f   - decimal fraction with leading dot, trailing zeros trimmed
+#   %.Nf  - decimal fraction with leading dot, fixed N digits (N = 1-9)
+#   %Nf   - fractional digits without dot, fixed N digits (N = 1-9)
 #
 # Arguments:
 #   format - strftime format string
 #   time   - Time value to format
 #
-# Example:
-#   def now = getTime Unit
-#   formatTime "%Y-%m-%d" now                    # "2026-03-10"
-#   formatTime "%Y-%m-%d %H:%M:%S" now           # "2026-03-10 08:15:07"
-#   formatTime "%Y-%m-%d %H:%M:%S.%.3f" now      # "2026-03-10 08:15:07.026"
+# Examples:
+#   formatTime "%Y-%m-%d" (getTime Unit)              # "2026-03-10"
+#   formatTime "%Y-%m-%d %H:%M:%S" (getTime Unit)     # "2026-03-10 08:15:07"
+#   formatTime "%H:%M:%S%.3f" (getTime Unit)          # "08:15:07.026" (milliseconds)
+#   formatTime "%H:%M:%S%.6f" (getTime Unit)          # "08:15:07.026490" (microseconds)
+#   formatTime "%H:%M:%S%3f" (getTime Unit)           # "08:15:07026" (no dot)
+#   formatTime "%H:%M:%S%.f" (getTime Unit)           # "08:15:07.02649" (trimmed)
 export def formatTime (format: String) (time: Time): String =
     (\f \t prim "format_time") format time
 

--- a/share/wake/lib/system/time.wake
+++ b/share/wake/lib/system/time.wake
@@ -48,10 +48,10 @@ export def getTime (_: a): Time =
 # Examples:
 #   formatTime "%Y-%m-%d" (getTime Unit)              # "2026-03-10"
 #   formatTime "%Y-%m-%d %H:%M:%S" (getTime Unit)     # "2026-03-10 08:15:07"
+#   formatTime "%H:%M:%S:%f" (getTime Unit)           # "08:15:07:123456789" 
+#   formatTime "%H:%M:%S%.f" (getTime Unit)           # "08:15:07.02649" (trimmed)
 #   formatTime "%H:%M:%S%.3f" (getTime Unit)          # "08:15:07.026" (milliseconds)
 #   formatTime "%H:%M:%S%.6f" (getTime Unit)          # "08:15:07.026490" (microseconds)
-#   formatTime "%H:%M:%S%3f" (getTime Unit)           # "08:15:07026" (no dot)
-#   formatTime "%H:%M:%S%.f" (getTime Unit)           # "08:15:07.02649" (trimmed)
 export def formatTime (format: String) (time: Time): String =
     (\f \t prim "format_time") format time
 
@@ -103,7 +103,7 @@ export def printTimeLnLevel (format: String) (time: Time) (logLevel: LogLevel) (
 
 # printTimeLn: Print a ISO 8601 timestamped message at report level.
 #
-# Output: [2026-04-07T01:15:07-0700] message
+# Output: [2026-04-07T01:15:07-0700]<message>
 #
 # Example:
 #   printTimeLn (getTime Unit) "build started"

--- a/share/wake/lib/system/time.wake
+++ b/share/wake/lib/system/time.wake
@@ -85,24 +85,21 @@ export def timeToSeconds (time: Time): Double =
 
 # printTimeLnLevel: Print a message with a timestamp prefix at a given log level.
 #
-# The timestamp is formatted using strftime format specifiers in the specified
-# timezone. Use "UTC" for UTC output, or an IANA timezone name. Empty string
-# uses the local machine timezone.
+# The timestamp is formatted using strftime format specifiers in the timezone
+# specified by the TZ environment variable, or the local machine timezone if TZ is unset.
 #
 # Arguments:
 #   format   - strftime format string for the timestamp
-#   timezone - IANA timezone name (e.g., "UTC", "America/Los_Angeles")
 #   time     - Time value to format
 #   logLevel - LogLevel to print at
 #   message  - message to print
 #
 # Example:
-#   printTimeLnLevel "%H:%M:%S" "UTC" (getTime Unit) logWarning "something happened"
-#   printTimeLnLevel "%H:%M:%S" "America/Los_Angeles" (getTime Unit) logReport "hello"
-export def printTimeLnLevel (format: String) (timezone: String) (time: Time) (logLevel: LogLevel) (message: String): Unit =
+#   printTimeLnLevel "%H:%M:%S" (getTime Unit) logWarning "something happened"
+export def printTimeLnLevel (format: String) (time: Time) (logLevel: LogLevel) (message: String): Unit =
     def LogLevel name = logLevel
 
-    (\f \tz \t \s \m prim "time_print") format timezone time name "{message}\n"
+    (\f \t \s \m prim "time_print") format time name "{message}\n"
 
 # printTsLn: Print a local-timezone ISO 8601 timestamped message at report level.
 #
@@ -111,7 +108,7 @@ export def printTimeLnLevel (format: String) (timezone: String) (time: Time) (lo
 # Example:
 #   printTsLn (getTime Unit) "build started"
 export def printTsLn (time: Time) (message: String): Unit =
-    printTimeLnLevel '[%Y-%m-%dT%H:%M:%S%.3f%z]' '' time logReport message
+    printTimeLnLevel '[%Y-%m-%dT%H:%M:%S%.3f%z]' time logReport message
 
 # printCurrentTsLn: Print a local-timezone ISO 8601 timestamped message at report level.
 # Automatically captures the current time.

--- a/src/dst/expr.cpp
+++ b/src/dst/expr.cpp
@@ -70,6 +70,8 @@ Top::Top() : packages(), globals(), def_package(nullptr) {
       std::make_pair("Array", SymbolSource(FRAGMENT_CPP_LINE, "Array@builtin", SYM_LEAF)));
   builtin->package.types.insert(
       std::make_pair("Job", SymbolSource(FRAGMENT_CPP_LINE, "Job@builtin", SYM_LEAF)));
+  builtin->package.types.insert(
+      std::make_pair("Time", SymbolSource(FRAGMENT_CPP_LINE, "Time@builtin", SYM_LEAF)));
   builtin->exports = builtin->package;
 }
 

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1314,7 +1314,7 @@ static std::vector<std::string> chop_null(const std::string &str) {
   return out;
 }
 
-std::string Time::as_string() const {
+std::string DBTime::as_string() const {
   char buf[100];
   struct tm tm;
   time_t time = t / 1000000000;
@@ -1556,10 +1556,10 @@ static JobReflection find_one(const Database *db, sqlite3_stmt *query) {
   desc.environment = chop_null(rip_column(query, 4));
   desc.stack = rip_column(query, 5);
   desc.stdin_file = rip_column(query, 6);
-  desc.starttime = Time(sqlite3_column_int64(query, 7));
-  desc.endtime = Time(sqlite3_column_int64(query, 8));
+  desc.starttime = DBTime(sqlite3_column_int64(query, 7));
+  desc.endtime = DBTime(sqlite3_column_int64(query, 8));
   desc.stale = sqlite3_column_int64(query, 9) != 0;
-  desc.wake_start = Time(sqlite3_column_int64(query, 10));
+  desc.wake_start = DBTime(sqlite3_column_int64(query, 10));
   desc.wake_cmdline = rip_column(query, 11);
   desc.usage.status = sqlite3_column_int64(query, 12);
   desc.usage.runtime = sqlite3_column_double(query, 13);
@@ -1922,7 +1922,7 @@ std::vector<RunReflection> Database::get_runs() const {
   while (sqlite3_step(imp->get_all_runs) == SQLITE_ROW) {
     RunReflection run;
     run.id = sqlite3_column_int(imp->get_all_runs, 0);
-    run.time = Time(sqlite3_column_int64(imp->get_all_runs, 1));
+    run.time = DBTime(sqlite3_column_int64(imp->get_all_runs, 1));
     run.cmdline = rip_column(imp->get_all_runs, 2);
     out.emplace_back(run);
   }

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -62,17 +62,17 @@ struct JobTag {
       : job(job_), uri(std::move(uri_)), content(std::move(content_)) {}
 };
 
-struct Time {
+struct DBTime {
   int64_t t;
-  Time() : t(0) {}
-  explicit Time(int64_t _t) : t(_t) {}
+  DBTime() : t(0) {}
+  explicit DBTime(int64_t _t) : t(_t) {}
   int64_t as_int64() const { return t; }
   std::string as_string() const;
 };
 
 struct RunReflection {
   int id;
-  Time time;
+  DBTime time;
   std::string cmdline;
   RunReflection() = default;
   RunReflection(int id_, int64_t time_, std::string cmdline_)
@@ -88,9 +88,9 @@ struct JobReflection {
   std::vector<std::string> environment;
   std::string stack;
   std::string stdin_file;
-  Time starttime;
-  Time endtime;
-  Time wake_start;
+  DBTime starttime;
+  DBTime endtime;
+  DBTime wake_start;
   std::string wake_cmdline;
   // List of interleaved writes to (1) stdout, (2) stderr, (3) runner output, and (4) runner errors
   std::vector<std::pair<std::string, int>> std_writes;

--- a/src/runtime/prim.cpp
+++ b/src/runtime/prim.cpp
@@ -205,6 +205,7 @@ PrimMap prim_register_all(StringInfo *info, JobTable *jobtable, CASContext *cas_
   prim_register_json(pmap);
   prim_register_job(jobtable, pmap);
   prim_register_sources(pmap);
+  prim_register_time(pmap);
   if (cas_ctx) {
     prim_register_cas(cas_ctx, pmap);
   }

--- a/src/runtime/prim.h
+++ b/src/runtime/prim.h
@@ -147,6 +147,7 @@ void prim_register_target(PrimMap &pmap);
 void prim_register_json(PrimMap &pmap);
 void prim_register_job(JobTable *jobtable, PrimMap &pmap);
 void prim_register_sources(PrimMap &pmap);
+void prim_register_time(PrimMap &pmap);
 
 PrimMap prim_register_all(StringInfo *info, JobTable *jobtable, CASContext *cas_ctx);
 

--- a/src/runtime/time.cpp
+++ b/src/runtime/time.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2026 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Open Group Base Specifications Issue 7
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
+
+#include <gmp.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <string>
+
+#include "prim.h"
+#include "status.h"
+#include "types/data.h"
+#include "value.h"
+
+// Pre-process a format string to expand %f sub-second specifiers before passing to strftime.
+// Supported: %f (9 digits), %.f (trimmed), %.Nf (dot + N digits), %Nf (N digits) where N is 1-9
+static std::string expand_subsecond_formats(const char *fmt, int64_t nanoseconds) {
+  int64_t sub_nanos = nanoseconds % 1000000000LL;
+  if (sub_nanos < 0) sub_nanos += 1000000000LL;
+
+  char nanos_str[10];
+  snprintf(nanos_str, sizeof(nanos_str), "%09lld", (long long)sub_nanos);
+
+  std::string result;
+  for (const char *p = fmt; *p; ++p) {
+    if (*p != '%') {
+      result += *p;
+      continue;
+    }
+
+    // Look ahead from '%'
+    if (p[1] == '.' && p[2] >= '1' && p[2] <= '9' && p[3] == 'f') {
+      // %.Nf — dot + fixed N digits (N = 1-9)
+      int n = p[2] - '0';
+      result += '.';
+      result.append(nanos_str, n);
+      p += 3;
+    } else if (p[1] == '.' && p[2] == 'f') {
+      // %.f — dot + trimmed trailing zeros
+      std::string frac(nanos_str, 9);
+      size_t last = frac.find_last_not_of('0');
+      if (last != std::string::npos) {
+        result += '.';
+        result.append(frac, 0, last + 1);
+      }
+      p += 2;
+    } else if (p[1] >= '1' && p[1] <= '9' && p[2] == 'f') {
+      // %Nf — fixed N digits, no dot (N = 1-9)
+      int n = p[1] - '0';
+      result.append(nanos_str, n);
+      p += 2;
+    } else if (p[1] == 'f') {
+      // %f — all 9 digits, no dot
+      result.append(nanos_str, 9);
+      p += 1;
+    } else {
+      // Not a sub-second specifier — pass through for strftime
+      result += '%';
+    }
+  }
+  return result;
+}
+
+// Format a Time's nanoseconds using strftime with sub-second expansion.
+// If timezone is nullptr, uses UTC (gmtime_r). Otherwise sets TZ and uses localtime_r.
+// Empty string timezone means system default (unset TZ).
+static std::string format_time_str(const char *fmt, int64_t nanoseconds, const char *timezone) {
+  std::chrono::nanoseconds nanos_duration(nanoseconds);
+  std::chrono::system_clock::time_point tp(
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(nanos_duration));
+  time_t seconds = std::chrono::system_clock::to_time_t(tp);
+
+  struct tm tm_info;
+
+  if (timezone == nullptr) {
+    gmtime_r(&seconds, &tm_info);
+  } else {
+    char *old_tz = getenv("TZ");
+    std::string saved_tz;
+    bool had_tz = (old_tz != nullptr);
+    if (had_tz) saved_tz = old_tz;
+
+    if (timezone[0] == '\0') {
+      unsetenv("TZ");
+    } else {
+      setenv("TZ", timezone, 1);
+    }
+    tzset();
+    localtime_r(&seconds, &tm_info);
+
+    if (had_tz) {
+      setenv("TZ", saved_tz.c_str(), 1);
+    } else {
+      unsetenv("TZ");
+    }
+    tzset();
+  }
+
+  std::string expanded = expand_subsecond_formats(fmt, nanoseconds);
+  char buffer[256];
+  strftime(buffer, sizeof(buffer), expanded.c_str(), &tm_info);
+  return std::string(buffer);
+}
+
+// Get current time in nanoseconds since Unix epoch using chrono
+static PRIMFN(prim_get_time) {
+  EXPECT(0);
+
+  // Use chrono to get current time with nanosecond precision
+  auto now = std::chrono::system_clock::now();
+  auto duration = now.time_since_epoch();
+  auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
+
+  RETURN(Time::alloc(runtime.heap, nanos.count()));
+}
+
+static PRIMTYPE(type_get_time) { return args.size() == 0 && out->unify(Data::typeTime); }
+
+// Format a Time value using strftime (UTC)
+static PRIMFN(prim_format_time) {
+  EXPECT(2);
+  STRING(format, 0);
+
+  HeapObject *time_obj = args[1];
+  REQUIRE(typeid(*time_obj) == typeid(Time));
+  Time *time = static_cast<Time *>(time_obj);
+
+  std::string result = format_time_str(format->c_str(), time->nanoseconds, nullptr);
+  RETURN(String::alloc(runtime.heap, result.c_str(), result.size()));
+}
+
+static PRIMTYPE(type_format_time) {
+  return args.size() == 2 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeTime) &&
+         out->unify(Data::typeString);
+}
+
+// Print a timestamped message: format Time with timezone, prepend to message, write to stream
+// Args: format, timezone, time, stream, message
+static PRIMFN(prim_time_print) {
+  EXPECT(5);
+  STRING(format, 0);
+  STRING(timezone, 1);
+
+  HeapObject *time_obj = args[2];
+  REQUIRE(typeid(*time_obj) == typeid(Time));
+  Time *time = static_cast<Time *>(time_obj);
+
+  STRING(stream, 3);
+  STRING(message, 4);
+
+  std::string ts = format_time_str(format->c_str(), time->nanoseconds, timezone->c_str());
+
+  runtime.heap.reserve(reserve_unit());
+  status_get_generic_stream(stream->c_str()) << ts << message->as_str();
+  RETURN(claim_unit(runtime.heap));
+}
+
+static PRIMTYPE(type_time_print) {
+  return args.size() == 5 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeString) &&
+         args[2]->unify(Data::typeTime) && args[3]->unify(Data::typeString) &&
+         args[4]->unify(Data::typeString) && out->unify(Data::typeUnit);
+}
+
+// Extract nanoseconds from a Time value as an Integer
+static PRIMFN(prim_time_to_nanos) {
+  EXPECT(1);
+
+  HeapObject *time_obj = args[0];
+  REQUIRE(typeid(*time_obj) == typeid(Time));
+  Time *time = static_cast<Time *>(time_obj);
+
+  MPZ result;
+  mpz_set_si(result.value, time->nanoseconds);
+
+  RETURN(Integer::alloc(runtime.heap, result));
+}
+
+static PRIMTYPE(type_time_to_nanos) {
+  return args.size() == 1 && args[0]->unify(Data::typeTime) && out->unify(Data::typeInteger);
+}
+
+void prim_register_time(PrimMap &pmap) {
+  prim_register(pmap, "get_time", prim_get_time, type_get_time, PRIM_ORDERED);
+  prim_register(pmap, "format_time", prim_format_time, type_format_time, PRIM_PURE);
+  prim_register(pmap, "time_to_nanos", prim_time_to_nanos, type_time_to_nanos, PRIM_PURE);
+  prim_register(pmap, "time_print", prim_time_print, type_time_print, PRIM_ORDERED);
+}

--- a/src/runtime/time.cpp
+++ b/src/runtime/time.cpp
@@ -32,7 +32,8 @@
 #include "value.h"
 
 // Pre-process a format string to expand %f sub-second specifiers before passing to strftime.
-// Supported: %f (9 digits), %.f (trimmed), %.Nf (dot + N digits), %Nf (N digits) where N is 1-9
+// Supported: %f (9 digits), %.f (dot + trimmed), %.Nf (dot + N digits), %Nf (N digits) where N is
+// 1-9
 static std::string expand_subsecond_formats(const char *fmt, int64_t nanoseconds) {
   int64_t sub_nanos = nanoseconds % 1000000000LL;
   if (sub_nanos < 0) sub_nanos += 1000000000LL;
@@ -72,6 +73,10 @@ static std::string expand_subsecond_formats(const char *fmt, int64_t nanoseconds
       // %f — all 9 digits, no dot
       result.append(nanos_str, 9);
       p += 1;
+    } else if (p[1] == '%') {
+      // %% — pass through escaped percent for strftime
+      result += "%%";
+      p += 1;
     } else {
       // Not a sub-second specifier — pass through for strftime
       result += '%';
@@ -82,7 +87,7 @@ static std::string expand_subsecond_formats(const char *fmt, int64_t nanoseconds
 
 // Format a Time's nanoseconds using strftime with sub-second expansion.
 // If timezone is nullptr, uses UTC (gmtime_r). Otherwise sets TZ and uses localtime_r.
-// Empty string timezone means system default (unset TZ).
+// Empty string timezone means system default.
 // Invalid timezone inputs will fallback to using UTC
 static std::string format_time_str(const char *fmt, int64_t nanoseconds, const char *timezone) {
   std::chrono::nanoseconds nanos_duration(nanoseconds);

--- a/src/runtime/time.cpp
+++ b/src/runtime/time.cpp
@@ -154,21 +154,21 @@ static PRIMTYPE(type_format_time) {
          out->unify(Data::typeString);
 }
 
-// Print a timestamped message: format Time with timezone, prepend to message, write to stream
-// Args: format, timezone, time, stream, message
+// Print a timestamped message: format Time, prepend to message, write to stream
+// The timezone is specified by the TZ environment variable, or the local machine timezone if TZ is unset.
+// Args: format, time, stream, message
 static PRIMFN(prim_time_print) {
-  EXPECT(5);
+  EXPECT(4);
   STRING(format, 0);
-  STRING(timezone, 1);
 
-  HeapObject *time_obj = args[2];
+  HeapObject *time_obj = args[1];
   REQUIRE(typeid(*time_obj) == typeid(Time));
   Time *time = static_cast<Time *>(time_obj);
 
-  STRING(stream, 3);
-  STRING(message, 4);
+  STRING(stream, 2);
+  STRING(message, 3);
 
-  std::string ts = format_time_str(format->c_str(), time->nanoseconds, timezone->c_str());
+  std::string ts = format_time_str(format->c_str(), time->nanoseconds, "");
 
   runtime.heap.reserve(reserve_unit());
   status_get_generic_stream(stream->c_str()) << ts << message->as_str();
@@ -176,9 +176,9 @@ static PRIMFN(prim_time_print) {
 }
 
 static PRIMTYPE(type_time_print) {
-  return args.size() == 5 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeString) &&
-         args[2]->unify(Data::typeTime) && args[3]->unify(Data::typeString) &&
-         args[4]->unify(Data::typeString) && out->unify(Data::typeUnit);
+  return args.size() == 4 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeTime) &&
+         args[2]->unify(Data::typeString) && args[3]->unify(Data::typeString) &&
+         out->unify(Data::typeUnit);
 }
 
 // Extract nanoseconds from a Time value as an Integer

--- a/src/runtime/time.cpp
+++ b/src/runtime/time.cpp
@@ -83,6 +83,7 @@ static std::string expand_subsecond_formats(const char *fmt, int64_t nanoseconds
 // Format a Time's nanoseconds using strftime with sub-second expansion.
 // If timezone is nullptr, uses UTC (gmtime_r). Otherwise sets TZ and uses localtime_r.
 // Empty string timezone means system default (unset TZ).
+// Invalid timezone inputs will fallback to using UTC
 static std::string format_time_str(const char *fmt, int64_t nanoseconds, const char *timezone) {
   std::chrono::nanoseconds nanos_duration(nanoseconds);
   std::chrono::system_clock::time_point tp(

--- a/src/runtime/time.cpp
+++ b/src/runtime/time.cpp
@@ -203,5 +203,5 @@ void prim_register_time(PrimMap &pmap) {
   prim_register(pmap, "get_time", prim_get_time, type_get_time, PRIM_ORDERED);
   prim_register(pmap, "format_time", prim_format_time, type_format_time, PRIM_PURE);
   prim_register(pmap, "time_to_nanos", prim_time_to_nanos, type_time_to_nanos, PRIM_PURE);
-  prim_register(pmap, "time_print", prim_time_print, type_time_print, PRIM_ORDERED);
+  prim_register(pmap, "time_print", prim_time_print, type_time_print, PRIM_IMPURE);
 }

--- a/src/runtime/time.cpp
+++ b/src/runtime/time.cpp
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <ctime>
+#include <mutex>
 #include <string>
 
 #include "prim.h"
@@ -100,6 +101,9 @@ static std::string format_time_str(const char *fmt, int64_t nanoseconds, const c
   if (timezone == nullptr) {
     gmtime_r(&seconds, &tm_info);
   } else {
+    static std::mutex tz_mutex;
+    std::lock_guard<std::mutex> lock(tz_mutex);
+
     char *old_tz = getenv("TZ");
     std::string saved_tz;
     bool had_tz = (old_tz != nullptr);

--- a/src/runtime/time.cpp
+++ b/src/runtime/time.cpp
@@ -155,8 +155,8 @@ static PRIMTYPE(type_format_time) {
 }
 
 // Print a timestamped message: format Time, prepend to message, write to stream
-// The timezone is specified by the TZ environment variable, or the local machine timezone if TZ is unset.
-// Args: format, time, stream, message
+// The timezone is specified by the TZ environment variable, or the local machine timezone if TZ is
+// unset. Args: format, time, stream, message
 static PRIMFN(prim_time_print) {
   EXPECT(4);
   STRING(format, 0);

--- a/src/runtime/value.cpp
+++ b/src/runtime/value.cpp
@@ -26,6 +26,7 @@
 #include <string.h>
 
 #include <algorithm>
+#include <iomanip>
 #include <sstream>
 
 #include "optimizer/ssa.h"
@@ -275,6 +276,34 @@ std::string Double::str(int format, int precision) const {
       return out;
     }
   }
+  return s.str();
+}
+
+Time *Time::claim(Heap &h, int64_t nanos) {
+  Time *out = new (h.claim(reserve())) Time(nanos);
+  HeapAgeTracker::setAge(out, 0);
+  return out;
+}
+
+Time *Time::alloc(Heap &h, int64_t nanos) {
+  Time *out = new (h.alloc(reserve())) Time(nanos);
+  HeapAgeTracker::setAge(out, 0);
+  return out;
+}
+
+RootPointer<Time> Time::literal(Heap &h, int64_t nanos) {
+  h.guarantee(reserve());
+  Time *out = claim(h, nanos);
+  return h.root(out);
+}
+
+void Time::format(std::ostream &os, FormatState &state) const { os << str(); }
+
+Hash Time::shallow_hash() const { return Hash(&nanoseconds, sizeof(nanoseconds)) ^ TYPE_TIME; }
+
+std::string Time::str() const {
+  std::stringstream s;
+  s << nanoseconds;
   return s.str();
 }
 

--- a/src/runtime/value.h
+++ b/src/runtime/value.h
@@ -45,6 +45,7 @@ class RE2;
 #define TYPE_RECORD 7
 #define TYPE_SCOPE 8
 #define TYPE_TARGET 9
+#define TYPE_TIME 10
 
 /* Values */
 
@@ -210,6 +211,23 @@ struct Double final : public GCObject<Double, Value> {
 
   // Never call this during runtime! It can invalidate the heap.
   static RootPointer<Double> literal(Heap &h, const char *str);
+};
+
+struct Time final : public GCObject<Time, Value> {
+  typedef GCObject<Time, Value> Parent;
+  int64_t nanoseconds;
+
+  Time(int64_t nanos_ = 0) : nanoseconds(nanos_) {}
+
+  std::string str() const;
+  void format(std::ostream &os, FormatState &state) const override;
+  Hash shallow_hash() const override;
+
+  static Time *claim(Heap &h, int64_t nanos);
+  static Time *alloc(Heap &h, int64_t nanos);
+
+  // Never call this during runtime! It can invalidate the heap.
+  static RootPointer<Time> literal(Heap &h, int64_t nanos);
 };
 
 struct RegExp final : public GCObject<RegExp, DestroyableObject> {

--- a/src/types/data.cpp
+++ b/src/types/data.cpp
@@ -27,6 +27,7 @@ TypeVar Data::typeDouble("Double@builtin", 0);
 TypeVar Data::typeRegExp("RegExp@builtin", 0);
 TypeVar Data::typeJob("Job@builtin", 0);
 TypeVar Data::typeTarget("Target@builtin", 0);
+TypeVar Data::typeTime("Time@builtin", 0);
 
 TypeVar Data::typeBoolean("Boolean@wake", 0);
 TypeVar Data::typeOrder("Order@wake", 0);

--- a/src/types/data.h
+++ b/src/types/data.h
@@ -28,6 +28,7 @@ struct Data {
   static TypeVar typeRegExp;
   static TypeVar typeJob;
   static TypeVar typeTarget;
+  static TypeVar typeTime;
   // standard library supplied
   static TypeVar typeBoolean;
   static TypeVar typeOrder;

--- a/tests/standard-library/time/.wakeroot
+++ b/tests/standard-library/time/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/standard-library/time/pass.sh
+++ b/tests/standard-library/time/pass.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+set -e
+WAKE="${1:+$1/wake}"
+
+"${WAKE:-wake}" --stdout=warning,report testTimeLibrary

--- a/tests/standard-library/time/test.wake
+++ b/tests/standard-library/time/test.wake
@@ -1,0 +1,47 @@
+from time import _
+
+from wake import _
+
+# Test basic time library functionality
+export def testTimeLibrary _ =
+    # Test getTime returns a time with positive nanoseconds (after epoch)
+    def now = getTime Unit
+    def nanos = timeToNanoseconds now
+    require True = (nanos > 0)
+    else False
+
+    # Test timeToSeconds returns a positive Double
+    def secs = timeToSeconds now
+    require True = (secs >. 0.0)
+    else False
+
+    # Test timeToMilliseconds returns a positive Double
+    def millis = timeToMilliseconds now
+    require True = (millis >. 0.0)
+    else False
+
+    # Test formatTime produces a non-empty string
+    def formatted = formatTime '%Y-%m-%d %H:%M:%S' now
+    require True = (strlen formatted > 0)
+    else False
+
+    # Test getTimeISO returns a non-empty string
+    def iso = getTimeISO Unit
+    require True = (strlen iso > 0)
+    else False
+
+    # Test format returns nanoseconds as a string
+    def fmt = format now
+    require True = (fmt ==* str nanos)
+    else False
+
+    # Test printTimeLnLevel runs without error
+    def _ = printTimeLnLevel '%H:%M:%S%Z' 'America/Los_Angeles' (getTime Unit) logReport 'printTimeLnLevel test'
+
+    # Test printTsLn (local tz)
+    def _ = printTsLn (getTime Unit) 'printTsLn test'
+
+    # Test printCurrentTsLn (local tz, auto time)
+    def _ = printCurrentTsLn 'printCurrentTsLn test'
+
+    True

--- a/tests/standard-library/time/test.wake
+++ b/tests/standard-library/time/test.wake
@@ -25,6 +25,16 @@ export def testTimeLibrary _ =
     require True = (strlen formatted > 0)
     else False
 
+    # Test that %%f is not expanded as a sub-second specifier
+    def double_pct = formatTime '%%f' now
+    require True = (double_pct ==* '%f')
+    else False
+
+    # Test that %%S is not expanded during sub-second parsing 
+    def double_pct = formatTime '%%S' now
+    require True = (double_pct ==* '%S')
+    else False
+
     # Test getTimeISO returns a non-empty string
     def iso = getTimeISO Unit
     require True = (strlen iso > 0)

--- a/tests/standard-library/time/test.wake
+++ b/tests/standard-library/time/test.wake
@@ -36,12 +36,12 @@ export def testTimeLibrary _ =
     else False
 
     # Test printTimeLnLevel runs without error
-    def _ = printTimeLnLevel '%H:%M:%S%Z' 'America/Los_Angeles' (getTime Unit) logReport 'printTimeLnLevel test'
+    def _ = printTimeLnLevel '%H:%M:%S%Z' (getTime Unit) logReport 'printTimeLnLevel test'
 
-    # Test printTsLn (local tz)
-    def _ = printTsLn (getTime Unit) 'printTsLn test'
+    # Test printTimeLn (local tz)
+    def _ = printTimeLn (getTime Unit) 'printTimeLn test'
 
-    # Test printCurrentTsLn (local tz, auto time)
-    def _ = printCurrentTsLn 'printCurrentTsLn test'
+    # Test printCurrentTimeLn (local tz, auto time)
+    def _ = printCurrentTimeLn 'printCurrentTimeLn test'
 
     True


### PR DESCRIPTION
Creates a builtin type Time for the main purpose of handling timestamps.

Time is stored as a unit of nanoseconds since linux epoch.

This uses the chrono library to help safely handle time. Since we are using c++17, I'm still using strftime to format the string. This does augment strftime with a `%f` formatter for specifying subsecond time.

Functions include:
getTime
formatTime in UTC
Time conversion to nanoseconds ,milliseconds and seconds (integer, double, double)
Println to specify format and timezone.

I did rename the database Time struct to DBTime to avoid conflicts.

This is a more narrowly scoped feature set for Time than original [PR](https://github.com/sifiveinc/wake/pull/1768). The biggest difference is the avoidance of Timezone due to its complexities. The only way timezone can be specified is through the print statement, otherwise everything is handled in UTC.