### PR TITLE
wake: add --ps command to show currently running jobs

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -104,6 +104,7 @@ struct Database::detail {
   sqlite3_stmt *get_incomplete_runs;
   sqlite3_stmt *clear_run_files;
   sqlite3_stmt *set_starttime;
+  sqlite3_stmt *get_open_run_jobs;
 
   long run_id;
   long gc_watermark;
@@ -161,6 +162,7 @@ struct Database::detail {
         get_incomplete_runs(0),
         clear_run_files(0),
         set_starttime(0),
+        get_open_run_jobs(0),
         run_id(0),
         gc_watermark(0) {}
 };
@@ -490,6 +492,13 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   const char *sql_get_incomplete_runs = "select run_id, time from runs where end_time is null";
   const char *sql_clear_run_files = "delete from run_files where run_id = ?";
   const char *sql_set_starttime = "update jobs set starttime=? where job_id=?";
+  const char *sql_get_open_run_jobs =
+      "select rj.run_id, j.job_id, j.label, j.starttime"
+      " from run_jobs rj"
+      " join jobs j on rj.job_id = j.job_id"
+      " join runs r on rj.run_id = r.run_id"
+      " where r.end_time is null and j.stat_id is null"
+      " order by rj.run_id, j.starttime, j.job_id";
 
 #define PREPARE(sql, member)                                                                     \
   ret = sqlite3_prepare_v2(imp->db, sql, -1, &imp->member, 0);                                   \
@@ -549,6 +558,7 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   PREPARE(sql_get_incomplete_runs, get_incomplete_runs);
   PREPARE(sql_clear_run_files, clear_run_files);
   PREPARE(sql_set_starttime, set_starttime);
+  PREPARE(sql_get_open_run_jobs, get_open_run_jobs);
 
   return "";
 }
@@ -617,6 +627,7 @@ void Database::close() {
   FINALIZE(get_incomplete_runs);
   FINALIZE(clear_run_files);
   FINALIZE(set_starttime);
+  FINALIZE(get_open_run_jobs);
 
   imp->run_lock.reset();
 
@@ -2177,6 +2188,22 @@ void Database::start_job(long job, int64_t starttime) {
   bind_integer(why, imp->set_starttime, 2, job);
   single_step(why, imp->set_starttime, imp->debugdb);
   end_txn();
+}
+
+std::vector<OpenRunJobReflection> Database::get_open_run_jobs() const {
+  std::vector<OpenRunJobReflection> out;
+  begin_ro_txn();
+  while (sqlite3_step(imp->get_open_run_jobs) == SQLITE_ROW) {
+    OpenRunJobReflection j;
+    j.run_id = sqlite3_column_int(imp->get_open_run_jobs, 0);
+    j.job_id = sqlite3_column_int64(imp->get_open_run_jobs, 1);
+    j.label = rip_column(imp->get_open_run_jobs, 2);
+    j.starttime = sqlite3_column_int64(imp->get_open_run_jobs, 3);
+    out.emplace_back(std::move(j));
+  }
+  finish_stmt("Could not retrieve open run jobs", imp->get_open_run_jobs, imp->debugdb);
+  end_txn();
+  return out;
 }
 
 std::vector<std::pair<std::string, int>> Database::get_interleaved_output(long job_id) const {

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -104,7 +104,6 @@ struct Database::detail {
   sqlite3_stmt *get_incomplete_runs;
   sqlite3_stmt *clear_run_files;
   sqlite3_stmt *set_starttime;
-  sqlite3_stmt *get_open_run_jobs;
 
   long run_id;
   long gc_watermark;
@@ -162,7 +161,6 @@ struct Database::detail {
         get_incomplete_runs(0),
         clear_run_files(0),
         set_starttime(0),
-        get_open_run_jobs(0),
         run_id(0),
         gc_watermark(0) {}
 };
@@ -492,13 +490,6 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   const char *sql_get_incomplete_runs = "select run_id, time from runs where end_time is null";
   const char *sql_clear_run_files = "delete from run_files where run_id = ?";
   const char *sql_set_starttime = "update jobs set starttime=? where job_id=?";
-  const char *sql_get_open_run_jobs =
-      "select rj.run_id, j.job_id, j.label, j.starttime"
-      " from run_jobs rj"
-      " join jobs j on rj.job_id = j.job_id"
-      " join runs r on rj.run_id = r.run_id"
-      " where r.end_time is null and j.stat_id is null"
-      " order by rj.run_id, j.starttime, j.job_id";
 
 #define PREPARE(sql, member)                                                                     \
   ret = sqlite3_prepare_v2(imp->db, sql, -1, &imp->member, 0);                                   \
@@ -558,7 +549,6 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   PREPARE(sql_get_incomplete_runs, get_incomplete_runs);
   PREPARE(sql_clear_run_files, clear_run_files);
   PREPARE(sql_set_starttime, set_starttime);
-  PREPARE(sql_get_open_run_jobs, get_open_run_jobs);
 
   return "";
 }
@@ -627,7 +617,6 @@ void Database::close() {
   FINALIZE(get_incomplete_runs);
   FINALIZE(clear_run_files);
   FINALIZE(set_starttime);
-  FINALIZE(get_open_run_jobs);
 
   imp->run_lock.reset();
 
@@ -1963,7 +1952,7 @@ std::string collapse_and(const std::vector<std::vector<std::string>> &ands, int 
   return out;
 }
 
-std::vector<JobReflection> Database::matching(
+static std::string build_matching_id_query(
     const std::vector<std::vector<std::string>> &core_filters,
     std::vector<std::vector<std::string>> input_file_filters,
     std::vector<std::vector<std::string>> output_file_filters) {
@@ -2063,6 +2052,16 @@ std::vector<JobReflection> Database::matching(
         collapse_and(core_filters, 1);
   }
 
+  return id_query;
+}
+
+std::vector<JobReflection> Database::matching(
+    const std::vector<std::vector<std::string>> &core_filters,
+    std::vector<std::vector<std::string>> input_file_filters,
+    std::vector<std::vector<std::string>> output_file_filters) {
+  auto id_query = build_matching_id_query(core_filters, std::move(input_file_filters),
+                                          std::move(output_file_filters));
+
   // Adapts the id_query to match the columns needed to create a JobReflection
   std::string query =
       "SELECT j.job_id, j.label, j.directory, j.commandline, j.environment, j.stack, j.stdin, "
@@ -2091,6 +2090,47 @@ std::vector<JobReflection> Database::matching(
   end_txn();
 
   sqlite3_finalize(stmt);
+  return out;
+}
+
+std::vector<OpenRunJobReflection> Database::matching_open_runs(
+    const std::vector<std::vector<std::string>> &core_filters,
+    std::vector<std::vector<std::string>> input_file_filters,
+    std::vector<std::vector<std::string>> output_file_filters) {
+  auto id_query = build_matching_id_query(core_filters, std::move(input_file_filters),
+                                          std::move(output_file_filters));
+
+  auto query = R"(
+    SELECT rj.run_id, j.job_id, j.label, j.starttime
+    FROM run_jobs rj
+    JOIN jobs j ON rj.job_id = j.job_id
+    JOIN runs r on rj.run_id = r.run_id
+    WHERE r.end_time IS NULL and j.stat_id IS NULL and j.job_id IN (
+  )" + id_query +
+               R"()
+    ORDER BY rj.run_id, j.starttime, j.job_id;
+  )";
+
+  sqlite3_stmt *stmt;
+  if (sqlite3_prepare_v2(imp->db, query.c_str(), -1, &stmt, 0) != SQLITE_OK) {
+    std::string out = std::string("sqlite3_prepare_v2 (dyn ps): ") + sqlite3_errmsg(imp->db);
+    std::cerr << out << std::endl;
+    sqlite3_finalize(stmt);
+    return {};
+  }
+
+  std::vector<OpenRunJobReflection> out;
+  begin_ro_txn();
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    auto run_id = sqlite3_column_int(stmt, 0);
+    auto job_id = sqlite3_column_int64(stmt, 1);
+    auto label = rip_column(stmt, 2);
+    auto starttime = sqlite3_column_int64(stmt, 3);
+    out.emplace_back(OpenRunJobReflection{run_id, job_id, std::move(label), starttime});
+  }
+  sqlite3_finalize(stmt);
+  end_txn();
+
   return out;
 }
 
@@ -2188,22 +2228,6 @@ void Database::start_job(long job, int64_t starttime) {
   bind_integer(why, imp->set_starttime, 2, job);
   single_step(why, imp->set_starttime, imp->debugdb);
   end_txn();
-}
-
-std::vector<OpenRunJobReflection> Database::get_open_run_jobs() const {
-  std::vector<OpenRunJobReflection> out;
-  begin_ro_txn();
-  while (sqlite3_step(imp->get_open_run_jobs) == SQLITE_ROW) {
-    OpenRunJobReflection j;
-    j.run_id = sqlite3_column_int(imp->get_open_run_jobs, 0);
-    j.job_id = sqlite3_column_int64(imp->get_open_run_jobs, 1);
-    j.label = rip_column(imp->get_open_run_jobs, 2);
-    j.starttime = sqlite3_column_int64(imp->get_open_run_jobs, 3);
-    out.emplace_back(std::move(j));
-  }
-  finish_stmt("Could not retrieve open run jobs", imp->get_open_run_jobs, imp->debugdb);
-  end_txn();
-  return out;
 }
 
 std::vector<std::pair<std::string, int>> Database::get_interleaved_output(long job_id) const {

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1952,14 +1952,11 @@ std::string collapse_and(const std::vector<std::vector<std::string>> &ands, int 
   return out;
 }
 
-static std::string build_matching_id_query(
-    const std::vector<std::vector<std::string>> &core_filters,
-    std::vector<std::vector<std::string>> input_file_filters,
-    std::vector<std::vector<std::string>> output_file_filters) {
+static std::string build_matching_id_query(MatchingQueryFilters filters) {
   std::string input_file_join = "";
-  if (!input_file_filters.empty()) {
-    input_file_filters.push_back({"access = 1"});
-    std::string conds = collapse_and(input_file_filters, 3);
+  if (!filters.input_file_filters.empty()) {
+    filters.input_file_filters.push_back({"access = 1"});
+    std::string conds = collapse_and(filters.input_file_filters, 3);
     input_file_join =
         "        INNER JOIN (\n"
         "            SELECT filetree.job_id FROM filetree\n"
@@ -1971,9 +1968,9 @@ static std::string build_matching_id_query(
   }
 
   std::string output_file_join = "";
-  if (!output_file_filters.empty()) {
-    output_file_filters.push_back({"access = 2"});
-    std::string conds = collapse_and(output_file_filters, 3);
+  if (!filters.output_file_filters.empty()) {
+    filters.output_file_filters.push_back({"access = 2"});
+    std::string conds = collapse_and(filters.output_file_filters, 3);
     output_file_join =
         "        INNER JOIN (\n"
         "            SELECT filetree.job_id FROM filetree\n"
@@ -1984,31 +1981,13 @@ static std::string build_matching_id_query(
         conds + "\n" + "        ) ft_output ON core.job_id = ft_output.job_id\n";
   }
 
-  // This query creates a subtable of the following shape:
-  //
-  // clang-format off
-  // | job_id | label | run_id | starttime | endtime | stat_id | commandline | runner_status | status | runtime |       tags       |
-  // -------------------------------------------------------------------------------------------------------------------------------
-  // |    1   |  foo  |   1    |   12340   |  12350  |   42    | ls lah .    | NULL          |   0    |   2.8   | <d>a=b<d>c=d<d>  |
-  // |    2   |  bar  |   1    |   0       |  0      |  NULL   | cat f.txt   | "Job failed"  |   0    |   0.0   |      null        |
-  // clang-format on
-  //
-  // The subtable is constructed by joining the jobs table with the minimal set of other dependent
-  // tables with the following extra processing excluding input_files and output_files which are
-  // too expensive to include.
-  // 1. tags are flattened from two columns (uri, content) to one column (tags) with a = separator
-  // 2. tags are group_concat'd into a single row per job. <d> is
-  //    used as a deliminator between each value. The deliminator is also placed at the beginning
-  //    and end of each row so that queries don't need to special case the first/last entry.
-  //
-  // Any inspection flag/user code may add any WHERE expression conditions to the main query using
-  // the columns of the subtable for fine grain filters.
-  //
-  // For example, the query below will return all jobs that exited with status code 0 and where
-  // tagged with key = foo, value = var
-  //   SELECT job_id FROM **SUBTABLE**
-  //   WHERE status = 0 AND tags like '%<d>foo=bar<d>%'
-  std::string core_table = R"delim(        (
+  // Build the core table based on what features the filters need.
+  // Performance optimization: skip expensive GROUP BY + tag concatenation if not needed.
+  std::string core_table;
+
+  if (filters.needs_tag_concat) {
+    // Full query with GROUP BY for tag concatenation (needed for LIKE queries on tags)
+    core_table = R"delim(        (
             SELECT
                 j.job_id,
                 j.label,
@@ -2034,33 +2013,51 @@ static std::string build_matching_id_query(
                 j.job_id
         ) core
 )delim";
+  } else {
+    // Simplified query without tag concatenation (much faster!)
+    core_table = R"delim(        (
+            SELECT
+                j.job_id,
+                j.label,
+                j.run_id,
+                j.starttime,
+                j.endtime,
+                j.stat_id,
+                j.commandline,
+                j.runner_status,
+                s.status,
+                s.runtime
+            FROM jobs j
+            LEFT JOIN (
+                SELECT stat_id, status, runtime FROM stats
+            ) s
+            ON j.stat_id=s.stat_id
+        ) core
+)delim";
+  }
 
   std::string subtable = core_table + input_file_join + output_file_join;
 
-  // This query wraps the subtable, applies the requested filters, and returns the matching jobs
+  // This query selects from the subtable, applies the requested filters,
+  // and returns matching job_ids.
   std::string id_query =
       "    SELECT core.job_id\n"
-      "    FROM\n"
-      "    (\n" +
-      subtable + "    )";
+      "    FROM\n" +
+      subtable;
 
-  if (!core_filters.empty()) {
+  if (!filters.core_filters.empty()) {
     id_query +=
         "\n"
         "    WHERE\n"
         "        " +
-        collapse_and(core_filters, 1);
+        collapse_and(filters.core_filters, 1);
   }
 
   return id_query;
 }
 
-std::vector<JobReflection> Database::matching(
-    const std::vector<std::vector<std::string>> &core_filters,
-    std::vector<std::vector<std::string>> input_file_filters,
-    std::vector<std::vector<std::string>> output_file_filters) {
-  auto id_query = build_matching_id_query(core_filters, std::move(input_file_filters),
-                                          std::move(output_file_filters));
+std::vector<JobReflection> Database::matching(MatchingQueryFilters filters) {
+  auto id_query = build_matching_id_query(std::move(filters));
 
   // Adapts the id_query to match the columns needed to create a JobReflection
   std::string query =
@@ -2093,12 +2090,8 @@ std::vector<JobReflection> Database::matching(
   return out;
 }
 
-std::vector<OpenRunJobReflection> Database::matching_open_runs(
-    const std::vector<std::vector<std::string>> &core_filters,
-    std::vector<std::vector<std::string>> input_file_filters,
-    std::vector<std::vector<std::string>> output_file_filters) {
-  auto id_query = build_matching_id_query(core_filters, std::move(input_file_filters),
-                                          std::move(output_file_filters));
+std::vector<OpenRunJobReflection> Database::matching_open_runs(MatchingQueryFilters filters) {
+  auto id_query = build_matching_id_query(std::move(filters));
 
   auto query = R"(
     SELECT rj.run_id, j.job_id, j.label, j.starttime

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -81,6 +81,13 @@ struct RunReflection {
   RunReflection() = default;
 };
 
+struct OpenRunJobReflection {
+  int run_id;
+  long job_id;
+  std::string label;
+  int64_t starttime;  // 0 = queued (not yet forked), non-zero = wall-clock ns at fork
+};
+
 struct JobReflection {
   long job;
   bool stale;
@@ -216,6 +223,9 @@ struct Database {
   std::vector<JobTag> get_tags();
 
   std::vector<RunReflection> get_runs() const;
+  // Returns all unfinished jobs (endtime==0) in DB-open runs (end_time IS NULL).
+  // Ordered by run_id, starttime, job_id — queued (starttime==0) sort before running.
+  std::vector<OpenRunJobReflection> get_open_run_jobs() const;
 
   std::vector<FileDependency> get_file_dependencies() const;
 

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -223,9 +223,14 @@ struct Database {
   std::vector<JobTag> get_tags();
 
   std::vector<RunReflection> get_runs() const;
-  // Returns all unfinished jobs (endtime==0) in DB-open runs (end_time IS NULL).
+
+  // Returns all unfinished jobs matching the provided filters.
   // Ordered by run_id, starttime, job_id — queued (starttime==0) sort before running.
-  std::vector<OpenRunJobReflection> get_open_run_jobs() const;
+  // Additional filtering needed to determine if runs are "actually" live.
+  std::vector<OpenRunJobReflection> matching_open_runs(
+      const std::vector<std::vector<std::string>> &core_filters,
+      std::vector<std::vector<std::string>> input_file_filters,
+      std::vector<std::vector<std::string>> output_file_filters);
 
   std::vector<FileDependency> get_file_dependencies() const;
 

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -128,6 +128,18 @@ struct FileDependency {
   JAST to_json() const;
 };
 
+// Encapsulates filter conditions for job matching queries.
+// Tracks both the filter vectors and metadata about what database features they require.
+struct MatchingQueryFilters {
+  // Filter vectors: outer vec = AND groups, inner vec = OR conditions within each group
+  std::vector<std::vector<std::string>> core_filters;
+  std::vector<std::vector<std::string>> input_file_filters;
+  std::vector<std::vector<std::string>> output_file_filters;
+
+  // Metadata: what features do the filters require?
+  bool needs_tag_concat = false;  // True if filters use the concatenated 'tags' column (e.g., LIKE)
+};
+
 struct Database {
   struct detail;
   std::unique_ptr<detail> imp;
@@ -212,12 +224,8 @@ struct Database {
   void add_hash(const std::string &file, const std::string &type, const std::string &hash,
                 long mode);
 
-  // In core_filters, the outer vec is a set of filters to be AND'd together, inner vec is a set of
-  // queries to be OR'd together. This holds for input_file_filters and output_file_filters as well
-  // but is less useful as its restricted to the column 'path' in the files table.
-  std::vector<JobReflection> matching(const std::vector<std::vector<std::string>> &core_filters,
-                                      std::vector<std::vector<std::string>> input_file_filters,
-                                      std::vector<std::vector<std::string>> output_file_filters);
+  // Returns all jobs matching the provided filters.
+  std::vector<JobReflection> matching(MatchingQueryFilters filters);
 
   std::vector<JobEdge> get_edges();
   std::vector<JobTag> get_tags();
@@ -227,10 +235,7 @@ struct Database {
   // Returns all unfinished jobs matching the provided filters.
   // Ordered by run_id, starttime, job_id — queued (starttime==0) sort before running.
   // Additional filtering needed to determine if runs are "actually" live.
-  std::vector<OpenRunJobReflection> matching_open_runs(
-      const std::vector<std::vector<std::string>> &core_filters,
-      std::vector<std::vector<std::string>> input_file_filters,
-      std::vector<std::vector<std::string>> output_file_filters);
+  std::vector<OpenRunJobReflection> matching_open_runs(MatchingQueryFilters filters);
 
   std::vector<FileDependency> get_file_dependencies() const;
 

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -41,6 +41,7 @@ struct CommandLineOptions {
   bool last_use;
   bool last_exe;
   bool history;
+  bool ps;
   bool active;
   bool lsp;
   bool failed;
@@ -141,6 +142,7 @@ struct CommandLineOptions {
       {0, "last-used", GOPT_ARGUMENT_FORBIDDEN},
       {0, "last-executed", GOPT_ARGUMENT_FORBIDDEN},
       {0, "history", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "ps", GOPT_ARGUMENT_FORBIDDEN},
       {0, "active", GOPT_ARGUMENT_FORBIDDEN},
       {0, "queued", GOPT_ARGUMENT_FORBIDDEN},
       {0, "in-flight", GOPT_ARGUMENT_FORBIDDEN},
@@ -206,6 +208,7 @@ struct CommandLineOptions {
     last_use = arg(options, "last")->count || arg(options, "last-used")->count;
     last_exe = arg(options, "last-executed")->count;
     history = arg(options, "history")->count;
+    ps = arg(options, "ps")->count;
     active = arg(options, "active")->count;
     queued = arg(options, "queued")->count;
     in_flight = arg(options, "in-flight")->count;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -170,7 +170,11 @@ void make_and_group(const std::vector<std::vector<std::string>> &query, const st
 }
 
 void hide_internal_jobs(std::vector<std::vector<std::string>> &out) {
-  out.push_back({"tags NOT LIKE '%<d>inspect.visibility=hidden<d>%'", "tags IS NULL"});
+  // Use a NOT IN subquery instead of LIKE on concatenated tags.
+  // This avoids the expensive tag concatenation on the common path.
+  out.push_back(
+      {"core.job_id NOT IN (SELECT job_id FROM tags\n"
+       "                    WHERE uri = 'inspect.visibility' AND content = 'hidden')"});
 }
 
 static std::string format_duration(int64_t nanos) {
@@ -232,40 +236,43 @@ std::string run_id_filter(bool in, const std::vector<int> &ids) {
   return q;
 }
 
-void build_query_filters(const CommandLineOptions &clo, Database &db,
-                         std::vector<std::vector<std::string>> &collect_ands,
-                         std::vector<std::vector<std::string>> &collect_input_ands,
-                         std::vector<std::vector<std::string>> &collect_output_ands) {
+MatchingQueryFilters build_query_filters(const CommandLineOptions &clo, Database &db) {
+  MatchingQueryFilters filters;
+
   // Process --job
-  make_and_group(clo.job_ids, "cast(job_id as TEXT)", "", collect_ands);
+  make_and_group(clo.job_ids, "cast(job_id as TEXT)", "", filters.core_filters);
 
   // --label
-  make_and_group(clo.labels, "label", "", collect_ands);
+  make_and_group(clo.labels, "label", "", filters.core_filters);
 
   // --input
-  make_and_group(clo.input_files, "path", "", collect_input_ands);
+  make_and_group(clo.input_files, "path", "", filters.input_file_filters);
 
   // --output
-  make_and_group(clo.output_files, "path", "", collect_output_ands);
+  make_and_group(clo.output_files, "path", "", filters.output_file_filters);
 
-  // --tag
-  make_and_group(clo.tags, "tags", "<d>", collect_ands);
+  // --tag (uses the concatenated tags column with LIKE)
+  if (!clo.tags.empty()) {
+    make_and_group(clo.tags, "tags", "<d>", filters.core_filters);
+    filters.needs_tag_concat = true;  // Mark that we need the expensive GROUP BY
+  }
 
   // --last-exe
   if (clo.last_exe) {
-    collect_ands.push_back({"run_id == (select max(run_id) from runs where end_time is not null)"});
+    filters.core_filters.push_back(
+        {"run_id == (select max(run_id) from runs where end_time is not null)"});
   }
 
   // --last-use
   if (clo.last_use) {
-    collect_ands.push_back(
+    filters.core_filters.push_back(
         {"job_id in (select job_id from run_jobs where run_id = "
          "(select max(run_id) from runs where end_time is not null))"});
   }
 
   // --failed
   if (clo.failed) {
-    collect_ands.push_back({"(status <> 0 OR runner_status IS NOT NULL)"});
+    filters.core_filters.push_back({"(status <> 0 OR runner_status IS NOT NULL)"});
   }
 
   // Filters on unfinished jobs (stat_id is null).
@@ -274,46 +281,42 @@ void build_query_filters(const CommandLineOptions &clo, Database &db,
     auto live_run_ids = get_live_run_ids(db);
     // finish_job unconditinoally sets stat_id for jobs.
     // endtime=0 is close but includes jobs that finished.
-    collect_ands.push_back({"stat_id is null"});
+    filters.core_filters.push_back({"stat_id is null"});
 
     // --canceled: jobs from non-live runs (run crashed before job finished)
     if (clo.canceled) {
-      collect_ands.push_back({run_id_filter(/*in=*/false, live_run_ids)});
+      filters.core_filters.push_back({run_id_filter(/*in=*/false, live_run_ids)});
     }
 
     // --active: forked jobs (starttime!=0) in a live run
     if (clo.active) {
-      collect_ands.push_back({"starttime != 0"});
-      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
+      filters.core_filters.push_back({"starttime != 0"});
+      filters.core_filters.push_back({run_id_filter(/*in=*/true, live_run_ids)});
     }
 
     // --queued: not-yet-forked jobs (starttime==0) in a live run
     if (clo.queued) {
-      collect_ands.push_back({"starttime = 0"});
-      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
+      filters.core_filters.push_back({"starttime = 0"});
+      filters.core_filters.push_back({run_id_filter(/*in=*/true, live_run_ids)});
     }
 
     // --in-flight (or --ps): all unfinished jobs (running or queued) in a live run
     if (is_in_flight) {
-      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
+      filters.core_filters.push_back({run_id_filter(/*in=*/true, live_run_ids)});
     }
   }
 
   // Hide introspection jobs by default unless --include-hidden is specified
   if (!clo.include_hidden) {
-    hide_internal_jobs(collect_ands);
+    hide_internal_jobs(filters.core_filters);
   }
+
+  return filters;
 }
 
 void query_ps(const CommandLineOptions &clo, Database &db) {
-  std::vector<std::vector<std::string>> collect_ands;
-  std::vector<std::vector<std::string>> collect_input_ands;
-  std::vector<std::vector<std::string>> collect_output_ands;
-
-  build_query_filters(clo, db, collect_ands, collect_input_ands, collect_output_ands);
-
-  const auto jobs = db.matching_open_runs(collect_ands, std::move(collect_input_ands),
-                                          std::move(collect_output_ands));
+  auto filters = build_query_filters(clo, db);
+  const auto jobs = db.matching_open_runs(std::move(filters));
 
   if (jobs.empty()) {
     std::cout << "No jobs currently running." << std::endl;
@@ -351,14 +354,8 @@ void query_ps(const CommandLineOptions &clo, Database &db) {
 }
 
 void query_jobs(const CommandLineOptions &clo, Database &db) {
-  std::vector<std::vector<std::string>> collect_ands;
-  std::vector<std::vector<std::string>> collect_input_ands;
-  std::vector<std::vector<std::string>> collect_output_ands;
-
-  build_query_filters(clo, db, collect_ands, collect_input_ands, collect_output_ands);
-
-  auto matching_jobs =
-      db.matching(collect_ands, std::move(collect_input_ands), std::move(collect_output_ands));
+  auto filters = build_query_filters(clo, db);
+  auto matching_jobs = db.matching(std::move(filters));
 
   if (matching_jobs.empty()) {
     std::cerr << "No jobs matched query" << std::endl;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -232,25 +232,88 @@ std::string run_id_filter(bool in, const std::vector<int> &ids) {
   return q;
 }
 
-// Returns jobs from DB-open runs (end_time IS NULL) that are also proven live by lock probe.
-// Results are ordered by run_id so we probe once per run.
-std::vector<OpenRunJobReflection> get_live_open_run_jobs(Database &db) {
-  auto all = db.get_open_run_jobs();
-  int cur_run = -1;
-  bool cur_live = false;
-  std::vector<OpenRunJobReflection> live;
-  for (auto &j : all) {
-    if (j.run_id != cur_run) {
-      cur_run = j.run_id;
-      cur_live = RunLockProbe::is_live(j.run_id);
-    }
-    if (cur_live) live.push_back(std::move(j));
+void build_query_filters(const CommandLineOptions &clo, Database &db,
+                         std::vector<std::vector<std::string>> &collect_ands,
+                         std::vector<std::vector<std::string>> &collect_input_ands,
+                         std::vector<std::vector<std::string>> &collect_output_ands) {
+  // Process --job
+  make_and_group(clo.job_ids, "cast(job_id as TEXT)", "", collect_ands);
+
+  // --label
+  make_and_group(clo.labels, "label", "", collect_ands);
+
+  // --input
+  make_and_group(clo.input_files, "path", "", collect_input_ands);
+
+  // --output
+  make_and_group(clo.output_files, "path", "", collect_output_ands);
+
+  // --tag
+  make_and_group(clo.tags, "tags", "<d>", collect_ands);
+
+  // --last-exe
+  if (clo.last_exe) {
+    collect_ands.push_back({"run_id == (select max(run_id) from runs where end_time is not null)"});
   }
-  return live;
+
+  // --last-use
+  if (clo.last_use) {
+    collect_ands.push_back(
+        {"job_id in (select job_id from run_jobs where run_id = "
+         "(select max(run_id) from runs where end_time is not null))"});
+  }
+
+  // --failed
+  if (clo.failed) {
+    collect_ands.push_back({"(status <> 0 OR runner_status IS NOT NULL)"});
+  }
+
+  // Filters on unfinished jobs (stat_id is null).
+  bool is_in_flight = clo.in_flight || clo.ps;
+  if (clo.canceled || clo.active || clo.queued || is_in_flight) {
+    auto live_run_ids = get_live_run_ids(db);
+    // finish_job unconditinoally sets stat_id for jobs.
+    // endtime=0 is close but includes jobs that finished.
+    collect_ands.push_back({"stat_id is null"});
+
+    // --canceled: jobs from non-live runs (run crashed before job finished)
+    if (clo.canceled) {
+      collect_ands.push_back({run_id_filter(/*in=*/false, live_run_ids)});
+    }
+
+    // --active: forked jobs (starttime!=0) in a live run
+    if (clo.active) {
+      collect_ands.push_back({"starttime != 0"});
+      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
+    }
+
+    // --queued: not-yet-forked jobs (starttime==0) in a live run
+    if (clo.queued) {
+      collect_ands.push_back({"starttime = 0"});
+      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
+    }
+
+    // --in-flight (or --ps): all unfinished jobs (running or queued) in a live run
+    if (is_in_flight) {
+      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
+    }
+  }
+
+  // Hide introspection jobs by default unless --include-hidden is specified
+  if (!clo.include_hidden) {
+    hide_internal_jobs(collect_ands);
+  }
 }
 
-void query_ps(Database &db) {
-  const auto jobs = get_live_open_run_jobs(db);
+void query_ps(const CommandLineOptions &clo, Database &db) {
+  std::vector<std::vector<std::string>> collect_ands;
+  std::vector<std::vector<std::string>> collect_input_ands;
+  std::vector<std::vector<std::string>> collect_output_ands;
+
+  build_query_filters(clo, db, collect_ands, collect_input_ands, collect_output_ands);
+
+  const auto jobs = db.matching_open_runs(collect_ands, std::move(collect_input_ands),
+                                          std::move(collect_output_ands));
 
   if (jobs.empty()) {
     std::cout << "No jobs currently running." << std::endl;
@@ -288,78 +351,14 @@ void query_ps(Database &db) {
 }
 
 void query_jobs(const CommandLineOptions &clo, Database &db) {
-  std::vector<std::vector<std::string>> collect_ands = {};
-  std::vector<std::vector<std::string>> collect_input_ands = {};
-  std::vector<std::vector<std::string>> collect_output_ands = {};
+  std::vector<std::vector<std::string>> collect_ands;
+  std::vector<std::vector<std::string>> collect_input_ands;
+  std::vector<std::vector<std::string>> collect_output_ands;
 
-  // Process --job
-  make_and_group(clo.job_ids, "cast(job_id as TEXT)", "", collect_ands);
+  build_query_filters(clo, db, collect_ands, collect_input_ands, collect_output_ands);
 
-  // --label
-  make_and_group(clo.labels, "label", "", collect_ands);
-
-  // --input
-  make_and_group(clo.input_files, "path", "", collect_input_ands);
-
-  // --output
-  make_and_group(clo.output_files, "path", "", collect_output_ands);
-
-  // --tag
-  make_and_group(clo.tags, "tags", "<d>", collect_ands);
-
-  // --last-exe
-  if (clo.last_exe) {
-    collect_ands.push_back({"run_id == (select max(run_id) from runs where end_time is not null)"});
-  }
-
-  // --last-use
-  if (clo.last_use) {
-    collect_ands.push_back(
-        {"job_id in (select job_id from run_jobs where run_id = "
-         "(select max(run_id) from runs where end_time is not null))"});
-  }
-
-  // --failed
-  if (clo.failed) {
-    collect_ands.push_back({"(status <> 0 OR runner_status IS NOT NULL)"});
-  }
-
-  // Filters on unfinished jobs (stat_id is null).
-  if (clo.canceled || clo.active || clo.queued || clo.in_flight) {
-    auto live_run_ids = get_live_run_ids(db);
-    // finish_job unconditinoally sets stat_id for jobs.
-    // endtime=0 is close but includes jobs that finished.
-    collect_ands.push_back({"stat_id is null"});
-
-    // --canceled: jobs from non-live runs (run crashed before job finished)
-    if (clo.canceled) {
-      collect_ands.push_back({run_id_filter(/*in=*/false, live_run_ids)});
-    }
-
-    // --active: forked jobs (starttime!=0) in a live run
-    if (clo.active) {
-      collect_ands.push_back({"starttime != 0"});
-      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
-    }
-
-    // --queued: not-yet-forked jobs (starttime==0) in a live run
-    if (clo.queued) {
-      collect_ands.push_back({"starttime = 0"});
-      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
-    }
-
-    // --in-flight: all unfinished jobs (running or queued) in a live run
-    if (clo.in_flight) {
-      collect_ands.push_back({run_id_filter(/*in=*/true, live_run_ids)});
-    }
-  }
-
-  // Hide introspection jobs by default unless --include-hidden is specified
-  if (!clo.include_hidden) {
-    hide_internal_jobs(collect_ands);
-  }
-
-  auto matching_jobs = db.matching(collect_ands, collect_input_ands, collect_output_ands);
+  auto matching_jobs =
+      db.matching(collect_ands, std::move(collect_input_ands), std::move(collect_output_ands));
 
   if (matching_jobs.empty()) {
     std::cerr << "No jobs matched query" << std::endl;
@@ -375,7 +374,7 @@ void inspect_database(const CommandLineOptions &clo, Database &db) {
   if (clo.tagdag) {
     output_tagdag(db, clo.tagdag);
   } else if (clo.ps) {
-    query_ps(db);
+    query_ps(clo, db);
   } else if (clo.history) {
     query_runs(db);
   } else {

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -232,6 +232,61 @@ std::string run_id_filter(bool in, const std::vector<int> &ids) {
   return q;
 }
 
+// Returns jobs from DB-open runs (end_time IS NULL) that are also proven live by lock probe.
+// Results are ordered by run_id so we probe once per run.
+std::vector<OpenRunJobReflection> get_live_open_run_jobs(Database &db) {
+  auto all = db.get_open_run_jobs();
+  int cur_run = -1;
+  bool cur_live = false;
+  std::vector<OpenRunJobReflection> live;
+  for (auto &j : all) {
+    if (j.run_id != cur_run) {
+      cur_run = j.run_id;
+      cur_live = RunLockProbe::is_live(j.run_id);
+    }
+    if (cur_live) live.push_back(std::move(j));
+  }
+  return live;
+}
+
+void query_ps(Database &db) {
+  const auto jobs = get_live_open_run_jobs(db);
+
+  if (jobs.empty()) {
+    std::cout << "No jobs currently running." << std::endl;
+    return;
+  }
+
+  struct timespec now;
+  clock_gettime(CLOCK_REALTIME, &now);
+  int64_t now_ns = (int64_t)now.tv_sec * 1000000000LL + now.tv_nsec;
+
+  auto runs = db.get_runs();
+  std::unordered_map<int, std::string_view> run_cmdlines;
+  for (auto &r : runs)
+    if (!r.end_time) run_cmdlines[r.id] = r.cmdline;
+
+  int cur_run = -1;
+  std::cout << std::left;
+  for (const auto &j : jobs) {
+    if (j.run_id != cur_run) {
+      cur_run = j.run_id;
+      std::cout << "\nRun " << cur_run << ": " << run_cmdlines[cur_run] << std::endl;
+      std::cout << "  " << std::setw(8) << "JOB" << std::setw(12) << "ELAPSED"
+                << "LABEL" << std::endl;
+    }
+    if (j.starttime == 0) {
+      std::cout << "  " << std::setw(8) << j.job_id << std::setw(12) << "[queued]" << j.label
+                << std::endl;
+    } else {
+      int64_t elapsed_ns = now_ns - j.starttime;
+      std::string elapsed = "[" + format_duration(elapsed_ns) + "]";
+      std::cout << "  " << std::setw(8) << j.job_id << std::setw(12) << elapsed << j.label
+                << std::endl;
+    }
+  }
+}
+
 void query_jobs(const CommandLineOptions &clo, Database &db) {
   std::vector<std::vector<std::string>> collect_ands = {};
   std::vector<std::vector<std::string>> collect_input_ands = {};
@@ -319,6 +374,8 @@ void inspect_database(const CommandLineOptions &clo, Database &db) {
   // rest of the queries which operate on the jobs table.
   if (clo.tagdag) {
     output_tagdag(db, clo.tagdag);
+  } else if (clo.ps) {
+    query_ps(db);
   } else if (clo.history) {
     query_runs(db);
   } else {
@@ -368,6 +425,7 @@ void print_help(const char *argv0) {
     << "    --last-used        Capture all jobs used by last build. Regardless of cache"   << std::endl
     << "    --last-executed    Capture all jobs executed by the last build. Skips cache"   << std::endl
     << "    --history          Report the cmndline history of all wake commands recorded"  << std::endl
+    << "    --ps               Show jobs currently running in active wake builds"          << std::endl
     << "    --failed   -f      Capture jobs which failed last build"                       << std::endl
     << "    --tag      KEY=VAL Capture jobs which are tagged, matching KEY and VAL globs"  << std::endl
     << "    --canceled         Capture jobs which were canceled (run ended before job finished)" << std::endl
@@ -553,10 +611,11 @@ int main(int argc, char **argv) {
     clo.argv[1] = clo.shebang;
   }
 
-  bool is_db_inspect_capture =
-      !clo.job_ids.empty() || !clo.output_files.empty() || !clo.input_files.empty() ||
-      !clo.labels.empty() || !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
-      clo.tagdag || clo.canceled || clo.active || clo.queued || clo.in_flight || clo.history;
+  bool is_db_inspect_capture = !clo.job_ids.empty() || !clo.output_files.empty() ||
+                               !clo.input_files.empty() || !clo.labels.empty() ||
+                               !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
+                               clo.tagdag || clo.canceled || clo.active || clo.queued ||
+                               clo.in_flight || clo.history || clo.ps;
 
   // DescribePolicy::human() is the default and doesn't have a flag.
   // DescribePolicy::debug() is overloaded and can't be marked as a db flag


### PR DESCRIPTION
Lists jobs grouped by run_id, showing elapsed time for running jobs and [queued] for jobs not yet forked. Uses get_live_open_run_jobs() so crashed-but-unreaped runs are excluded.