### PR TITLE
Revert "mtime-preservation: Explicitly serialize wake invocations."

### DIFF
--- a/tests/runtime/mtime-preservation/pass.sh
+++ b/tests/runtime/mtime-preservation/pass.sh
@@ -12,18 +12,23 @@ export WAKE_CAS=1
 
 rm -rf .build .fuse wake.db* wake.log output.txt result-a.txt result-b.txt
 
-echo "Fresh runs:"
+echo "Fresh concurrent (if supported) runs:"
 
-"${WAKE}" -q --no-tty -x "consumerA Unit"
-"${WAKE}" -q --no-tty -x "consumerB Unit"
+"${WAKE}" -q --no-tty -x "consumerA Unit" &
+"${WAKE}" -q --no-tty -x "consumerB Unit" &
 
+wait
+
+# (output.txt can have either value)
 tail result-a.txt result-b.txt
 
 echo
 echo "Reuse:"
 
-"${WAKE}" -q --no-tty -x "consumerA Unit"
-"${WAKE}" -q --no-tty -x "consumerB Unit"
+"${WAKE}" -q --no-tty -x "consumerA Unit" &
+"${WAKE}" -q --no-tty -x "consumerB Unit" &
+
+wait
 
 # (output.txt can have either value)
 tail result-a.txt result-b.txt

--- a/tests/runtime/mtime-preservation/stdout
+++ b/tests/runtime/mtime-preservation/stdout
@@ -1,4 +1,4 @@
-Fresh runs:
+Fresh concurrent (if supported) runs:
 ==> result-a.txt <==
 2020-01-01T00:00:00+00:00
 


### PR DESCRIPTION
Not neeed for multi-wake, was temporary workaround.

cc #1830.

This reverts commit d9b0c58aca8dc1459dfed3ef0e963208a708ea1e.