### PR TITLE
job: bail if wake_spawn fails.

### DIFF
--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -890,6 +890,12 @@ static void launch(JobTable *jobtable) {
     sigaddset(&set, SIGCHLD);
     sigprocmask(SIG_UNBLOCK, &set, 0);
     pid_t pid = wake_spawn(cmdline[0], cmdline, environ);
+    if (pid == -1) {
+      status_get_generic_stream(STREAM_ERROR)
+          << "error launching job using command line '" << cmdline[0] << "': " << strerror(errno)
+          << std::endl;
+      exit(1);
+    }
     sigprocmask(SIG_BLOCK, &set, 0);
 
     delete[] cmdline;


### PR DESCRIPTION
Prevents infinite loop as well as situations where wake sends SIGTERM to -1 which is interpreted as all processes.

Fixes #1791.