### PR TITLE
Implement a sqrt heap growth curve

### DIFF
--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -215,6 +215,8 @@ POLICY_STATIC_DEFINES(SharedCacheMissOnFailure)
 POLICY_STATIC_DEFINES(LogHeaderAlignPolicy)
 POLICY_STATIC_DEFINES(BulkLoggingDirPolicy)
 POLICY_STATIC_DEFINES(InterpreterRuntimeWarningPolicy)
+POLICY_STATIC_DEFINES(HeapFactorPolicy)
+POLICY_STATIC_DEFINES(HeapPivotPolicy)
 
 /********************************************************************
  * Non-Trivial Defaults
@@ -279,6 +281,18 @@ void InterpreterRuntimeWarningPolicy::set(InterpreterRuntimeWarningPolicy& p, co
   auto json_value = json.expect_integer();
   if (json_value) {
     p.interpreter_runtime_warning_s = *json_value;
+  }
+}
+
+void HeapFactorPolicy::set(HeapFactorPolicy& p, const JAST& json) {
+  if (json.kind == JSON_DOUBLE || json.kind == JSON_INTEGER) {
+    p.heap_factor = std::stod(json.value);
+  }
+}
+
+void HeapPivotPolicy::set(HeapPivotPolicy& p, const JAST& json) {
+  if (json.kind == JSON_DOUBLE || json.kind == JSON_INTEGER) {
+    p.heap_pivot_mb = std::stod(json.value);
   }
 }
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -261,6 +261,9 @@ struct InterpreterRuntimeWarningPolicy {
   }
 };
 
+// Controls how aggressively the GC grows the heap after each collection cycle.
+// Floor limit: must be > 1.0 — values at or below 1.0 leave no post-collection
+// headroom and cause GC to loop.
 struct HeapFactorPolicy {
   using type = double;
   using input_type = type;
@@ -279,6 +282,10 @@ struct HeapFactorPolicy {
   static void set_env_var(HeapFactorPolicy& p, const char*) {}
 };
 
+// Sets the live-data size (in MB) at which the GC heap growth switches from linear
+// to sqrt scaling. Also controls the growth rate of the sqrt formula — a larger
+// pivot means larger sqrt growth.
+// Floor limit: must be > 1MB
 struct HeapPivotPolicy {
   using type = double;
   using input_type = type;

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -53,6 +53,10 @@ struct WakeConfigOverrides {
 
   // Lets you specify an alternative user config
   std::optional<std::string> user_config;
+
+  // GC heap tuning
+  std::optional<double> heap_factor;
+  std::optional<double> heap_pivot_mb;
 };
 
 template <class T>
@@ -257,6 +261,42 @@ struct InterpreterRuntimeWarningPolicy {
   }
 };
 
+struct HeapFactorPolicy {
+  using type = double;
+  using input_type = type;
+  static constexpr const char* key = "heap_factor";
+  static constexpr bool allowed_in_wakeroot = true;
+  static constexpr bool allowed_in_userconfig = false;
+  type heap_factor = 4.0;
+  static constexpr type HeapFactorPolicy::*value = &HeapFactorPolicy::heap_factor;
+  static constexpr Override<input_type> override_value = &WakeConfigOverrides::heap_factor;
+  static constexpr const char* env_var = nullptr;
+
+  HeapFactorPolicy() = default;
+  static void set(HeapFactorPolicy& p, const JAST& json);
+  static void set_input(HeapFactorPolicy& p, const input_type& v) { p.*value = v; }
+  static void emit(const HeapFactorPolicy& p, std::ostream& os) { os << p.*value; }
+  static void set_env_var(HeapFactorPolicy& p, const char*) {}
+};
+
+struct HeapPivotPolicy {
+  using type = double;
+  using input_type = type;
+  static constexpr const char* key = "heap_pivot_mb";
+  static constexpr bool allowed_in_wakeroot = true;
+  static constexpr bool allowed_in_userconfig = false;
+  type heap_pivot_mb = 64.0;
+  static constexpr type HeapPivotPolicy::*value = &HeapPivotPolicy::heap_pivot_mb;
+  static constexpr Override<input_type> override_value = &WakeConfigOverrides::heap_pivot_mb;
+  static constexpr const char* env_var = nullptr;
+
+  HeapPivotPolicy() = default;
+  static void set(HeapPivotPolicy& p, const JAST& json);
+  static void set_input(HeapPivotPolicy& p, const input_type& v) { p.*value = v; }
+  static void emit(const HeapPivotPolicy& p, std::ostream& os) { os << p.*value; }
+  static void set_env_var(HeapPivotPolicy& p, const char*) {}
+};
+
 /********************************************************************
  * Generic WakeConfig implementation
  *********************************************************************/
@@ -402,7 +442,8 @@ struct WakeConfigImpl : public Policies... {
 using WakeConfigImplFull =
     WakeConfigImpl<UserConfigPolicy, VersionPolicy, LogHeaderPolicy, LogHeaderSourceWidthPolicy,
                    LabelFilterPolicy, SharedCacheMissOnFailure, LogHeaderAlignPolicy,
-                   BulkLoggingDirPolicy, InterpreterRuntimeWarningPolicy>;
+                   BulkLoggingDirPolicy, InterpreterRuntimeWarningPolicy, HeapFactorPolicy,
+                   HeapPivotPolicy>;
 
 struct WakeConfig final : public WakeConfigImplFull {
   static bool init(const std::string& wakeroot_path, const WakeConfigOverrides& overrides);

--- a/src/runtime/gc.cpp
+++ b/src/runtime/gc.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <fstream>
 #include <iomanip>
 #include <map>
@@ -121,6 +122,7 @@ void Space::resize(size_t size_) {
 struct Heap::Imp {
   int profile_heap;
   double heap_factor;
+  size_t heap_pivot_pads;
   Space spaces[2];
   int space;
   size_t last_pads;
@@ -133,9 +135,10 @@ struct Heap::Imp {
   size_t gc_count;
   size_t total_gc_time;
 
-  Imp(int profile_heap_, double heap_factor_)
+  Imp(int profile_heap_, double heap_factor_, size_t heap_pivot_pads_)
       : profile_heap(profile_heap_),
         heap_factor(heap_factor_),
+        heap_pivot_pads(heap_pivot_pads_),
         spaces(),
         space(0),
         last_pads(0),
@@ -146,10 +149,23 @@ struct Heap::Imp {
         finalize(nullptr),
         gc_count(0),
         total_gc_time(0) {}
+
+  size_t desired_size(size_t live_pads, size_t requested_pads) const {
+    size_t linear = static_cast<size_t>(heap_factor * live_pads);
+    size_t sqrt_desired =
+        live_pads +
+        static_cast<size_t>(heap_factor * std::sqrt(static_cast<double>(live_pads) *
+                                                    static_cast<double>(heap_pivot_pads)));
+    return std::min(linear, sqrt_desired) + requested_pads;
+  }
 };
 
-Heap::Heap(int profile_heap_, double heap_factor_)
-    : imp(new Imp(profile_heap_, heap_factor_)),
+static size_t mb_to_pads(double mb) {
+  return static_cast<size_t>(mb * 1024.0 * 1024.0 / sizeof(PadObject));
+}
+
+Heap::Heap(int profile_heap_, double heap_factor_, double heap_pivot_mb_)
+    : imp(new Imp(profile_heap_, heap_factor_, mb_to_pads(heap_pivot_mb_))),
       roots(),
       free(imp->spaces[imp->space].array),
       end(free + imp->spaces[imp->space].size) {}
@@ -222,7 +238,7 @@ void Heap::GC(size_t requested_pads) {
 
   Space &from = imp->spaces[imp->space];
   size_t no_gc_overrun = (free - from.array) + requested_pads;
-  size_t estimate_desired_size = imp->heap_factor * imp->last_pads + requested_pads;
+  size_t estimate_desired_size = imp->desired_size(imp->last_pads, requested_pads);
   size_t elems = std::max(no_gc_overrun, estimate_desired_size);
 
   // Resize the to space based on the above "calculation"
@@ -294,7 +310,7 @@ void Heap::GC(size_t requested_pads) {
   free = progress.free;              // The place to append new things on the heap
   imp->last_pads = free - to.array;  // how many bytes were copied to the to space
   // Contain heap growth due to no_gc_overrun pessimism
-  size_t desired_sized = imp->heap_factor * imp->last_pads + requested_pads;
+  size_t desired_sized = imp->desired_size(imp->last_pads, requested_pads);
   if (desired_sized < elems) {
     end =
         to.array + desired_sized;  // Update the end to be smaller if we don't need that much space

--- a/src/runtime/gc.h
+++ b/src/runtime/gc.h
@@ -277,7 +277,7 @@ struct GCNeededException {
 };
 
 struct Heap {
-  Heap(int profile_heap_, double heap_factor_);
+  Heap(int profile_heap_, double heap_factor_, double heap_pivot_mb_);
   ~Heap();
 
   // Call this from main loop (no pointers on stack) when GCNeededException

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -48,10 +48,10 @@ void Work::format(std::ostream &os, FormatState &state) const { os << "Work"; }
 
 Category Work::category() const { return WORK; }
 
-Runtime::Runtime(Profile *profile_, int profile_heap, double heap_factor)
+Runtime::Runtime(Profile *profile_, int profile_heap, double heap_factor, double heap_pivot_mb)
     : abort(false),
       profile(profile_),
-      heap(profile_heap, heap_factor),
+      heap(profile_heap, heap_factor, heap_pivot_mb),
       stack(heap.root<Work>(nullptr)),
       output(heap.root<HeapObject>(nullptr)),
       sources(heap.root<HeapObject>(nullptr)) {

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -51,7 +51,7 @@ struct Runtime {
   RootPointer<HeapObject> output;
   RootPointer<Record> sources;  // Vector String
 
-  Runtime(Profile *profile_, int profile_heap, double heap_factor);
+  Runtime(Profile *profile_, int profile_heap, double heap_factor, double heap_pivot_mb);
   ~Runtime();
   void run();
 

--- a/tests/config/default-json/stdout
+++ b/tests/config/default-json/stdout
@@ -8,3 +8,5 @@ Wake config:
   log_header_align = 'false' (Default)
   bulk_logging_dir = '' (Default)
   interpreter_runtime_warning_s = '0' (Default)
+  heap_factor = '4' (Default)
+  heap_pivot_mb = '64' (Default)

--- a/tests/config/empty-json/stdout
+++ b/tests/config/empty-json/stdout
@@ -5,3 +5,5 @@ Wake config:
   log_header_align = 'false' (Default)
   bulk_logging_dir = '' (Default)
   interpreter_runtime_warning_s = '0' (Default)
+  heap_factor = '4' (Default)
+  heap_pivot_mb = '64' (Default)

--- a/tests/config/empty/stdout
+++ b/tests/config/empty/stdout
@@ -5,3 +5,5 @@ Wake config:
   log_header_align = 'false' (Default)
   bulk_logging_dir = '' (Default)
   interpreter_runtime_warning_s = '0' (Default)
+  heap_factor = '4' (Default)
+  heap_pivot_mb = '64' (Default)

--- a/tests/config/extra_keys/stdout
+++ b/tests/config/extra_keys/stdout
@@ -8,3 +8,5 @@ Wake config:
   log_header_align = 'false' (Default)
   bulk_logging_dir = '' (Default)
   interpreter_runtime_warning_s = '0' (Default)
+  heap_factor = '4' (Default)
+  heap_pivot_mb = '64' (Default)

--- a/tests/config/missing_user_config/stdout
+++ b/tests/config/missing_user_config/stdout
@@ -8,3 +8,5 @@ Wake config:
   log_header_align = 'false' (Default)
   bulk_logging_dir = '' (Default)
   interpreter_runtime_warning_s = '0' (Default)
+  heap_factor = '4' (Default)
+  heap_pivot_mb = '64' (Default)

--- a/tests/config/nominal/stdout
+++ b/tests/config/nominal/stdout
@@ -8,3 +8,5 @@ Wake config:
   log_header_align = 'true' (WakeRoot)
   bulk_logging_dir = '/tmp/wake_bulk_logs' (UserConfig)
   interpreter_runtime_warning_s = '10' (WakeRoot)
+  heap_factor = '4' (Default)
+  heap_pivot_mb = '64' (Default)

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -72,6 +72,7 @@ struct CommandLineOptions {
   const char *jobs_str;
   const char *memory_str;
   const char *heapf;
+  const char *heappivot;
   const char *profile;
   const char *init;
   const char *chdir;
@@ -124,6 +125,7 @@ struct CommandLineOptions {
       {0, "batch", GOPT_ARGUMENT_FORBIDDEN},
       {0, "fatal-warnings", GOPT_ARGUMENT_FORBIDDEN},
       {0, "heap-factor", GOPT_ARGUMENT_REQUIRED | GOPT_ARGUMENT_NO_HYPHEN},
+      {0, "heap-pivot", GOPT_ARGUMENT_REQUIRED | GOPT_ARGUMENT_NO_HYPHEN},
       {0, "profile-heap", GOPT_ARGUMENT_FORBIDDEN | GOPT_REPEATABLE},
       {0, "profile", GOPT_ARGUMENT_REQUIRED},
       {'C', "chdir", GOPT_ARGUMENT_REQUIRED},
@@ -229,6 +231,7 @@ struct CommandLineOptions {
     jobs_str = arg(options, "jobs")->argument;
     memory_str = arg(options, "memory")->argument;
     heapf = arg(options, "heap-factor")->argument;
+    heappivot = arg(options, "heap-pivot")->argument;
     profile = arg(options, "profile")->argument;
     init = arg(options, "init")->argument;
     chdir = arg(options, "chdir")->argument;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -445,27 +445,6 @@ int main(int argc, char **argv) {
     }
   }
 
-  double heap_factor = 4.0;
-  if (clo.heapf) {
-    char *tail;
-    heap_factor = strtod(clo.heapf, &tail);
-    if (*tail || heap_factor < 1.1) {
-      std::cerr << "Cannot run with " << clo.heapf << " heap-factor (must be >= 1.1)!" << std::endl;
-      return 1;
-    }
-  }
-
-  double heap_pivot_mb = 64.0;
-  if (clo.heappivot) {
-    char *tail;
-    heap_pivot_mb = strtod(clo.heappivot, &tail);
-    if (*tail || heap_pivot_mb < 1.0) {
-      std::cerr << "Cannot run with " << clo.heappivot << " heap-pivot (must be >= 1.0 MB)!"
-                << std::endl;
-      return 1;
-    }
-  }
-
   // Change directory to the location of the invoked script
   // and execute the specified target function
   if (clo.shebang) {
@@ -557,6 +536,27 @@ int main(int argc, char **argv) {
   config_override.log_header_align = clo.log_header_align;
   config_override.cache_miss_on_failure = clo.cache_miss_on_failure;
 
+  if (clo.heapf) {
+    char *tail;
+    double v = strtod(clo.heapf, &tail);
+    if (*tail || v < 1.1) {
+      std::cerr << "Cannot run with " << clo.heapf << " heap-factor (must be >= 1.1)!" << std::endl;
+      return 1;
+    }
+    config_override.heap_factor = v;
+  }
+
+  if (clo.heappivot) {
+    char *tail;
+    double v = strtod(clo.heappivot, &tail);
+    if (*tail || v < 1.0) {
+      std::cerr << "Cannot run with " << clo.heappivot << " heap-pivot (must be >= 1.0 MB)!"
+                << std::endl;
+      return 1;
+    }
+    config_override.heap_pivot_mb = v;
+  }
+
   if (!WakeConfig::init(".wakeroot", config_override)) {
     return 1;
   }
@@ -565,6 +565,9 @@ int main(int argc, char **argv) {
     std::cout << *WakeConfig::get();
     return 0;
   }
+
+  double heap_factor = WakeConfig::get()->heap_factor;
+  double heap_pivot_mb = WakeConfig::get()->heap_pivot_mb;
 
   // Bulk logging
   std::string bulk_dir = WakeConfig::get()->bulk_logging_dir;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -266,7 +266,8 @@ void print_help(const char *argv0) {
     << "    --no-wait          Do not wait to obtain database lock; fail immediately"      << std::endl
     << "    --no-workspace     Do not open a database or scan for sources files"           << std::endl
     << "    --fatal-warnings   Do not execute if there are any warnings"                   << std::endl
-    << "    --heap-factor X    Heap-size is X * live data after the last GC (default 4.0)" << std::endl
+    << "    --heap-factor X    GC headroom scale factor: desired = live + X*sqrt(live*pivot) (default 4.0)" << std::endl
+    << "    --heap-pivot  X    Pivot point in MB where GC growth curve transitions (default 64)" << std::endl
     << "    --profile-heap     Report memory consumption on every garbage collection"      << std::endl
     << "    --profile     FILE Report runtime breakdown by stack trace to HTML/JSON file"  << std::endl
     << "    --chdir    -C PATH Locate database and default package starting from PATH"     << std::endl
@@ -450,6 +451,17 @@ int main(int argc, char **argv) {
     heap_factor = strtod(clo.heapf, &tail);
     if (*tail || heap_factor < 1.1) {
       std::cerr << "Cannot run with " << clo.heapf << " heap-factor (must be >= 1.1)!" << std::endl;
+      return 1;
+    }
+  }
+
+  double heap_pivot_mb = 64.0;
+  if (clo.heappivot) {
+    char *tail;
+    heap_pivot_mb = strtod(clo.heappivot, &tail);
+    if (*tail || heap_pivot_mb < 1.0) {
+      std::cerr << "Cannot run with " << clo.heappivot << " heap-pivot (must be >= 1.0 MB)!"
+                << std::endl;
       return 1;
     }
   }
@@ -734,7 +746,7 @@ int main(int argc, char **argv) {
   }
 
   Profile tree;
-  Runtime runtime(clo.profile ? &tree : nullptr, clo.profileh, heap_factor);
+  Runtime runtime(clo.profile ? &tree : nullptr, clo.profileh, heap_factor, heap_pivot_mb);
   bool sources = false;
   {
     auto start = std::chrono::steady_clock::now();

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -266,7 +266,7 @@ void print_help(const char *argv0) {
     << "    --no-wait          Do not wait to obtain database lock; fail immediately"      << std::endl
     << "    --no-workspace     Do not open a database or scan for sources files"           << std::endl
     << "    --fatal-warnings   Do not execute if there are any warnings"                   << std::endl
-    << "    --heap-factor X    GC headroom scale factor: desired = live + X*sqrt(live*pivot) (default 4.0)" << std::endl
+    << "    --heap-factor X    GC headroom scale factor (default 4.0)"                     << std::endl
     << "    --heap-pivot  X    Pivot point in MB where GC growth curve transitions (default 64)" << std::endl
     << "    --profile-heap     Report memory consumption on every garbage collection"      << std::endl
     << "    --profile     FILE Report runtime breakdown by stack trace to HTML/JSON file"  << std::endl


### PR DESCRIPTION
Wake Heap allocation is based on a simple geomtric growth curve: 
`max (Heap_factor * last_live_heap, current_heap_size)` 

This is a Stop-and-copy GC with 2 semi-spaces, we pay double the cost for the heap. We also have a blind 1.5x multiplier when we actually `malloc/realloc` to help avoid having to pay extra malloc costs. 

This does not scale well or reflect most use cases once it approaches GB heap size. Kilobytes are free, megabytes are cheap, gigabytes of memory gets expensive or unattainable. 

This PR updates the growth algorithm to include a Pivot point (`heap_pivot`) where the growth goes from an aggressive linear growth to a sqrt growth. 
`last_live_heap + heap_factor* sqrt(last_live_heap * heap_pivot))`

`Heap-factor` is still used to impact the growth rate, but it's impact is tied to the sqrt growth. This doesn't address anything about always keeping 2x heap around or switch our GC approach. I decided not to touch the 1.5x overhead malloc in this PR or anything about the heap downsizing (1/3) but I believe it should also follow some growth curve. 

Performance impacts:
There's a lot of variables in play I tried to consider (fast/slow growth, long/short heap objects, how often GC gets triggered, etc.), but don't have any strong mathematical backing or data to share. 

In any real testing example I have, I did not see anything of concern with GC being invoked too aggressively. This mostly helped ensure large heaps don't hit OOM issues unnecessarily. 


Here are a couple graphs showing the growth curve before and after change.
<img width="2400" height="1050" alt="image" src="https://github.com/user-attachments/assets/c93ada04-41c7-4dc3-aed1-08b43f1b78b8" />

<img width="2400" height="1050" alt="image" src="https://github.com/user-attachments/assets/cde694ce-d35c-4a6a-bf5f-6b7f2ec38db8" />


Here's some literature i referenced when creating this:
https://dl.acm.org/doi/epdf/10.1145/3563323
