### PR TITLE
build: Limit version description to v* tags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Bootstrap build file
 
-VERSION	:= $(shell if test -f manifest.wake; then sed -n "/publish releaseAs/ s/^[^']*'\([^']*\)'.*/\1/p" manifest.wake; else git describe --tags --dirty | cut -c 2- | tr -d '\n' | sed 's/$$/-bootstrap/'; fi)
+VERSION	:= $(shell if test -f manifest.wake; then sed -n "/publish releaseAs/ s/^[^']*'\([^']*\)'.*/\1/p" manifest.wake; else git describe --tags --dirty --match='v*' | cut -c 2- | tr -d '\n' | sed 's/$$/-bootstrap/'; fi)
 
 CC	:= cc -std=c11
 CXX	:= c++

--- a/vendor/git.wake
+++ b/vendor/git.wake
@@ -22,7 +22,7 @@ topic releaseAs: String
 def buildAs Unit = match (subscribe releaseAs)
     version, Nil -> Pass version
     _ ->
-        def cmdline = which "git", "describe", "--tags", "--dirty", Nil
+        def cmdline = which "git", "describe", "--tags", "--dirty", "--match=v*", Nil
 
         require Pass stdout =
             makeExecPlan cmdline Nil


### PR DESCRIPTION
This avoids other tags breaking wake expecting a version-like string to be produced here.