### PR TITLE
Revert parseJSONFile API change and claim result jsons

### DIFF
--- a/share/wake/lib/core/json.wake
+++ b/share/wake/lib/core/json.wake
@@ -63,10 +63,10 @@ export def parseJSONBody (body: String): Result JValue Error =
         Pass jvalue -> Pass jvalue
         Fail cause -> Fail (makeError cause)
 
-export def parseJSONFile (path: String): Result JValue Error =
+export def parseJSONFile (path: Path): Result JValue Error =
     def imp f = prim "json_file"
 
-    match (imp path)
+    match (imp path.getPathName)
         Pass body -> Pass body
         Fail f -> Fail (makeError f)
 

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -557,7 +557,14 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
             Some "Non-zero exit status ({str runnerStatusCode}) for JSON runner on {specFile}".makeError
             | RunnerOutput Nil emptyStagedOutputs (specFile, Nil) runnerUsage
 
-        require Pass content = parseJSONFile resultFile
+        def claimResult =
+            claim resultFile
+            | addErrorContext "Failed to claim {resultFile} for JSON runner: "
+
+        require Pass resultPath = claimResult
+        else RunnerOutput Nil emptyStagedOutputs (specFile, Nil) runnerUsage claimResult.getFail
+
+        require Pass content = parseJSONFile resultPath
         else
             Some "Failed to parse output {resultFile} for JSON runner".makeError
             | RunnerOutput Nil emptyStagedOutputs (specFile, Nil) runnerUsage

--- a/tests/standard-library/json-normalize-merge/json-test.wake
+++ b/tests/standard-library/json-normalize-merge/json-test.wake
@@ -22,7 +22,7 @@ def test (preprocessFn: JValue => a) (testFn: a => Result JValue Error) (input: 
         # input file, so claim it instead.
         claimFileAsPath input "build/claimed-json/{input}"
     require Pass json =
-        parseJSONFile inputPath.getPathName
+        parseJSONFile inputPath
     def testResult =
         json
         | preprocessFn


### PR DESCRIPTION
Make parseJSONFIle accept Path objects again to keep its safety 