### PR TITLE
Drop hashcode, confirm; --check as unsupported (for now).

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -278,26 +278,6 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
 
         job
 
-    def confirm abort last job =
-        # notOk cannot be deadcode eliminated thanks to printlnLevel having effects
-        def notOk pathInfo =
-            def name = pathInfo.getPathInfoName
-            def hash = pathInfo.getPathInfoHash
-
-            if hashcode name ==* hash then
-                Unit
-            # The panic will not be deadcode dropped, because it's an alternative return of the effect-ful notOk
-            else if abort then
-                panic "The hashcode of output file '{name}' has changed from {hash} (when wake last ran) to {hashcode name} (when inspected this time). Presumably it was hand edited. Please move this file out of the way. Aborting the build to prevent loss of your data."
-            else
-                printlnLevel
-                logError
-                "Wake was run with '-c' and the hashcode of output file '{name}' has changed, despite being produced from identical inputs. In the prior run, it was {hash} and now it is {hashcode name}. Hashes of dependent jobs using this file will not be checked."
-
-        def _ = waitJobMerged (\_ map notOk last) job
-
-        job
-
     def materializeCachedOutputs (outputs: List PathInfo): Result Unit Error =
         outputs
         | map materializeCachedItemFromCas
@@ -325,8 +305,9 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
             require Pass _ = materializeCachedOutputs cachedOutputs
             else build Unit
 
-            confirm True cachedOutputs job
-        Pair Nil _ -> confirm False cachedOutputs (build Unit)
+            job
+        # Cache miss, or -c mode (TODO: determine checking is needed, compare output paths!)
+        Pair Nil _ -> build Unit
 
 # Only run if the first four arguments differ
 target runOnce cmd env dir stdin vis isatty run \ res usage finputs foutputs keep echo stdout stderr label =

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -289,36 +289,6 @@ def hashUsage =
     defaultUsage
     | setUsageCPUtime 0.1
 
-target hashcode (f: String): String =
-    def get f = prim "get_hash"
-    def reuse = get f
-
-    if reuse !=* "" then
-        reuse
-    else
-        def hashPlan cmd =
-            Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun Nil hashUsage identity identity False
-            | addCasHashEnv
-
-        def job =
-            # "<hash>" is a magic string which triggers main.cpp to hash the file rather than read
-            # the "command" as an actual command.
-            hashPlan ("<hash>", f, Nil)
-            | setPlanLabel "hash: {f}"
-            | setPlanEcho logDebug
-            | runJobWith localRunner
-            | setJobInspectVisibilityHidden
-
-        def hashLines =
-            job.getJobStdout
-            | getWhenFail ""
-            | tokenize `\n`
-            | filter (_ !=* "")
-
-        match job.isJobOk hashLines
-            True (x, Nil) -> x
-            _ _ -> "BadHash"
-
 # Allow an untracked file to be removed via `wake --clean`
 export target markFileCleanable (filepath: String): Result Unit Error =
     def hashPlan cmd =

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -978,6 +978,11 @@ int main(int argc, char **argv) {
   status_set_bulk_fd(4, clo.fd4);
   status_set_bulk_fd(5, clo.fd5);
 
+  if (clo.check) {
+    std::cerr << "error: '--check' feature is not currently supported." << std::endl;
+    return 1;
+  }
+
   /* Primitives */
   JobTable jobtable(&db, memory_budget, cpu_budget, clo.debug, clo.verbose, clo.quiet, clo.check,
                     clo.batch);


### PR DESCRIPTION
These are inherently race-prone and unreliable in multi-wake.

We'd like to have these check "does the workspace path have a hash I recognize?" (multi-wake extension of current check; in spirit of "don't delete files I couldn't replace") but even that is challenging to accomplish without TOCTTOU issues without some coordination or locking guarding materialization.

Furthermore, one angle to look at these checks is that if the workspace output does NOT have the expected hashes (matching reuse candidate job's outputs) wake traditionally couldn't do anything safely at all.

With this in mind, stopping was only safe thing to do -- continuing and running new jobs that believe the output has hash X instead of Y would propagate errors through the database recording job results for given inputs incorrectly (!).

This is not an issue for multi-wake + CAS.