### PR TITLE
enable cas unit tests, refactor cas to use constants

### DIFF
--- a/src/cas/cas.cpp
+++ b/src/cas/cas.cpp
@@ -36,19 +36,20 @@ namespace fs = std::filesystem;
 
 namespace cas {
 
-// Global counter for unique temp file names during materialization
-// Used to avoid collisions when multiple processes materialize files concurrently
-static std::atomic<uint64_t> g_materialize_counter{0};
+static constexpr unsigned SHARD_LEN = 2U;
+static_assert(SHARD_LEN < HASH_HEX_LEN, "hash length must be longer than shard length");
+
+// Global counter for unique temp file names when ingesting files.
 static std::atomic<uint64_t> g_store_counter{0};
 // Helper functions for hash-based directory sharding
 static std::string hash_prefix(const ContentHash& hash) {
   std::string hex = hash.to_hex();
-  return hex.substr(0, 2);
+  return hex.substr(0, SHARD_LEN);
 }
 
 static std::string hash_suffix(const ContentHash& hash) {
   std::string hex = hash.to_hex();
-  return hex.substr(2);
+  return hex.substr(SHARD_LEN);
 }
 
 std::string cas_error_to_string(CASError error) {
@@ -314,12 +315,12 @@ std::vector<std::string> Cas::enumerate_blobs_strings() const {
     for (const auto& prefix_entry : fs::directory_iterator(blobs_dir_, ec)) {
       if (ec || !prefix_entry.is_directory()) continue;
       std::string prefix = prefix_entry.path().filename().string();
-      if (prefix.size() != 2) continue;
+      if (prefix.size() != SHARD_LEN) continue;
 
       for (const auto& blob_entry : fs::directory_iterator(prefix_entry.path(), ec)) {
         if (ec || !blob_entry.is_regular_file()) continue;
         std::string suffix = blob_entry.path().filename().string();
-        if (suffix.size() != 62) continue;
+        if (suffix.size() != (HASH_HEX_LEN - SHARD_LEN)) continue;
 
         result.push_back(prefix + suffix);
       }

--- a/src/cas/content_hash.cpp
+++ b/src/cas/content_hash.cpp
@@ -24,6 +24,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <algorithm>
+
+#include "blake2/blake2.h"
 #include "wcl/unique_fd.h"
 
 namespace cas {
@@ -77,13 +80,13 @@ wcl::result<ContentHash, wcl::posix_error_t> ContentHash::from_file(const std::s
 }
 
 wcl::result<ContentHash, ContentHashError> ContentHash::from_hex(const std::string& hex) {
-  if (hex.size() != 64) {
+  if (hex.size() != HASH_HEX_LEN) {
     return wcl::make_error<ContentHash, ContentHashError>(ContentHashError::InvalidHexLength);
   }
 
   ContentHash hash;
   uint8_t* bytes = reinterpret_cast<uint8_t*>(hash.data);
-  for (size_t i = 0; i < 32; ++i) {
+  for (size_t i = 0; i < (HASH_HEX_LEN >> 1U); ++i) {
     uint8_t high = hex_to_nibble(hex[i * 2]);
     uint8_t low = hex_to_nibble(hex[i * 2 + 1]);
     if (high == 0xFF || low == 0xFF) {
@@ -96,9 +99,9 @@ wcl::result<ContentHash, ContentHashError> ContentHash::from_hex(const std::stri
 
 std::string ContentHash::to_hex() const {
   std::string result;
-  result.reserve(64);
+  result.reserve(HASH_HEX_LEN);
   const uint8_t* bytes = reinterpret_cast<const uint8_t*>(data);
-  for (size_t i = 0; i < 32; ++i) {
+  for (size_t i = 0; i < (HASH_HEX_LEN >> 1U); ++i) {
     // Extract high nibble (upper 4 bits) and convert to hex
     result += nibble_to_hex((bytes[i] >> 4) & 0x0F);
     // Extract low nibble (lower 4 bits) and convert to hex
@@ -108,18 +111,14 @@ std::string ContentHash::to_hex() const {
 }
 
 bool ContentHash::operator==(const ContentHash& other) const {
-  return data[0] == other.data[0] && data[1] == other.data[1] && data[2] == other.data[2] &&
-         data[3] == other.data[3];
+  return std::equal(data, data + NUM_HASH_ELEMENTS, other.data, other.data + NUM_HASH_ELEMENTS);
 }
 
 bool ContentHash::operator!=(const ContentHash& other) const { return !(*this == other); }
 
 bool ContentHash::operator<(const ContentHash& other) const {
-  for (int i = 0; i < 4; ++i) {
-    if (data[i] < other.data[i]) return true;
-    if (data[i] > other.data[i]) return false;
-  }
-  return false;
+  return std::lexicographical_compare(data, data + NUM_HASH_ELEMENTS, other.data,
+                                      other.data + NUM_HASH_ELEMENTS);
 }
 
 }  // namespace cas

--- a/src/cas/content_hash.h
+++ b/src/cas/content_hash.h
@@ -21,16 +21,19 @@
 
 #include <string>
 
-#include "blake2/blake2.h"
 #include "wcl/result.h"
 
 namespace cas {
 
 enum class ContentHashError { InvalidHexLength, InvalidHexChar };
 
+static constexpr unsigned HASH_BITS_LEN = 256U;
+static constexpr unsigned HASH_HEX_LEN = HASH_BITS_LEN >> 2U;
+
 // 256-bit content hash using BLAKE2b
 struct ContentHash {
-  uint64_t data[4] = {0};
+  static constexpr unsigned NUM_HASH_ELEMENTS = HASH_BITS_LEN >> 6U;
+  uint64_t data[NUM_HASH_ELEMENTS] = {0};
 
   ContentHash() = default;
   ContentHash(const ContentHash&) = default;

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -1,8 +1,30 @@
 PASSED:
+  cas_store_blob_from_file
+  cas_store_blob_roundtrip
+  cas_store_deduplication
+  cas_store_enumerate
+  cas_store_enumerate_empty
+  cas_store_file_and_symlink_same_payload_same_hash
+  cas_store_file_blob_roundtrip
+  cas_store_has_blob_not_found
+  cas_store_materialize_blob
+  cas_store_open
+  cas_store_symlink_target_blob_roundtrip
   cli_options_basic
   cli_options_shebang
   cli_options_target
   cli_options_timline
+  content_hash_equality
+  content_hash_from_file
+  content_hash_from_file_not_found
+  content_hash_from_string_different_content
+  content_hash_from_string_empty
+  content_hash_from_string_same_content
+  content_hash_hex_roundtrip
+  content_hash_roundtrip
+  content_hash_same_bytes_match_for_file_and_symlink_payloads
+  content_hash_to_hex_length
+  content_hash_to_hex_valid_chars
   diff_add
   diff_empty
   diff_fuzz1
@@ -34,6 +56,8 @@ PASSED:
   iterator_split_by_no_delim
   iterator_split_by_nominal
   iterator_split_by_only_delim
+  reflink_or_copy_file_basic
+  reflink_or_copy_file_src_not_found
   result_assign1
   result_assign2
   result_copy

--- a/tests/wake-unit/unit-test.sh
+++ b/tests/wake-unit/unit-test.sh
@@ -2,12 +2,4 @@
 
 set -e
 
-TERM=xterm-256color script --return --quiet -c "$1 --no-color --tag threaded" /dev/null
-
-# We run the tests *twice* so that shared caching can run without a clean slate
-TERM=xterm-256color script --return --quiet -c "$1 --no-color --tag threaded" /dev/null > /dev/null
-
-rm -rf job_cache_test
-rm -rf .job_cache_test
-rm -rf job_cache_test2
-rm -rf .job_cache_test2
+TERM=xterm-256color script --return --quiet -c "$1 --no-color --tag cas" /dev/null

--- a/tools/wake-unit/cas_test.cpp
+++ b/tools/wake-unit/cas_test.cpp
@@ -57,7 +57,7 @@ TEST(content_hash_from_string_empty, "cas") {
   auto hash = ContentHash::from_string("");
 
   // Empty string should still produce a valid hash
-  EXPECT_EQUAL(hash.to_hex().length(), 64u);
+  EXPECT_EQUAL(hash.to_hex().length(), HASH_HEX_LEN);
 }
 
 TEST(content_hash_hex_roundtrip, "cas") {
@@ -73,8 +73,8 @@ TEST(content_hash_to_hex_length, "cas") {
   auto hash = ContentHash::from_string("test");
   std::string hex = hash.to_hex();
 
-  // BLAKE2b-256 produces 64 hex characters
-  EXPECT_EQUAL(hex.length(), 64u);
+  // BLAKE2b-256 produces 64 (HASH_HEX_LEN) hex characters
+  EXPECT_EQUAL(hex.length(), HASH_HEX_LEN);
 }
 
 TEST(content_hash_to_hex_valid_chars, "cas") {

--- a/tools/wake-unit/cas_test.cpp
+++ b/tools/wake-unit/cas_test.cpp
@@ -389,3 +389,48 @@ TEST(cas_store_file_and_symlink_same_payload_same_hash, "cas") {
   fs::remove(input_file);
   fs::remove_all(store_path);
 }
+
+TEST(cas_store_enumerate, "cas") {
+  std::string store_path = "cas_test_store10";
+  fs::remove_all(store_path);
+
+  auto store_result = Cas::open(store_path);
+  ASSERT_TRUE((bool)store_result);
+  auto& store = *store_result;
+
+  auto hash_result = store.store_blob("foo");
+  ASSERT_TRUE((bool)hash_result);
+
+  auto hash2_result = store.store_blob("bar");
+  ASSERT_TRUE((bool)hash2_result);
+
+  auto blobs = store.enumerate_blobs_strings();
+  ASSERT_EQUAL(blobs.size(), 2U);
+
+  // Ordering may be reliable, sort both before checking.
+  std::vector<std::string> hashes;
+  hashes.push_back(hash_result->to_hex());
+  hashes.push_back(hash2_result->to_hex());
+
+  std::sort(hashes.begin(), hashes.end());
+  std::sort(blobs.begin(), blobs.end());
+
+  EXPECT_EQUAL(blobs[0], hashes[0]);
+  EXPECT_EQUAL(blobs[1], hashes[1]);
+
+  fs::remove_all(store_path);
+}
+
+TEST(cas_store_enumerate_empty, "cas") {
+  std::string store_path = "cas_test_store11";
+  fs::remove_all(store_path);
+
+  auto store_result = Cas::open(store_path);
+  ASSERT_TRUE((bool)store_result);
+  auto& store = *store_result;
+
+  auto blobs = store.enumerate_blobs_strings();
+  EXPECT_TRUE(blobs.empty());
+
+  fs::remove_all(store_path);
+}


### PR DESCRIPTION
Also add unit tests for enumerate_blobs_strings functionality.

~Pulled out because CI unit test failed at first? Not sure what happened there, see: https://github.com/sifiveinc/wake/actions/runs/25867633443/job/76013909717~ (file listing order is unpredictable, whoops, fixed)