### PR TITLE
runner.wake: Fix fetching failed wake-stage stderr.

### DIFF
--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -266,7 +266,7 @@ export def stageWorkspaceOutputs (allOutputPaths: List String) (filteredOutputPa
 
         require Exited 0 = getJobStatus stageJob
         else
-            require Pass stderr = getJobStderr stageJob
+            require Pass stderr = getJobFailedStderr stageJob
             else failWithError "workspace staging helper failed"
 
             failWithError "workspace staging helper failed: {stderr}"


### PR DESCRIPTION
Use getJobFailedStderr for non-zero exit job.

Sending to feature branch so it can be included in beta for multi-wake while waiting for #1828 to reach master.