### PR TITLE
mtime-preservation: Explicitly serialize wake invocations.

### DIFF
--- a/tests/runtime/mtime-preservation/pass.sh
+++ b/tests/runtime/mtime-preservation/pass.sh
@@ -12,23 +12,18 @@ export WAKE_CAS=1
 
 rm -rf .build .fuse wake.db* wake.log output.txt result-a.txt result-b.txt
 
-echo "Fresh concurrent (if supported) runs:"
+echo "Fresh runs:"
 
-"${WAKE}" -q --no-tty -x "consumerA Unit" &
-"${WAKE}" -q --no-tty -x "consumerB Unit" &
+"${WAKE}" -q --no-tty -x "consumerA Unit"
+"${WAKE}" -q --no-tty -x "consumerB Unit"
 
-wait
-
-# (output.txt can have either value)
 tail result-a.txt result-b.txt
 
 echo
 echo "Reuse:"
 
-"${WAKE}" -q --no-tty -x "consumerA Unit" &
-"${WAKE}" -q --no-tty -x "consumerB Unit" &
-
-wait
+"${WAKE}" -q --no-tty -x "consumerA Unit"
+"${WAKE}" -q --no-tty -x "consumerB Unit"
 
 # (output.txt can have either value)
 tail result-a.txt result-b.txt

--- a/tests/runtime/mtime-preservation/stdout
+++ b/tests/runtime/mtime-preservation/stdout
@@ -1,4 +1,4 @@
-Fresh concurrent (if supported) runs:
+Fresh runs:
 ==> result-a.txt <==
 2020-01-01T00:00:00+00:00
 


### PR DESCRIPTION
Wake's build lock is expected to serialize these for us, but in CI we're seeing some serious failures.

Serialize these for now.