### PR TITLE
database: fix uninitialized member variables, causing crash.

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -136,6 +136,11 @@ struct Database::detail {
         get_all_runs(0),
         get_edges(0),
         get_file_dependency(0),
+        get_output_files(0),
+        remove_output_files(0),
+        remove_all_jobs(0),
+        get_unhashed_file_paths(0),
+        insert_unhashed_file(0),
         get_interleaved_output(0),
         set_runner_status(0),
         get_runner_status(0) {}


### PR DESCRIPTION
In some situations resulting in PREPARE failing (in open()), the subsequent call to close() invokes FINALIZE on all members.

When these aren't initialized that leads to a crash.