### PR TITLE
wake: record starttime early, add capture filters; fix --canceled

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1987,10 +1987,10 @@ std::vector<JobReflection> Database::matching(
   // This query creates a subtable of the following shape:
   //
   // clang-format off
-  // | job_id | label | run_id | endtime | commandline | runner_status | status | runtime |       tags       |
-  // -----------------------------------------------------------------------------------------------------------
-  // |    1   |  foo  |   1    |  1234   | ls lah .    | NULL          |   0    |   2.8   | <d>a=b<d>c=d<d>  |
-  // |    2   |  bar  |   1    |  0000   | cat f.txt   | "Job failed"  |   0    |   0.0   |      null        |
+  // | job_id | label | run_id | starttime | endtime | stat_id | commandline | runner_status | status | runtime |       tags       |
+  // -------------------------------------------------------------------------------------------------------------------------------
+  // |    1   |  foo  |   1    |   12340   |  12350  |   42    | ls lah .    | NULL          |   0    |   2.8   | <d>a=b<d>c=d<d>  |
+  // |    2   |  bar  |   1    |   0       |  0      |  NULL   | cat f.txt   | "Job failed"  |   0    |   0.0   |      null        |
   // clang-format on
   //
   // The subtable is constructed by joining the jobs table with the minimal set of other dependent

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -103,6 +103,7 @@ struct Database::detail {
   sqlite3_stmt *set_run_end_time;
   sqlite3_stmt *get_incomplete_runs;
   sqlite3_stmt *clear_run_files;
+  sqlite3_stmt *set_starttime;
 
   long run_id;
   long gc_watermark;
@@ -159,6 +160,7 @@ struct Database::detail {
         set_run_end_time(0),
         get_incomplete_runs(0),
         clear_run_files(0),
+        set_starttime(0),
         run_id(0),
         gc_watermark(0) {}
 };
@@ -387,8 +389,7 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   const char *sql_add_stats =
       "insert into stats(hashcode, status, runtime, cputime, membytes, ibytes, obytes)"
       " values(?, ?, ?, ?, ?, ?, ?)";
-  const char *sql_link_stats =
-      "update jobs set stat_id=?, starttime=?, endtime=?, keep=? where job_id=?";
+  const char *sql_link_stats = "update jobs set stat_id=?, endtime=?, keep=? where job_id=?";
   const char *sql_detect_overlap =
       "select f1.path, t2.job_id from filetree t1, filetree t2, files f1, files f2, run_jobs rj"
       " where t1.job_id=?1 and t1.access=2"
@@ -488,6 +489,7 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   const char *sql_set_run_end_time = "update runs set end_time = ? where run_id = ?";
   const char *sql_get_incomplete_runs = "select run_id, time from runs where end_time is null";
   const char *sql_clear_run_files = "delete from run_files where run_id = ?";
+  const char *sql_set_starttime = "update jobs set starttime=? where job_id=?";
 
 #define PREPARE(sql, member)                                                                     \
   ret = sqlite3_prepare_v2(imp->db, sql, -1, &imp->member, 0);                                   \
@@ -546,6 +548,7 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   PREPARE(sql_set_run_end_time, set_run_end_time);
   PREPARE(sql_get_incomplete_runs, get_incomplete_runs);
   PREPARE(sql_clear_run_files, clear_run_files);
+  PREPARE(sql_set_starttime, set_starttime);
 
   return "";
 }
@@ -613,6 +616,7 @@ void Database::close() {
   FINALIZE(set_run_end_time);
   FINALIZE(get_incomplete_runs);
   FINALIZE(clear_run_files);
+  FINALIZE(set_starttime);
 
   imp->run_lock.reset();
 
@@ -1279,10 +1283,9 @@ void Database::finish_job(long job, const std::string &inputs, const std::string
   bind_integer(why, imp->add_stats, 7, reality.obytes);
   single_step(why, imp->add_stats, imp->debugdb);
   bind_integer(why, imp->link_stats, 1, sqlite3_last_insert_rowid(imp->db));
-  bind_integer(why, imp->link_stats, 2, starttime);
-  bind_integer(why, imp->link_stats, 3, endtime);
-  bind_integer(why, imp->link_stats, 4, keep ? 1 : 0);
-  bind_integer(why, imp->link_stats, 5, job);
+  bind_integer(why, imp->link_stats, 2, endtime);
+  bind_integer(why, imp->link_stats, 3, keep ? 1 : 0);
+  bind_integer(why, imp->link_stats, 4, job);
   single_step(why, imp->link_stats, imp->debugdb);
 
   // Grab the visible set.
@@ -2010,6 +2013,7 @@ std::vector<JobReflection> Database::matching(
                 j.job_id,
                 j.label,
                 j.run_id,
+                j.starttime,
                 j.endtime,
                 j.commandline,
                 j.runner_status,
@@ -2163,6 +2167,15 @@ std::vector<RunReflection> Database::get_runs() const {
   finish_stmt("Could not retrieve runs", imp->get_all_runs, imp->debugdb);
   end_txn();
   return out;
+}
+
+void Database::start_job(long job, int64_t starttime) {
+  const char *why = "Could not record job start time";
+  begin_rw_txn();
+  bind_integer(why, imp->set_starttime, 1, starttime);
+  bind_integer(why, imp->set_starttime, 2, job);
+  single_step(why, imp->set_starttime, imp->debugdb);
+  end_txn();
 }
 
 std::vector<std::pair<std::string, int>> Database::get_interleaved_output(long job_id) const {

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -2015,6 +2015,7 @@ std::vector<JobReflection> Database::matching(
                 j.run_id,
                 j.starttime,
                 j.endtime,
+                j.stat_id,
                 j.commandline,
                 j.runner_status,
                 s.status,

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -168,6 +168,8 @@ struct Database {
       uint64_t signature,  // this must match to qualify for reuse
       const std::string &label, const std::string &stack, bool is_atty, const std::string &visible,
       long *job);  // key used for accesses below
+
+  void start_job(long job, int64_t starttime);  // record wall-clock start time eagerly
   void finish_job(long job,
                   const std::string &inputs,       // null separated
                   const std::string &outputs,      // null separated

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -904,6 +904,9 @@ static void launch(JobTable *jobtable) {
     jobtable->imp->pidmap[pid] = entry;
     entry->job->pid = entry->pid = pid;
     entry->job->state |= STATE_FORKED;
+    int64_t starttime_ns =
+        (int64_t)entry->job->start.tv_sec * 1000000000LL + entry->job->start.tv_nsec;
+    jobtable->imp->db->start_job(entry->job->job, starttime_ns);
     close(stdout_stream[1]);
     close(stderr_stream[1]);
     close(runner_out_stream[1]);
@@ -1327,6 +1330,8 @@ static PRIMFN(prim_job_virtual) {
 
   clock_gettime(CLOCK_REALTIME, &job->start);
   job->stop = job->start;
+  int64_t starttime_ns = (int64_t)job->start.tv_sec * 1000000000LL + job->start.tv_nsec;
+  job->db->start_job(job->job, starttime_ns);
 
   if (!stdout_payload->empty())
     job->db->save_output(job->job, 1, stdout_payload->c_str(), stdout_payload->size(), 0);

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -41,6 +41,7 @@ struct CommandLineOptions {
   bool last_use;
   bool last_exe;
   bool history;
+  bool active;
   bool lsp;
   bool failed;
   bool script;
@@ -62,6 +63,8 @@ struct CommandLineOptions {
   bool simple_timeline;
   bool simple;
   bool canceled;
+  bool queued;
+  bool in_flight;
   bool clean;
   bool list_outputs;
   bool include_hidden;
@@ -138,6 +141,9 @@ struct CommandLineOptions {
       {0, "last-used", GOPT_ARGUMENT_FORBIDDEN},
       {0, "last-executed", GOPT_ARGUMENT_FORBIDDEN},
       {0, "history", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "active", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "queued", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "in-flight", GOPT_ARGUMENT_FORBIDDEN},
       {0, "lsp", GOPT_ARGUMENT_FORBIDDEN},
       {'f', "failed", GOPT_ARGUMENT_FORBIDDEN},
       {'s', "script", GOPT_ARGUMENT_FORBIDDEN},
@@ -200,6 +206,9 @@ struct CommandLineOptions {
     last_use = arg(options, "last")->count || arg(options, "last-used")->count;
     last_exe = arg(options, "last-executed")->count;
     history = arg(options, "history")->count;
+    active = arg(options, "active")->count;
+    queued = arg(options, "queued")->count;
+    in_flight = arg(options, "in-flight")->count;
     lsp = arg(options, "lsp")->count;
     failed = arg(options, "failed")->count;
     script = arg(options, "script")->count;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -210,6 +210,28 @@ void query_runs(Database &db) {
   }
 }
 
+// Returns lock-proven live run_ids (DB-open runs confirmed by lock probe).
+std::vector<int> get_live_run_ids(Database &db) {
+  std::vector<int> live;
+  for (auto &r : db.get_runs())
+    if (!r.end_time && RunLockProbe::is_live(r.id)) live.push_back(r.id);
+  return live;
+}
+
+// Build a run_id in/not-in predicate for use in core_filters.
+std::string run_id_filter(bool in, const std::vector<int> &ids) {
+  std::string q = in ? "run_id in (" : "run_id not in (";
+  bool any = false;
+  for (auto id : ids) {
+    if (any) q += ',';
+    q += std::to_string(id);
+    any = true;
+  }
+  if (!any) return in ? "0" : "1";
+  q += ')';
+  return q;
+}
+
 void query_jobs(const CommandLineOptions &clo, Database &db) {
   std::vector<std::vector<std::string>> collect_ands = {};
   std::vector<std::vector<std::string>> collect_input_ands = {};
@@ -247,9 +269,33 @@ void query_jobs(const CommandLineOptions &clo, Database &db) {
     collect_ands.push_back({"(status <> 0 OR runner_status IS NOT NULL)"});
   }
 
-  // --canceled
-  if (clo.canceled) {
+  // Filters on unfinished jobs (endtime == 0).
+  if (clo.canceled || clo.active || clo.queued || clo.in_flight) {
+    auto live_run_ids = get_live_run_ids(db);
+
     collect_ands.push_back({"endtime = 0"});
+
+    // --canceled: jobs from non-live runs (run crashed before job finished)
+    if (clo.canceled) {
+      collect_ands.push_back({run_id_filter(/*in=*/false, live_run_ids)});
+    }
+
+    // --active: forked jobs (starttime!=0) in a live run
+    if (clo.active) {
+      collect_ands.push_back({"starttime != 0"});
+      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
+    }
+
+    // --queued: not-yet-forked jobs (starttime==0) in a live run
+    if (clo.queued) {
+      collect_ands.push_back({"starttime = 0"});
+      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
+    }
+
+    // --in-flight: all unfinished jobs (running or queued) in a live run
+    if (clo.in_flight) {
+      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
+    }
   }
 
   // Hide introspection jobs by default unless --include-hidden is specified
@@ -323,7 +369,10 @@ void print_help(const char *argv0) {
     << "    --history          Report the cmndline history of all wake commands recorded"  << std::endl
     << "    --failed   -f      Capture jobs which failed last build"                       << std::endl
     << "    --tag      KEY=VAL Capture jobs which are tagged, matching KEY and VAL globs"  << std::endl
-    << "    --canceled         Capture jobs which were canceled in the last build"         << std::endl
+    << "    --canceled         Capture jobs which were canceled (run ended before job finished)" << std::endl
+    << "    --active           Capture jobs currently running in active builds"             << std::endl
+    << "    --queued           Capture jobs queued but not yet launched in active builds"  << std::endl
+    << "    --in-flight        Capture jobs running or queued in active builds"            << std::endl
     << "    --timeline         Report timeline of captured jobs as HTML"                   << std::endl
     << "    --simple-timeline  Report simplified timeline of captured jobs as HTML"        << std::endl
     << "    --verbose  -v      Report metadata, stdout and stderr of captured jobs"        << std::endl
@@ -503,10 +552,10 @@ int main(int argc, char **argv) {
     clo.argv[1] = clo.shebang;
   }
 
-  bool is_db_inspect_capture = !clo.job_ids.empty() || !clo.output_files.empty() ||
-                               !clo.input_files.empty() || !clo.labels.empty() ||
-                               !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
-                               clo.tagdag || clo.canceled || clo.history;
+  bool is_db_inspect_capture =
+      !clo.job_ids.empty() || !clo.output_files.empty() || !clo.input_files.empty() ||
+      !clo.labels.empty() || !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
+      clo.tagdag || clo.canceled || clo.active || clo.queued || clo.in_flight || clo.history;
 
   // DescribePolicy::human() is the default and doesn't have a flag.
   // DescribePolicy::debug() is overloaded and can't be marked as a db flag

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -269,11 +269,12 @@ void query_jobs(const CommandLineOptions &clo, Database &db) {
     collect_ands.push_back({"(status <> 0 OR runner_status IS NOT NULL)"});
   }
 
-  // Filters on unfinished jobs (endtime == 0).
+  // Filters on unfinished jobs (stat_id is null).
   if (clo.canceled || clo.active || clo.queued || clo.in_flight) {
     auto live_run_ids = get_live_run_ids(db);
-
-    collect_ands.push_back({"endtime = 0"});
+    // finish_job unconditinoally sets stat_id for jobs.
+    // endtime=0 is close but includes jobs that finished.
+    collect_ands.push_back({"stat_id is null"});
 
     // --canceled: jobs from non-live runs (run crashed before job finished)
     if (clo.canceled) {


### PR DESCRIPTION
Record starttime eagerly via start_job() at fork time rather than writing it in finish_job, so queued jobs (starttime==0) are distinguishable from running ones.

Also allows showing how long jobs have actually been running.

Add --active, --queued, --in-flight capture filters, and fix --canceled (now only jobs not part of live runs).

Tweak canceled (and all of these) to determine "unfinished" as "stat_id is null", which means finish_job was not called.