### PR TITLE
No mtime optimization on outputs, remove get_hash/get_cached_path.

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -218,7 +218,7 @@ def finalizeJob job inputs outputs cleanable reality runnerError =
         require Pass _ = workspaceOutputsReadyResult
 
         match finalRunnerError
-            None -> Pass (outputs.getStagedOutputsPostFinalize Unit)
+            None -> Pass (outputs.getStagedOutputsPostFinalize preparedOutputStagingItems)
             Some _ -> Pass Unit
 
     # Clean up the empty staging root directory now that all staged files are consumed.

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -165,20 +165,6 @@ def dirHash =
 export def getPathParent (path: Path): String =
     simplify "{getPathName path}/.."
 
-def getCachedPathInfo (file: String) (mtimeNs: Integer): Result (Option PathInfo) Error =
-    def get f m = prim "get_cached_path"
-    def Pair pathTypeString (Pair hash mode) = get file mtimeNs
-
-    if hash ==* "" then
-        Pass None
-    else
-        require Pass pathType = pathTypeFromString pathTypeString
-        else failWithError "Failed to decode cached path type '{pathTypeString}' for {file}"
-
-        def cachedPathInfo = PathInfo file pathType hash mode mtimeNs
-
-        Pass (Some cachedPathInfo)
-
 # Store path hash/metadata into the files DB.
 # The returned Path represents the now-recorded DB-backed path metadata.
 def storePath (pathInfo: PathInfo): Path =

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -358,17 +358,16 @@ export def rscApiPostStringBlob (name: String) (value: String) (api: RemoteCache
 #  api | rscApiPostFileBlob "foo" "/some/path/to/foo" = Pass "asdf-fdsa-asdf-fdsa"
 #  (RemoteCacheApi "foo" 1 None) | rscApiPostFileBlob "foo" "/some/path/to/foo" = Fail "authorization required"
 # ```
-export def rscApiPostFileBlob (name: String) (file: String) (api: RemoteCacheApi): Result String Error =
+export def rscApiPostFileBlob (name: String) (file: String) (hash: String) (api: RemoteCacheApi): Result String Error =
     require Pass _ = guardRemoteCacheDisabled Unit
 
     # We must use unsafe here since we cannot elevate *file* to a Path without either copying it
     # or triggering the 'job output by multiple files' error.
 
+    # TODO: Obtain the size in a different way, reading from workspace is problematic in multi-wake.
     def contentType = match (unsafe_stat file)
         Pass (Stat _ _ size) -> contentTypeFromSize size
         Fail _ -> None
-
-    require Pass hash = rscHashFile file
 
     def setBlobFn = addFormDataWithHash name file contentType hash
 
@@ -690,7 +689,8 @@ export def rscApiGetFileBlob ((CacheSearchBlob blobId uri contentHash): CacheSea
     require Pass blobPath = (uri | resolveUriResponse resolveDbSchemeToFile resolveBlobFileScheme)
 
     # Verify content hash if provided
-    require Pass actualHash = rscHashFile blobPath.getPathName
+    def actualHash = blobPath.getPathHash
+
     require Pass _ = verifyBlobHash blobId actualHash contentHash
 
     def fixupScript =
@@ -1157,12 +1157,3 @@ def mkCacheSearchResponse (json: JValue): Result CacheSearchResponse Error =
     | Match
     | Pass
 
-# RSC version of computing hashes for files, similar to Hashcode target in path.wake
-def rscHashFile (file: String): Result String Error =
-    def get f = prim "get_hash"
-    def cached = get file
-
-    if cached !=* "" then
-        Pass cached
-    else
-        failWithError "rsc: hash not found in DB for {file}"

--- a/share/wake/lib/system/remote_cache_api_test.wake
+++ b/share/wake/lib/system/remote_cache_api_test.wake
@@ -72,7 +72,7 @@ export def testDisablingCacheWithEndpoints (api: RemoteCacheApi): Result Unit Er
         Pass Unit
 
     def testFileBlobUpload Unit: Result Unit Error =
-        require Pass _ = rscApiPostFileBlob "test-blob" "/path/to/test/file" api
+        require Pass _ = rscApiPostFileBlob "test-blob" "/path/to/test/file" "test-hash" api
 
         Pass Unit
 

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -60,8 +60,8 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
         # workspace materialization), it invokes this to upload outputs from their permanent
         # workspace locations. This is left as 'def _' so that wake won't block progess
         # on it but it will stil be joined on before wake exits.
-        def postFinalize _ =
-            def _ = postJob rscApi job wakeroot hashKey input output
+        def postFinalize preparedItems =
+            def _ = postJob rscApi job wakeroot hashKey input output preparedItems
 
             Unit
 
@@ -389,7 +389,7 @@ def mkCacheAllowedRequest ((RunnerInput label cmd vis env dir stdin _res _prefix
     CacheAllowedRequest label cmd dir env hidden isAtty stdin vis jobStatus runtime cputime mem obytes
 
 # Posts a completed job to the remote cache
-def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: String) (input: RunnerInput) (output: RunnerOutput): Result Unit Error =
+def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: String) (input: RunnerInput) (output: RunnerOutput) (preparedItems: List PreparedStagingItem): Result Unit Error =
     def stagedOutputs = output.getRunnerOutputOutputs
     def StagedOutputs filteredOutputPaths _ stagingItems _ _ = stagedOutputs
 
@@ -410,27 +410,22 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
         require True = subset scmp filteredOutputPaths stagedOutputPaths
         else failWithError "rsc: Missing staging metadata for published outputs"
 
-        def uploadStagingFile (StagingFileOutput destPath _stagingPath mode _ _) =
-            # Post-finalization: staging file has been consumed. Upload from workspace dest path.
-            def doUpload =
-                rscApi
-                | rscApiPostFileBlob destPath destPath
-
-            require Pass id = doUpload
-
-            CachePostRequestOutputFile destPath mode id
-            | Pass
-
-        def publishedFileUpload (item: StagingItem): Option (Result CachePostRequestOutputFile Error) =
+        # Upload staged and prepared (hashed) files.  In the future this should upload files from their CAS blobs.
+        def uploadPreparedFile ((PreparedStagingItem item hash): PreparedStagingItem): Option (Result CachePostRequestOutputFile Error) =
             match item
-                StagingFile file ->
-                    if isPublishedOutput file.getStagingFileOutputDestPath then
-                        Some (uploadStagingFile file)
+                StagingFile (StagingFileOutput destPath _stagingPath mode _ _) ->
+                    if isPublishedOutput destPath then
+                        # Post-finalization: staging file has been consumed. Upload from workspace dest path.
+                        # TODO: Upload using CAS blob contents directly, this is wrong for multi-wake!
+                        rscApi
+                        | rscApiPostFileBlob destPath destPath hash
+                        | rmap (CachePostRequestOutputFile destPath mode)
+                        | Some
                     else
                         None
                 _ -> None
 
-        def publishedSymlinkUpload (item: StagingItem): Option (Result CachePostRequestOutputSymlink Error) =
+        def uploadPreparedSymlink ((PreparedStagingItem item _hash): PreparedStagingItem): Option (Result CachePostRequestOutputSymlink Error) =
             match item
                 StagingSymlink (StagingSymlinkOutput destPath symlinkTarget _ _) ->
                     if isPublishedOutput destPath then
@@ -439,41 +434,17 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
                         None
                 _ -> None
 
-        def publishedDirectoryUpload (item: StagingItem): Option CachePostRequestOutputDirectory =
-            match item
-                StagingDirectory (StagingDirectoryOutput destPath mode _ _) ->
-                    if isPublishedOutput destPath then
-                        Some (CachePostRequestOutputDirectory destPath mode False)
-                    else
-                        None
-                _ -> None
+        # Directories carry no meaningful hash, so iterate staging items directly.
+        # Both published and hidden directories are uploaded.
+        # (hidden=True marks them as ancillary — restored on rehydration but not listed as job outputs).
+        def uploadDirectory (item: StagingItem): Option CachePostRequestOutputDirectory = match item
+            StagingDirectory (StagingDirectoryOutput destPath mode _ _) ->
+                Some (CachePostRequestOutputDirectory destPath mode (! isPublishedOutput destPath))
+            _ -> None
 
-        def hiddenDirectoryUpload (item: StagingItem): Option CachePostRequestOutputDirectory =
-            match item
-                StagingDirectory (StagingDirectoryOutput destPath mode _ _) ->
-                    if isPublishedOutput destPath then
-                        None
-                    else
-                        Some (CachePostRequestOutputDirectory destPath mode True)
-                _ -> None
-
-        def fileUploads =
-            stagingItems
-            | mapPartial publishedFileUpload
-
-        def symlinksUpload =
-            stagingItems
-            | mapPartial publishedSymlinkUpload
-
-        def publishedDirectoriesUpload =
-            stagingItems
-            | mapPartial publishedDirectoryUpload
-
-        def hiddenDirectoriesUpload =
-            stagingItems
-            | mapPartial hiddenDirectoryUpload
-
-        def directoriesUpload = publishedDirectoriesUpload ++ hiddenDirectoriesUpload
+        def fileUploads = mapPartial uploadPreparedFile preparedItems
+        def symlinksUpload = mapPartial uploadPreparedSymlink preparedItems
+        def directoriesUpload = mapPartial uploadDirectory stagingItems
 
         Pass (Triple fileUploads directoriesUpload symlinksUpload)
 

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -97,9 +97,11 @@ export tuple StagedOutputs =
     # before this final rmdir cleanup.
     export StagingRoot: Option String
     # Callback invoked after finalization (CAS ingestion + workspace materialization).
-    # Used by RSC to upload outputs from their permanent workspace locations.
+    # Receives the list of prepared staging items for all published outputs.
+    # Used by RSC to upload outputs using this recorded information.
+    # For now RSC upload reads contents from their materialized workspace locations.
     # Default: no-op.
-    export PostFinalize: Unit => Unit
+    export PostFinalize: List PreparedStagingItem => Unit
 
 export def emptyStagedOutputs: StagedOutputs =
     StagedOutputs Nil True Nil None (\_ Unit)

--- a/share/wake/lib/system/staging_outputs.wake
+++ b/share/wake/lib/system/staging_outputs.wake
@@ -180,59 +180,25 @@ export def parseStagingFiles (content: JValue): Result (List StagingItem) Error 
             | map parseStagingEntry
             | findFail
 
-# Picks the staged filesystem paths that still need hashing from disk.
-# Note: Symlinks are excluded here because their hashes are computed directly from the
-# target string.
-def stagingHashInput (item: StagingItem): Option (Triple String String Integer) = match item
-    StagingFile (StagingFileOutput destPath stagingPath _ mtimeSec mtimeNsec) ->
-        Some (Triple destPath stagingPath (mtimeNsFromParts mtimeSec mtimeNsec))
-    _ -> None
-
-# Converts staged metadata into PreparedStagingItem values by hashing staged files from their
-# staging paths and deriving hashes for symlinks/directories. Checks the dest-path hash cache
-# first to avoid re-hashing files whose content is already known (e.g. unchanged source files).
+# Hashes staged outputs and wraps them with their computed hashes.
+# Regular files are hashed from their staging paths. Symlinks are hashed from their
+# target string (they have no on-disk staging file). Directories use a fixed zero hash.
 export def prepareStagingOutputs (stagingItems: List StagingItem): Result (List PreparedStagingItem) Error =
-    # Check if the dest path already has a cached hash using the staging item's mtime.
-    def tryCachedFileHash (destPath: String) (mtimeNs: Integer): Option String =
-        match (getCachedPathInfo destPath mtimeNs)
-            Pass (Some pathInfo) -> Some pathInfo.getPathInfoHash
-            _ -> None
-
-    # Look up the dest-path hash cache once per input so that splitting into cached and uncached
-    # below doesn't double the database queries.
-    def lookupHash (Triple destPath stagingPath mtimeNs) =
-        Pair (Triple destPath stagingPath mtimeNs) (tryCachedFileHash destPath mtimeNs)
-
-    def hashInputs =
+    def fileInputs =
         stagingItems
-        | mapPartial stagingHashInput
-        | map lookupHash
-
-    # Split into cached (hash already known) and uncached (needs wake-hash).
-    def cachedByDest =
-        hashInputs
         | mapPartial (
-            \(Pair (Triple destPath _ _) maybeHash) match maybeHash
-                Some hash -> Some (Pair destPath hash)
-                None -> None
+            \item match item
+                StagingFile (StagingFileOutput destPath stagingPath _ _ _) ->
+                    Some (Pair destPath stagingPath)
+                _ -> None
         )
 
-    def uncachedInputs =
-        hashInputs
-        | mapPartial (
-            \(Pair triple maybeHash) match maybeHash
-                Some _ -> None
-                None -> Some triple
-        )
+    require Pass hashes = computeHashes (map getPairSecond fileInputs)
 
-    # Only hash files that missed the cache.
-    require Pass freshHashes = computeHashes (map getTripleSecond uncachedInputs)
-
-    def freshByDest = zip (map getTripleFirst uncachedInputs) freshHashes
-    def allHashesByDest = listToMap scmp (cachedByDest ++ freshByDest)
+    def hashesByDest = listToMap scmp (zip (map getPairFirst fileInputs) hashes)
 
     def lookupFileHash (destPath: String): Result String Error =
-        match (mlookup destPath allHashesByDest)
+        match (mlookup destPath hashesByDest)
             Some hash -> Pass hash
             None -> failWithError "Missing hash for staged file {destPath}"
 

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -77,8 +77,6 @@ struct Database::detail {
   sqlite3_stmt *delete_overlap;
   sqlite3_stmt *find_prior;
   sqlite3_stmt *delete_prior;
-  sqlite3_stmt *fetch_hash;
-  sqlite3_stmt *fetch_cached_path;
   sqlite3_stmt *delete_jobs;
   sqlite3_stmt *delete_dups;
   sqlite3_stmt *delete_stats;
@@ -133,8 +131,6 @@ struct Database::detail {
         delete_overlap(0),
         find_prior(0),
         delete_prior(0),
-        fetch_hash(0),
-        fetch_cached_path(0),
         delete_jobs(0),
         delete_dups(0),
         delete_stats(0),
@@ -410,14 +406,6 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
       "  and j2.job_id<>?2"
       "  and (select coalesce(max(run_id), 0) from run_jobs where job_id=j2.job_id) <= ?1"
       ")";
-  const char *sql_fetch_hash =
-      "select f.hash from filetree t "
-      "join files f on t.file_id = f.file_id "
-      "where f.path=? and t.modified=? limit 1";
-  const char *sql_fetch_cached_path =
-      "select f.hash, f.type, f.mode from filetree t "
-      "join files f on t.file_id = f.file_id "
-      "where f.path=? and t.modified=? limit 1";
   const char *sql_delete_jobs =
       "delete from jobs where keep=0"
       "  and not exists (select 1 from filetree where"
@@ -519,8 +507,6 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   PREPARE(sql_delete_overlap, delete_overlap);
   PREPARE(sql_find_prior, find_prior);
   PREPARE(sql_delete_prior, delete_prior);
-  PREPARE(sql_fetch_hash, fetch_hash);
-  PREPARE(sql_fetch_cached_path, fetch_cached_path);
   PREPARE(sql_delete_jobs, delete_jobs);
   PREPARE(sql_delete_dups, delete_dups);
   PREPARE(sql_delete_stats, delete_stats);
@@ -586,8 +572,6 @@ void Database::close() {
   FINALIZE(delete_overlap);
   FINALIZE(find_prior);
   FINALIZE(delete_prior);
-  FINALIZE(fetch_hash);
-  FINALIZE(fetch_cached_path);
   FINALIZE(delete_jobs);
   FINALIZE(delete_dups);
   FINALIZE(delete_stats);
@@ -1516,35 +1500,6 @@ void Database::add_hash(const std::string &file, const std::string &type, const 
   bind_string(why, imp->insert_file, 4, file);
   single_step(why, imp->insert_file, imp->debugdb);
   end_txn();
-}
-
-std::string Database::get_hash(const std::string &file, long modified) {
-  std::string out;
-  const char *why = "Could not fetch a hash";
-  begin_ro_txn();
-  bind_string(why, imp->fetch_hash, 1, file);
-  bind_integer(why, imp->fetch_hash, 2, modified);
-  if (sqlite3_step(imp->fetch_hash) == SQLITE_ROW) out = rip_column(imp->fetch_hash, 0);
-  finish_stmt(why, imp->fetch_hash, imp->debugdb);
-  end_txn();
-  return out;
-}
-
-std::tuple<std::string, std::string, long> Database::get_cached_path(const std::string &file,
-                                                                     long modified) {
-  std::tuple<std::string, std::string, long> out;
-  const char *why = "Could not fetch a cached path";
-  begin_ro_txn();
-  bind_string(why, imp->fetch_cached_path, 1, file);
-  bind_integer(why, imp->fetch_cached_path, 2, modified);
-  if (sqlite3_step(imp->fetch_cached_path) == SQLITE_ROW) {
-    std::get<0>(out) = rip_column(imp->fetch_cached_path, 0);
-    std::get<1>(out) = rip_column(imp->fetch_cached_path, 1);
-    std::get<2>(out) = sqlite3_column_int64(imp->fetch_cached_path, 2);
-  }
-  finish_stmt(why, imp->fetch_cached_path, imp->debugdb);
-  end_txn();
-  return out;
 }
 
 static std::vector<std::string> chop_null(const std::string &str) {

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -202,10 +202,6 @@ struct Database {
   void add_hash(const std::string &file, const std::string &type, const std::string &hash,
                 long mode);
 
-  std::string get_hash(const std::string &file, long modified);
-  std::tuple<std::string, std::string, long> get_cached_path(const std::string &file,
-                                                             long modified);
-
   // In core_filters, the outer vec is a set of filters to be AND'd together, inner vec is a set of
   // queries to be OR'd together. This holds for input_file_filters and output_file_filters as well
   // but is less useful as its restricted to the column 'path' in the files table.

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -1794,47 +1794,6 @@ static PRIMFN(prim_add_hash) {
   RETURN(args[0]);
 }
 
-static PRIMTYPE(type_get_hash) {
-  return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(Data::typeString);
-}
-
-static PRIMFN(prim_get_hash) {
-  JobTable *jobtable = static_cast<JobTable *>(data);
-  EXPECT(1);
-  STRING(file, 0);
-  std::string hash = jobtable->imp->db->get_hash(file->as_str(), getmtime_ns(file->c_str()));
-  RETURN(String::alloc(runtime.heap, hash));
-}
-
-static PRIMTYPE(type_get_cached_path) {
-  TypeVar outer, inner;
-  Data::typePair.clone(outer);
-  Data::typePair.clone(inner);
-  outer[0].unify(Data::typeString);
-  inner[0].unify(Data::typeString);
-  inner[1].unify(Data::typeInteger);
-  outer[1].unify(inner);
-  return args.size() == 2 && args[0]->unify(Data::typeString) &&
-         args[1]->unify(Data::typeInteger) && out->unify(outer);
-}
-
-static PRIMFN(prim_get_cached_path) {
-  JobTable *jobtable = static_cast<JobTable *>(data);
-  EXPECT(2);
-  STRING(file, 0);
-  INTEGER_MPZ(mtime_mpz, 1);
-  long mtime = mpz_get_si(mtime_mpz);
-  auto cached_path = jobtable->imp->db->get_cached_path(file->as_str(), mtime);
-  const std::string &hash = std::get<0>(cached_path);
-  const std::string &type = std::get<1>(cached_path);
-  long mode = std::get<2>(cached_path);
-  runtime.heap.reserve(reserve_tuple2() * 2 + String::reserve(type.size()) +
-                       String::reserve(hash.size()) + Integer::reserve(mode));
-  RETURN(claim_tuple2(runtime.heap, String::claim(runtime.heap, type),
-                      claim_tuple2(runtime.heap, String::claim(runtime.heap, hash),
-                                   Integer::claim(runtime.heap, mode))));
-}
-
 static PRIMTYPE(type_get_modtime) {
   return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(Data::typeInteger);
 }
@@ -2128,12 +2087,6 @@ void prim_register_job(JobTable *jobtable, PrimMap &pmap) {
   /*****************************************************************************************
    * Dead-code elimination ok, but not CSE/const-prop ok (must be ordered wrt. filesystem) *
    *****************************************************************************************/
-
-  // Get's the hash of a file if it was previouslly hashed in the database by a cached
-  // job this session. Returns the empty string otherwise.
-  prim_register(pmap, "get_hash", prim_get_hash, type_get_hash, PRIM_ORDERED, jobtable);
-  prim_register(pmap, "get_cached_path", prim_get_cached_path, type_get_cached_path, PRIM_ORDERED,
-                jobtable);
 
   // Get's the modtime of a file, super simple
   prim_register(pmap, "get_modtime", prim_get_modtime, type_get_modtime, PRIM_ORDERED);


### PR DESCRIPTION
Despite nanosecond precision,
with multi-wake it's possible to obtain same mtime
for two files with different contents but same path.

Drop this mechanism entirely.

High-level:
This fast-path should only be done for files from the user,
(source and claim) where job reuse mechanism
and the way mtime is part of source job's "command"
avoids re-hashing "outputs" (inputs) unnecessarily.

All jobs we now unconditionally hash outputs,
as the job freshly created those files regardless of mtime.

Fixes https://github.com/sifiveinc/wake/issues/1815.

Modify RSC upload to avoid reading from workspace for hash,
instead use already-computed hash when preparing the staging items.
RSC still does so for checking size and actual contents (!).

This is a known issue and planned to be improved upon
but not immediately critical.  For single-wake this is as
safe (and unsafe) as it always has been.
For multi-wake this is about as unsafe as it already is.
