### PR TITLE
Move modified into filetree (and add to Path!).

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -251,6 +251,7 @@ def finalizeJob job inputs outputs cleanable reality runnerError =
             hash,
             pathTypeToString (getStagingItemPathType item),
             str (getStagingItemMode item),
+            str (getStagingItemMtimeNs item),
         )
 
     def preparedOutputStrings = map pstr preparedOutputStagingItems
@@ -270,6 +271,7 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
             p.getPathHash,
             pathTypeToString p.getPathType,
             str p.getPathMode,
+            str p.getPathMtimeNs,
         )
 
     def visKey =

--- a/share/wake/lib/system/path.wake
+++ b/share/wake/lib/system/path.wake
@@ -138,7 +138,7 @@ export def pathTypeFromString (pathType: String): Result PathType Error = match 
     "" -> Pass PathTypeRegularFile
     _ -> failWithError "Unknown path type '{pathType}'"
 
-# A Path is intended to represent metadata that has already been recorded in the files DB.
+# A Path is intended to represent metadata that has already been recorded in the DB.
 tuple Path =
     Name: String
     Type: PathType
@@ -179,10 +179,10 @@ def getCachedPathInfo (file: String) (mtimeNs: Integer): Result (Option PathInfo
 
         Pass (Some cachedPathInfo)
 
-# Store path hash/metadata into the files DB. MtimeNs == 0 falls back to getmtime_ns(path).
+# Store path hash/metadata into the files DB.
 # The returned Path represents the now-recorded DB-backed path metadata.
 def storePath (pathInfo: PathInfo): Path =
-    def addHash f t h m mtimeNs = prim "add_hash"
+    def addHash f t h m = prim "add_hash"
 
     def _ =
         addHash
@@ -190,7 +190,6 @@ def storePath (pathInfo: PathInfo): Path =
         (pathTypeToString pathInfo.getPathInfoType)
         pathInfo.getPathInfoHash
         pathInfo.getPathInfoMode
-        pathInfo.getPathInfoMtimeNs
 
     Path
     pathInfo.getPathInfoName

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -67,7 +67,6 @@ struct Database::detail {
   sqlite3_stmt *insert_tree_file_id;
   sqlite3_stmt *insert_log;
   sqlite3_stmt *insert_file;
-  sqlite3_stmt *update_file;
   sqlite3_stmt *get_log;
   sqlite3_stmt *replay_log;
   sqlite3_stmt *get_tree;
@@ -124,7 +123,6 @@ struct Database::detail {
         insert_tree_file_id(0),
         insert_log(0),
         insert_file(0),
-        update_file(0),
         get_log(0),
         replay_log(0),
         get_tree(0),
@@ -359,26 +357,24 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
       "signature, stack, is_atty)"
       " values(?, ?, ?, ?, ?, ?, ?, ?, ?)";
   const char *sql_insert_tree =
-      "insert into filetree(access, job_id, file_id)"
-      " values(?, ?, (select file_id from files where path=? and hash=? and type=? and mode=?))";
+      "insert into filetree(access, job_id, file_id, modified)"
+      " values(?, ?, (select file_id from files where path=? and hash=? and type=? and mode=?), ?)";
   const char *sql_insert_tree_file_id =
-      "insert into filetree(access, job_id, file_id)"
-      " values(?, ?, ?)";
+      "insert into filetree(access, job_id, file_id, modified)"
+      " values(?, ?, ?, ?)";
   const char *sql_insert_log =
       "insert into log(job_id, descriptor, seconds, output)"
       " values(?, ?, ?, ?)";
   const char *sql_insert_file =
-      "insert or ignore into files(hash, type, mode, modified, path) values (?, ?, ?, ?, ?)";
-  const char *sql_update_file =
-      "update files set modified=? where hash=? and type=? and mode=? and path=?";
+      "insert or ignore into files(hash, type, mode, path) values (?, ?, ?, ?)";
   const char *sql_get_log =
       "select output from log where job_id=? and descriptor=? order by log_id";
   const char *sql_replay_log = "select descriptor, output from log where job_id=? order by log_id";
   const char *sql_get_tree =
-      "select f.path, f.hash, f.type, f.mode, f.modified from filetree t, files f"
+      "select f.path, f.hash, f.type, f.mode, t.modified from filetree t, files f"
       " where t.job_id=? and t.access=? and f.file_id=t.file_id order by t.tree_id";
   const char *sql_get_tree_id =
-      "select f.path, f.file_id from filetree t, files f"
+      "select f.path, f.file_id, t.modified from filetree t, files f"
       " where t.job_id=? and t.access=? and f.file_id=t.file_id order by t.tree_id";
   const char *sql_add_stats =
       "insert into stats(hashcode, status, runtime, cputime, membytes, ibytes, obytes)"
@@ -414,9 +410,14 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
       "  and j2.job_id<>?2"
       "  and (select coalesce(max(run_id), 0) from run_jobs where job_id=j2.job_id) <= ?1"
       ")";
-  const char *sql_fetch_hash = "select hash from files where path=? and modified=?";
+  const char *sql_fetch_hash =
+      "select f.hash from filetree t "
+      "join files f on t.file_id = f.file_id "
+      "where f.path=? and t.modified=? limit 1";
   const char *sql_fetch_cached_path =
-      "select hash, type, mode from files where path=? and modified=?";
+      "select f.hash, f.type, f.mode from filetree t "
+      "join files f on t.file_id = f.file_id "
+      "where f.path=? and t.modified=? limit 1";
   const char *sql_delete_jobs =
       "delete from jobs where keep=0"
       "  and not exists (select 1 from filetree where"
@@ -439,7 +440,7 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
       "update stats set pathtime=runtime+("
       "  select coalesce(max(s.pathtime),0) from filetree f1, filetree f2, jobs j, stats s"
       "  where f1.job_id=?1 and f1.access=2 and f1.file_id=f2.file_id and f2.access=1 and "
-      "f2.job_id=j.job_id and j.stat_id=s.stat_id"
+      "f2.job_id=j.job_id and j.stat_id=s.stat_id and f1.modified=f2.modified"
       ") where stat_id=(select stat_id from jobs where job_id=?1)";
   const char *sql_tag_job = "insert into tags(job_id, uri, content) values(?, ?, ?)";
   const char *sql_get_tags = "select job_id, uri, content from tags where job_id=?";
@@ -508,7 +509,6 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   PREPARE(sql_insert_tree_file_id, insert_tree_file_id);
   PREPARE(sql_insert_log, insert_log);
   PREPARE(sql_insert_file, insert_file);
-  PREPARE(sql_update_file, update_file);
   PREPARE(sql_get_log, get_log);
   PREPARE(sql_replay_log, replay_log);
   PREPARE(sql_get_tree, get_tree);
@@ -576,7 +576,6 @@ void Database::close() {
   FINALIZE(insert_tree_file_id);
   FINALIZE(insert_log);
   FINALIZE(insert_file);
-  FINALIZE(update_file);
   FINALIZE(get_log);
   FINALIZE(replay_log);
   FINALIZE(get_tree);
@@ -934,10 +933,13 @@ struct PathInfo {
   std::string_view hash;
   std::string_view type;
   long mode;
+  long modified;
 
-  bool operator==(const PathInfo &b) const {
+  // Compare, ignoring mtime.
+  bool same_identity(const PathInfo &b) const {
     return path == b.path && hash == b.hash && type == b.type && mode == b.mode;
   }
+  bool operator==(const PathInfo &b) const { return same_identity(b) && modified == b.modified; }
   bool operator!=(const PathInfo &b) const { return !(*this == b); }
 };
 }  // end namespace
@@ -971,11 +973,21 @@ static bool foreach_pathinfo(std::string_view s, F &&f) {
     if (m_end == std::string_view::npos || m_end == m_start) return false;
 
     long mode;
-    auto [_, ec] = std::from_chars(s.data() + m_start, s.data() + m_end, mode);
-    if (ec != std::errc()) return false;
+    if (auto [_, ec] = std::from_chars(s.data() + m_start, s.data() + m_end, mode);
+        ec != std::errc())
+      return false;
+
+    size_t mod_start = m_end + 1;
+    size_t mod_end = s.find('\0', mod_start);
+    if (mod_end == std::string_view::npos || mod_end == mod_start) return false;
+
+    long modified;
+    if (auto [_, ec] = std::from_chars(s.data() + mod_start, s.data() + mod_end, modified);
+        ec != std::errc())
+      return false;
 
     const PathInfo pi{s.substr(pos, p_end - pos), s.substr(h_start, h_end - h_start),
-                      s.substr(t_start, t_end - t_start), mode};
+                      s.substr(t_start, t_end - t_start), mode, modified};
 
     if constexpr (!std::is_void_v<R>) {
       if (!std::invoke(f, pi)) return false;
@@ -983,7 +995,7 @@ static bool foreach_pathinfo(std::string_view s, F &&f) {
       std::invoke(f, pi);
     }
 
-    pos = m_end + 1;
+    pos = mod_end + 1;
   }
 
   return true;
@@ -1053,10 +1065,11 @@ Usage Database::reuse_job(const std::string &directory, const std::string &envir
       auto hash = rip_column(imp->get_tree, 1);
       auto type = rip_column(imp->get_tree, 2);
       long mode = sqlite3_column_int64(imp->get_tree, 3);
-      PathInfo vis{path, hash, type, mode};
+      PathInfo vis{path, hash, type, mode, /*modified=*/0};
 
+      // Deliberately do not consider 'modified' for purposes of job reuse.
       auto it = vis_hashes->find(path);
-      if (it == vis_hashes->end() || it->second != vis) {
+      if (it == vis_hashes->end() || !it->second.same_identity(vis)) {
         finish_stmt(why, imp->get_tree, imp->debugdb);
         return false;
       }
@@ -1190,6 +1203,7 @@ void Database::insert_job(const std::string &directory, const std::string &comma
     bind_string(why, imp->insert_tree, 4, pi.hash);
     bind_string(why, imp->insert_tree, 5, pi.type);
     bind_integer(why, imp->insert_tree, 6, pi.mode);
+    bind_integer(why, imp->insert_tree, 7, pi.modified);
     single_step(why, imp->insert_tree, imp->debugdb);
   });
 
@@ -1264,13 +1278,18 @@ void Database::finish_job(long job, const std::string &inputs, const std::string
   single_step(why, imp->link_stats, imp->debugdb);
 
   // Grab the visible set.
-  std::unordered_map<std::string, long> visible_files;
+  struct FileAndMtime {
+    long file_id;
+    long mtime;
+  };
+  std::unordered_map<std::string, FileAndMtime> visible_files;
   bind_integer(why, imp->get_tree_id, 1, job);
   bind_integer(why, imp->get_tree_id, 2, VISIBLE);
   while (sqlite3_step(imp->get_tree_id) == SQLITE_ROW) {
     auto path = rip_column(imp->get_tree_id, 0);
     auto file_id = sqlite3_column_int64(imp->get_tree_id, 1);
-    visible_files.emplace(std::move(path), file_id);
+    auto modified = sqlite3_column_int64(imp->get_tree_id, 2);
+    visible_files.emplace(std::move(path), FileAndMtime{file_id, modified});
   }
   finish_stmt(why, imp->get_tree_id, imp->debugdb);
 
@@ -1285,7 +1304,8 @@ void Database::finish_job(long job, const std::string &inputs, const std::string
     } else {
       bind_integer(why, imp->insert_tree_file_id, 1, INPUT);
       bind_integer(why, imp->insert_tree_file_id, 2, job);
-      bind_integer(why, imp->insert_tree_file_id, 3, it->second);
+      bind_integer(why, imp->insert_tree_file_id, 3, it->second.file_id);
+      bind_integer(why, imp->insert_tree_file_id, 4, it->second.mtime);
       single_step(why, imp->insert_tree_file_id, imp->debugdb);
     }
   });
@@ -1298,6 +1318,7 @@ void Database::finish_job(long job, const std::string &inputs, const std::string
     bind_string(why, imp->insert_tree, 4, output.hash);
     bind_string(why, imp->insert_tree, 5, output.type);
     bind_integer(why, imp->insert_tree, 6, output.mode);
+    bind_integer(why, imp->insert_tree, 7, output.modified);
     single_step(why, imp->insert_tree, imp->debugdb);
   }
 
@@ -1486,20 +1507,13 @@ void Database::replay_output(long job, const char *stdout, const char *stderr,
 }
 
 void Database::add_hash(const std::string &file, const std::string &type, const std::string &hash,
-                        long mode, long modified) {
+                        long mode) {
   const char *why = "Could not insert a hash";
   begin_rw_txn();
-  bind_integer(why, imp->update_file, 1, modified);
-  bind_string(why, imp->update_file, 2, hash);
-  bind_string(why, imp->update_file, 3, type);
-  bind_integer(why, imp->update_file, 4, mode);
-  bind_string(why, imp->update_file, 5, file);
-  single_step(why, imp->update_file, imp->debugdb);
   bind_string(why, imp->insert_file, 1, hash);
   bind_string(why, imp->insert_file, 2, type);
   bind_integer(why, imp->insert_file, 3, mode);
-  bind_integer(why, imp->insert_file, 4, modified);
-  bind_string(why, imp->insert_file, 5, file);
+  bind_string(why, imp->insert_file, 4, file);
   single_step(why, imp->insert_file, imp->debugdb);
   end_txn();
 }

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -200,7 +200,7 @@ struct Database {
   bool clear_jobs_if_safe(std::function<void(std::vector<std::string>)> delete_files);
 
   void add_hash(const std::string &file, const std::string &type, const std::string &hash,
-                long mode, long modified);
+                long mode);
 
   std::string get_hash(const std::string &file, long modified);
   std::tuple<std::string, std::string, long> get_cached_path(const std::string &file,

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -1775,26 +1775,22 @@ static PRIMFN(prim_job_tag) {
   RETURN(claim_unit(runtime.heap));
 }
 
-// add_hash: stores the hash and metadata for a file. mtime_ns == 0 means read from filesystem.
+// add_hash: stores the hash and metadata for a file.
 static PRIMTYPE(type_add_hash) {
-  return args.size() == 5 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeString) &&
+  return args.size() == 4 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeString) &&
          args[2]->unify(Data::typeString) && args[3]->unify(Data::typeInteger) &&
-         args[4]->unify(Data::typeInteger) && out->unify(Data::typeString);
+         out->unify(Data::typeString);
 }
 
 static PRIMFN(prim_add_hash) {
   JobTable *jobtable = static_cast<JobTable *>(data);
-  EXPECT(5);
+  EXPECT(4);
   STRING(file, 0);
   STRING(type, 1);
   STRING(hash, 2);
   INTEGER_MPZ(mode, 3);
-  INTEGER_MPZ(mtime_ns, 4);
   long mode_bits = mpz_get_si(mode);
-  long mtime = mpz_get_si(mtime_ns);
-  long actual_mtime = (mtime != 0) ? mtime : getmtime_ns(file->c_str());
-  jobtable->imp->db->add_hash(file->as_str(), type->as_str(), hash->as_str(), mode_bits,
-                              actual_mtime);
+  jobtable->imp->db->add_hash(file->as_str(), type->as_str(), hash->as_str(), mode_bits);
   RETURN(args[0]);
 }
 

--- a/src/runtime/schema.h
+++ b/src/runtime/schema.h
@@ -1,7 +1,7 @@
 #ifndef WAKE_SCHEMA_H
 #define WAKE_SCHEMA_H
 
-#define SCHEMA_VERSION "12"
+#define SCHEMA_VERSION "13"
 
 // Per-connection settings to always apply.  Do this first!
 inline const char *getCommonPragmaSQL() {
@@ -41,8 +41,7 @@ inline const char *getWakeSchemaSQLTxn() {
          "  path      text    not null,"
          "  hash      text    not null,"
          "  type      text    not null,"
-         "  mode      integer not null,"
-         "  modified  integer not null);"
+         "  mode      integer not null);"
          "create unique index if not exists file_path_hash_type_mode on files(path, hash, type, "
          "mode);"
          "create index if not exists filenames on files(path);"
@@ -83,6 +82,7 @@ inline const char *getWakeSchemaSQLTxn() {
          "  access   integer not null,"  // 0=visible, 1=input, 2=output
          "  job_id   integer not null references jobs(job_id) on delete cascade,"
          "  file_id  integer not null references files(file_id),"
+         "  modified integer not null,"
          "  unique(job_id, access, file_id) on conflict ignore);"
          "create index if not exists filesearch on filetree(file_id, access, job_id);"
          "create table if not exists log("

--- a/tools/wake-migrate/main.cpp
+++ b/tools/wake-migrate/main.cpp
@@ -392,6 +392,73 @@ static std::vector<Migration> get_migrations() {
        },
        "Per-job hashes: remove stale column, unique index on (path, hash, type, mode)"},
 
+      // Version 12 -> 13: Move modified from files to filetree
+      // - Remove modified column from files table
+      // - Add modified column to filetree table
+      // - Populate filetree.modified from old files.modified via JOIN
+      {12, 13,
+       [](sqlite3* db) -> bool {
+         // Step 1: Create files_new without modified column
+         if (!exec_sql(db, R"(
+           CREATE TABLE files_new(
+             file_id integer primary key,
+             path    text    not null,
+             hash    text    not null,
+             type    text    not null,
+             mode    integer not null
+           );
+         )"))
+           return false;
+
+         // Step 2: Copy files data
+         if (!exec_sql(db, R"(
+           INSERT INTO files_new (file_id, path, hash, type, mode)
+           SELECT file_id, path, hash, type, mode FROM files;
+         )"))
+           return false;
+
+         // Step 3: Create filetree_new with modified column
+         if (!exec_sql(db, R"(
+           CREATE TABLE filetree_new(
+             tree_id  integer primary key autoincrement,
+             access   integer not null,
+             job_id   integer not null references jobs(job_id) on delete cascade,
+             file_id  integer not null references files(file_id),
+             modified integer not null,
+             unique(job_id, access, file_id) on conflict ignore
+           );
+         )"))
+           return false;
+
+         // Step 4: Copy filetree data, pulling modified from old files via JOIN
+         if (!exec_sql(db, R"(
+           INSERT INTO filetree_new (tree_id, access, job_id, file_id, modified)
+           SELECT ft.tree_id, ft.access, ft.job_id, ft.file_id, f.modified
+           FROM filetree ft JOIN files f ON ft.file_id = f.file_id;
+         )"))
+           return false;
+
+         // Step 5: Drop old tables — auto-drops their indexes, freeing up the index names
+         if (!exec_sql(db, "DROP TABLE filetree;")) return false;
+         if (!exec_sql(db, "DROP TABLE files;")) return false;
+
+         // Step 6: Rename new tables to final names
+         if (!exec_sql(db, "ALTER TABLE files_new RENAME TO files;")) return false;
+         if (!exec_sql(db, "ALTER TABLE filetree_new RENAME TO filetree;")) return false;
+
+         // Step 7: Create indexes
+         if (!exec_sql(db,
+                       "CREATE UNIQUE INDEX file_path_hash_type_mode ON files(path, hash, type, "
+                       "mode);"))
+           return false;
+         if (!exec_sql(db, "CREATE INDEX filenames ON files(path);")) return false;
+         if (!exec_sql(db, "CREATE INDEX filesearch ON filetree(file_id, access, job_id);"))
+           return false;
+
+         return true;
+       },
+       "Move modified from files to filetree"},
+
   };
 }
 


### PR DESCRIPTION
No longer attempt to fetch mtime raw from workspace, it must be passed in (!).

Modified observed (recorded) originally for a job
persists and seeing otherwise same file does not alter this. This is used in materialization.

Explicitly do not consider modified as part of job reuse candidate selection.  Similar behavior to having jobs point to a record with a mutable mtime field, supports important use cases like git operations.

Must now check modified as well as file_id when matching on filetree.

get_hash and get_cached_path only return information for files that are recorded in filetree:
add_hash is not sufficient.

Require modified to match for critpath updates,
but not for file dep tracking (visualization).

Bump to schema 13.
Add wake-migrate support, tested locally.

----

Replaces #1806, incorporates feedback given there (🙏 🙏 ).

New version of #1804, with upstreamed changes for fuse-waked split out and minor tweaks:
* Migrate was overkill
* Don't require modified matches for dep tracking