### PR TITLE
fuse-waked: fix waitpid continue on EINTR logic.

### DIFF
--- a/tools/fuse-waked/main.cpp
+++ b/tools/fuse-waked/main.cpp
@@ -1301,17 +1301,16 @@ static void handle_exit(int sig) {
   // Reap prior attempts
   if (pid != -1) {
     int status = 0;
-    do {
+    while (true) {
       int ret = waitpid(pid, &status, 0);
       if (ret == -1) {
-        if (errno == EINTR) {
-          continue;
-        } else {
-          fprintf(stderr, "waitpid(%d): %s\n", pid, strerror(errno));
-          break;
-        }
+        if (errno == EINTR) continue;
+        status = 0;
+        fprintf(stderr, "waitpid(%d): %s\n", pid, strerror(errno));
+        break;
       }
-    } while (WIFSTOPPED(status));
+      if (!WIFSTOPPED(status)) break;
+    }
     pid = -1;
 
     if (WIFEXITED(status) && WEXITSTATUS(status) == 42) {


### PR DESCRIPTION
On interrupt, wait again until we reap the child.

Match the intent of the original ("continue" vs "break").

I believe this is unlikely to fix situations encountered in practice, unless we send SIGTERM / SIGQUIT to our fuse daemons?

The common flow for handle_exit is via SIGALRM (this is in the handler), during which a new signal of SIGALRM should be blocked and not interrupt us (due to how we've configured things).

Regardless this code is wrong as-is -- let's fix it.