### PR TITLE
Update RSC to be mw/CAS compliant and fix filetype collision issue

### DIFF
--- a/rust/entity/src/output_symlink.rs
+++ b/rust/entity/src/output_symlink.rs
@@ -11,6 +11,7 @@ pub struct Model {
     pub link: String,
     pub job_id: Uuid,
     pub created_at: DateTime,
+    pub hash: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/rust/migration/src/lib.rs
+++ b/rust/migration/src/lib.rs
@@ -17,6 +17,7 @@ mod m20240809_213440_add_job_audit_table;
 mod m20240819_193352_add_output_indexes;
 mod m20240919_214610_add_hidden_to_output_dir;
 mod m20250900_000000_add_content_hash_to_blob;
+mod m20260511_000000_add_hash_to_output_symlink;
 
 pub struct Migrator;
 
@@ -41,6 +42,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240819_193352_add_output_indexes::Migration),
             Box::new(m20240919_214610_add_hidden_to_output_dir::Migration),
             Box::new(m20250900_000000_add_content_hash_to_blob::Migration),
+            Box::new(m20260511_000000_add_hash_to_output_symlink::Migration),
         ]
     }
 }

--- a/rust/migration/src/m20260511_000000_add_hash_to_output_symlink.rs
+++ b/rust/migration/src/m20260511_000000_add_hash_to_output_symlink.rs
@@ -1,0 +1,43 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add hash of the symlink target string so the client can ingest the
+        // target into CAS without recomputing it. Mirrors how output files already carry
+        // their content hash.
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(OutputSymlink::Table)
+                    .add_column(
+                        ColumnDef::new(OutputSymlink::Hash)
+                            .string()
+                            .not_null()
+                            .default(""),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(OutputSymlink::Table)
+                    .drop_column(OutputSymlink::Hash)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum OutputSymlink {
+    Table,
+    Hash,
+}

--- a/rust/rsc/src/bin/rsc/add_job.rs
+++ b/rust/rsc/src/bin/rsc/add_job.rs
@@ -77,6 +77,7 @@ pub async fn add_job(
                             path: Set(out_symlink.path),
                             link: Set(out_symlink.link),
                             job_id: Set(job_id),
+                            hash: Set(out_symlink.hash),
                         })
                         .collect(),
                 )

--- a/rust/rsc/src/bin/rsc/add_job.rs
+++ b/rust/rsc/src/bin/rsc/add_job.rs
@@ -77,7 +77,7 @@ pub async fn add_job(
                             path: Set(out_symlink.path),
                             link: Set(out_symlink.link),
                             job_id: Set(job_id),
-                            hash: Set(out_symlink.hash),
+                            hash: Set(out_symlink.hash.unwrap_or_default()),
                         })
                         .collect(),
                 )

--- a/rust/rsc/src/bin/rsc/read_job.rs
+++ b/rust/rsc/src/bin/rsc/read_job.rs
@@ -223,6 +223,7 @@ pub async fn read_job(
         .map(|m| Symlink {
             path: m.path,
             link: m.link,
+            hash: m.hash,
         })
         .collect();
 

--- a/rust/rsc/src/bin/rsc/types.rs
+++ b/rust/rsc/src/bin/rsc/types.rs
@@ -36,14 +36,14 @@ pub trait JobKeyHash {
             hasher.update(file.path.as_bytes());
             hasher.update(&file.hash.len().to_le_bytes());
             hasher.update(file.hash.as_bytes());
-            // Skip when `type` is empty so old-client keys (no type/mode) hash exactly
+            // Skip when `type` is absent so old-client keys (no type/mode) hash exactly
             // as before, preserving their cache. New-client keys mix in type+mode and
             // land in a disjoint namespace, fixing the symlink-vs-file collision.
             //
             // TODO: Remove this check once all clients have been migrated to the newer version.
-            if !file.r#type.is_empty() {
-                hasher.update(&file.r#type.len().to_le_bytes());
-                hasher.update(file.r#type.as_bytes());
+            if let Some(r#type) = &file.r#type {
+                hasher.update(&r#type.len().to_le_bytes());
+                hasher.update(r#type.as_bytes());
                 hasher.update(&file.mode.to_le_bytes());
             }
         }
@@ -55,9 +55,9 @@ pub trait JobKeyHash {
 pub struct VisibleFile {
     pub path: String,
     pub hash: String,
-    // Absent in old client payloads; defaults keep old keys unchanged.
+    // Absent in old client payloads; None keeps old keys unchanged.
     #[serde(rename = "type", default)]
-    pub r#type: String,
+    pub r#type: Option<String>,
     #[serde(default)]
     pub mode: i32,
 }
@@ -81,9 +81,16 @@ pub struct Dir {
 pub struct Symlink {
     pub path: String,
     pub link: String,
-    // Absent in old client payloads; "" means no CAS hash available (legacy entry).
-    #[serde(default)]
     pub hash: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SymlinkPayload {
+    pub path: String,
+    pub link: String,
+    // Absent in old client payloads; None means no CAS hash available (legacy entry).
+    #[serde(default)]
+    pub hash: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -96,7 +103,7 @@ pub struct AddJobPayload {
     pub hidden_info: String,
     pub visible_files: Vec<VisibleFile>,
     pub output_dirs: Vec<Dir>,
-    pub output_symlinks: Vec<Symlink>,
+    pub output_symlinks: Vec<SymlinkPayload>,
     pub output_files: Vec<File>,
     pub stdout_blob_id: Uuid,
     pub stderr_blob_id: Uuid,
@@ -349,7 +356,7 @@ mod tests {
         VisibleFile {
             path: path.to_string(),
             hash: hash.to_string(),
-            r#type: ty.to_string(),
+            r#type: Some(ty.to_string()),
             mode,
         }
     }

--- a/rust/rsc/src/bin/rsc/types.rs
+++ b/rust/rsc/src/bin/rsc/types.rs
@@ -36,6 +36,16 @@ pub trait JobKeyHash {
             hasher.update(file.path.as_bytes());
             hasher.update(&file.hash.len().to_le_bytes());
             hasher.update(file.hash.as_bytes());
+            // Skip when `type` is empty so old-client keys (no type/mode) hash exactly
+            // as before, preserving their cache. New-client keys mix in type+mode and
+            // land in a disjoint namespace, fixing the symlink-vs-file collision.
+            //
+            // TODO: Remove this check once all clients have been migrated to the newer version.
+            if !file.r#type.is_empty() {
+                hasher.update(&file.r#type.len().to_le_bytes());
+                hasher.update(file.r#type.as_bytes());
+                hasher.update(&file.mode.to_le_bytes());
+            }
         }
         hasher.finalize().to_string()
     }
@@ -45,6 +55,11 @@ pub trait JobKeyHash {
 pub struct VisibleFile {
     pub path: String,
     pub hash: String,
+    // Absent in old client payloads; defaults keep old keys unchanged.
+    #[serde(rename = "type", default)]
+    pub r#type: String,
+    #[serde(default)]
+    pub mode: i32,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -66,6 +81,9 @@ pub struct Dir {
 pub struct Symlink {
     pub path: String,
     pub link: String,
+    // Absent in old client payloads; "" means no CAS hash available (legacy entry).
+    #[serde(default)]
+    pub hash: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -321,4 +339,49 @@ pub struct DashboardStatsResponse {
     pub most_space_efficient_jobs: Vec<DashboardStatsSizeRuntimeValueJob>,
     pub most_space_use_jobs: Vec<DashboardStatsSizeRuntimeValueJob>,
     pub blob_use_by_store: Vec<DashboardStatsBlobUseByStore>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vf(path: &str, hash: &str, ty: &str, mode: i32) -> VisibleFile {
+        VisibleFile {
+            path: path.to_string(),
+            hash: hash.to_string(),
+            r#type: ty.to_string(),
+            mode,
+        }
+    }
+
+    fn payload_with_visible(visible_files: Vec<VisibleFile>) -> ReadJobPayload {
+        ReadJobPayload {
+            cmd: vec![],
+            env: vec![],
+            cwd: "/".to_string(),
+            stdin: "".to_string(),
+            is_atty: false,
+            hidden_info: "".to_string(),
+            visible_files,
+        }
+    }
+
+    /// Symlink-vs-file collision regression test.
+    ///
+    /// Asserts that two visible files with identical path and content hash but
+    /// different `type` and `mode` produce distinct RSC job keys.
+    #[test]
+    fn symlink_vs_file_with_same_content_hash_no_longer_collide() {
+        let same_content_hash = "abc123";
+        let same_path = "tools/cc";
+
+        let as_file = payload_with_visible(vec![vf(same_path, same_content_hash, "regular_file", 0o644)]);
+        let as_symlink = payload_with_visible(vec![vf(same_path, same_content_hash, "symlink", 0o777)]);
+
+        assert_ne!(
+            as_file.hash(),
+            as_symlink.hash(),
+            "VisibleFile entries with same path+hash but different type/mode must hash to different RSC keys"
+        );
+    }
 }

--- a/rust/rsc/src/database.rs
+++ b/rust/rsc/src/database.rs
@@ -533,7 +533,7 @@ pub async fn create_many_output_files<T: ConnectionTrait>(
 
     let chunked: Vec<Vec<output_file::ActiveModel>> = output_files
         .into_iter()
-        .chunks((MAX_SQLX_PARAMS / 6).into())
+        .chunks((MAX_SQLX_PARAMS / 7).into())
         .into_iter()
         .map(|chunk| chunk.collect())
         .collect();
@@ -566,7 +566,7 @@ pub async fn create_many_output_symlinks<T: ConnectionTrait>(
 
     let chunked: Vec<Vec<output_symlink::ActiveModel>> = output_symlinks
         .into_iter()
-        .chunks((MAX_SQLX_PARAMS / 5).into())
+        .chunks((MAX_SQLX_PARAMS / 6).into())
         .into_iter()
         .map(|chunk| chunk.collect())
         .collect();

--- a/share/wake/lib/system/cas.wake
+++ b/share/wake/lib/system/cas.wake
@@ -25,7 +25,7 @@ export def primCasDir: String =
 
 # Returns the absolute CAS filesystem path for the blob with the given content hash.
 # Fails if the blob is not present in the local CAS store.
-export def primCasBlobPath (hash: String): Result String Error =
+export def primCasBlobPathStr (hash: String): Result String Error =
     def raw hash = prim "cas_blob_path"
 
     raw hash

--- a/share/wake/lib/system/cas.wake
+++ b/share/wake/lib/system/cas.wake
@@ -23,6 +23,14 @@ export def addCasHashEnv = match (getenv "WAKE_CAS")
 export def primCasDir: String =
     prim "cas_dir"
 
+# Returns the absolute CAS filesystem path for the blob with the given content hash.
+# Fails if the blob is not present in the local CAS store.
+export def primCasBlobPath (hash: String): Result String Error =
+    def raw hash = prim "cas_blob_path"
+
+    raw hash
+    | rmapError makeError
+
 # Materialize an item from CAS to workspace.
 def primCasMaterializeItem (destPath: String) (itemType: String) (hashOrTarget: String) (mode: Integer) (mtimeSec: Integer) (mtimeNsec: Integer): Result Unit Error =
     def raw destPath itemType hashOrTarget mode mtimeSec mtimeNsec = prim "cas_materialize_item"

--- a/share/wake/lib/system/cas.wake
+++ b/share/wake/lib/system/cas.wake
@@ -25,8 +25,8 @@ export def primCasDir: String =
 
 # Returns the absolute CAS filesystem path for the blob with the given content hash.
 # Fails if the blob is not present in the local CAS store.
-export def primCasBlobPathStr (hash: String): Result String Error =
-    def raw hash = prim "cas_blob_path"
+export def primCasBlobAbsPathStr (hash: String): Result String Error =
+    def raw hash = prim "cas_blob_abs_path"
 
     raw hash
     | rmapError makeError

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -366,7 +366,7 @@ export def rscApiPostFileBlob (name: String) (hash: String) (api: RemoteCacheApi
     require Pass _ = guardRemoteCacheDisabled Unit
 
     require Pass sourcePath =
-        primCasBlobPathStr hash
+        primCasBlobAbsPathStr hash
         | addErrorContext "rsc: blob {hash} expected in CAS but not found"
 
     def contentType = match (unsafe_stat sourcePath)

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -88,10 +88,12 @@ tuple CacheSearchOutputDirectory =
 
 # A symlink created by a cached job
 tuple CacheSearchOutputSymlink =
-    # The path on disk of the symlink
+    # The symlink target (what the symlink points to)
     Path: String
-    # The file being linked to
+    # The symlink disk path (where the symlink lives on disk)
     Link: String
+    # The hash of the target string for CAS addressing; "" for legacy entries
+    Hash: String
 
 # A match response from the server. Specifies all details of a cached job
 tuple CacheSearchResponseMatch =
@@ -147,10 +149,12 @@ tuple CachePostRequestOutputDirectory =
 
 # A symlink created by a job
 tuple CachePostRequestOutputSymlink =
-    # The path on disk of the symlink
+    # The symlink target (what the symlink points to)
     Path: String
-    # The file being linked to
+    # The symlink disk path (where the symlink lives on disk)
     Link: String
+    # The hash of the symlink target string for CAS addressing
+    Hash: String
 
 # A request to the remote server to cache a job
 tuple CachePostRequest =
@@ -351,27 +355,25 @@ export def rscApiPostStringBlob (name: String) (value: String) (api: RemoteCache
 
     uploadBlobRequest api setBlobFn
 
-# rscApiPostFileBlob: Posts a named file on disk to the remote server defined by *api*
-#                     then returns the id associated to the blob. Requires authorization.
+# rscApiPostFileBlob: Posts a named file to the remote server defined by *api*, sourcing bytes from the
+#                     CAS blob path. Returns the blob id. Requires authorization.
 #
 # ```
-#  api | rscApiPostFileBlob "foo" "/some/path/to/foo" = Pass "asdf-fdsa-asdf-fdsa"
-#  (RemoteCacheApi "foo" 1 None) | rscApiPostFileBlob "foo" "/some/path/to/foo" = Fail "authorization required"
+#  api | rscApiPostFileBlob "foo" "abc123..." = Pass "asdf-fdsa-asdf-fdsa"
+#  (RemoteCacheApi "foo" 1 None) | rscApiPostFileBlob "foo" "abc123..." = Fail "authorization required"
 # ```
-export def rscApiPostFileBlob (name: String) (file: String) (hash: String) (api: RemoteCacheApi): Result String Error =
+export def rscApiPostFileBlob (name: String) (hash: String) (api: RemoteCacheApi): Result String Error =
     require Pass _ = guardRemoteCacheDisabled Unit
 
-    # We must use unsafe here since we cannot elevate *file* to a Path without either copying it
-    # or triggering the 'job output by multiple files' error.
+    require Pass sourcePath =
+        primCasBlobPath hash
+        | addErrorContext "rsc: blob {hash} expected in CAS but not found"
 
-    # TODO: Obtain the size in a different way, reading from workspace is problematic in multi-wake.
-    def contentType = match (unsafe_stat file)
+    def contentType = match (unsafe_stat sourcePath)
         Pass (Stat _ _ size) -> contentTypeFromSize size
         Fail _ -> None
 
-    def setBlobFn = addFormDataWithHash name file contentType hash
-
-    uploadBlobRequest api setBlobFn
+    uploadBlobRequest api (addFormDataWithHash name sourcePath contentType hash)
 
 # rscApiPostJob: Posts a job defined by *req* to the remote cache server. Requires authorization.
 #
@@ -693,38 +695,20 @@ export def rscApiGetFileBlob ((CacheSearchBlob blobId uri contentHash): CacheSea
 
     require Pass _ = verifyBlobHash blobId actualHash contentHash
 
-    def fixupScript =
-        """
-        # 1. No failures are acceptable
-        set -e
-        # 2. Remove the old rsctmp file if it exists
-        rm -f '%{path}.rsctmp'
-        # 3. Hardlink the file to not use 2x disk space
-        cp -l %{blobPath.getPathName} '%{path}.rsctmp'
-        # 4. Set the permissions as specified
-        chmod %{mode | strOctal} '%{path}.rsctmp'
-        # 5. If the file was previously created with the exact inode by the rsc but not cleaned up
-        #    then it needs to be removed so we can complete the atomic mv
-        [ '%{path}.rsctmp' -ef '%{path}' ] && rm '%{path}'
-        # 6. Atomically move so interruptions don't effect the build.
-        mv '%{path}.rsctmp' '%{path}'
-        """
+    # Build a synthetic PreparedStagingItem from the staging path under ".build/wake-{pid}/...".
+    # That path will be ingested and reflink/copy'd into CAS.
+    def preparedItem =
+        PreparedStagingItem
+        (StagingFile (StagingFileOutput path blobPath.getPathName mode 0 0)) # use 0 for mtime; This will be set to the current time on materialization.
+        contentHash
 
-    def job =
-        makeShellPlan fixupScript (blobPath, Nil)
-        | setPlanLabel "rsc: fixup blob {path} from {blobPath.getPathName}"
-        | setPlanPersistence Once
-        # We need to copy the file over another jobs output space so:
-        #   - We must run with the localRunner
-        #   - We must lie and say we output nothing
-        #   - The *path* must be listed as another jobs output to be available to the system
-        | setPlanFnOutputs (\_ Nil)
-        | setPlanEcho logDebug
-        | runJobWith localRunner
-        | setJobInspectVisibilityHidden
+    require Pass _ =
+        ingestPreparedStagingItemIntoCas preparedItem
+        | addErrorContext "rsc: Failed to ingest blob {blobId} into CAS for {path}"
 
-    require True = job.isJobOk
-    else failWithError "Failed to cleanup downloaded file {path} from {blobPath.getPathName}"
+    require Pass _ =
+        materializePreparedStagingItemFromCas preparedItem
+        | addErrorContext "rsc: Failed to materialize blob {blobId} to {path}"
 
     Pass path
 
@@ -826,6 +810,8 @@ def getPathAsJson path =
     JObject (
         "path" :-> JString path.getPathName,
         "hash" :-> JString path.getPathHash,
+        "type" :-> JString (pathTypeToString path.getPathType),
+        "mode" :-> JInteger path.getPathMode,
     )
 
 # Helper function for further processing the result of a http request in relation to the rsc
@@ -986,10 +972,11 @@ def getCachePostRequestJson (req: CachePostRequest): JValue =
             "hidden" :-> JBoolean hidden,
         )
 
-    def mkOutputSymlinkJson (CachePostRequestOutputSymlink path link) =
+    def mkOutputSymlinkJson (CachePostRequestOutputSymlink path link hash) =
         JObject (
             "path" :-> JString path,
             "link" :-> JString link,
+            "hash" :-> JString hash,
         )
 
     JObject (
@@ -1084,7 +1071,12 @@ def mkCacheSearchResponse (json: JValue): Result CacheSearchResponse Error =
             failWithError
             "rsc: JSON response has incorrect schema. output_symlinks[x] must have string key 'link'"
 
-        CacheSearchOutputSymlink path link
+        require Pass (JString hash) = jField v "hash"
+        else
+            failWithError
+            "rsc: JSON response has incorrect schema. output_symlinks[x] must have string key 'hash'"
+
+        CacheSearchOutputSymlink path link hash
         | Pass
 
     def mkOutputDirectory (v: JValue): Result CacheSearchOutputDirectory Error =

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -366,7 +366,7 @@ export def rscApiPostFileBlob (name: String) (hash: String) (api: RemoteCacheApi
     require Pass _ = guardRemoteCacheDisabled Unit
 
     require Pass sourcePath =
-        primCasBlobPath hash
+        primCasBlobPathStr hash
         | addErrorContext "rsc: blob {hash} expected in CAS but not found"
 
     def contentType = match (unsafe_stat sourcePath)

--- a/share/wake/lib/system/remote_cache_api_test.wake
+++ b/share/wake/lib/system/remote_cache_api_test.wake
@@ -72,7 +72,7 @@ export def testDisablingCacheWithEndpoints (api: RemoteCacheApi): Result Unit Er
         Pass Unit
 
     def testFileBlobUpload Unit: Result Unit Error =
-        require Pass _ = rscApiPostFileBlob "test-blob" "/path/to/test/file" "test-hash" api
+        require Pass _ = rscApiPostFileBlob "test-blob" "test-hash" api
 
         Pass Unit
 

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -57,8 +57,8 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
         else output
 
         # Attach a post-finalization callback. After job.wake finalizes (CAS ingestion +
-        # workspace materialization), it invokes this to upload outputs from their permanent
-        # workspace locations. This is left as 'def _' so that wake won't block progess
+        # workspace materialization), it invokes this to upload outputs from their CAS
+        # blob paths. This is left as 'def _' so that wake won't block progess
         # on it but it will stil be joined on before wake exits.
         def postFinalize preparedItems =
             def _ = postJob rscApi job wakeroot hashKey input output preparedItems
@@ -96,101 +96,44 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
         def stdoutDownload = rscApiGetStringBlob stdoutBlob
         def stderrDownload = rscApiGetStringBlob stderrBlob
 
+        # Since RSC doesn't store mtimes, set the mtime as (0,0) so materialization
+        # can set the mtime at creation for files, symlinks, and directories.
+
         def doMakeDirectory (CacheSearchOutputDirectory path mode _hidden) =
-            # wake-format off
-            def cmd =
-                "mkdir",
-                "-m", mode.strOctal,
-                "-p", path,
+            def preparedItem =
+                PreparedStagingItem (StagingDirectory (StagingDirectoryOutput path mode 0 0)) ""
 
-            require True =
-                makeExecPlan cmd Nil
-                | setPlanLabel "rsc: mkdir output dir {path}"
-                | setPlanPersistence Once
-                | setPlanEcho logDebug
-                # As we are deliberately creating directories one step at at time to properly handle
-                # permissions on any ancestors, but can't have this job claiming ownership of the
-                # directory in case it's listed as one of the rehydrated job's outputs, the localRunner
-                # is required to be able to see those ancestor directories.
-                | runJobWith localRunner
-                | setJobInspectVisibilityHidden
-                | isJobOk
-            else failWithError "rsc: Failed to mkdir output dir: {path}"
+            materializePreparedStagingItemFromCas preparedItem
+            | addErrorContext "rsc: Failed to create directory {path}"
 
-            Pass Unit
-
-        # We need to create directories from shallowest to deepest, each directory along the
-        # chain may have a different permission set and by creating short dirs first we
-        # ensure they don't incorrectly inheret the permissions of a subdir. This required
-        # ordering significantly decreases parallism, however this is mitigated by the fact
-        # that most outputs are files, not dirs.
-        def dirLoop (dirs: List CacheSearchOutputDirectory) = match dirs
-            Nil -> Pass Nil
-            h, t ->
-                require Pass dir = doMakeDirectory h
-                require Pass rest = dirLoop t
-
-                Pass (dir, rest)
-
-        def lenOrder lhs rhs =
-            def lhsLen = lhs.getCacheSearchOutputDirectoryPath.strlen
-            def rhsLen = rhs.getCacheSearchOutputDirectoryPath.strlen
-
-            if lhsLen == rhsLen then
-                EQ
-            else if lhsLen < rhsLen then
-                LT
-            else
-                GT
-
-        def orderedDirs =
-            outputDirs
-            | sortBy lenOrder
-
-        # We don't actually care about the result here but we need to ensure that all
-        # directories are created before potentially downloading files into them.
-        require Pass _ = dirLoop orderedDirs
-        else failWithError "rsc: Failed to make output directory"
-
-        # The path is downloaded directly, as is, because it is relative to the workspace.
-        # Everything besides Command is stored in the server as workspace relative
+        # Files: download blob → ingest into CAS → materialize from CAS.
+        # rscApiGetFileBlob handles the CAS path end-to-end.
         def doDownload (CacheSearchOutputFile path mode blob) = rscApiGetFileBlob blob path mode
 
-        # Link must point to path. We do the reverse here of what is done for posting a job
-        def doMakeSymlink (CacheSearchOutputSymlink path link) =
-            require True =
-                makeExecPlan
-                (
-                    "ln",
-                    # create symbolic link
-                    "-s",
-                    # overwrite <link> on disk if a file already exists at that path.
-                    # Ideally, we could just fail but its very common to delete wake.db
-                    # without cleaning all the outputs. This causes problems since the link
-                    # would already exist on disk
-                    "-f",
-                    path,
-                    link,
-                )
-                Nil
-                | setPlanLabel "rsc: symlink {link} to {path}"
-                | setPlanPersistence Once
-                | setPlanEcho logDebug
-                # Since we don't have a Path to the directory containing the symlink, we need to
-                # use localRunner to have visibility into the full workspace.
-                | runJobWith localRunner
-                | setJobInspectVisibilityHidden
-                | isJobOk
-            else failWithError "rsc: Failed to link {link} to {path}"
+        # Symlinks: target is always inline. Ingest the target string into CAS under its
+        # hash, then materialize as a symlink. Reuses the same helpers used for local job
+        # outputs.
+        def doMakeSymlink (CacheSearchOutputSymlink symlinkTarget symlinkPath hash) =
+            def preparedItem =
+                PreparedStagingItem (StagingSymlink (StagingSymlinkOutput symlinkPath symlinkTarget 0 0)) hash
 
-            Pass Unit
+            require Pass _ =
+                ingestPreparedStagingItemIntoCas preparedItem
+                | addErrorContext "rsc: Failed to ingest symlink {symlinkPath} into CAS"
+
+            materializePreparedStagingItemFromCas preparedItem
+            | addErrorContext "rsc: Failed to materialize symlink {symlinkPath}"
 
         def outputFilesDownload =
             outputFiles
             | map doDownload
 
-        # Symlinks don't need to wait for files, the symlinks will just momentarily be invalid if created first
-        def outputSymlinksDownload =
+        def outputDirectoriesCreate =
+            outputDirs
+            | map doMakeDirectory
+
+        # Symlinks don't need to wait for files; momentarily dangling symlinks are fine.
+        def outputSymlinksCreate =
             outputSymlinks
             | map doMakeSymlink
 
@@ -222,7 +165,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
 
         def symlinkStagingItems =
             outputSymlinks
-            | map (\(CacheSearchOutputSymlink path link) StagingSymlink (StagingSymlinkOutput link path 0 0))
+            | map (\(CacheSearchOutputSymlink path link _) StagingSymlink (StagingSymlinkOutput link path 0 0))
 
         def publishedDirectoryStagingItems =
             publishedDirectories
@@ -257,7 +200,12 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
             | addErrorContext "rsc: Failed to download a blob"
 
         require Pass _ =
-            outputSymlinksDownload
+            outputDirectoriesCreate
+            | findFail
+            | addErrorContext "rsc: Failed to create an output directory"
+
+        require Pass _ =
+            outputSymlinksCreate
             | findFail
             | addErrorContext "rsc: Failed to create a symlink"
 
@@ -410,26 +358,23 @@ def postJob (rscApi: RemoteCacheApi) (job: Job) (_wakeroot: String) (hidden: Str
         require True = subset scmp filteredOutputPaths stagedOutputPaths
         else failWithError "rsc: Missing staging metadata for published outputs"
 
-        # Upload staged and prepared (hashed) files.  In the future this should upload files from their CAS blobs.
         def uploadPreparedFile ((PreparedStagingItem item hash): PreparedStagingItem): Option (Result CachePostRequestOutputFile Error) =
             match item
                 StagingFile (StagingFileOutput destPath _stagingPath mode _ _) ->
                     if isPublishedOutput destPath then
-                        # Post-finalization: staging file has been consumed. Upload from workspace dest path.
-                        # TODO: Upload using CAS blob contents directly, this is wrong for multi-wake!
                         rscApi
-                        | rscApiPostFileBlob destPath destPath hash
-                        | rmap (CachePostRequestOutputFile destPath mode)
+                        | rscApiPostFileBlob destPath hash
+                        | rmap (\blobId CachePostRequestOutputFile destPath mode blobId)
                         | Some
                     else
                         None
                 _ -> None
 
-        def uploadPreparedSymlink ((PreparedStagingItem item _hash): PreparedStagingItem): Option (Result CachePostRequestOutputSymlink Error) =
+        def uploadPreparedSymlink ((PreparedStagingItem item hash): PreparedStagingItem): Option (Result CachePostRequestOutputSymlink Error) =
             match item
                 StagingSymlink (StagingSymlinkOutput destPath symlinkTarget _ _) ->
                     if isPublishedOutput destPath then
-                        Some (Pass (CachePostRequestOutputSymlink symlinkTarget destPath))
+                        Some (Pass (CachePostRequestOutputSymlink symlinkTarget destPath hash))
                     else
                         None
                 _ -> None

--- a/src/cas/cas.cpp
+++ b/src/cas/cas.cpp
@@ -285,16 +285,20 @@ wcl::result<bool, CASError> Cas::materialize_blob(const ContentHash& hash,
     reflink_supported_ = false;
   }
 
-  // Apply timestamp to temp file before rename
-  struct timespec times[2];
-  times[0].tv_sec = 0;
-  times[0].tv_nsec = UTIME_OMIT;  // Don't change atime
-  times[1].tv_sec = mtime_sec;
-  times[1].tv_nsec = mtime_nsec;
+  // Apply timestamp to temp file before rename. (0, 0) is a sentinel meaning
+  // "leave the kernel-set mtime from the reflink/copy" — matches the convention
+  // in cas_prim.cpp::apply_mtime.
+  if (mtime_sec != 0 || mtime_nsec != 0) {
+    struct timespec times[2];
+    times[0].tv_sec = 0;
+    times[0].tv_nsec = UTIME_OMIT;  // Don't change atime
+    times[1].tv_sec = mtime_sec;
+    times[1].tv_nsec = mtime_nsec;
 
-  if (utimensat(AT_FDCWD, temp_path.c_str(), times, 0) != 0) {
-    fs::remove(temp_path, ec);
-    return wcl::make_error<bool, CASError>(CASError::IOError);
+    if (utimensat(AT_FDCWD, temp_path.c_str(), times, 0) != 0) {
+      fs::remove(temp_path, ec);
+      return wcl::make_error<bool, CASError>(CASError::IOError);
+    }
   }
 
   // Atomically rename over destination - last one wins

--- a/src/runtime/cas_prim.cpp
+++ b/src/runtime/cas_prim.cpp
@@ -524,12 +524,57 @@ static PRIMFN(prim_cas_ingest_staged_item) {
   RETURN(claim_result(runtime.heap, true, claim_unit(runtime.heap)));
 }
 
+// prim "cas_blob_path" hash -> Result String Error
+// Returns the absolute filesystem path to the CAS-managed blob for the given content hash.
+// Fails if the blob is not present in CAS. Result is a filesystem path that may be passed
+// directly to upload tools (e.g. RSC blob POST) without reading through the workspace.
+static PRIMTYPE(type_cas_blob_path) {
+  TypeVar result;
+  Data::typeResult.clone(result);
+  result[0].unify(Data::typeString);
+  result[1].unify(Data::typeString);
+  return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(result);
+}
+
+static PRIMFN(prim_cas_blob_path) {
+  CASContext* ctx = static_cast<CASContext*>(data);
+  EXPECT(1);
+  STRING(hash_str, 0);
+
+  cas::Cas* store = ctx->get_store();
+  if (!store) {
+    runtime.heap.reserve(reserve_result() + String::reserve(28));
+    auto err = String::claim(runtime.heap, "CAS store not initialized");
+    RETURN(claim_result(runtime.heap, false, err));
+  }
+
+  cas::ContentHash hash;
+  std::string parse_error;
+  if (!parse_hash_string(hash_str->c_str(), hash, parse_error)) {
+    runtime.heap.reserve(reserve_result() + String::reserve(parse_error.size()));
+    auto err = String::claim(runtime.heap, parse_error);
+    RETURN(claim_result(runtime.heap, false, err));
+  }
+
+  if (!store->has_blob(hash)) {
+    std::string msg = "Blob not in CAS: " + std::string(hash_str->c_str());
+    runtime.heap.reserve(reserve_result() + String::reserve(msg.size()));
+    auto err = String::claim(runtime.heap, msg);
+    RETURN(claim_result(runtime.heap, false, err));
+  }
+
+  std::string path = store->blob_path(hash);
+  runtime.heap.reserve(reserve_result() + String::reserve(path.size()));
+  RETURN(claim_result(runtime.heap, true, String::claim(runtime.heap, path)));
+}
+
 // ============================================================================
 // Primitive Registration
 // ============================================================================
 
 void prim_register_cas(CASContext* ctx, PrimMap& pmap) {
   prim_register(pmap, "cas_dir", prim_cas_dir, type_cas_dir, PRIM_PURE, ctx);
+  prim_register(pmap, "cas_blob_path", prim_cas_blob_path, type_cas_blob_path, PRIM_PURE, ctx);
   prim_register(pmap, "cas_materialize_item", prim_cas_materialize_item, type_cas_materialize_item,
                 PRIM_IMPURE, ctx);
   prim_register(pmap, "materialize_staged_workspace_item", prim_materialize_staged_workspace_item,

--- a/src/runtime/cas_prim.cpp
+++ b/src/runtime/cas_prim.cpp
@@ -574,8 +574,8 @@ static PRIMFN(prim_cas_blob_abs_path) {
 
 void prim_register_cas(CASContext* ctx, PrimMap& pmap) {
   prim_register(pmap, "cas_dir", prim_cas_dir, type_cas_dir, PRIM_PURE, ctx);
-  prim_register(pmap, "cas_blob_abs_path", prim_cas_blob_abs_path, type_cas_blob_abs_path, PRIM_PURE,
-                ctx);
+  prim_register(pmap, "cas_blob_abs_path", prim_cas_blob_abs_path, type_cas_blob_abs_path,
+                PRIM_PURE, ctx);
   prim_register(pmap, "cas_materialize_item", prim_cas_materialize_item, type_cas_materialize_item,
                 PRIM_IMPURE, ctx);
   prim_register(pmap, "materialize_staged_workspace_item", prim_materialize_staged_workspace_item,

--- a/src/runtime/cas_prim.cpp
+++ b/src/runtime/cas_prim.cpp
@@ -524,11 +524,11 @@ static PRIMFN(prim_cas_ingest_staged_item) {
   RETURN(claim_result(runtime.heap, true, claim_unit(runtime.heap)));
 }
 
-// prim "cas_blob_path" hash -> Result String Error
+// prim "cas_blob_abs_path" hash -> Result String Error
 // Returns the absolute filesystem path to the CAS-managed blob for the given content hash.
 // Fails if the blob is not present in CAS. Result is a filesystem path that may be passed
 // directly to upload tools (e.g. RSC blob POST) without reading through the workspace.
-static PRIMTYPE(type_cas_blob_path) {
+static PRIMTYPE(type_cas_blob_abs_path) {
   TypeVar result;
   Data::typeResult.clone(result);
   result[0].unify(Data::typeString);
@@ -536,7 +536,7 @@ static PRIMTYPE(type_cas_blob_path) {
   return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(result);
 }
 
-static PRIMFN(prim_cas_blob_path) {
+static PRIMFN(prim_cas_blob_abs_path) {
   CASContext* ctx = static_cast<CASContext*>(data);
   EXPECT(1);
   STRING(hash_str, 0);
@@ -574,7 +574,8 @@ static PRIMFN(prim_cas_blob_path) {
 
 void prim_register_cas(CASContext* ctx, PrimMap& pmap) {
   prim_register(pmap, "cas_dir", prim_cas_dir, type_cas_dir, PRIM_PURE, ctx);
-  prim_register(pmap, "cas_blob_path", prim_cas_blob_path, type_cas_blob_path, PRIM_PURE, ctx);
+  prim_register(pmap, "cas_blob_abs_path", prim_cas_blob_abs_path, type_cas_blob_abs_path, PRIM_PURE,
+                ctx);
   prim_register(pmap, "cas_materialize_item", prim_cas_materialize_item, type_cas_materialize_item,
                 PRIM_IMPURE, ctx);
   prim_register(pmap, "materialize_staged_workspace_item", prim_materialize_staged_workspace_item,


### PR DESCRIPTION
* Make RSC client upload from CAS
* Make RSC client download to staging, and ingest + materialize into/from CAS
* Fix filetype collision issue in RSC (add filetype and mode to job reuse key)
* Add hash to output symlink target string so RSC client doesn't need to recompute it