### PR TITLE
Minimize use of re2::StringPiece.

### DIFF
--- a/src/parser/wakefiles.cpp
+++ b/src/parser/wakefiles.cpp
@@ -36,6 +36,7 @@
 #include <fstream>
 #include <memory>
 #include <sstream>
+#include <string_view>
 
 #include "compat/readable.h"
 #include "compat/windows.h"
@@ -142,7 +143,7 @@ bool push_files(int ok, char *files, std::vector<std::string> &out, const re2::R
                 size_t skip) {
   if (ok) {
     for (char *file = files; *file; file += strlen(file) + 1) {
-      re2::StringPiece p(file + skip, strlen(file) - skip);
+      std::string_view p(file + skip, strlen(file) - skip);
       if (RE2::FullMatch(p, re)) {
         out.emplace_back(file);
       }
@@ -227,7 +228,7 @@ static bool push_files(std::vector<std::string> &out, const std::string &path, i
 
     if (!push_files_is_directory(dirfd, path, f, &failed)) {
       // Append the current file if it matches the regex
-      re2::StringPiece p(name.c_str() + skip, name.size() - skip);
+      std::string_view p(name.c_str() + skip, name.size() - skip);
       if (RE2::FullMatch(p, re)) out.emplace_back(std::move(name));
       continue;
     }
@@ -302,7 +303,7 @@ std::string glob2regexp(const std::string &glob) {
   std::string exp("(?s)");
   size_t s = 0, e;
   while ((e = glob.find_first_of("\\[?*", s)) != std::string::npos) {
-    re2::StringPiece piece(glob.c_str() + s, e - s);
+    std::string_view piece(glob.c_str() + s, e - s);
     exp.append(RE2::QuoteMeta(piece));
     if (glob[e] == '\\') {
       // Trailing \ is left as a raw '\'
@@ -310,7 +311,7 @@ std::string glob2regexp(const std::string &glob) {
       if (e + 1 == glob.size() || static_cast<unsigned char>(glob[e + 1]) >= 0x80) {
         s = e + 1;
       } else {
-        re2::StringPiece piece(glob.c_str() + e + 1, 1);
+        std::string_view piece(glob.c_str() + e + 1, 1);
         exp.append(RE2::QuoteMeta(piece));
         s = e + 2;
       }
@@ -435,7 +436,7 @@ static std::vector<std::string> filter_wakefiles(std::vector<std::string> &&wake
     bool skip = false;
     size_t prefix = std::string::npos;
     for (auto &filter : filters) {
-      re2::StringPiece piece(wakefile.c_str() + filter.prefix, wakefile.size() - filter.prefix);
+      std::string_view piece(wakefile.c_str() + filter.prefix, wakefile.size() - filter.prefix);
       if (skip == filter.allow && RE2::FullMatch(piece, *filter.exp)) {
         skip = !filter.allow;
         prefix = filter.prefix;

--- a/src/runtime/regexp.cpp
+++ b/src/runtime/regexp.cpp
@@ -29,8 +29,6 @@
 #include "util/sfinae.h"
 #include "value.h"
 
-static re2::StringPiece sp(String *s) { return re2::StringPiece(s->c_str(), s->size()); }
-
 static PRIMTYPE(type_rcmp) {
   return args.size() == 2 && args[0]->unify(Data::typeRegExp) && args[1]->unify(Data::typeRegExp) &&
          out->unify(Data::typeOrder);
@@ -56,7 +54,7 @@ static PRIMFN(prim_re2) {
   STRING(arg0, 0);
   size_t need = reserve_result() + RegExp::reserve();
   runtime.heap.reserve(need);
-  RegExp *regexp = RegExp::claim(runtime.heap, runtime.heap, sp(arg0));
+  RegExp *regexp = RegExp::claim(runtime.heap, runtime.heap, arg0->as_sv());
   if (regexp->exp->ok()) {
     RETURN(claim_result(runtime.heap, true, regexp));
   } else {
@@ -89,7 +87,7 @@ static PRIMTYPE(type_quote) {
 static PRIMFN(prim_quote) {
   EXPECT(1);
   STRING(arg0, 0);
-  RETURN(String::alloc(runtime.heap, RE2::QuoteMeta(sp(arg0))));
+  RETURN(String::alloc(runtime.heap, RE2::QuoteMeta(arg0->as_sv())));
 }
 
 static bool check_re2_bug(size_t size) {
@@ -122,7 +120,7 @@ static PRIMFN(prim_match) {
   RE2_BUG(arg1);
 
   runtime.heap.reserve(reserve_bool());
-  auto out = RE2::FullMatch(sp(arg1), *arg0->exp);
+  auto out = RE2::FullMatch(arg1->as_sv(), *arg0->exp);
   RETURN(claim_bool(runtime.heap, out));
 }
 
@@ -142,7 +140,7 @@ static PRIMFN(prim_extract) {
 
   int matches = arg0->exp->NumberOfCapturingGroups();
   std::vector<re2::StringPiece> submatch(matches + 1);
-  re2::StringPiece input = sp(arg1);
+  auto input = arg1->as_sv();
 
   if (arg0->exp->Match(input, 0, input.size(), RE2::ANCHOR_BOTH, &submatch[0], matches + 1)) {
     size_t need = reserve_list(matches);
@@ -176,7 +174,7 @@ static PRIMFN(prim_replace) {
   RE2_BUG(arg2);
 
   std::string buffer = arg2->as_str();
-  RE2::GlobalReplace(&buffer, *arg0->exp, sp(arg1));
+  RE2::GlobalReplace(&buffer, *arg0->exp, arg1->as_sv());
   RETURN(String::alloc(runtime.heap, buffer));
 }
 
@@ -194,14 +192,14 @@ static PRIMFN(prim_tokenize) {
   STRING(arg1, 1);
   RE2_BUG(arg1);
 
-  re2::StringPiece input = sp(arg1);
+  std::string_view input = arg1->as_sv();
   re2::StringPiece hit;
-  std::vector<re2::StringPiece> tokens;
+  std::vector<std::string_view> tokens;
   size_t need = 0;
 
   while (arg0->exp->Match(input, 0, input.size(), RE2::UNANCHORED, &hit, 1)) {
     if (hit.empty()) break;
-    re2::StringPiece token(input.data(), hit.data() - input.data());
+    std::string_view token(input.data(), hit.data() - input.data());
     tokens.emplace_back(token);
     need += String::reserve(token.size());
     input.remove_prefix(token.size() + hit.size());
@@ -217,7 +215,7 @@ static PRIMFN(prim_tokenize) {
 
   std::vector<Value *> out;
   for (size_t i = 0; i < tokens.size(); ++i) {
-    re2::StringPiece &p = tokens[i];
+    std::string_view p = tokens[i];
     out.emplace_back(String::claim(runtime.heap, p.data(), p.size()));
   }
 

--- a/src/runtime/sources.cpp
+++ b/src/runtime/sources.cpp
@@ -337,7 +337,7 @@ static PRIMFN(prim_sources) {
   std::vector<Value *> found;
   for (Promise *i = low; i != high; ++i) {
     String *s = i->coerce<String>();
-    re2::StringPiece piece(s->c_str() + skip, s->size() - skip);
+    std::string_view piece(s->c_str() + skip, s->size() - skip);
     if (RE2::FullMatch(piece, *arg1->exp)) found.push_back(s);
   }
 

--- a/src/runtime/value.cpp
+++ b/src/runtime/value.cpp
@@ -303,11 +303,11 @@ MyOpts::MyOpts() {
 
 static MyOpts opts;
 
-RegExp::RegExp(Heap &h, const re2::StringPiece &regexp)
+RegExp::RegExp(Heap &h, std::string_view regexp)
     : Parent(h),
       exp(std::make_shared<RE2>(has_set_dot_nl<RE2::Options>::value
-                                    ? re2::StringPiece(regexp)
-                                    : re2::StringPiece("(?s)" + regexp.as_string()),
+                                    ? std::string(regexp)
+                                    : std::string("(?s)" + std::string(regexp)),
                                 opts)) {}
 
 void RegExp::format(std::ostream &os, FormatState &state) const {

--- a/src/runtime/value.h
+++ b/src/runtime/value.h
@@ -24,13 +24,13 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "gc.h"
 
 namespace re2 {
 class RE2;
-class StringPiece;
 }  // namespace re2
 
 #define APP_PRECEDENCE 14
@@ -82,6 +82,7 @@ struct String final : public GCObject<String, Value> {
   const char *c_str() const { return static_cast<const char *>(data()); }
   char *c_str() { return static_cast<char *>(data()); }
   std::string as_str() const { return std::string(c_str(), length); }
+  std::string_view as_sv() const { return std::string_view(c_str(), length); }
   size_t size() { return length; }
   bool empty() { return length == 0; }
 
@@ -216,7 +217,7 @@ struct RegExp final : public GCObject<RegExp, DestroyableObject> {
 
   std::shared_ptr<re2::RE2> exp;
 
-  RegExp(Heap &h, const re2::StringPiece &regexp);
+  RegExp(Heap &h, std::string_view regexp);
 
   void format(std::ostream &os, FormatState &state) const override;
   Hash shallow_hash() const override;


### PR DESCRIPTION
This is std::string_view.

Only use it where necessary
to interface with re2::Match.