### PR TITLE
Targeted fix for re2's StringPiece differences across versions.

### DIFF
--- a/src/runtime/regexp.cpp
+++ b/src/runtime/regexp.cpp
@@ -56,7 +56,7 @@ static PRIMFN(prim_re2) {
   STRING(arg0, 0);
   size_t need = reserve_result() + RegExp::reserve();
   runtime.heap.reserve(need);
-  RegExp *regexp = RegExp::claim(runtime.heap, runtime.heap, sp(arg0));
+  RegExp *regexp = RegExp::claim(runtime.heap, runtime.heap, arg0->as_sv());
   if (regexp->exp->ok()) {
     RETURN(claim_result(runtime.heap, true, regexp));
   } else {

--- a/src/runtime/value.cpp
+++ b/src/runtime/value.cpp
@@ -303,11 +303,13 @@ MyOpts::MyOpts() {
 
 static MyOpts opts;
 
-RegExp::RegExp(Heap &h, const re2::StringPiece &regexp)
+static re2::StringPiece sp(std::string_view sv) { return re2::StringPiece(sv.data(), sv.size()); }
+
+RegExp::RegExp(Heap &h, std::string_view regexp)
     : Parent(h),
       exp(std::make_shared<RE2>(has_set_dot_nl<RE2::Options>::value
-                                    ? re2::StringPiece(regexp)
-                                    : re2::StringPiece("(?s)" + regexp.as_string()),
+                                    ? sp(regexp)
+                                    : re2::StringPiece(std::string("(?s)") + std::string(regexp)),
                                 opts)) {}
 
 void RegExp::format(std::ostream &os, FormatState &state) const {

--- a/src/runtime/value.h
+++ b/src/runtime/value.h
@@ -24,13 +24,13 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "gc.h"
 
 namespace re2 {
 class RE2;
-class StringPiece;
 }  // namespace re2
 
 #define APP_PRECEDENCE 14
@@ -82,6 +82,7 @@ struct String final : public GCObject<String, Value> {
   const char *c_str() const { return static_cast<const char *>(data()); }
   char *c_str() { return static_cast<char *>(data()); }
   std::string as_str() const { return std::string(c_str(), length); }
+  std::string_view as_sv() const { return std::string_view(c_str(), length); }
   size_t size() { return length; }
   bool empty() { return length == 0; }
 
@@ -216,7 +217,7 @@ struct RegExp final : public GCObject<RegExp, DestroyableObject> {
 
   std::shared_ptr<re2::RE2> exp;
 
-  RegExp(Heap &h, const re2::StringPiece &regexp);
+  RegExp(Heap &h, std::string_view regexp);
 
   void format(std::ostream &os, FormatState &state) const override;
   Hash shallow_hash() const override;


### PR DESCRIPTION
This is std::string_view most everywhere for some time, but Debian 7's patched version prevents direct use.

Use StringPiece everywhere except sending strings to RegExp, but explicitly construct back to StringPiece.