### PR TITLE
FUSE virtual directory stat update

### DIFF
--- a/tools/fuse-waked/main.cpp
+++ b/tools/fuse-waked/main.cpp
@@ -724,6 +724,7 @@ static int wakefuse_getattr(const char *path, struct stat *stbuf) {
                           [stbuf](const StagedDirectoryData &d) {
                             // Return synthetic directory stat
                             memset(stbuf, 0, sizeof(*stbuf));
+                            stbuf->st_size = 4096;
                             stbuf->st_mode = S_IFDIR | (d.mode & 07777);
                             stbuf->st_nlink = 2;
                             stbuf->st_uid = getuid();

--- a/tools/fuse-waked/main.cpp
+++ b/tools/fuse-waked/main.cpp
@@ -770,6 +770,7 @@ static int wakefuse_getattr(const char *path, struct stat *stbuf) {
       if (type == "directory") {
         memset(stbuf, 0, sizeof(*stbuf));
         stbuf->st_mode = S_IFDIR | visible_mode_or(visible_it->second, 0755);
+        stbuf->st_size = 4096;
         stbuf->st_nlink = 2;
         stbuf->st_uid = getuid();
         stbuf->st_gid = getgid();

--- a/tools/fuse-waked/main.cpp
+++ b/tools/fuse-waked/main.cpp
@@ -726,7 +726,7 @@ static int wakefuse_getattr(const char *path, struct stat *stbuf) {
                             memset(stbuf, 0, sizeof(*stbuf));
                             stbuf->st_size = 4096;
                             stbuf->st_mode = S_IFDIR | (d.mode & 07777);
-                            stbuf->st_nlink = 2;
+                            stbuf->st_nlink = 1;
                             stbuf->st_uid = getuid();
                             stbuf->st_gid = getgid();
                             stbuf->st_mtim = d.mtime;
@@ -771,7 +771,7 @@ static int wakefuse_getattr(const char *path, struct stat *stbuf) {
         memset(stbuf, 0, sizeof(*stbuf));
         stbuf->st_mode = S_IFDIR | visible_mode_or(visible_it->second, 0755);
         stbuf->st_size = 4096;
-        stbuf->st_nlink = 2;
+        stbuf->st_nlink = 1;
         stbuf->st_uid = getuid();
         stbuf->st_gid = getgid();
         return 0;


### PR DESCRIPTION
FUSE:
Updates `st_size` for a directory type to be a standard 4KB size.
Updates `st_nlink` for a directory type is set to 1 to indicate wake FUSE does not follow normal conventions.