### PR TITLE
Specialize integers that fit in 63-bits

### DIFF
--- a/src/optimizer/cse.cpp
+++ b/src/optimizer/cse.cpp
@@ -23,6 +23,7 @@
 #include <unordered_map>
 
 #include "runtime/runtime.h"
+#include "runtime/value.h"
 #include "ssa.h"
 
 namespace std {
@@ -87,8 +88,11 @@ void RArg::pass_cse(PassCSE &p, std::unique_ptr<Term> self) { p.stream.transfer(
 
 void RLit::pass_cse(PassCSE &p, std::unique_ptr<Term> self) {
   HeapObject *obj = value->get();
-  Hash h = Hash(typeid(RLit).hash_code(), typeid(*obj).hash_code()) +
-           (*value)->deep_hash(p.runtime.heap);
+  // Tagged small-Integer pointers carry no object to dispatch on; tag both
+  // representations as Integer so the CSE bucket is consistent.
+  std::size_t type_code =
+      is_small_int(obj) ? typeid(Integer).hash_code() : typeid(*obj).hash_code();
+  Hash h = Hash(typeid(RLit).hash_code(), type_code) + (*value)->deep_hash(p.runtime.heap);
   cse_reduce(p, h, std::move(self));
 }
 

--- a/src/runtime/gc.cpp
+++ b/src/runtime/gc.cpp
@@ -236,7 +236,7 @@ void Heap::GC(size_t requested_pads) {
 
   // Move and compact all root objects over to the new space
   for (RootRing *root = roots.next; root != &roots; root = root->next) {
-    if (!root->root) continue;
+    if (!root->root || is_small_int(root->root)) continue;
     auto out = root->root->moveto(progress.free);
     progress.free = out.free;
     root->root = out.obj;

--- a/src/runtime/gc.h
+++ b/src/runtime/gc.h
@@ -28,6 +28,7 @@
 #ifdef DEBUG_GC
 #include <cassert>
 #endif
+#include "small_int.h"
 #include "util/hash.h"
 
 #if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
@@ -198,14 +199,14 @@ struct HeapPointerBase {
 };
 
 inline PadObject *HeapPointerBase::moveto(PadObject *free) {
-  if (!obj) return free;
+  if (!obj || is_small_int(obj)) return free;
   Placement out = obj->moveto(free);
   obj = out.obj;
   return out.free;
 }
 
 inline HeapStep HeapPointerBase::explore(HeapStep step) {
-  if (obj) *step.found++ = obj;
+  if (obj && !is_small_int(obj)) *step.found++ = obj;
   return step;
 }
 

--- a/src/runtime/prim.cpp
+++ b/src/runtime/prim.cpp
@@ -125,17 +125,21 @@ static HeapHash deep_hash_imp(Heap &heap, HeapObject *obj) {
   Hash code;
   for (HeapObject **done = scratch; done != step.found; ++done) {
     HeapObject *head = *done;
+
+    // Tagged small-Integer pointers carry their value in the bits and have
+    // no heap object to dispatch on. Hash directly; nothing to traverse.
+    uintptr_t key = reinterpret_cast<uintptr_t>(static_cast<void *>(head));
+    auto out = explored.insert(std::make_pair(key, done - scratch));
+    code = code + out.first->second;
+    if (!out.second) continue;
+
+    if (is_small_int(head)) {
+      code = code + small_int_shallow_hash(small_int_value(head));
+      continue;
+    }
+
     assert(head->category() == VALUE);
     Value *value = static_cast<Value *>(head);
-
-    // Assign objects virtual addreses based on visitation order
-    uintptr_t key = reinterpret_cast<uintptr_t>(static_cast<void *>(value));
-    auto out = explored.insert(std::make_pair(key, done - scratch));
-
-    // Include hash of child's virtual address
-    code = code + out.first->second;
-    // Only visit object once
-    if (!out.second) continue;
 
     // Hash this object and enqueue its children for hashing
     step = value->explore(step);

--- a/src/runtime/prim.h
+++ b/src/runtime/prim.h
@@ -92,12 +92,10 @@ void require_fail(const char *message, unsigned size, Runtime &runtime, const Sc
   Closure *arg = static_cast<Closure *>(args[i]);
 #define RECORD(arg, i) Record *arg = static_cast<Record *>(args[i]);
 
-#define INTEGER_MPZ(arg, i)                   \
-  do {                                        \
-    HeapObject *arg = args[i];                \
-    REQUIRE(typeid(*arg) == typeid(Integer)); \
-  } while (0);                                \
-  mpz_t arg = {static_cast<Integer *>(args[i])->wrap()};
+#define INTEGER_MPZ(arg, i)        \
+  REQUIRE(is_integer(args[i]));    \
+  IntegerView arg##_view(args[i]); \
+  mpz_t arg = {arg##_view.mpz};
 
 /* Useful expressions for primitives */
 Value *alloc_order(Heap &h, int x);

--- a/src/runtime/small_int.h
+++ b/src/runtime/small_int.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SMALL_INT_H
+#define SMALL_INT_H
+
+#include <gmp.h>
+#include <stdint.h>
+
+#include <cstddef>
+
+// Tagged-pointer encoding for "small Integer" values that fit in a single
+// machine word. Bit 0 of any pointer to a real heap object is zero (heap
+// objects are aligned to sizeof(PadObject) == 8); when bit 0 is set, the
+// pointer is not a real pointer but a 63-bit signed integer payload.
+struct HeapObject;
+
+constexpr uintptr_t SMALL_INT_TAG = 1;
+
+static_assert(sizeof(mp_limb_t) >= 8,
+              "small_int.h assumes mp_limb_t is at least 64 bits; "
+              "32-bit-limb GMP builds need the IntegerView two-limb path");
+
+inline bool is_small_int(const HeapObject *p) {
+  return (reinterpret_cast<uintptr_t>(p) & SMALL_INT_TAG) != 0;
+}
+
+inline int64_t small_int_value(const HeapObject *p) {
+  return static_cast<int64_t>(reinterpret_cast<intptr_t>(p)) >> 1;
+}
+
+inline HeapObject *make_small_int(int64_t v) {
+  return reinterpret_cast<HeapObject *>((static_cast<uintptr_t>(v) << 1) | SMALL_INT_TAG);
+}
+
+inline bool fits_small_int(int64_t v) {
+  return v >= -(int64_t{1} << 62) && v < (int64_t{1} << 62);
+}
+
+// Returns true and writes the value to *out when the MPZ fits the small-int
+// range; otherwise leaves *out untouched.
+inline bool fits_small_mpz(const __mpz_struct &m, int64_t *out) {
+  int s = m._mp_size;
+  if (s == 0) {
+    *out = 0;
+    return true;
+  }
+  if (s == 1) {
+    mp_limb_t l = m._mp_d[0];
+    if (l < (uint64_t{1} << 62)) {
+      *out = static_cast<int64_t>(l);
+      return true;
+    }
+  } else if (s == -1) {
+    mp_limb_t l = m._mp_d[0];
+    // The most-negative representable value is -(2^62), corresponding to
+    // limb == 2^62. Both INT64_MIN and overflow are excluded.
+    if (l <= (uint64_t{1} << 62)) {
+      *out = -static_cast<int64_t>(l);
+      return true;
+    }
+  }
+  return false;
+}
+
+#endif

--- a/src/runtime/tuple.h
+++ b/src/runtime/tuple.h
@@ -27,7 +27,11 @@ struct Constructor;
 struct alignas(PadObject) Promise {
   Category category() const {
     HeapObject *obj = value.get();
-    return obj ? obj->category() : WORK;
+    if (!obj) return WORK;
+    // Tagged small-Integer pointers carry no object to dispatch on; they
+    // are always Values.
+    if (is_small_int(obj)) return VALUE;
+    return obj->category();
   }
 
   explicit operator bool() const { return category() == VALUE; }

--- a/src/runtime/value.cpp
+++ b/src/runtime/value.cpp
@@ -53,7 +53,11 @@ void HeapObject::format(std::ostream &os, const HeapObject *value, bool detailed
     state.current = state.stack.back();
     state.stack.pop_back();
     if (state.current.value) {
-      state.current.value->format(os, state);
+      if (is_small_int(state.current.value)) {
+        os << small_int_value(state.current.value);
+      } else {
+        state.current.value->format(os, state);
+      }
     } else {
       os << term_colour(TERM_RED) << "<future>" << term_normal();
     }
@@ -202,6 +206,9 @@ Integer::Integer(const Integer &i) : length(i.length) {
 }
 
 Integer *Integer::claim(Heap &h, const MPZ &mpz) {
+  int64_t small;
+  if (fits_small_mpz(mpz.value[0], &small))
+    return static_cast<Integer *>(make_small_int(small));
   Integer *out = new (h.claim(reserve(mpz))) Integer(mpz.value[0]._mp_size);
   HeapAgeTracker::setAge(out, 0);
   memcpy(out->data(), mpz.value[0]._mp_d, sizeof(mp_limb_t) * abs(out->length));
@@ -209,6 +216,9 @@ Integer *Integer::claim(Heap &h, const MPZ &mpz) {
 }
 
 Integer *Integer::alloc(Heap &h, const MPZ &mpz) {
+  int64_t small;
+  if (fits_small_mpz(mpz.value[0], &small))
+    return static_cast<Integer *>(make_small_int(small));
   Integer *out = new (h.alloc(reserve(mpz))) Integer(mpz.value[0]._mp_size);
   HeapAgeTracker::setAge(out, 0);
   memcpy(out->data(), mpz.value[0]._mp_d, sizeof(mp_limb_t) * abs(out->length));
@@ -233,6 +243,18 @@ void Integer::format(std::ostream &os, FormatState &state) const { os << str(); 
 
 Hash Integer::shallow_hash() const {
   return Hash(data(), abs(length) * sizeof(mp_limb_t)) ^ TYPE_INTEGER;
+}
+
+// Hash of a tagged small-Integer value, defined to match the heap-form hash
+// of the same numeric value (single-limb absolute value, or empty for zero,
+// XOR TYPE_INTEGER). Allocation canonicalization makes coexistence of the
+// two representations impossible, but the equivalence is the contract.
+Hash small_int_shallow_hash(int64_t v) {
+  mp_limb_t limb = 0;
+  if (v == 0) return Hash(&limb, 0) ^ TYPE_INTEGER;
+  limb = (v > 0) ? static_cast<mp_limb_t>(v)
+                 : static_cast<mp_limb_t>(-static_cast<uint64_t>(v));
+  return Hash(&limb, sizeof(limb)) ^ TYPE_INTEGER;
 }
 
 RootPointer<Double> Double::literal(Heap &h, const char *str) {

--- a/src/runtime/value.h
+++ b/src/runtime/value.h
@@ -140,6 +140,10 @@ struct String final : public GCObject<String, Value> {
   explicit String(size_t length_);
 };
 
+// Hash of a tagged small-Integer value, defined to match the heap-form hash
+// of the equivalent numeric value.
+Hash small_int_shallow_hash(int64_t v);
+
 // An exception-safe wrapper for mpz_t
 struct MPZ {
   mpz_t value;
@@ -168,6 +172,8 @@ struct Integer final : public GCObject<Integer, Value> {
            (abs(length) * sizeof(mp_limb_t) + sizeof(PadObject) - 1) / sizeof(PadObject);
   }
   static size_t reserve(const MPZ &mpz) {
+    int64_t small;
+    if (fits_small_mpz(mpz.value[0], &small)) return 0;
     return sizeof(Integer) / sizeof(PadObject) +
            (abs(mpz.value[0]._mp_size) * sizeof(mp_limb_t) + sizeof(PadObject) - 1) /
                sizeof(PadObject);
@@ -188,6 +194,37 @@ struct Integer final : public GCObject<Integer, Value> {
   // Never call this during runtime! It can invalidate the heap.
   static RootPointer<Integer> literal(Heap &h, const std::string &str);
 };
+
+// Materialize an mpz_t from either a tagged small-Integer pointer or a heap
+// Integer. The IntegerView owns its own one-limb backing storage; do not let
+// it outlive the mpz_t derived from it.
+struct IntegerView {
+  mp_limb_t limb;
+  __mpz_struct mpz;
+  explicit IntegerView(const HeapObject *p) {
+    if (is_small_int(p)) {
+      int64_t v = small_int_value(p);
+      mpz._mp_d = &limb;
+      mpz._mp_alloc = 1;
+      if (v == 0) {
+        mpz._mp_size = 0;
+        limb = 0;
+      } else if (v > 0) {
+        mpz._mp_size = 1;
+        limb = static_cast<mp_limb_t>(v);
+      } else {
+        mpz._mp_size = -1;
+        limb = static_cast<mp_limb_t>(-static_cast<uint64_t>(v));
+      }
+    } else {
+      mpz = static_cast<const Integer *>(p)->wrap();
+    }
+  }
+};
+
+inline bool is_integer(const HeapObject *p) {
+  return is_small_int(p) || typeid(*p) == typeid(Integer);
+}
 
 #define FIXED 0
 #define SCIENTIFIC 1

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -1069,8 +1069,10 @@ int main(int argc, char **argv) {
     HeapObject *v = runtime.output.get();
     if (!v) {
       pass = false;
-    } else if (Record *r = dynamic_cast<Record *>(v)) {
-      if (r->cons->ast.name == "Fail") pass = false;
+    } else if (!is_small_int(v)) {
+      if (Record *r = dynamic_cast<Record *>(v)) {
+        if (r->cons->ast.name == "Fail") pass = false;
+      }
     }
     std::ostream &os = pass ? (std::cout) : (std::cerr);
     if (clo.verbose) {


### PR DESCRIPTION
This saves heap allocating GMP basically always.

AI-assisted-by: Claude Code (Claude Opus 4.7, Claude Haiku 4.5)

This is totally vibecoded, so feel free to reject 🙂 

It also probably needs some benchmarking.