### PR TITLE
Remove artifacts created in the course of testing

### DIFF
--- a/tests/pending/negative-input/pass.sh
+++ b/tests/pending/negative-input/pass.sh
@@ -16,3 +16,8 @@ echo "bar" > bar
 # 3. Run job testing for bar with bar visible
 echo "=== Run 2: bar exists ==="
 "${WAKE}" --no-tty -x 'test_bar Unit'
+
+# Clean up
+err=$?
+rm -f bar
+exit $err

--- a/tests/pending/permission-change/pass.sh
+++ b/tests/pending/permission-change/pass.sh
@@ -25,3 +25,8 @@ touch script
 # Step 3: Run wake again
 echo "=== Run 2: executable ==="
 "${WAKE}" --no-tty -x 'test Unit'
+
+# Clean up
+err=$?
+rm -f script
+exit $err

--- a/tests/pending/symlink-type-confusion/pass.sh
+++ b/tests/pending/symlink-type-confusion/pass.sh
@@ -22,3 +22,8 @@ printf 'target' > input
 # Step 3: Run wake again
 echo "=== Run 2: file ==="
 "${WAKE}" --no-tty -x 'test Unit'
+
+# Clean up
+err=$?
+rm -f input
+exit $err

--- a/tests/runtime/mtime-observe/pass.sh
+++ b/tests/runtime/mtime-observe/pass.sh
@@ -11,3 +11,8 @@ export WAKE_CAS=1
 rm -rf .build .fuse wake.db* wake.log output.txt
 
 "${WAKE}" -x "go Unit"
+
+# Clean up
+err=$?
+rm -f output.txt
+exit $err

--- a/tests/runtime/mtime-preservation/pass.sh
+++ b/tests/runtime/mtime-preservation/pass.sh
@@ -27,3 +27,8 @@ echo "Reuse:"
 
 # (output.txt can have either value)
 tail result-a.txt result-b.txt
+
+# Clean up
+err=$?
+rm -f output.txt result-a.txt result-b.txt
+exit $err

--- a/tests/runtime/mtime-reopen/pass.sh
+++ b/tests/runtime/mtime-reopen/pass.sh
@@ -26,5 +26,11 @@ actual=$(date -Isec -ur output.txt)
 expected="2000-01-01T00:00:00+00:00"
 if [ "$actual" != "$expected" ]; then
     echo "FAIL: workspace output.txt mtime is '$actual', expected '$expected'" >&2
+    rm -f output.txt
     exit 1
 fi
+
+# Clean up
+err=$?
+rm -f output.txt
+exit $err

--- a/tests/runtime/overlap-detection/fail.sh
+++ b/tests/runtime/overlap-detection/fail.sh
@@ -6,3 +6,8 @@ WAKE="${WAKE:-wake}"
 
 rm -f overlap.txt wake.db wake.log
 "${WAKE}" -v test
+
+# Clean up
+err=$?
+rm -f .wake-build-lock overlap.txt
+exit $err


### PR DESCRIPTION
A number of our tests create files to test visibility, collisions, etc.  These have been sticking around after the test is complete and cluttering `git status`.  This PR adds cleanup `rm`s at the end of the relevant tests so that the workspace is left in the same state it started.

Two notes on the implementation:

* None of these files should be critical for debugging errors, if we do wind up regressing one or more of these tests.  (If they were, the better solution would be adding them to `.gitignore` -- as we do for the `wake.db` and similar which *are* kept around.)
* We still want to keep the removals of these same files at the beginning of the scripts, in case one of them gets interrupted halfway through and needs cleanup before the next run.