### PR TITLE
wake_spawn: set PR_SET_PDEATHSIG on spawned processes

### DIFF
--- a/src/compat/spawn.c
+++ b/src/compat/spawn.c
@@ -23,10 +23,17 @@
 
 #include <sys/types.h>
 #include <unistd.h>
+#ifdef __linux__
+#include <signal.h>
+#include <sys/prctl.h>
+#endif
 
 pid_t wake_spawn(const char *cmd, char **cmdline, char **environ) {
   pid_t pid = vfork();
   if (pid == 0) {
+#ifdef __linux__
+    if (prctl(PR_SET_PDEATHSIG, SIGKILL) == -1) _exit(1);
+#endif
     execve(cmdline[0], cmdline, environ);
     _exit(127);
   }

--- a/src/compat/spawn.c
+++ b/src/compat/spawn.c
@@ -29,10 +29,13 @@
 #endif
 
 pid_t wake_spawn(const char *cmd, char **cmdline, char **environ) {
+  pid_t parent = getpid();
+  (void)parent;
   pid_t pid = vfork();
   if (pid == 0) {
 #ifdef __linux__
     if (prctl(PR_SET_PDEATHSIG, SIGKILL) == -1) _exit(1);
+    if (getppid() != parent) _exit(2);
 #endif
     execve(cmdline[0], cmdline, environ);
     _exit(127);

--- a/tests/inspection/history/pass.sh
+++ b/tests/inspection/history/pass.sh
@@ -6,9 +6,6 @@ set -eu
 WAKE="${1:+$1/wake}"
 WAKE="${WAKE:-wake}"
 
-echo "Skipping test until https://github.com/sifiveinc/wake/issues/1781 is resolved"
-exit 0
-
 cleanup() {
   if [ -n "${WAKE_PID:-}" ]; then
     kill $WAKE_PID 2>/dev/null || true

--- a/tests/runtime/clean-safety/pass.sh
+++ b/tests/runtime/clean-safety/pass.sh
@@ -6,9 +6,6 @@ set -eu
 WAKE="${1:+$1/wake}"
 WAKE="${WAKE:-wake}"
 
-echo "Skipping test until https://github.com/sifiveinc/wake/issues/1781 is resolved"
-exit 0
-
 cleanup() {
   if [ -n "${WAKE_PID:-}" ]; then
     kill $WAKE_PID 2>/dev/null || true


### PR DESCRIPTION
This is for multi-wake, but should go to master as well to fix stale wakebox processes after `wake` has been killed.