### PR TITLE
wcl: add function_ref; database: use it

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1447,7 +1447,7 @@ std::vector<std::string> Database::clear_jobs() {
   return out;
 }
 
-bool Database::clear_jobs_if_safe(std::function<void(std::vector<std::string>)> delete_files) {
+bool Database::clear_jobs_if_safe(wcl::function_ref<void(std::vector<std::string>)> delete_files) {
   const char *why = "Could not clear jobs";
   std::vector<std::string> out;
 
@@ -2283,7 +2283,7 @@ std::vector<FileDependency> Database::get_file_dependencies() const {
 }
 
 void Database::gc_if_dead(const std::vector<std::string> &hashes,
-                          const std::function<void(std::vector<std::string>)> &callback) {
+                          wcl::function_ref<void(std::vector<std::string>)> callback) {
   constexpr size_t BATCH_SIZE = 256;            // number of hashes per query, must match statement!
   constexpr size_t TXN_DEAD_SIZE = 1ULL << 11;  // transaction limit for dead hashes
   constexpr size_t TXN_HASHES = 1ULL << 13;     // transaction limit for total hashes checked

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -18,7 +18,6 @@
 #ifndef DATABASE_H
 #define DATABASE_H
 
-#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -28,6 +27,7 @@
 
 #include "json/json5.h"
 #include "run_lock.h"
+#include "wcl/function_ref.h"
 
 struct FileReflection {
   std::string path;
@@ -219,7 +219,7 @@ struct Database {
   // Returns false if there are incomplete runs (active builds).
   // The check, DB clear, and file deletion (via callback) all happen
   // within the same transaction to prevent races with new builds.
-  bool clear_jobs_if_safe(std::function<void(std::vector<std::string>)> delete_files);
+  bool clear_jobs_if_safe(wcl::function_ref<void(std::vector<std::string>)> delete_files);
 
   void add_hash(const std::string &file, const std::string &type, const std::string &hash,
                 long mode);
@@ -248,7 +248,7 @@ struct Database {
   std::pair<bool, std::string> get_runner_status(long job_id);
 
   void gc_if_dead(const std::vector<std::string> &hashes,
-                  const std::function<void(std::vector<std::string>)> &callback);
+                  wcl::function_ref<void(std::vector<std::string>)> callback);
 
  private:
   void begin_ro_txn() const;

--- a/src/wcl/function_ref.h
+++ b/src/wcl/function_ref.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+namespace wcl {
+
+// An efficient, type-erasing, non-owning reference to a callable. This is
+// intended for use as the type of a function parameter that is not used
+// after the function in question returns.
+//
+// This class does not own the callable, so it is not in general safe to store
+// a function_ref.
+//
+// Based on LLVM's function_ref and std::function_ref (C++26).
+// Compared to LLVM's function_ref, this version is not nullable (like in C++26),
+// and has some safety and optimization for function pointers.
+template <typename Fn>
+class function_ref;
+
+template <typename Ret, typename... Args>
+class function_ref<Ret(Args...)> {
+ private:
+  intptr_t callable_;
+
+  Ret (*trampoline_)(intptr_t, Args...);
+
+  // Trampoline for callable objects (lambdas, functors)
+  template <typename Callable>
+  static constexpr Ret trampoline_impl(intptr_t callable, Args... args) {
+    return (*reinterpret_cast<Callable*>(callable))(std::forward<Args>(args)...);
+  }
+
+  // Trampoline for function pointers - callable is the function itself, not pointer-to-pointer
+  template <typename F>
+  static constexpr Ret function_trampoline_impl(intptr_t fn_ptr, Args... args) {
+    return reinterpret_cast<F*>(fn_ptr)(std::forward<Args>(args)...);
+  }
+
+ public:
+  // Construct from function pointer (stores function directly, not pointer-to-pointer)
+  // This overload prevents dangling when passing function pointers through temporaries
+  template <typename F, typename = std::enable_if_t<std::is_function_v<F> &&
+                                                    std::is_invocable_r_v<Ret, F*, Args...>>>
+  constexpr function_ref(F* f) noexcept
+      : callable_(reinterpret_cast<intptr_t>(f)), trampoline_(function_trampoline_impl<F>) {
+    static_assert(sizeof(f) == sizeof(callable_), "Function pointer size mismatch");
+  }
+
+  // Construct from any other compatible callable (lambda, function object, etc.)
+  // Disallows use as copy constructor.
+  template <typename Callable,
+            typename = std::enable_if_t<!std::is_same_v<std::decay_t<Callable>, function_ref> &&
+                                        !std::is_pointer_v<std::decay_t<Callable>> &&
+                                        std::is_invocable_r_v<Ret, Callable, Args...>>>
+  constexpr function_ref(Callable&& callable) noexcept
+      : callable_(reinterpret_cast<intptr_t>(std::addressof(callable))),
+        trampoline_(trampoline_impl<std::remove_reference_t<Callable>>) {}
+
+  constexpr Ret operator()(Args... args) const {
+    return trampoline_(callable_, std::forward<Args>(args)...);
+  }
+
+  constexpr function_ref(const function_ref&) noexcept = default;
+  constexpr function_ref& operator=(const function_ref&) noexcept = default;
+
+  // Prevent assignment from anything other than function_ref (C++26 behavior)
+  template <typename T>
+  function_ref& operator=(T) = delete;
+};
+
+}  // namespace wcl

--- a/tests/wake-unit/stdout
+++ b/tests/wake-unit/stdout
@@ -52,6 +52,19 @@ PASSED:
   filepath_range_only_slash
   filepath_range_two_slash
   filepath_relative_to
+  function_ref_const_lambda
+  function_ref_copy_assignment
+  function_ref_copy_constructor
+  function_ref_function_pointer
+  function_ref_function_reference
+  function_ref_functor
+  function_ref_lambda_capture
+  function_ref_multiple_params
+  function_ref_mutable_lambda
+  function_ref_optional_return
+  function_ref_return_conversion
+  function_ref_stateless_lambda
+  function_ref_void_return
   iterator_split_by_empty
   iterator_split_by_no_delim
   iterator_split_by_nominal

--- a/tools/wake-unit/function_ref.cpp
+++ b/tools/wake-unit/function_ref.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <wcl/function_ref.h>
+
+#include <optional>
+#include <string>
+
+#include "unit.h"
+
+// Compile-time checks.
+static_assert(std::is_trivially_copyable<wcl::function_ref<void()>>::value,
+              "function_ref should be trivially copyable");
+static_assert(std::is_trivially_copyable<wcl::function_ref<int(int, double)>>::value,
+              "function_ref should be trivially copyable");
+static_assert(sizeof(wcl::function_ref<void()>) == 2 * sizeof(void*),
+              "function_ref should be exactly 2 pointers");
+static_assert(sizeof(wcl::function_ref<int(int, double, std::string)>) == 2 * sizeof(void*),
+              "function_ref should be exactly 2 pointers");
+
+// Test helper functions
+static int add_one(int x) { return x + 1; }
+static int multiply_by_two(int x) { return x * 2; }
+static std::optional<std::string> return_nullopt(const std::string&) { return std::nullopt; }
+static std::optional<std::string> return_error(const std::string& s) { return "error: " + s; }
+
+// Test basic construction and invocation
+TEST(function_ref_lambda_capture) {
+  int counter = 0;
+  auto lambda = [&counter]() { return ++counter; };
+  wcl::function_ref<int()> ref = lambda;
+
+  EXPECT_EQUAL(1, ref());
+  EXPECT_EQUAL(2, ref());
+  EXPECT_EQUAL(2, counter);
+}
+
+TEST(function_ref_const_lambda) {
+  const auto lambda = [](int x) { return x * 3; };
+  wcl::function_ref<int(int)> ref = lambda;
+
+  EXPECT_EQUAL(15, ref(5));
+}
+
+TEST(function_ref_function_pointer) {
+  wcl::function_ref<int(int)> ref = add_one;
+
+  EXPECT_EQUAL(43, ref(42));
+  EXPECT_EQUAL(101, ref(100));
+}
+
+TEST(function_ref_function_reference) {
+  // Functions decay to pointers
+  wcl::function_ref<int(int)> ref = multiply_by_two;
+
+  EXPECT_EQUAL(10, ref(5));
+}
+
+TEST(function_ref_copy_constructor) {
+  auto lambda = [](int x) { return x + 10; };
+  wcl::function_ref<int(int)> ref1 = lambda;
+  wcl::function_ref<int(int)> ref2 = ref1;
+
+  EXPECT_EQUAL(15, ref1(5));
+  EXPECT_EQUAL(15, ref2(5));
+}
+
+TEST(function_ref_copy_assignment) {
+  auto lambda1 = [](int x) { return x + 1; };
+  auto lambda2 = [](int x) { return x + 2; };
+
+  wcl::function_ref<int(int)> ref1 = lambda1;
+  wcl::function_ref<int(int)> ref2 = lambda2;
+
+  EXPECT_EQUAL(11, ref1(10));
+  EXPECT_EQUAL(12, ref2(10));
+
+  ref2 = ref1;  // Copy assign
+
+  EXPECT_EQUAL(11, ref2(10));  // Now points to lambda1
+}
+
+TEST(function_ref_return_conversion) {
+  // int return type converts to long
+  auto lambda = [](int x) { return x + 1; };
+  wcl::function_ref<long(int)> ref = lambda;
+
+  long result = ref(41);
+  EXPECT_EQUAL(42L, result);
+}
+
+TEST(function_ref_optional_return) {
+  wcl::function_ref<std::optional<std::string>(const std::string&)> ref1 = return_nullopt;
+  wcl::function_ref<std::optional<std::string>(const std::string&)> ref2 = return_error;
+
+  auto result1 = ref1("test");
+  EXPECT_FALSE(result1.has_value());
+
+  auto result2 = ref2("test");
+  ASSERT_TRUE(result2.has_value());
+  EXPECT_EQUAL("error: test", *result2);
+}
+
+TEST(function_ref_functor) {
+  struct Adder {
+    int value;
+    int operator()(int x) const { return x + value; }
+  };
+
+  Adder add5{5};
+  wcl::function_ref<int(int)> ref = add5;
+
+  EXPECT_EQUAL(15, ref(10));
+}
+
+TEST(function_ref_mutable_lambda) {
+  auto lambda = [x = 0]() mutable { return ++x; };
+  wcl::function_ref<int()> ref = lambda;
+
+  EXPECT_EQUAL(1, ref());
+  EXPECT_EQUAL(2, ref());
+  EXPECT_EQUAL(3, ref());
+}
+
+TEST(function_ref_stateless_lambda) {
+  auto lambda = [](int x) { return x * x; };
+  wcl::function_ref<int(int)> ref = lambda;
+
+  EXPECT_EQUAL(16, ref(4));
+  EXPECT_EQUAL(25, ref(5));
+}
+
+// Test multiple parameters
+TEST(function_ref_multiple_params) {
+  auto lambda = [](int a, int b, int c) { return a + b + c; };
+  wcl::function_ref<int(int, int, int)> ref = lambda;
+
+  EXPECT_EQUAL(6, ref(1, 2, 3));
+  EXPECT_EQUAL(15, ref(4, 5, 6));
+}
+
+// Test void return type
+TEST(function_ref_void_return) {
+  int counter = 0;
+  auto lambda = [&counter](int x) { counter += x; };
+  wcl::function_ref<void(int)> ref = lambda;
+
+  ref(5);
+  EXPECT_EQUAL(5, counter);
+  ref(10);
+  EXPECT_EQUAL(15, counter);
+}


### PR DESCRIPTION
Based on LLVM's function_ref[1] and std::function_ref[2]

[1] https://github.com/llvm/llvm-project/blob/70cbd7591abee944151922edecc34093f6a9910e/llvm/include/llvm/ADT/STLFunctionalExtras.h#L37
[2] https://en.cppreference.com/cpp/utility/functional/function_ref (C++26)

Make use of this in database's callback methods.