### PR TITLE
Add --ps command to show currently running jobs; add --active capture filter.

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -103,6 +103,8 @@ struct Database::detail {
   sqlite3_stmt *set_run_end_time;
   sqlite3_stmt *get_incomplete_runs;
   sqlite3_stmt *clear_run_files;
+  sqlite3_stmt *set_starttime;
+  sqlite3_stmt *get_active_jobs;
 
   long run_id;
   long gc_watermark;
@@ -159,6 +161,8 @@ struct Database::detail {
         set_run_end_time(0),
         get_incomplete_runs(0),
         clear_run_files(0),
+        set_starttime(0),
+        get_active_jobs(0),
         run_id(0),
         gc_watermark(0) {}
 };
@@ -387,8 +391,7 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   const char *sql_add_stats =
       "insert into stats(hashcode, status, runtime, cputime, membytes, ibytes, obytes)"
       " values(?, ?, ?, ?, ?, ?, ?)";
-  const char *sql_link_stats =
-      "update jobs set stat_id=?, starttime=?, endtime=?, keep=? where job_id=?";
+  const char *sql_link_stats = "update jobs set stat_id=?, endtime=?, keep=? where job_id=?";
   const char *sql_detect_overlap =
       "select f1.path, t2.job_id from filetree t1, filetree t2, files f1, files f2, run_jobs rj"
       " where t1.job_id=?1 and t1.access=2"
@@ -488,6 +491,14 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   const char *sql_set_run_end_time = "update runs set end_time = ? where run_id = ?";
   const char *sql_get_incomplete_runs = "select run_id, time from runs where end_time is null";
   const char *sql_clear_run_files = "delete from run_files where run_id = ?";
+  const char *sql_set_starttime = "update jobs set starttime=? where job_id=?";
+  const char *sql_get_active_jobs =
+      "select rj.run_id, j.job_id, j.label, j.starttime"
+      " from run_jobs rj"
+      " join jobs j on rj.job_id = j.job_id"
+      " join runs r on rj.run_id = r.run_id"
+      " where r.end_time is null and j.starttime != 0 and j.endtime == 0"
+      " order by rj.run_id, j.starttime";
 
 #define PREPARE(sql, member)                                                                     \
   ret = sqlite3_prepare_v2(imp->db, sql, -1, &imp->member, 0);                                   \
@@ -546,6 +557,8 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   PREPARE(sql_set_run_end_time, set_run_end_time);
   PREPARE(sql_get_incomplete_runs, get_incomplete_runs);
   PREPARE(sql_clear_run_files, clear_run_files);
+  PREPARE(sql_set_starttime, set_starttime);
+  PREPARE(sql_get_active_jobs, get_active_jobs);
 
   return "";
 }
@@ -613,6 +626,8 @@ void Database::close() {
   FINALIZE(set_run_end_time);
   FINALIZE(get_incomplete_runs);
   FINALIZE(clear_run_files);
+  FINALIZE(set_starttime);
+  FINALIZE(get_active_jobs);
 
   imp->run_lock.reset();
 
@@ -1279,10 +1294,9 @@ void Database::finish_job(long job, const std::string &inputs, const std::string
   bind_integer(why, imp->add_stats, 7, reality.obytes);
   single_step(why, imp->add_stats, imp->debugdb);
   bind_integer(why, imp->link_stats, 1, sqlite3_last_insert_rowid(imp->db));
-  bind_integer(why, imp->link_stats, 2, starttime);
-  bind_integer(why, imp->link_stats, 3, endtime);
-  bind_integer(why, imp->link_stats, 4, keep ? 1 : 0);
-  bind_integer(why, imp->link_stats, 5, job);
+  bind_integer(why, imp->link_stats, 2, endtime);
+  bind_integer(why, imp->link_stats, 3, keep ? 1 : 0);
+  bind_integer(why, imp->link_stats, 4, job);
   single_step(why, imp->link_stats, imp->debugdb);
 
   // Grab the visible set.
@@ -2161,6 +2175,31 @@ std::vector<RunReflection> Database::get_runs() const {
     out.emplace_back(run);
   }
   finish_stmt("Could not retrieve runs", imp->get_all_runs, imp->debugdb);
+  end_txn();
+  return out;
+}
+
+void Database::start_job(long job, int64_t starttime) {
+  const char *why = "Could not record job start time";
+  begin_rw_txn();
+  bind_integer(why, imp->set_starttime, 1, starttime);
+  bind_integer(why, imp->set_starttime, 2, job);
+  single_step(why, imp->set_starttime, imp->debugdb);
+  end_txn();
+}
+
+std::vector<ActiveJobReflection> Database::get_active_jobs() const {
+  std::vector<ActiveJobReflection> out;
+  begin_ro_txn();
+  while (sqlite3_step(imp->get_active_jobs) == SQLITE_ROW) {
+    ActiveJobReflection aj;
+    aj.run_id = sqlite3_column_int(imp->get_active_jobs, 0);
+    aj.job_id = sqlite3_column_int64(imp->get_active_jobs, 1);
+    aj.label = rip_column(imp->get_active_jobs, 2);
+    aj.starttime = sqlite3_column_int64(imp->get_active_jobs, 3);
+    out.emplace_back(aj);
+  }
+  finish_stmt("Could not retrieve active jobs", imp->get_active_jobs, imp->debugdb);
   end_txn();
   return out;
 }

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -81,6 +81,13 @@ struct RunReflection {
   RunReflection() = default;
 };
 
+struct ActiveJobReflection {
+  int run_id;
+  long job_id;
+  std::string label;
+  int64_t starttime;  // wall-clock ns when job was started
+};
+
 struct JobReflection {
   long job;
   bool stale;
@@ -167,7 +174,8 @@ struct Database {
       // ^^^ only these matter to identify the job
       uint64_t signature,  // this must match to qualify for reuse
       const std::string &label, const std::string &stack, bool is_atty, const std::string &visible,
-      long *job);  // key used for accesses below
+      long *job);                               // key used for accesses below
+  void start_job(long job, int64_t starttime);  // record wall-clock start time eagerly
   void finish_job(long job,
                   const std::string &inputs,       // null separated
                   const std::string &outputs,      // null separated
@@ -214,6 +222,7 @@ struct Database {
   std::vector<JobTag> get_tags();
 
   std::vector<RunReflection> get_runs() const;
+  std::vector<ActiveJobReflection> get_active_jobs() const;
 
   std::vector<FileDependency> get_file_dependencies() const;
 

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -904,6 +904,9 @@ static void launch(JobTable *jobtable) {
     jobtable->imp->pidmap[pid] = entry;
     entry->job->pid = entry->pid = pid;
     entry->job->state |= STATE_FORKED;
+    int64_t starttime_ns =
+        (int64_t)entry->job->start.tv_sec * 1000000000LL + entry->job->start.tv_nsec;
+    jobtable->imp->db->start_job(entry->job->job, starttime_ns);
     close(stdout_stream[1]);
     close(stderr_stream[1]);
     close(runner_out_stream[1]);
@@ -1327,6 +1330,8 @@ static PRIMFN(prim_job_virtual) {
 
   clock_gettime(CLOCK_REALTIME, &job->start);
   job->stop = job->start;
+  int64_t starttime_ns = (int64_t)job->start.tv_sec * 1000000000LL + job->start.tv_nsec;
+  job->db->start_job(job->job, starttime_ns);
 
   if (!stdout_payload->empty())
     job->db->save_output(job->job, 1, stdout_payload->c_str(), stdout_payload->size(), 0);

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -42,6 +42,7 @@ struct CommandLineOptions {
   bool last_exe;
   bool history;
   bool ps;
+  bool active;
   bool lsp;
   bool failed;
   bool script;
@@ -140,6 +141,7 @@ struct CommandLineOptions {
       {0, "last-executed", GOPT_ARGUMENT_FORBIDDEN},
       {0, "history", GOPT_ARGUMENT_FORBIDDEN},
       {0, "ps", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "active", GOPT_ARGUMENT_FORBIDDEN},
       {0, "lsp", GOPT_ARGUMENT_FORBIDDEN},
       {'f', "failed", GOPT_ARGUMENT_FORBIDDEN},
       {'s', "script", GOPT_ARGUMENT_FORBIDDEN},
@@ -203,6 +205,7 @@ struct CommandLineOptions {
     last_exe = arg(options, "last-executed")->count;
     history = arg(options, "history")->count;
     ps = arg(options, "ps")->count;
+    active = arg(options, "active")->count;
     lsp = arg(options, "lsp")->count;
     failed = arg(options, "failed")->count;
     script = arg(options, "script")->count;

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -41,6 +41,7 @@ struct CommandLineOptions {
   bool last_use;
   bool last_exe;
   bool history;
+  bool ps;
   bool lsp;
   bool failed;
   bool script;
@@ -138,6 +139,7 @@ struct CommandLineOptions {
       {0, "last-used", GOPT_ARGUMENT_FORBIDDEN},
       {0, "last-executed", GOPT_ARGUMENT_FORBIDDEN},
       {0, "history", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "ps", GOPT_ARGUMENT_FORBIDDEN},
       {0, "lsp", GOPT_ARGUMENT_FORBIDDEN},
       {'f', "failed", GOPT_ARGUMENT_FORBIDDEN},
       {'s', "script", GOPT_ARGUMENT_FORBIDDEN},
@@ -200,6 +202,7 @@ struct CommandLineOptions {
     last_use = arg(options, "last")->count || arg(options, "last-used")->count;
     last_exe = arg(options, "last-executed")->count;
     history = arg(options, "history")->count;
+    ps = arg(options, "ps")->count;
     lsp = arg(options, "lsp")->count;
     failed = arg(options, "failed")->count;
     script = arg(options, "script")->count;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -278,6 +278,13 @@ void query_jobs(const CommandLineOptions &clo, Database &db) {
     collect_ands.push_back({"endtime = 0"});
   }
 
+  // --active
+  if (clo.active) {
+    collect_ands.push_back(
+        {"starttime != 0 AND endtime == 0 and run_id in (select run_id from runs where run_id is "
+         "null)"});
+  }
+
   // Hide introspection jobs by default unless --include-hidden is specified
   if (!clo.include_hidden) {
     hide_internal_jobs(collect_ands);
@@ -353,6 +360,7 @@ void print_help(const char *argv0) {
     << "    --failed   -f      Capture jobs which failed last build"                       << std::endl
     << "    --tag      KEY=VAL Capture jobs which are tagged, matching KEY and VAL globs"  << std::endl
     << "    --canceled         Capture jobs which were canceled in the last build"         << std::endl
+    << "    --active           Capture jobs currently running across all active builds"    << std::endl
     << "    --timeline         Report timeline of captured jobs as HTML"                   << std::endl
     << "    --simple-timeline  Report simplified timeline of captured jobs as HTML"        << std::endl
     << "    --verbose  -v      Report metadata, stdout and stderr of captured jobs"        << std::endl
@@ -535,7 +543,7 @@ int main(int argc, char **argv) {
   bool is_db_inspect_capture = !clo.job_ids.empty() || !clo.output_files.empty() ||
                                !clo.input_files.empty() || !clo.labels.empty() ||
                                !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
-                               clo.tagdag || clo.canceled || clo.history || clo.ps;
+                               clo.tagdag || clo.canceled || clo.active || clo.history || clo.ps;
 
   // DescribePolicy::human() is the default and doesn't have a flag.
   // DescribePolicy::debug() is overloaded and can't be marked as a db flag

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -207,6 +207,35 @@ void query_runs(Database &db) {
   }
 }
 
+void query_ps(Database &db) {
+  const auto jobs = db.get_active_jobs();
+
+  if (jobs.empty()) {
+    std::cout << "No jobs currently running." << std::endl;
+    return;
+  }
+
+  // Get current time for elapsed calculation
+  struct timespec now;
+  clock_gettime(CLOCK_REALTIME, &now);
+  int64_t now_ns = (int64_t)now.tv_sec * 1000000000LL + now.tv_nsec;
+
+  int cur_run = -1;
+  std::cout << std::left;
+  for (const auto &aj : jobs) {
+    if (aj.run_id != cur_run) {
+      cur_run = aj.run_id;
+      std::cout << "\nRun " << cur_run << ":" << std::endl;
+      std::cout << "  " << std::setw(8) << "JOB" << std::setw(12) << "ELAPSED"
+                << "LABEL" << std::endl;
+    }
+    int64_t elapsed_ns = now_ns - aj.starttime;
+    std::string elapsed = "[" + format_duration(elapsed_ns) + "]";
+    std::cout << "  " << std::setw(8) << aj.job_id << std::setw(12) << elapsed << aj.label
+              << std::endl;
+  }
+}
+
 void query_jobs(const CommandLineOptions &clo, Database &db) {
   std::vector<std::vector<std::string>> collect_ands = {};
   std::vector<std::vector<std::string>> collect_input_ands = {};
@@ -271,6 +300,8 @@ void inspect_database(const CommandLineOptions &clo, Database &db) {
     output_tagdag(db, clo.tagdag);
   } else if (clo.history) {
     query_runs(db);
+  } else if (clo.ps) {
+    query_ps(db);
   } else {
     query_jobs(clo, db);
   }
@@ -318,6 +349,7 @@ void print_help(const char *argv0) {
     << "    --last-used        Capture all jobs used by last build. Regardless of cache"   << std::endl
     << "    --last-executed    Capture all jobs executed by the last build. Skips cache"   << std::endl
     << "    --history          Report the cmndline history of all wake commands recorded"  << std::endl
+    << "    --ps               Show jobs currently running in active wake builds"          << std::endl
     << "    --failed   -f      Capture jobs which failed last build"                       << std::endl
     << "    --tag      KEY=VAL Capture jobs which are tagged, matching KEY and VAL globs"  << std::endl
     << "    --canceled         Capture jobs which were canceled in the last build"         << std::endl
@@ -503,7 +535,7 @@ int main(int argc, char **argv) {
   bool is_db_inspect_capture = !clo.job_ids.empty() || !clo.output_files.empty() ||
                                !clo.input_files.empty() || !clo.labels.empty() ||
                                !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
-                               clo.tagdag || clo.canceled || clo.history;
+                               clo.tagdag || clo.canceled || clo.history || clo.ps;
 
   // DescribePolicy::human() is the default and doesn't have a flag.
   // DescribePolicy::debug() is overloaded and can't be marked as a db flag


### PR DESCRIPTION
Sharing early, still needs more self-review.

For transparency but not responsibility, written with help from Claude Sonnet 4.6.

Idea is as discussed a few times:
* Set starttime when starting a job so have that information available.  Today this is committed as part of finish_job.
* Query DB For jobs that have started that haven't finished and are part of runs that aren't known to have finished.
* Present this information to the user.

See commit message for `--active`; need to sort out `--canceled` and then have a story for these together.