### PR TITLE
wake --clean: recover freed space on disk

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -814,16 +814,26 @@ void Database::clean() {
   // Add checkpoint after cleanup operations
   checkpoint(false);  // Non-blocking checkpoint for sync point
 
-  // This cannot be a prepared statement, because pragmas may run on prepare
-  char *fail;
-  int ret = sqlite3_exec(imp->db, "pragma incremental_vacuum;", 0, 0, &fail);
-  if (ret != SQLITE_OK) std::cerr << "Could not recover space: " << fail << std::endl;
+  vacuum();
+}
+
+void Database::vacuum(bool incremental) {
+  // Non-incremental requires extended exclusive access to entire DB.
+  auto *command = incremental ? "PRAGMA incremental_vacuum;" : "vacuum;";
+
+  char *fail = nullptr;
+  int ret = sqlite3_exec(imp->db, command, 0, 0, &fail);
+  auto *err = fail ? fail : "unknown error";
+  auto *kind = incremental ? "incremental" : "full";
+  if (ret != SQLITE_OK)
+    std::cerr << "Could not recover space (" << kind << "):" << err << std::endl;
+  sqlite3_free(fail);
 }
 
 void Database::checkpoint(bool blocking) {
   if (!imp->db) return;
 
-  int mode = blocking ? SQLITE_CHECKPOINT_RESTART : SQLITE_CHECKPOINT_PASSIVE;
+  int mode = blocking ? SQLITE_CHECKPOINT_TRUNCATE : SQLITE_CHECKPOINT_PASSIVE;
   int wal_pages, checkpointed_pages;
 
   int ret = sqlite3_wal_checkpoint_v2(imp->db, nullptr, mode, &wal_pages, &checkpointed_pages);

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -826,7 +826,7 @@ void Database::vacuum(bool incremental) {
   auto *err = fail ? fail : "unknown error";
   auto *kind = incremental ? "incremental" : "full";
   if (ret != SQLITE_OK)
-    std::cerr << "Could not recover space (" << kind << "):" << err << std::endl;
+    std::cerr << "Could not recover space (" << kind << "): " << err << std::endl;
   sqlite3_free(fail);
 }
 

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -125,11 +125,16 @@ struct Database {
   void prepare(const std::string &cmdline);  // prepare for job execution
   void clean();                              // finished execution; sweep stale jobs
 
+  // Reclaim space on disk from deleted records.
+  // If not incremental, will lock DB exclusively for duration.
+  // Recommend a blocking checkpoint after full.
+  void vacuum(bool incremental = true);
+
   // Force SQLite WAL checkpoint to sync changes to main database file
   // Needed to prevent WAL from growing unbounded during long builds
   // and ensure data is persisted to the main database file
   //
-  // blocking=true: RESTART mode, waits for all readers to finish
+  // blocking=true: TRUNCATE mode, waits for all readers to finish and truncates log file
   // blocking=false: PASSIVE mode, non-blocking sync attempt
   void checkpoint(bool blocking = false);
 

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -625,6 +625,12 @@ int main(int argc, char **argv) {
       }
     }
 
+    // Full vacuum, we likely just deleted most of the database.
+    db.vacuum(/*incremental=*/false);
+
+    // Blocking checkpoint, truncate the log file.
+    db.checkpoint(/*blocking=*/true);
+
     // Since the log is append only, we should clean it up from time to time.
     // TODO: this is just "unlink_no_fail". Those functions should be moved to
     // a more generic library


### PR DESCRIPTION
We likely just deleted a large portion of the database.

To avoid pathological behavior asking sqlite to later do incremental vacuum on a mostly-empty database
(which can be very slow with WAL enabled),
take this opportunity to reclaim disk space
for the database and its log file.

Vacuum does compaction + defragmentation as well.