### PR TITLE
wake: fix --clean: don't attempt vacuum from within transaction.

### DIFF
--- a/tests/runtime/clean-safety/stdout
+++ b/tests/runtime/clean-safety/stdout
@@ -1,0 +1,2 @@
+PASS: --clean refused while build active
+PASS: --clean succeeded after reaping dead run

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -712,12 +712,6 @@ int main(int argc, char **argv) {
         }
       }
 
-      // Full vacuum, we likely just deleted most of the database.
-      db.vacuum(/*incremental=*/false);
-
-      // Blocking checkpoint, truncate the log file.
-      db.checkpoint(/*blocking=*/true);
-
       // Since the log is append only, we should clean it up from time to time.
       // TODO: this is just "unlink_no_fail". Those functions should be moved to
       // a more generic library
@@ -735,6 +729,12 @@ int main(int argc, char **argv) {
       std::cerr << "hint: use 'wake --history' to see active runs" << std::endl;
       return 1;
     }
+
+    // Full vacuum, we likely just deleted most of the database.
+    db.vacuum(/*incremental=*/false);
+
+    // Blocking checkpoint, truncate the log file.
+    db.checkpoint(/*blocking=*/true);
 
     return delete_error ? 1 : 0;
   }


### PR DESCRIPTION
Touchup clean-safety test to check stdout and especially stderr.

Require no error output, which would fail before this change.