### PR TITLE
wakebox prim

### DIFF
--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -366,20 +366,17 @@ export def defaultRunner: Runner =
 
             fuseRunner
 
-export data MountOpType =
-    MountBind
-    MountCreateDir
-    MountCreateFile
-    MountSquashfs
-    MountTmpfs
-    MountWorkspace
-
-# A mount operation for the wakebox spec.
-export tuple WakeboxMountOp =
-    export Type: MountOpType
-    export Source: String
-    export Dest: String
-    export ReadOnly: Boolean
+# Mount operations for the wakebox spec.
+# These constructors match validate_mount() and do_mounts() in wakebox.
+# See: src/wakefs/namespace.cpp
+# wake-format off
+export data WakeboxMountOp =
+    WakeboxBindOp          (source: String) (dest: String) (readonly: Boolean)
+    WakeboxSquashfsOp      (source: String) (dest: String)
+    WakeboxTmpfsOp                          (dest: String)
+    WakeboxCreateDirOp                      (dest: String)
+    WakeboxCreateFileOp                     (dest: String)
+    WakeboxFuseWorkspaceOp                  (dest: String)
 
 # Fields consumed by the wakebox/fuse sandbox when reading the spec JSON.
 export tuple WakeboxSpec =
@@ -454,7 +451,7 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
             primCasDir
             False
             False
-            (WakeboxMountOp MountWorkspace "" "." False, Nil)
+            (WakeboxFuseWorkspaceOp ".", Nil)
             ""
             ""
             None

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -366,6 +366,40 @@ export def defaultRunner: Runner =
 
             fuseRunner
 
+# A mount operation for the wakebox spec.
+export tuple WakeboxMountOp =
+    export Type: String
+    export Source: String
+    export Dest: String
+    export ReadOnly: Boolean
+
+# Fields consumed by the wakebox/fuse sandbox when reading the spec JSON.
+export tuple WakeboxSpec =
+    export Command: List String
+    export Environment: List String
+    export Visible: List Path
+    export Directory: String
+    export Stdin: String
+    export CasDir: String
+    export IsolateNetwork: Boolean
+    export IsolatePids: Boolean
+    export MountOps: List WakeboxMountOp
+    export Hostname: String
+    export Domainname: String
+    export UserId: Option Integer
+    export GroupId: Option Integer
+    export CommandTimeout: Option Integer
+    export Runner: String
+
+# Write a WakeboxSpec to a JSON file at the given path.
+# indent: spaces per level (0 = compact).
+# The prim correctly awaits any unresolved field promises before writing.
+export def writeWakeboxSpec (spec: WakeboxSpec) (indent: Integer) (filePath: String): Result Unit Error =
+    def f spec ind path = prim "write_wakebox_spec"
+
+    f spec indent filePath
+    | rmapError makeError
+
 # A plan describing how to construct a JSONRunner
 # RawScript: the path to the script to run jobs with
 # ExtraArgs: extra arguments to pass to ``RawScript``
@@ -388,7 +422,7 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
     def script = which (simplify rawScript)
     def executeOk = access script xOK
 
-    def run (job: Job) ((RunnerInput label command visible environment directory stdin res prefix record isatty fnInputs fnOutputs): RunnerInput): RunnerOutput =
+    def run (job: Job) ((RunnerInput label command visible environment directory stdin _ prefix record isatty fnInputs fnOutputs): RunnerInput): RunnerOutput =
         require True = executeOk
         else
             def runnerError = "Runner {script} is not executable".makeError
@@ -396,76 +430,31 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
 
             RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some runnerError)
 
-        def Usage jobStatus runtime cputime membytes inbytes outbytes = record
-
-        def mkVisibleJson (p: Path): Result JValue Error =
-            require True = match p.getPathType
-                PathTypeRegularFile -> True
-                PathTypeDirectory -> True
-                PathTypeSymlink -> True
-                _ -> False
-            else
-                failWithError "Visible path {p.getPathName} has unsupported transport type {pathTypeToString p.getPathType}"
-
-            Pass (
-                JObject (
-                    "path" :-> JString p.getPathName,
-                    "type" :-> JString (pathTypeToString p.getPathType),
-                    "hash" :-> JString p.getPathHash,
-                    "mode" :-> JInteger p.getPathMode,
-                    "mtime" :-> JInteger p.getPathMtimeNs,
-                    Nil
-                )
-            )
-
-        def visibleJsonResult =
-            visible
-            | map mkVisibleJson
-            | findFail
-
-        require Pass visibleJson = visibleJsonResult
-        else
-            def runnerError =
-                visibleJsonResult
-                | getWhenPass "Failed to encode visible inputs with cached modes".makeError
-
-            def _ = markJobSetupFailure job runnerError
-
-            RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some runnerError)
-
-        def json =
-            JObject (
-                "label" :-> JString label,
-                "command" :-> command | map JString | JArray,
-                "environment" :-> environment | map JString | JArray,
-                "visible" :-> JArray visibleJson,
-                "directory" :-> JString directory,
-                "stdin" :-> JString stdin,
-                "resources" :-> res | map JString | JArray,
-                "version" :-> JString version,
-                "isolate-network" :-> JBoolean False,
-                "isolate-pids" :-> JBoolean False,
-                "mount-ops" :-> JArray (JObject ("type" :-> JString "workspace", "destination" :-> JString ".", Nil), Nil),
-                "cas-dir" :-> JString primCasDir,
-                "usage" :-> JObject (
-                    "status" :-> JInteger jobStatus,
-                    "runtime" :-> JDouble runtime,
-                    "cputime" :-> JDouble cputime,
-                    "membytes" :-> JInteger membytes,
-                    "inbytes" :-> JInteger inbytes,
-                    "outbytes" :-> JInteger outbytes,
-                    Nil
-                ),
-                Nil
-            )
-
         def buildDirName = ".build"
         def specFile = "{buildDirName}/spec-{prefix}.json"
         def resultFile = "{buildDirName}/result-{prefix}.json"
 
+        def spec =
+            WakeboxSpec
+            command
+            environment
+            visible
+            directory
+            stdin
+            primCasDir
+            False
+            False
+            (WakeboxMountOp "workspace" "" "." False, Nil)
+            ""
+            ""
+            None
+            None
+            None
+            script
+
         def writeResult =
-            write specFile (prettyJSON json)
-            | addErrorContext "Failed to 'write {specFile}: '"
+            writeWakeboxSpec spec 2 specFile
+            | addErrorContext "Failed to write {specFile}: "
             | rmapFail (markJobSetupFailure job)
 
         require Pass _ = writeResult

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -367,8 +367,6 @@ export def defaultRunner: Runner =
             fuseRunner
 
 # Mount operations for the wakebox spec.
-# These constructors match validate_mount() and do_mounts() in wakebox.
-# See: src/wakefs/namespace.cpp
 # wake-format off
 export data WakeboxMountOp =
     WakeboxBindOp          (source: String) (dest: String) (readonly: Boolean)

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -383,6 +383,7 @@ export tuple WakeboxMountOp =
 
 # Fields consumed by the wakebox/fuse sandbox when reading the spec JSON.
 export tuple WakeboxSpec =
+    export Label: String
     export Command: List String
     export Environment: List String
     export Visible: List Path
@@ -444,6 +445,7 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
 
         def spec =
             WakeboxSpec
+            label
             command
             environment
             visible

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -380,7 +380,7 @@ export data WakeboxMountOp =
 
 # Fields consumed by the wakebox/fuse sandbox when reading the spec JSON.
 export tuple WakeboxSpec =
-    export Label: String
+    export Label: Option String
     export Command: List String
     export Environment: List String
     export Visible: List Path
@@ -390,12 +390,12 @@ export tuple WakeboxSpec =
     export IsolateNetwork: Boolean
     export IsolatePids: Boolean
     export MountOps: List WakeboxMountOp
-    export Hostname: String
-    export Domainname: String
+    export Hostname: Option String
+    export DomainName: Option String
     export UserId: Option Integer
     export GroupId: Option Integer
     export CommandTimeout: Option Integer
-    export Runner: String
+    export Runner: Option String
 
 # Write a WakeboxSpec to a JSON file at the given path.
 # indent: spaces per level (0 = compact).
@@ -442,7 +442,7 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
 
         def spec =
             WakeboxSpec
-            label
+            (Some label)
             command
             environment
             visible
@@ -452,12 +452,12 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
             False
             False
             (WakeboxFuseWorkspaceOp ".", Nil)
-            ""
-            ""
             None
             None
             None
-            script
+            None
+            None
+            (Some script)
 
         def writeResult =
             writeWakeboxSpec spec 2 specFile

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -366,9 +366,17 @@ export def defaultRunner: Runner =
 
             fuseRunner
 
+export data MountOpType =
+    MountBind
+    MountCreateDir
+    MountCreateFile
+    MountSquashfs
+    MountTmpfs
+    MountWorkspace
+
 # A mount operation for the wakebox spec.
 export tuple WakeboxMountOp =
-    export Type: String
+    export Type: MountOpType
     export Source: String
     export Dest: String
     export ReadOnly: Boolean
@@ -444,7 +452,7 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
             primCasDir
             False
             False
-            (WakeboxMountOp "workspace" "" "." False, Nil)
+            (WakeboxMountOp MountWorkspace "" "." False, Nil)
             ""
             ""
             None

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -367,6 +367,7 @@ export def defaultRunner: Runner =
             fuseRunner
 
 # Mount operations for the wakebox spec.
+# Dev note: any changes here must be reflected in wakebox_prim.cpp.
 # wake-format off
 export data WakeboxMountOp =
     WakeboxBindOp          (source: String) (dest: String) (readonly: Boolean)
@@ -377,6 +378,7 @@ export data WakeboxMountOp =
     WakeboxFuseWorkspaceOp                  (dest: String)
 
 # Fields consumed by the wakebox/fuse sandbox when reading the spec JSON.
+# Dev note: any changes here must be reflected in wakebox_prim.cpp.
 export tuple WakeboxSpec =
     export Label: Option String
     export Command: List String

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -383,19 +383,20 @@ export tuple WakeboxSpec =
     export Label: Option String
     export Command: List String
     export Environment: List String
-    export Visible: List Path
-    export Directory: String
     export Stdin: String
-    export CasDir: String
+    export Directory: String
+    export CommandTimeout: Option Integer
     export IsolateNetwork: Boolean
     export IsolatePids: Boolean
-    export MountOps: List WakeboxMountOp
     export Hostname: Option String
     export DomainName: Option String
     export UserId: Option Integer
     export GroupId: Option Integer
-    export CommandTimeout: Option Integer
+    export Version: Option String
     export Runner: Option String
+    export CasDir: String
+    export MountOps: List WakeboxMountOp
+    export Visible: List Path
 
 # Write a WakeboxSpec to a JSON file at the given path.
 # indent: spaces per level (0 = compact).
@@ -445,19 +446,20 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
             (Some label)
             command
             environment
-            visible
-            directory
             stdin
-            primCasDir
+            directory
+            None
             False
             False
-            (WakeboxFuseWorkspaceOp ".", Nil)
             None
             None
             None
             None
-            None
+            (Some version)
             (Some script)
+            primCasDir
+            (WakeboxFuseWorkspaceOp ".", Nil)
+            visible
 
         def writeResult =
             writeWakeboxSpec spec 2 specFile

--- a/src/runtime/prim.cpp
+++ b/src/runtime/prim.cpp
@@ -37,6 +37,7 @@
 #include "types/sums.h"
 #include "util/location.h"
 #include "value.h"
+#include "wakebox_prim.h"
 
 void require_fail(const char *message, unsigned size, Runtime &runtime, const Scope *scope) {
   std::stringstream ss;
@@ -208,6 +209,7 @@ PrimMap prim_register_all(StringInfo *info, JobTable *jobtable, CASContext *cas_
   prim_register_sources(pmap);
   prim_register_time(pmap);
   prim_register_stage(pmap);
+  prim_register_wakebox(pmap);
 
   if (cas_ctx) {
     prim_register_cas(cas_ctx, pmap);

--- a/src/runtime/prim.h
+++ b/src/runtime/prim.h
@@ -148,6 +148,7 @@ void prim_register_json(PrimMap &pmap);
 void prim_register_job(JobTable *jobtable, PrimMap &pmap);
 void prim_register_sources(PrimMap &pmap);
 void prim_register_time(PrimMap &pmap);
+void prim_register_wakebox(PrimMap &pmap);
 
 PrimMap prim_register_all(StringInfo *info, JobTable *jobtable, CASContext *cas_ctx);
 

--- a/src/runtime/record_helpers.h
+++ b/src/runtime/record_helpers.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RECORD_HELPERS_H
+#define RECORD_HELPERS_H
+
+#include <string>
+#include <vector>
+
+#include "types/sums.h"
+#include "value.h"
+
+// ---------------------------------------------------------------------------
+// rh — Record field helpers with Promise-retry semantics.
+//
+// Each function reads one field from a Wake Record, returning nullptr on
+// success (with the output written) or the first unfulfilled Promise so the
+// caller can suspend and retry when that Promise is fulfilled.
+//
+// Typical usage inside a collect_* function:
+//
+//   Promise *broken;
+//   #define TRY(expr) do { broken = (expr); if (broken) return broken; } while(0)
+//   TRY(rh::string(rec, 0, data.label));
+//   TRY(rh::integer(rec, 1, data.count));
+//   #undef TRY
+// ---------------------------------------------------------------------------
+
+namespace rh {
+
+inline Promise *string(Record *rec, int idx, std::string &out) {
+  Promise *p = rec->at(idx);
+  if (!*p) return p;
+  out = p->coerce<String>()->as_str();
+  return nullptr;
+}
+
+inline Promise *boolean(Record *rec, int idx, bool &out) {
+  Promise *p = rec->at(idx);
+  if (!*p) return p;
+  // Boolean: True = members[0], False = members[1]
+  out = (p->coerce<Record>()->cons == &Boolean->members[0]);
+  return nullptr;
+}
+
+inline Promise *integer(Record *rec, int idx, long &out) {
+  Promise *p = rec->at(idx);
+  if (!*p) return p;
+  mpz_t v = {p->coerce<Integer>()->wrap()};
+  out = mpz_get_si(v);
+  return nullptr;
+}
+
+// Option Integer: sets has_val=true and out if Some, has_val=false if None.
+inline Promise *opt_integer(Record *rec, int idx, bool &has_val, long &out) {
+  Promise *p = rec->at(idx);
+  if (!*p) return p;
+  Record *opt = p->coerce<Record>();
+  // Option: Some a = index 0 (one inner field), None = index 1
+  if (opt->cons->index == 0) {
+    Promise *inner = opt->at(0);
+    if (!*inner) return inner;
+    mpz_t v = {inner->coerce<Integer>()->wrap()};
+    out = mpz_get_si(v);
+    has_val = true;
+  } else {
+    has_val = false;
+  }
+  return nullptr;
+}
+
+inline Promise *string_list(Record *rec, int idx, std::vector<std::string> &out) {
+  Promise *p = rec->at(idx);
+  if (!*p) return p;
+  Record *list = p->coerce<Record>();
+  while (list->cons == &List->members[1]) {  // Cons
+    Promise *head = list->at(0);
+    if (!*head) return head;
+    out.push_back(head->coerce<String>()->as_str());
+    Promise *tail = list->at(1);
+    if (!*tail) return tail;
+    list = tail->coerce<Record>();
+  }
+  return nullptr;
+}
+
+}  // namespace rh
+
+#endif

--- a/src/runtime/record_helpers.h
+++ b/src/runtime/record_helpers.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include "types/datatype.h"
 #include "types/sums.h"
 #include "value.h"
 

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -88,88 +88,99 @@ namespace {
 // unfulfilled one. No data is extracted; this drives the retry loop in
 // WriteWakeboxJson::execute so it suspends on exactly the right Promise.
 // ---------------------------------------------------------------------------
+
+enum FieldKind {
+  FK_SCALAR,     // String / Boolean / Integer — check the top-level Promise only
+  FK_OPTION,     // Option T — check outer Promise; if Some, check the inner Promise
+  FK_LIST_STR,   // List String — walk nodes, check head and tail Promises
+  FK_LIST_PATH,  // List Path — walk nodes, check head + all 5 Path field Promises
+  FK_LIST_MOUNT, // List WakeboxMountOp — walk nodes, check head + variable field count
+};
+
 static Promise *check_spec_ready(Record *spec) {
-  Promise *p;
+  static const FieldKind kFields[] = {
+    FK_OPTION,     // Label            : Option String
+    FK_LIST_STR,   // Command          : List String
+    FK_LIST_STR,   // Environment      : List String
+    FK_LIST_PATH,  // Visible          : List Path
+    FK_SCALAR,     // Directory        : String
+    FK_SCALAR,     // Stdin            : String
+    FK_SCALAR,     // CasDir           : String
+    FK_SCALAR,     // IsolateNetwork   : Boolean
+    FK_SCALAR,     // IsolatePids      : Boolean
+    FK_LIST_MOUNT, // MountOps         : List WakeboxMountOp
+    FK_OPTION,     // Hostname         : Option String
+    FK_OPTION,     // DomainName       : Option String
+    FK_OPTION,     // UserId           : Option Integer
+    FK_OPTION,     // GroupId          : Option Integer
+    FK_OPTION,     // CommandTimeout   : Option Integer
+    FK_OPTION,     // Runner           : Option String
+  };
 
-  // Field 0: Label (Option String)
-  p = spec->at(0);
-  if (!*p) return p;
-  {
-    Record *opt = p->coerce<Record>();
-    if (opt->cons->index == 0) {
-      Promise *inner = opt->at(0);
-      if (!*inner) return inner;
-    }
-  }
-
-  // Fields 1-2: Command, Environment (List String)
-  for (int f = 1; f <= 2; ++f) {
-    p = spec->at(f);
+  for (int i = 0; i < (int)(sizeof(kFields) / sizeof(*kFields)); ++i) {
+    Promise *p = spec->at(i);
     if (!*p) return p;
-    Record *list = p->coerce<Record>();
-    while (list->cons == &List->members[1]) {
-      Promise *head = list->at(0);
-      if (!*head) return head;
-      Promise *tail = list->at(1);
-      if (!*tail) return tail;
-      list = tail->coerce<Record>();
-    }
-  }
 
-  // Field 3: Visible (List Path) — Path has 5 fields
-  p = spec->at(3);
-  if (!*p) return p;
-  {
-    Record *list = p->coerce<Record>();
-    while (list->cons == &List->members[1]) {
-      Promise *head = list->at(0);
-      if (!*head) return head;
-      Record *path = head->coerce<Record>();
-      for (int i = 0; i < 5; ++i) {
-        Promise *f = path->at(i);
-        if (!*f) return f;
+    switch (kFields[i]) {
+      case FK_SCALAR:
+        break;
+
+      case FK_OPTION: {
+        Record *opt = p->coerce<Record>();
+        if (opt->cons->index == 0) {
+          Promise *inner = opt->at(0);
+          if (!*inner) return inner;
+        }
+        break;
       }
-      Promise *tail = list->at(1);
-      if (!*tail) return tail;
-      list = tail->coerce<Record>();
-    }
-  }
 
-  // Fields 4-8: Directory, Stdin, CasDir, IsolateNetwork, IsolatePids
-  for (int f = 4; f <= 8; ++f) {
-    p = spec->at(f);
-    if (!*p) return p;
-  }
-
-  // Field 9: MountOps (List WakeboxMountOp)
-  // WakeboxBindOp=3 fields, WakeboxSquashfsOp=2, all others=1
-  p = spec->at(9);
-  if (!*p) return p;
-  {
-    Record *list = p->coerce<Record>();
-    while (list->cons == &List->members[1]) {
-      Promise *head = list->at(0);
-      if (!*head) return head;
-      Record *entry = head->coerce<Record>();
-      int nf = (entry->cons->index == 0) ? 3 : (entry->cons->index == 1) ? 2 : 1;
-      for (int i = 0; i < nf; ++i) {
-        Promise *f = entry->at(i);
-        if (!*f) return f;
+      case FK_LIST_STR: {
+        Record *list = p->coerce<Record>();
+        while (list->cons == &List->members[1]) {
+          Promise *head = list->at(0);
+          if (!*head) return head;
+          Promise *tail = list->at(1);
+          if (!*tail) return tail;
+          list = tail->coerce<Record>();
+        }
+        break;
       }
-      Promise *tail = list->at(1);
-      if (!*tail) return tail;
-      list = tail->coerce<Record>();
-    }
-  }
 
-  // Fields 10-15: all Option — Hostname, DomainName, UserId, GroupId, CommandTimeout, Runner
-  for (int f = 10; f <= 15; ++f) {
-    p = spec->at(f);
-    if (!*p) return p;
-    Record *opt = p->coerce<Record>();
-    if (opt->cons->index == 0) {  // Some — check the inner value
-      Promise *inner = opt->at(0);
-      if (!*inner) return inner;
+      case FK_LIST_PATH: {
+        Record *list = p->coerce<Record>();
+        while (list->cons == &List->members[1]) {
+          Promise *head = list->at(0);
+          if (!*head) return head;
+          Record *path = head->coerce<Record>();
+          for (int j = 0; j < 5; ++j) {
+            Promise *f = path->at(j);
+            if (!*f) return f;
+          }
+          Promise *tail = list->at(1);
+          if (!*tail) return tail;
+          list = tail->coerce<Record>();
+        }
+        break;
+      }
+
+      case FK_LIST_MOUNT: {
+        // WakeboxBindOp=3 fields, WakeboxSquashfsOp=2, all others=1
+        Record *list = p->coerce<Record>();
+        while (list->cons == &List->members[1]) {
+          Promise *head = list->at(0);
+          if (!*head) return head;
+          Record *entry = head->coerce<Record>();
+          int nf = (entry->cons->index == 0) ? 3 : (entry->cons->index == 1) ? 2 : 1;
+          for (int j = 0; j < nf; ++j) {
+            Promise *f = entry->at(j);
+            if (!*f) return f;
+          }
+          Promise *tail = list->at(1);
+          if (!*tail) return tail;
+          list = tail->coerce<Record>();
+        }
+        break;
+      }
     }
   }
 

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -30,6 +30,7 @@
 
 #include "json/json5.h"
 #include "prim.h"
+#include "record_helpers.h"
 #include "tuple.h"
 #include "types/data.h"
 #include "types/datatype.h"
@@ -125,34 +126,6 @@ struct SpecData {
   long command_timeout = 0;
 };
 
-// ---------------------------------------------------------------------------
-// Field-extraction helpers — each returns nullptr on success or the first
-// unfulfilled Promise it encounters.
-// ---------------------------------------------------------------------------
-
-static Promise *get_string(Record *rec, int idx, std::string &out) {
-  Promise *p = rec->at(idx);
-  if (!*p) return p;
-  out = p->coerce<String>()->as_str();
-  return nullptr;
-}
-
-static Promise *get_bool(Record *rec, int idx, bool &out) {
-  Promise *p = rec->at(idx);
-  if (!*p) return p;
-  // Boolean: True = members[0], False = members[1]
-  out = (p->coerce<Record>()->cons == &Boolean->members[0]);
-  return nullptr;
-}
-
-static Promise *get_long(Record *rec, int idx, long &out) {
-  Promise *p = rec->at(idx);
-  if (!*p) return p;
-  mpz_t v = {p->coerce<Integer>()->wrap()};
-  out = mpz_get_si(v);
-  return nullptr;
-}
-
 // Map a PathType ADT record to its wakebox JSON string.
 // Returns nullptr and sets `out` on success.
 // Returns nullptr and sets `error` for unsupported types.
@@ -178,39 +151,6 @@ static Promise *get_path_type_string(Record *path_rec, std::string &out, std::st
   return nullptr;
 }
 
-// Extract an Option Integer field. Sets has_val=true and out to the integer if Some,
-// has_val=false if None. Returns the unfulfilled Promise on suspension.
-static Promise *get_optional_long(Record *rec, int idx, bool &has_val, long &out) {
-  Promise *p = rec->at(idx);
-  if (!*p) return p;
-  Record *opt = p->coerce<Record>();
-  // Option: Some a (index 0, one inner field) | None (index 1, no fields)
-  if (opt->cons->index == 0) {  // Some
-    Promise *inner = opt->at(0);
-    if (!*inner) return inner;
-    mpz_t v = {inner->coerce<Integer>()->wrap()};
-    out = mpz_get_si(v);
-    has_val = true;
-  } else {
-    has_val = false;
-  }
-  return nullptr;
-}
-
-static Promise *get_string_list(Record *spec, int idx, std::vector<std::string> &out) {
-  Promise *p = spec->at(idx);
-  if (!*p) return p;
-  Record *list = p->coerce<Record>();
-  while (list->cons == &List->members[1]) {  // Cons
-    Promise *head = list->at(0);
-    if (!*head) return head;
-    out.push_back(head->coerce<String>()->as_str());
-    Promise *tail = list->at(1);
-    if (!*tail) return tail;
-    list = tail->coerce<Record>();
-  }
-  return nullptr;
-}
 
 // Try to collect all values from the WakeboxSpec record into plain C++ data.
 // Returns nullptr if everything is fulfilled, or the first unfulfilled Promise.
@@ -225,8 +165,8 @@ static Promise *collect_spec(Record *spec, SpecData &data) {
     if (broken) return broken; \
   } while (0)
 
-  TRY(get_string_list(spec, 0, data.command));
-  TRY(get_string_list(spec, 1, data.environment));
+  TRY(rh::string_list(spec, 0, data.command));
+  TRY(rh::string_list(spec, 1, data.environment));
 
   // Field 2: Visible — List Path
   // Path layout: [0]=Name:String, [1]=Type:PathType, [2]=Hash:String,
@@ -241,15 +181,15 @@ static Promise *collect_spec(Record *spec, SpecData &data) {
       Record *path = head->coerce<Record>();
 
       VisEntry ve;
-      TRY(get_string(path, 0, ve.path));
+      TRY(rh::string(path, 0, ve.path));
       {
         Promise *broken = get_path_type_string(path, ve.type, data.error);
         if (broken) return broken;
         if (!data.error.empty()) return nullptr;
       }
-      TRY(get_string(path, 2, ve.hash));
-      TRY(get_long(path, 3, ve.mode));
-      TRY(get_long(path, 4, ve.mtime));
+      TRY(rh::string(path, 2, ve.hash));
+      TRY(rh::integer(path, 3, ve.mode));
+      TRY(rh::integer(path, 4, ve.mtime));
       data.visible.push_back(std::move(ve));
 
       Promise *tail = list->at(1);
@@ -258,11 +198,11 @@ static Promise *collect_spec(Record *spec, SpecData &data) {
     }
   }
 
-  TRY(get_string(spec, 3, data.directory));
-  TRY(get_string(spec, 4, data.stdin_str));
-  TRY(get_string(spec, 5, data.cas_dir));
-  TRY(get_bool(spec, 6, data.isolate_network));
-  TRY(get_bool(spec, 7, data.isolate_pids));
+  TRY(rh::string(spec, 3, data.directory));
+  TRY(rh::string(spec, 4, data.stdin_str));
+  TRY(rh::string(spec, 5, data.cas_dir));
+  TRY(rh::boolean(spec, 6, data.isolate_network));
+  TRY(rh::boolean(spec, 7, data.isolate_pids));
 
   // Field 8: MountOps — List WakeboxMountOp
   {
@@ -275,10 +215,10 @@ static Promise *collect_spec(Record *spec, SpecData &data) {
       Record *entry = head->coerce<Record>();
 
       MountEntry me;
-      TRY(get_string(entry, 0, me.type));
-      TRY(get_string(entry, 1, me.source));
-      TRY(get_string(entry, 2, me.dest));
-      TRY(get_bool(entry, 3, me.read_only));
+      TRY(rh::string(entry, 0, me.type));
+      TRY(rh::string(entry, 1, me.source));
+      TRY(rh::string(entry, 2, me.dest));
+      TRY(rh::boolean(entry, 3, me.read_only));
       data.mounts.push_back(std::move(me));
 
       Promise *tail = list->at(1);
@@ -287,12 +227,12 @@ static Promise *collect_spec(Record *spec, SpecData &data) {
     }
   }
 
-  TRY(get_string(spec, 9, data.hostname));
-  TRY(get_string(spec, 10, data.domainname));
-  TRY(get_optional_long(spec, 11, data.has_user_id, data.user_id));
-  TRY(get_optional_long(spec, 12, data.has_group_id, data.group_id));
-  TRY(get_optional_long(spec, 13, data.has_command_timeout, data.command_timeout));
-  TRY(get_string(spec, 14, data.runner));
+  TRY(rh::string(spec, 9, data.hostname));
+  TRY(rh::string(spec, 10, data.domainname));
+  TRY(rh::opt_integer(spec, 11, data.has_user_id, data.user_id));
+  TRY(rh::opt_integer(spec, 12, data.has_group_id, data.group_id));
+  TRY(rh::opt_integer(spec, 13, data.has_command_timeout, data.command_timeout));
+  TRY(rh::string(spec, 14, data.runner));
 
 #undef TRY
 

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -486,8 +486,7 @@ static PRIMFN(prim_write_wakebox_spec) {
   INTEGER_MPZ(indent_mpz, 1);
   STRING(filepath, 2);
 
-  int indent = mpz_fits_sint_p(indent_mpz) ? mpz_get_si(indent_mpz) : 0;
-  if (indent < 0) indent = 0;
+  int indent = (mpz_fits_sint_p(indent_mpz) && mpz_get_si(indent_mpz) > 0) ? mpz_get_si(indent_mpz) : 0;
 
   // Reserve space for WriteWakeboxJson + the fulfiller continuation.
   runtime.heap.reserve(WriteWakeboxJson::reserve() + Tuple::fulfiller_pads);

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -91,43 +91,54 @@ namespace {
 // ---------------------------------------------------------------------------
 
 enum FieldKind {
-  FK_SCALAR,      // String / Boolean / Integer — check the top-level Promise only
-  FK_OPTION,      // Option T — check outer Promise; if Some, check the inner Promise
-  FK_LIST_STR,    // List String — walk nodes, check head and tail Promises
-  FK_LIST_PATH,   // List Path — walk nodes, check head + all 5 Path field Promises
-  FK_LIST_MOUNT,  // List WakeboxMountOp — walk nodes, check head + variable field count
+  FK_STRING,          // String
+  FK_BOOL,            // Boolean
+  FK_OPTION_STRING,   // Option String  — check outer Promise; if Some, check inner
+  FK_OPTION_INTEGER,  // Option Integer — check outer Promise; if Some, check inner
+  FK_LIST_STRING,     // List String    — walk nodes, check head and tail Promises
+  FK_LIST_PATH,       // List Path      — walk nodes, check head + all 5 Path field Promises
+  FK_LIST_MOUNT,      // List WakeboxMountOp — walk nodes, check head + variable field count
+};
+
+struct FieldSpec {
+  const char *name;
+  FieldKind kind;
 };
 
 static Promise *check_spec_ready(Record *spec) {
-  static const FieldKind kFields[] = {
-      FK_OPTION,      // [0]  Label            : Option String
-      FK_LIST_STR,    // [1]  Command          : List String
-      FK_LIST_STR,    // [2]  Environment      : List String
-      FK_SCALAR,      // [3]  Stdin            : String
-      FK_SCALAR,      // [4]  Directory        : String
-      FK_OPTION,      // [5]  CommandTimeout   : Option Integer
-      FK_SCALAR,      // [6]  IsolateNetwork   : Boolean
-      FK_SCALAR,      // [7]  IsolatePids      : Boolean
-      FK_OPTION,      // [8]  Hostname         : Option String
-      FK_OPTION,      // [9]  DomainName       : Option String
-      FK_OPTION,      // [10] UserId           : Option Integer
-      FK_OPTION,      // [11] GroupId          : Option Integer
-      FK_OPTION,      // [12] Version          : Option String
-      FK_OPTION,      // [13] Runner           : Option String
-      FK_SCALAR,      // [14] CasDir           : String
-      FK_LIST_MOUNT,  // [15] MountOps         : List WakeboxMountOp
-      FK_LIST_PATH,   // [16] Visible          : List Path
+  // clang-format off
+  static const FieldSpec kFields[] = {
+      { "Label",          FK_OPTION_STRING  },
+      { "Command",        FK_LIST_STRING    },
+      { "Environment",    FK_LIST_STRING    },
+      { "Stdin",          FK_STRING         },
+      { "Directory",      FK_STRING         },
+      { "CommandTimeout", FK_OPTION_INTEGER },
+      { "IsolateNetwork", FK_BOOL           },
+      { "IsolatePids",    FK_BOOL           },
+      { "Hostname",       FK_OPTION_STRING  },
+      { "DomainName",     FK_OPTION_STRING  },
+      { "UserId",         FK_OPTION_INTEGER },
+      { "GroupId",        FK_OPTION_INTEGER },
+      { "Version",        FK_OPTION_STRING  },
+      { "Runner",         FK_OPTION_STRING  },
+      { "CasDir",         FK_STRING         },
+      { "MountOps",       FK_LIST_MOUNT     },
+      { "Visible",        FK_LIST_PATH      },
   };
+  // clang-format on
 
   for (int i = 0; i < (int)(sizeof(kFields) / sizeof(*kFields)); ++i) {
     Promise *p = spec->at(i);
     if (!*p) return p;
 
-    switch (kFields[i]) {
-      case FK_SCALAR:
+    switch (kFields[i].kind) {
+      case FK_STRING:
+      case FK_BOOL:
         break;
 
-      case FK_OPTION: {
+      case FK_OPTION_STRING:
+      case FK_OPTION_INTEGER: {
         Record *opt = p->coerce<Record>();
         if (opt->cons->index == 0) {
           Promise *inner = opt->at(0);
@@ -136,7 +147,7 @@ static Promise *check_spec_ready(Record *spec) {
         break;
       }
 
-      case FK_LIST_STR: {
+      case FK_LIST_STRING: {
         Record *list = p->coerce<Record>();
         while (list->cons == &List->members[1]) {
           Promise *head = list->at(0);

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -24,9 +24,7 @@
 #include <unistd.h>
 
 #include <fstream>
-#include <sstream>
 #include <string>
-#include <vector>
 
 #include "json/json5.h"
 #include "prim.h"
@@ -86,314 +84,323 @@
 namespace {
 
 // ---------------------------------------------------------------------------
-// Collected plain-C++ representation of a WakeboxSpec
+// check_spec_ready: walk every Promise in the spec tree, returning the first
+// unfulfilled one. No data is extracted; this drives the retry loop in
+// WriteWakeboxJson::execute so it suspends on exactly the right Promise.
 // ---------------------------------------------------------------------------
-
-struct VisEntry {
-  std::string path;
-  std::string type;
-  std::string hash;
-  long mode;
-  long mtime;
-};
-
-struct MountEntry {
-  std::string type;
-  std::string source;  // empty = omit from JSON
-  std::string dest;
-  bool read_only = false;
-  bool has_read_only = false;  // only WakeboxBindOp carries readonly
-};
-
-struct SpecData {
-  // Set to a non-empty string on a validation error (e.g. unsupported path type).
-  // collect_spec returns nullptr in this case — callers must check this field.
-  std::string error;
-
-  std::string label;
-  std::vector<std::string> command;
-  std::vector<std::string> environment;
-  std::vector<VisEntry> visible;
-  std::string directory;
-  std::string stdin_str;
-  std::string cas_dir;
-  bool isolate_network;
-  bool isolate_pids;
-  std::vector<MountEntry> mounts;
-  std::string hostname;
-  std::string domainname;
-  std::string runner;
-  bool has_user_id = false;
-  bool has_group_id = false;
-  bool has_command_timeout = false;
-  long user_id = 0;
-  long group_id = 0;
-  long command_timeout = 0;
-};
-
-// Collect all fields from a WakeboxMountOp ADT value into a MountEntry.
-// WakeboxMountOp constructor indices (runner.wake declaration order):
-//   0=WakeboxBindOp(source,dest,readonly), 1=WakeboxSquashfsOp(source,dest),
-//   2=WakeboxTmpfsOp(dest), 3=WakeboxCreateDirOp(dest),
-//   4=WakeboxCreateFileOp(dest), 5=WakeboxFuseWorkspaceOp(dest)
-static Promise *collect_mount_entry(Record *entry, MountEntry &me) {
-  static const char *strings[] = {"bind",       "squashfs",    "tmpfs",
-                                  "create-dir", "create-file", "workspace"};
-  int idx = entry->cons->index;
-  if (idx < 0 || idx >= 6) return nullptr;
-  me.type = strings[idx];
-
+static Promise *check_spec_ready(Record *spec) {
   Promise *p;
-  switch (idx) {
-    case 0: {  // WakeboxBindOp(source, dest, readonly)
-      p = entry->at(0);
-      if (!*p) return p;
-      me.source = p->coerce<String>()->as_str();
-      p = entry->at(1);
-      if (!*p) return p;
-      me.dest = p->coerce<String>()->as_str();
-      p = entry->at(2);
-      if (!*p) return p;
-      me.read_only = (p->coerce<Record>()->cons == &Boolean->members[0]);
-      me.has_read_only = true;
-      break;
-    }
-    case 1: {  // WakeboxSquashfsOp(source, dest)
-      p = entry->at(0);
-      if (!*p) return p;
-      me.source = p->coerce<String>()->as_str();
-      p = entry->at(1);
-      if (!*p) return p;
-      me.dest = p->coerce<String>()->as_str();
-      break;
-    }
-    default: {  // TmpfsOp, CreateDirOp, CreateFileOp, FuseWorkspaceOp — only dest
-      p = entry->at(0);
-      if (!*p) return p;
-      me.dest = p->coerce<String>()->as_str();
-      break;
-    }
-  }
-  return nullptr;
-}
 
-// Map a PathType ADT record to its wakebox JSON string.
-// Returns nullptr and sets `out` on success.
-// Returns nullptr and sets `error` for unsupported types.
-// Returns the unfulfilled Promise if the PathType field is not yet ready.
-static Promise *get_path_type_string(Record *path_rec, std::string &out, std::string &error) {
-  // PathType is at field index 1 of the Path tuple.
-  Promise *p = path_rec->at(1);
+  // Field 0: Label (String)
+  p = spec->at(0);
   if (!*p) return p;
-  Record *pt = p->coerce<Record>();
-  // PathType constructor indices (io.wake declaration order):
-  //   0=RegularFile, 1=Directory, 2=CharDevice, 3=BlockDevice,
-  //   4=Fifo,        5=Symlink,   6=Socket
-  static const char *strings[] = {"file",  "directory", nullptr, nullptr,
-                                  nullptr, "symlink",   nullptr};
-  int idx = pt->cons->index;
-  if (idx < 0 || idx >= 7 || strings[idx] == nullptr) {
-    // Get the constructor name for a useful error message.
-    error = "write_wakebox_spec: unsupported path type '" + pt->cons->ast.name +
-            "' for wakebox (only file, directory, symlink are valid)";
-    return nullptr;
+
+  // Fields 1-2: Command, Environment (List String)
+  for (int f = 1; f <= 2; ++f) {
+    p = spec->at(f);
+    if (!*p) return p;
+    Record *list = p->coerce<Record>();
+    while (list->cons == &List->members[1]) {
+      Promise *head = list->at(0);
+      if (!*head) return head;
+      Promise *tail = list->at(1);
+      if (!*tail) return tail;
+      list = tail->coerce<Record>();
+    }
   }
-  out = strings[idx];
-  return nullptr;
-}
 
-// Try to collect all values from the WakeboxSpec record into plain C++ data.
-// Returns nullptr if everything is fulfilled, or the first unfulfilled Promise.
-// The caller must discard and reinitialise `data` on every retry since a
-// partial traversal may have partially filled vectors.
-static Promise *collect_spec(Record *spec, SpecData &data) {
-  Promise *broken;
-
-#define TRY(expr)              \
-  do {                         \
-    broken = (expr);           \
-    if (broken) return broken; \
-  } while (0)
-
-  TRY(rh::string(spec, 0, data.label));
-  TRY(rh::string_list(spec, 1, data.command));
-  TRY(rh::string_list(spec, 2, data.environment));
-
-  // Field 3: Visible — List Path
-  // Path layout: [0]=Name:String, [1]=Type:PathType, [2]=Hash:String,
-  //              [3]=Mode:Integer, [4]=MtimeNs:Integer
+  // Field 3: Visible (List Path) — Path has 5 fields
+  p = spec->at(3);
+  if (!*p) return p;
   {
-    Promise *p3 = spec->at(3);
-    if (!*p3) return p3;
-    Record *list = p3->coerce<Record>();
-    while (list->cons == &List->members[1]) {  // Cons
+    Record *list = p->coerce<Record>();
+    while (list->cons == &List->members[1]) {
       Promise *head = list->at(0);
       if (!*head) return head;
       Record *path = head->coerce<Record>();
-
-      VisEntry ve;
-      TRY(rh::string(path, 0, ve.path));
-      {
-        Promise *broken = get_path_type_string(path, ve.type, data.error);
-        if (broken) return broken;
-        if (!data.error.empty()) return nullptr;
+      for (int i = 0; i < 5; ++i) {
+        Promise *f = path->at(i);
+        if (!*f) return f;
       }
-      TRY(rh::string(path, 2, ve.hash));
-      TRY(rh::integer(path, 3, ve.mode));
-      TRY(rh::integer(path, 4, ve.mtime));
-      data.visible.push_back(std::move(ve));
-
       Promise *tail = list->at(1);
       if (!*tail) return tail;
       list = tail->coerce<Record>();
     }
   }
 
-  TRY(rh::string(spec, 4, data.directory));
-  TRY(rh::string(spec, 5, data.stdin_str));
-  TRY(rh::string(spec, 6, data.cas_dir));
-  TRY(rh::boolean(spec, 7, data.isolate_network));
-  TRY(rh::boolean(spec, 8, data.isolate_pids));
+  // Fields 4-8: Directory, Stdin, CasDir, IsolateNetwork, IsolatePids
+  for (int f = 4; f <= 8; ++f) {
+    p = spec->at(f);
+    if (!*p) return p;
+  }
 
-  // Field 9: MountOps — List WakeboxMountOp
+  // Field 9: MountOps (List WakeboxMountOp)
+  // WakeboxBindOp=3 fields, WakeboxSquashfsOp=2, all others=1
+  p = spec->at(9);
+  if (!*p) return p;
   {
-    Promise *p9 = spec->at(9);
-    if (!*p9) return p9;
-    Record *list = p9->coerce<Record>();
-    while (list->cons == &List->members[1]) {  // Cons
+    Record *list = p->coerce<Record>();
+    while (list->cons == &List->members[1]) {
       Promise *head = list->at(0);
       if (!*head) return head;
       Record *entry = head->coerce<Record>();
-
-      MountEntry me;
-      TRY(collect_mount_entry(entry, me));
-      data.mounts.push_back(std::move(me));
-
+      int nf = (entry->cons->index == 0) ? 3 : (entry->cons->index == 1) ? 2 : 1;
+      for (int i = 0; i < nf; ++i) {
+        Promise *f = entry->at(i);
+        if (!*f) return f;
+      }
       Promise *tail = list->at(1);
       if (!*tail) return tail;
       list = tail->coerce<Record>();
     }
   }
 
-  TRY(rh::string(spec, 10, data.hostname));
-  TRY(rh::string(spec, 11, data.domainname));
-  TRY(rh::opt_integer(spec, 12, data.has_user_id, data.user_id));
-  TRY(rh::opt_integer(spec, 13, data.has_group_id, data.group_id));
-  TRY(rh::opt_integer(spec, 14, data.has_command_timeout, data.command_timeout));
-  TRY(rh::string(spec, 15, data.runner));
+  // Fields 10-11: Hostname, Domainname (String)
+  for (int f = 10; f <= 11; ++f) {
+    p = spec->at(f);
+    if (!*p) return p;
+  }
 
-#undef TRY
+  // Fields 12-14: Option Integer (UserId, GroupId, CommandTimeout)
+  for (int f = 12; f <= 14; ++f) {
+    p = spec->at(f);
+    if (!*p) return p;
+    Record *opt = p->coerce<Record>();
+    if (opt->cons->index == 0) {  // Some — check the inner Integer
+      Promise *inner = opt->at(0);
+      if (!*inner) return inner;
+    }
+  }
 
-  return nullptr;  // all fields fulfilled
+  // Field 15: Runner (String)
+  p = spec->at(15);
+  if (!*p) return p;
+
+  return nullptr;
 }
 
-static void write_jast_pretty(std::ostream &os, const JAST &jast, int indent, int depth) {
-  switch (jast.kind) {
-    case JSON_OBJECT: {
-      if (jast.children.empty()) {
-        os << "{}";
-        return;
-      }
-      std::string inner(static_cast<size_t>((depth + 1) * indent), ' ');
-      std::string outer(static_cast<size_t>(depth * indent), ' ');
-      os << "{\n";
-      for (size_t i = 0; i < jast.children.size(); ++i) {
-        os << inner << '"' << json_escape(jast.children[i].first) << "\": ";
-        write_jast_pretty(os, jast.children[i].second, indent, depth + 1);
-        if (i + 1 < jast.children.size()) os << ',';
-        os << '\n';
-      }
-      os << outer << '}';
-      break;
-    }
-    case JSON_ARRAY: {
-      if (jast.children.empty()) {
-        os << "[]";
-        return;
-      }
-      std::string inner(static_cast<size_t>((depth + 1) * indent), ' ');
-      std::string outer(static_cast<size_t>(depth * indent), ' ');
-      os << "[\n";
-      for (size_t i = 0; i < jast.children.size(); ++i) {
-        os << inner;
-        write_jast_pretty(os, jast.children[i].second, indent, depth + 1);
-        if (i + 1 < jast.children.size()) os << ',';
-        os << '\n';
-      }
-      os << outer << ']';
-      break;
-    }
-    default:
-      os << jast;
-      break;
+// ---------------------------------------------------------------------------
+// JStream: minimal helper for streaming JSON to an ostream.
+// All Promises are fully fulfilled before this is called.
+// ---------------------------------------------------------------------------
+struct JStream {
+  std::ostream &os;
+  const int indent;
+  int depth = 0;
+
+  void nl() {
+    if (indent <= 0) return;
+    os << '\n';
+    for (int i = 0; i < depth * indent; ++i) os << ' ';
   }
+
+  void key(const char *k) {
+    os << '"' << k << (indent > 0 ? "\": " : "\":");
+  }
+
+  void str(const std::string &s) { os << '"' << json_escape(s) << '"'; }
+};
+
+static void write_str_array(JStream &js, Record *list) {
+  js.os << '[';
+  ++js.depth;
+  bool first = true;
+  while (list->cons == &List->members[1]) {
+    if (!first) js.os << ',';
+    first = false;
+    js.nl();
+    js.str(list->at(0)->coerce<String>()->as_str());
+    list = list->at(1)->coerce<Record>();
+  }
+  --js.depth;
+  if (!first) js.nl();
+  js.os << ']';
 }
 
-// Build a JAST from fully-collected SpecData and write it to filepath.
-// Returns an empty string on success, or an error message.
-static std::string write_spec_json(const SpecData &d, const char *filepath, int indent) {
-  JAST root(JSON_OBJECT);
+// PathType constructor indices (io.wake declaration order):
+//   0=RegularFile, 1=Directory, 2=CharDevice, 3=BlockDevice,
+//   4=Fifo, 5=Symlink, 6=Socket
+static const char *k_path_type_strings[] = {"file",  "directory", nullptr, nullptr,
+                                             nullptr, "symlink",   nullptr};
 
-  root.add("label", d.label);
+// MountOp type strings (runner.wake declaration order):
+//   0=bind, 1=squashfs, 2=tmpfs, 3=create-dir, 4=create-file, 5=workspace
+static const char *k_mount_type_strings[] = {"bind",       "squashfs",    "tmpfs",
+                                              "create-dir", "create-file", "workspace"};
 
-  JAST &cmd = root.add("command", JSON_ARRAY);
-  for (const auto &s : d.command) cmd.add(s);
-
-  JAST &env = root.add("environment", JSON_ARRAY);
-  for (const auto &s : d.environment) env.add(s);
-
-  JAST &vis = root.add("visible", JSON_ARRAY);
-  for (const auto &ve : d.visible) {
-    JAST &obj = vis.add(JSON_OBJECT);
-    obj.add("path", ve.path);
-    obj.add("type", ve.type);
-    obj.add("hash", ve.hash);
-    obj.add("mode", (long)ve.mode);
-    obj.add("mtime", (long long)ve.mtime);
-  }
-
-  root.add("directory", d.directory);
-  root.add("stdin", d.stdin_str);
-  root.add("cas-dir", d.cas_dir);
-  root.add_bool("isolate-network", d.isolate_network);
-  root.add_bool("isolate-pids", d.isolate_pids);
-
-  JAST &mops = root.add("mount-ops", JSON_ARRAY);
-  for (const auto &me : d.mounts) {
-    JAST &obj = mops.add(JSON_OBJECT);
-    obj.add("type", me.type);
-    if (!me.source.empty()) obj.add("source", me.source);
-    obj.add("destination", me.dest);
-    if (me.has_read_only) obj.add_bool("read_only", me.read_only);
-  }
-
-  if (!d.hostname.empty()) root.add("hostname", d.hostname);
-  if (!d.domainname.empty()) root.add("domainname", d.domainname);
-  if (d.has_user_id) root.add("user-id", d.user_id);
-  if (d.has_group_id) root.add("group-id", d.group_id);
-  if (d.has_command_timeout) root.add("command-timeout", d.command_timeout);
-  if (!d.runner.empty()) root.add("runner", d.runner);
-
-  // Unlink any existing file first so we don't fail on a stale copy.
+// Stream spec JSON directly to filepath without an intermediate SpecData or
+// JAST tree. All Promises must be fulfilled (call check_spec_ready first).
+// Returns an empty string on success, or an error message on failure.
+static std::string stream_spec_json(Record *spec, const char *filepath, int indent) {
   (void)unlink(filepath);
-
   std::ofstream out(filepath, std::ios_base::trunc);
-  if (out.fail()) {
-    std::string err = "write_wakebox_spec: failed to open ";
-    err += filepath;
-    return err;
+  if (out.fail()) return std::string("write_wakebox_spec: failed to open ") + filepath;
+
+  JStream js{out, indent};
+  bool need_sep = false;
+  auto sep = [&]() {
+    if (need_sep) out << ',';
+    need_sep = true;
+    js.nl();
+  };
+
+  out << '{';
+  ++js.depth;
+
+  // label
+  sep();
+  js.key("label");
+  js.str(spec->at(0)->coerce<String>()->as_str());
+
+  // command, environment
+  sep();
+  js.key("command");
+  write_str_array(js, spec->at(1)->coerce<Record>());
+  sep();
+  js.key("environment");
+  write_str_array(js, spec->at(2)->coerce<Record>());
+
+  // visible
+  sep();
+  js.key("visible");
+  out << '[';
+  {
+    ++js.depth;
+    bool first = true;
+    Record *list = spec->at(3)->coerce<Record>();
+    while (list->cons == &List->members[1]) {
+      if (!first) out << ',';
+      first = false;
+      js.nl();
+
+      Record *path = list->at(0)->coerce<Record>();
+      Record *pt = path->at(1)->coerce<Record>();
+      int pt_idx = pt->cons->index;
+      if (pt_idx < 0 || pt_idx >= 7 || k_path_type_strings[pt_idx] == nullptr) {
+        out.close();
+        (void)unlink(filepath);
+        return std::string("write_wakebox_spec: unsupported path type '") +
+               pt->cons->ast.name + "' for wakebox (only file, directory, symlink are valid)";
+      }
+
+      mpz_t mv = {path->at(3)->coerce<Integer>()->wrap()};
+      mpz_t tv = {path->at(4)->coerce<Integer>()->wrap()};
+
+      out << '{';
+      ++js.depth;
+      bool pf = false;
+      auto pk = [&]() {
+        if (pf) out << ',';
+        pf = true;
+        js.nl();
+      };
+      pk(); js.key("path"); js.str(path->at(0)->coerce<String>()->as_str());
+      pk(); js.key("type"); out << '"' << k_path_type_strings[pt_idx] << '"';
+      pk(); js.key("hash"); js.str(path->at(2)->coerce<String>()->as_str());
+      pk(); js.key("mode"); out << mpz_get_si(mv);
+      pk(); js.key("mtime"); out << mpz_get_si(tv);
+      --js.depth;
+      js.nl();
+      out << '}';
+
+      list = list->at(1)->coerce<Record>();
+    }
+    --js.depth;
+    if (!first) js.nl();
+    out << ']';
   }
-  if (indent > 0) {
-    write_jast_pretty(out, root, indent, 0);
-    out << '\n';
-  } else {
-    out << root;
+
+  // directory, stdin, cas-dir
+  sep(); js.key("directory"); js.str(spec->at(4)->coerce<String>()->as_str());
+  sep(); js.key("stdin");     js.str(spec->at(5)->coerce<String>()->as_str());
+  sep(); js.key("cas-dir");   js.str(spec->at(6)->coerce<String>()->as_str());
+
+  // isolate-network, isolate-pids
+  bool iso_net = (spec->at(7)->coerce<Record>()->cons == &Boolean->members[0]);
+  bool iso_pid = (spec->at(8)->coerce<Record>()->cons == &Boolean->members[0]);
+  sep(); js.key("isolate-network"); out << (iso_net ? "true" : "false");
+  sep(); js.key("isolate-pids");    out << (iso_pid ? "true" : "false");
+
+  // mount-ops
+  sep();
+  js.key("mount-ops");
+  out << '[';
+  {
+    ++js.depth;
+    bool first = true;
+    Record *list = spec->at(9)->coerce<Record>();
+    while (list->cons == &List->members[1]) {
+      if (!first) out << ',';
+      first = false;
+      js.nl();
+
+      Record *entry = list->at(0)->coerce<Record>();
+      int idx = entry->cons->index;
+
+      out << '{';
+      ++js.depth;
+      bool mf = false;
+      auto mk = [&]() {
+        if (mf) out << ',';
+        mf = true;
+        js.nl();
+      };
+      mk(); js.key("type"); out << '"' << k_mount_type_strings[idx] << '"';
+      if (idx == 0 || idx == 1) {  // bind or squashfs — have source + destination
+        mk(); js.key("source");      js.str(entry->at(0)->coerce<String>()->as_str());
+        mk(); js.key("destination"); js.str(entry->at(1)->coerce<String>()->as_str());
+        if (idx == 0) {  // bind also has read_only
+          bool ro = (entry->at(2)->coerce<Record>()->cons == &Boolean->members[0]);
+          mk(); js.key("read_only"); out << (ro ? "true" : "false");
+        }
+      } else {  // tmpfs, create-dir, create-file, workspace — destination only
+        mk(); js.key("destination"); js.str(entry->at(0)->coerce<String>()->as_str());
+      }
+      --js.depth;
+      js.nl();
+      out << '}';
+
+      list = list->at(1)->coerce<Record>();
+    }
+    --js.depth;
+    if (!first) js.nl();
+    out << ']';
   }
-  if (out.bad()) {
-    std::string err = "write_wakebox_spec: failed to write ";
-    err += filepath;
-    return err;
-  }
+
+  // Optional string fields
+  auto opt_str = [&](const char *k, int f) {
+    std::string s = spec->at(f)->coerce<String>()->as_str();
+    if (!s.empty()) {
+      sep();
+      js.key(k);
+      js.str(s);
+    }
+  };
+  opt_str("hostname", 10);
+  opt_str("domainname", 11);
+
+  // Optional integer fields
+  auto opt_int = [&](const char *k, int f) {
+    Record *opt = spec->at(f)->coerce<Record>();
+    if (opt->cons->index == 0) {  // Some
+      mpz_t v = {opt->at(0)->coerce<Integer>()->wrap()};
+      sep();
+      js.key(k);
+      out << mpz_get_si(v);
+    }
+  };
+  opt_int("user-id", 12);
+  opt_int("group-id", 13);
+  opt_int("command-timeout", 14);
+
+  opt_str("runner", 15);
+
+  --js.depth;
+  js.nl();
+  out << '}';
+  if (indent > 0) out << '\n';
+
+  if (out.bad()) return std::string("write_wakebox_spec: failed to write ") + filepath;
   return {};
 }
 
@@ -430,19 +437,15 @@ struct WriteWakeboxJson final : public GCObject<WriteWakeboxJson, Continuation> 
 };
 
 void WriteWakeboxJson::execute(Runtime &runtime) {
-  SpecData data;
-  Promise *broken = collect_spec(spec.get(), data);
-
-  if (broken) {
-    // Suspend until this Promise is fulfilled, then retry from scratch.
+  // Pass 1: check all Promises are fulfilled; suspend on the first that isn't.
+  if (Promise *broken = check_spec_ready(spec.get())) {
     next = nullptr;
     broken->await(runtime, this);
     return;
   }
 
-  // Propagate validation errors (e.g. unsupported PathType) as Fail results.
-  std::string err =
-      data.error.empty() ? write_spec_json(data, filepath->c_str(), indent) : data.error;
+  // Pass 2: stream JSON directly from the Wake tuple — no intermediate copies.
+  std::string err = stream_spec_json(spec.get(), filepath->c_str(), indent);
 
   // Reserve heap before any allocation.
   size_t need = reserve_result() + (err.empty() ? reserve_unit() : String::reserve(err.size()));

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -39,7 +39,7 @@
 // WakeboxSpec field layout (must match the tuple declaration order in Wake):
 //
 //   WakeboxSpec =
-//     [0]  Label            : String
+//     [0]  Label            : Option String
 //     [1]  Command          : List String
 //     [2]  Environment      : List String
 //     [3]  Visible          : List Path
@@ -49,12 +49,12 @@
 //     [7]  IsolateNetwork   : Boolean
 //     [8]  IsolatePids      : Boolean
 //     [9]  MountOps         : List WakeboxMountOp
-//     [10] Hostname         : String
-//     [11] Domainname       : String
+//     [10] Hostname         : Option String
+//     [11] DomainName       : Option String
 //     [12] UserId           : Option Integer
 //     [13] GroupId          : Option Integer
 //     [14] CommandTimeout   : Option Integer
-//     [15] Runner           : String
+//     [15] Runner           : Option String
 //
 //   Path (from io.wake / path.wake) =
 //     [0] Name    : String
@@ -91,9 +91,16 @@ namespace {
 static Promise *check_spec_ready(Record *spec) {
   Promise *p;
 
-  // Field 0: Label (String)
+  // Field 0: Label (Option String)
   p = spec->at(0);
   if (!*p) return p;
+  {
+    Record *opt = p->coerce<Record>();
+    if (opt->cons->index == 0) {
+      Promise *inner = opt->at(0);
+      if (!*inner) return inner;
+    }
+  }
 
   // Fields 1-2: Command, Environment (List String)
   for (int f = 1; f <= 2; ++f) {
@@ -155,26 +162,16 @@ static Promise *check_spec_ready(Record *spec) {
     }
   }
 
-  // Fields 10-11: Hostname, Domainname (String)
-  for (int f = 10; f <= 11; ++f) {
-    p = spec->at(f);
-    if (!*p) return p;
-  }
-
-  // Fields 12-14: Option Integer (UserId, GroupId, CommandTimeout)
-  for (int f = 12; f <= 14; ++f) {
+  // Fields 10-15: all Option — Hostname, DomainName, UserId, GroupId, CommandTimeout, Runner
+  for (int f = 10; f <= 15; ++f) {
     p = spec->at(f);
     if (!*p) return p;
     Record *opt = p->coerce<Record>();
-    if (opt->cons->index == 0) {  // Some — check the inner Integer
+    if (opt->cons->index == 0) {  // Some — check the inner value
       Promise *inner = opt->at(0);
       if (!*inner) return inner;
     }
   }
-
-  // Field 15: Runner (String)
-  p = spec->at(15);
-  if (!*p) return p;
 
   return nullptr;
 }
@@ -218,15 +215,25 @@ static void write_str_array(JStream &js, Record *list) {
 }
 
 // PathType constructor indices (io.wake declaration order):
-//   0=RegularFile, 1=Directory, 2=CharDevice, 3=BlockDevice,
-//   4=Fifo, 5=Symlink, 6=Socket
-static const char *k_path_type_strings[] = {"file",  "directory", nullptr, nullptr,
-                                             nullptr, "symlink",   nullptr};
+static const char *k_path_type_strings[] = {
+    "file",        // 0 PathTypeRegularFile
+    "directory",   // 1 PathTypeDirectory
+    nullptr,       // 2 PathTypeCharDevice   (unsupported)
+    nullptr,       // 3 PathTypeBlockDevice  (unsupported)
+    nullptr,       // 4 PathTypeFifo         (unsupported)
+    "symlink",     // 5 PathTypeSymlink
+    nullptr,       // 6 PathTypeSocket       (unsupported)
+};
 
-// MountOp type strings (runner.wake declaration order):
-//   0=bind, 1=squashfs, 2=tmpfs, 3=create-dir, 4=create-file, 5=workspace
-static const char *k_mount_type_strings[] = {"bind",       "squashfs",    "tmpfs",
-                                              "create-dir", "create-file", "workspace"};
+// WakeboxMountOp constructor indices (runner.wake declaration order):
+static const char *k_mount_type_strings[] = {
+    "bind",        // 0 WakeboxBindOp
+    "squashfs",    // 1 WakeboxSquashfsOp
+    "tmpfs",       // 2 WakeboxTmpfsOp
+    "create-dir",  // 3 WakeboxCreateDirOp
+    "create-file", // 4 WakeboxCreateFileOp
+    "workspace",   // 5 WakeboxFuseWorkspaceOp
+};
 
 // Stream spec JSON directly to filepath without an intermediate SpecData or
 // JAST tree. All Promises must be fulfilled (call check_spec_ready first).
@@ -244,13 +251,20 @@ static std::string stream_spec_json(Record *spec, const char *filepath, int inde
     js.nl();
   };
 
+  // Optional string fields — used for label, hostname, domainname, runner
+  auto opt_str = [&](const char *k, int f) {
+    Record *opt = spec->at(f)->coerce<Record>();
+    if (opt->cons->index == 0) {  // Some
+      sep();
+      js.key(k);
+      js.str(opt->at(0)->coerce<String>()->as_str());
+    }
+  };
+
   out << '{';
   ++js.depth;
 
-  // label
-  sep();
-  js.key("label");
-  js.str(spec->at(0)->coerce<String>()->as_str());
+  opt_str("label", 0);
 
   // command, environment
   sep();
@@ -367,15 +381,6 @@ static std::string stream_spec_json(Record *spec, const char *filepath, int inde
     out << ']';
   }
 
-  // Optional string fields
-  auto opt_str = [&](const char *k, int f) {
-    std::string s = spec->at(f)->coerce<String>()->as_str();
-    if (!s.empty()) {
-      sep();
-      js.key(k);
-      js.str(s);
-    }
-  };
   opt_str("hostname", 10);
   opt_str("domainname", 11);
 

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -74,7 +74,7 @@
 //     6 = PathTypeSocket          (unsupported by wakebox)
 //
 //   WakeboxMountOp =
-//     [0] Type     : String
+//     [0] Type     : MountOpType  (0=Bind,1=CreateDir,2=CreateFile,3=Squashfs,4=Tmpfs,5=Workspace)
 //     [1] Source   : String
 //     [2] Dest     : String
 //     [3] ReadOnly : Boolean
@@ -125,6 +125,20 @@ struct SpecData {
   long group_id = 0;
   long command_timeout = 0;
 };
+
+// Map a MountOpType ADT value to its wakebox JSON string.
+// MountOpType constructor indices (runner.wake declaration order):
+//   0=MountBind, 1=MountCreateDir, 2=MountCreateFile,
+//   3=MountSquashfs, 4=MountTmpfs, 5=MountWorkspace
+static Promise *get_mount_op_type_string(Record *mount_rec, std::string &out) {
+  Promise *p = mount_rec->at(0);  // Type field
+  if (!*p) return p;
+  static const char *strings[] = {"bind", "create-dir", "create-file",
+                                  "squashfs", "tmpfs", "workspace"};
+  int idx = p->coerce<Record>()->cons->index;
+  if (idx >= 0 && idx < 6) out = strings[idx];
+  return nullptr;
+}
 
 // Map a PathType ADT record to its wakebox JSON string.
 // Returns nullptr and sets `out` on success.
@@ -215,7 +229,7 @@ static Promise *collect_spec(Record *spec, SpecData &data) {
       Record *entry = head->coerce<Record>();
 
       MountEntry me;
-      TRY(rh::string(entry, 0, me.type));
+      TRY(get_mount_op_type_string(entry, me.type));
       TRY(rh::string(entry, 1, me.source));
       TRY(rh::string(entry, 2, me.dest));
       TRY(rh::boolean(entry, 3, me.read_only));

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -1,0 +1,500 @@
+/*
+ * Copyright 2026 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Open Group Base Specifications Issue 7
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
+
+#include "wakebox_prim.h"
+
+#include <unistd.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "json/json5.h"
+#include "prim.h"
+#include "tuple.h"
+#include "types/data.h"
+#include "types/datatype.h"
+#include "types/sums.h"
+#include "value.h"
+
+// ---------------------------------------------------------------------------
+// WakeboxSpec field layout (must match the tuple declaration order in Wake):
+//
+//   WakeboxSpec =
+//     [0]  Command          : List String
+//     [1]  Environment      : List String
+//     [2]  Visible          : List Path
+//     [3]  Directory        : String
+//     [4]  Stdin            : String
+//     [5]  CasDir           : String
+//     [6]  IsolateNetwork   : Boolean
+//     [7]  IsolatePids      : Boolean
+//     [8]  MountOps         : List WakeboxMountOp
+//     [9]  Hostname         : String
+//     [10] Domainname       : String
+//     [11] UserId           : Option Integer
+//     [12] GroupId          : Option Integer
+//     [13] CommandTimeout   : Option Integer
+//     [14] Runner           : String
+//
+//   Path (from io.wake / path.wake) =
+//     [0] Name    : String
+//     [1] Type    : PathType   -- ADT, mapped to string via cons->index (see below)
+//     [2] Hash    : String
+//     [3] Mode    : Integer
+//     [4] MtimeNs : Integer
+//
+//   PathType constructor indices (declaration order in io.wake):
+//     0 = PathTypeRegularFile  -> "file"
+//     1 = PathTypeDirectory    -> "directory"
+//     2 = PathTypeCharacterDevice (unsupported by wakebox)
+//     3 = PathTypeBlockDevice     (unsupported by wakebox)
+//     4 = PathTypeFifo            (unsupported by wakebox)
+//     5 = PathTypeSymlink      -> "symlink"
+//     6 = PathTypeSocket          (unsupported by wakebox)
+//
+//   WakeboxMountOp =
+//     [0] Type     : String
+//     [1] Source   : String
+//     [2] Dest     : String
+//     [3] ReadOnly : Boolean
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Collected plain-C++ representation of a WakeboxSpec
+// ---------------------------------------------------------------------------
+
+struct VisEntry {
+  std::string path;
+  std::string type;
+  std::string hash;
+  long mode;
+  long mtime;
+};
+
+struct MountEntry {
+  std::string type;
+  std::string source;
+  std::string dest;
+  bool read_only;
+};
+
+struct SpecData {
+  // Set to a non-empty string on a validation error (e.g. unsupported path type).
+  // collect_spec returns nullptr in this case — callers must check this field.
+  std::string error;
+
+  std::vector<std::string> command, environment;
+  std::vector<VisEntry> visible;
+  std::string directory, stdin_str, cas_dir;
+  bool isolate_network, isolate_pids;
+  std::vector<MountEntry> mounts;
+  std::string hostname, domainname, runner;
+  bool has_user_id = false, has_group_id = false, has_command_timeout = false;
+  long user_id = 0, group_id = 0, command_timeout = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Field-extraction helpers — each returns nullptr on success or the first
+// unfulfilled Promise it encounters.
+// ---------------------------------------------------------------------------
+
+static Promise *get_string(Record *rec, int idx, std::string &out) {
+  Promise *p = rec->at(idx);
+  if (!*p) return p;
+  out = p->coerce<String>()->as_str();
+  return nullptr;
+}
+
+static Promise *get_bool(Record *rec, int idx, bool &out) {
+  Promise *p = rec->at(idx);
+  if (!*p) return p;
+  // Boolean: True = members[0], False = members[1]
+  out = (p->coerce<Record>()->cons == &Boolean->members[0]);
+  return nullptr;
+}
+
+static Promise *get_long(Record *rec, int idx, long &out) {
+  Promise *p = rec->at(idx);
+  if (!*p) return p;
+  mpz_t v = {p->coerce<Integer>()->wrap()};
+  out = mpz_get_si(v);
+  return nullptr;
+}
+
+// Map a PathType ADT record to its wakebox JSON string.
+// Returns nullptr and sets `out` on success.
+// Returns nullptr and sets `error` for unsupported types.
+// Returns the unfulfilled Promise if the PathType field is not yet ready.
+static Promise *get_path_type_string(Record *path_rec, std::string &out, std::string &error) {
+  // PathType is at field index 1 of the Path tuple.
+  Promise *p = path_rec->at(1);
+  if (!*p) return p;
+  Record *pt = p->coerce<Record>();
+  // PathType constructor indices (io.wake declaration order):
+  //   0=RegularFile, 1=Directory, 2=CharDevice, 3=BlockDevice,
+  //   4=Fifo,        5=Symlink,   6=Socket
+  static const char *strings[] = {"file",  "directory", nullptr, nullptr,
+                                  nullptr, "symlink",   nullptr};
+  int idx = pt->cons->index;
+  if (idx < 0 || idx >= 7 || strings[idx] == nullptr) {
+    // Get the constructor name for a useful error message.
+    error = "write_wakebox_spec: unsupported path type '" + pt->cons->ast.name +
+            "' for wakebox (only file, directory, symlink are valid)";
+    return nullptr;
+  }
+  out = strings[idx];
+  return nullptr;
+}
+
+// Extract an Option Integer field. Sets has_val=true and out to the integer if Some,
+// has_val=false if None. Returns the unfulfilled Promise on suspension.
+static Promise *get_optional_long(Record *rec, int idx, bool &has_val, long &out) {
+  Promise *p = rec->at(idx);
+  if (!*p) return p;
+  Record *opt = p->coerce<Record>();
+  // Option: Some a (index 0, one inner field) | None (index 1, no fields)
+  if (opt->cons->index == 0) {  // Some
+    Promise *inner = opt->at(0);
+    if (!*inner) return inner;
+    mpz_t v = {inner->coerce<Integer>()->wrap()};
+    out = mpz_get_si(v);
+    has_val = true;
+  } else {
+    has_val = false;
+  }
+  return nullptr;
+}
+
+static Promise *get_string_list(Record *spec, int idx, std::vector<std::string> &out) {
+  Promise *p = spec->at(idx);
+  if (!*p) return p;
+  Record *list = p->coerce<Record>();
+  while (list->cons == &List->members[1]) {  // Cons
+    Promise *head = list->at(0);
+    if (!*head) return head;
+    out.push_back(head->coerce<String>()->as_str());
+    Promise *tail = list->at(1);
+    if (!*tail) return tail;
+    list = tail->coerce<Record>();
+  }
+  return nullptr;
+}
+
+// Try to collect all values from the WakeboxSpec record into plain C++ data.
+// Returns nullptr if everything is fulfilled, or the first unfulfilled Promise.
+// The caller must discard and reinitialise `data` on every retry since a
+// partial traversal may have partially filled vectors.
+static Promise *collect_spec(Record *spec, SpecData &data) {
+  Promise *broken;
+
+#define TRY(expr)              \
+  do {                         \
+    broken = (expr);           \
+    if (broken) return broken; \
+  } while (0)
+
+  TRY(get_string_list(spec, 0, data.command));
+  TRY(get_string_list(spec, 1, data.environment));
+
+  // Field 2: Visible — List Path
+  // Path layout: [0]=Name:String, [1]=Type:PathType, [2]=Hash:String,
+  //              [3]=Mode:Integer, [4]=MtimeNs:Integer
+  {
+    Promise *p2 = spec->at(2);
+    if (!*p2) return p2;
+    Record *list = p2->coerce<Record>();
+    while (list->cons == &List->members[1]) {  // Cons
+      Promise *head = list->at(0);
+      if (!*head) return head;
+      Record *path = head->coerce<Record>();
+
+      VisEntry ve;
+      TRY(get_string(path, 0, ve.path));
+      {
+        Promise *broken = get_path_type_string(path, ve.type, data.error);
+        if (broken) return broken;
+        if (!data.error.empty()) return nullptr;
+      }
+      TRY(get_string(path, 2, ve.hash));
+      TRY(get_long(path, 3, ve.mode));
+      TRY(get_long(path, 4, ve.mtime));
+      data.visible.push_back(std::move(ve));
+
+      Promise *tail = list->at(1);
+      if (!*tail) return tail;
+      list = tail->coerce<Record>();
+    }
+  }
+
+  TRY(get_string(spec, 3, data.directory));
+  TRY(get_string(spec, 4, data.stdin_str));
+  TRY(get_string(spec, 5, data.cas_dir));
+  TRY(get_bool(spec, 6, data.isolate_network));
+  TRY(get_bool(spec, 7, data.isolate_pids));
+
+  // Field 8: MountOps — List WakeboxMountOp
+  {
+    Promise *p8 = spec->at(8);
+    if (!*p8) return p8;
+    Record *list = p8->coerce<Record>();
+    while (list->cons == &List->members[1]) {  // Cons
+      Promise *head = list->at(0);
+      if (!*head) return head;
+      Record *entry = head->coerce<Record>();
+
+      MountEntry me;
+      TRY(get_string(entry, 0, me.type));
+      TRY(get_string(entry, 1, me.source));
+      TRY(get_string(entry, 2, me.dest));
+      TRY(get_bool(entry, 3, me.read_only));
+      data.mounts.push_back(std::move(me));
+
+      Promise *tail = list->at(1);
+      if (!*tail) return tail;
+      list = tail->coerce<Record>();
+    }
+  }
+
+  TRY(get_string(spec, 9, data.hostname));
+  TRY(get_string(spec, 10, data.domainname));
+  TRY(get_optional_long(spec, 11, data.has_user_id, data.user_id));
+  TRY(get_optional_long(spec, 12, data.has_group_id, data.group_id));
+  TRY(get_optional_long(spec, 13, data.has_command_timeout, data.command_timeout));
+  TRY(get_string(spec, 14, data.runner));
+
+#undef TRY
+
+  return nullptr;  // all fields fulfilled
+}
+
+static void write_jast_pretty(std::ostream &os, const JAST &jast, int indent, int depth) {
+  switch (jast.kind) {
+    case JSON_OBJECT: {
+      if (jast.children.empty()) {
+        os << "{}";
+        return;
+      }
+      std::string inner(static_cast<size_t>((depth + 1) * indent), ' ');
+      std::string outer(static_cast<size_t>(depth * indent), ' ');
+      os << "{\n";
+      for (size_t i = 0; i < jast.children.size(); ++i) {
+        os << inner << '"' << json_escape(jast.children[i].first) << "\": ";
+        write_jast_pretty(os, jast.children[i].second, indent, depth + 1);
+        if (i + 1 < jast.children.size()) os << ',';
+        os << '\n';
+      }
+      os << outer << '}';
+      break;
+    }
+    case JSON_ARRAY: {
+      if (jast.children.empty()) {
+        os << "[]";
+        return;
+      }
+      std::string inner(static_cast<size_t>((depth + 1) * indent), ' ');
+      std::string outer(static_cast<size_t>(depth * indent), ' ');
+      os << "[\n";
+      for (size_t i = 0; i < jast.children.size(); ++i) {
+        os << inner;
+        write_jast_pretty(os, jast.children[i].second, indent, depth + 1);
+        if (i + 1 < jast.children.size()) os << ',';
+        os << '\n';
+      }
+      os << outer << ']';
+      break;
+    }
+    default:
+      os << jast;
+      break;
+  }
+}
+
+// Build a JAST from fully-collected SpecData and write it to filepath.
+// Returns an empty string on success, or an error message.
+static std::string write_spec_json(const SpecData &d, const char *filepath, int indent) {
+  JAST root(JSON_OBJECT);
+
+  JAST &cmd = root.add("command", JSON_ARRAY);
+  for (const auto &s : d.command) cmd.add(s);
+
+  JAST &env = root.add("environment", JSON_ARRAY);
+  for (const auto &s : d.environment) env.add(s);
+
+  JAST &vis = root.add("visible", JSON_ARRAY);
+  for (const auto &ve : d.visible) {
+    JAST &obj = vis.add(JSON_OBJECT);
+    obj.add("path", ve.path);
+    obj.add("type", ve.type);
+    obj.add("hash", ve.hash);
+    obj.add("mode", (long)ve.mode);
+    obj.add("mtime", (long long)ve.mtime);
+  }
+
+  root.add("directory", d.directory);
+  root.add("stdin", d.stdin_str);
+  root.add("cas-dir", d.cas_dir);
+  root.add_bool("isolate-network", d.isolate_network);
+  root.add_bool("isolate-pids", d.isolate_pids);
+
+  JAST &mops = root.add("mount-ops", JSON_ARRAY);
+  for (const auto &me : d.mounts) {
+    JAST &obj = mops.add(JSON_OBJECT);
+    obj.add("type", me.type);
+    if (!me.source.empty()) obj.add("source", me.source);
+    obj.add("destination", me.dest);
+    obj.add_bool("read_only", me.read_only);
+  }
+
+  if (!d.hostname.empty()) root.add("hostname", d.hostname);
+  if (!d.domainname.empty()) root.add("domainname", d.domainname);
+  if (d.has_user_id) root.add("user-id", d.user_id);
+  if (d.has_group_id) root.add("group-id", d.group_id);
+  if (d.has_command_timeout) root.add("command-timeout", d.command_timeout);
+  if (!d.runner.empty()) root.add("runner", d.runner);
+
+  // Unlink any existing file first so we don't fail on a stale copy.
+  (void)unlink(filepath);
+
+  std::ofstream out(filepath, std::ios_base::trunc);
+  if (out.fail()) {
+    std::string err = "write_wakebox_spec: failed to open ";
+    err += filepath;
+    return err;
+  }
+  if (indent > 0) {
+    write_jast_pretty(out, root, indent, 0);
+    out << '\n';
+  } else {
+    out << root;
+  }
+  if (out.bad()) {
+    std::string err = "write_wakebox_spec: failed to write ";
+    err += filepath;
+    return err;
+  }
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Continuation: WriteWakeboxJson
+//
+// On each execute() call, attempts to collect all fields from the spec.  If
+// any Promise is still unfulfilled the continuation suspends itself on that
+// Promise (next=nullptr; p->await(runtime, this)) and will be rescheduled
+// when the value becomes available — the same "retry on first broken" pattern
+// used by CHash in prim.cpp.  Once all fields are ready the JSON is written
+// and the result Promise (held via `cont`) is fulfilled.
+// ---------------------------------------------------------------------------
+
+struct WriteWakeboxJson final : public GCObject<WriteWakeboxJson, Continuation> {
+  HeapPointer<Record> spec;
+  HeapPointer<String> filepath;
+  HeapPointer<Continuation> cont;  // fulfiller for the prim's output slot
+  int indent;                      // spaces per level (0 = compact); plain int, not GC-managed
+
+  WriteWakeboxJson(Record *s, String *f, Continuation *c, int i)
+      : spec(s), filepath(f), cont(c), indent(i) {}
+
+  template <typename T, T (HeapPointerBase::*memberfn)(T x)>
+  T recurse(T arg) {
+    arg = Continuation::recurse<T, memberfn>(arg);
+    arg = (spec.*memberfn)(arg);
+    arg = (filepath.*memberfn)(arg);
+    arg = (cont.*memberfn)(arg);
+    return arg;
+  }
+
+  void execute(Runtime &runtime) override;
+};
+
+void WriteWakeboxJson::execute(Runtime &runtime) {
+  SpecData data;
+  Promise *broken = collect_spec(spec.get(), data);
+
+  if (broken) {
+    // Suspend until this Promise is fulfilled, then retry from scratch.
+    next = nullptr;
+    broken->await(runtime, this);
+    return;
+  }
+
+  // Propagate validation errors (e.g. unsupported PathType) as Fail results.
+  std::string err =
+      data.error.empty() ? write_spec_json(data, filepath->c_str(), indent) : data.error;
+
+  // Reserve heap before any allocation.
+  size_t need = reserve_result() + (err.empty() ? reserve_unit() : String::reserve(err.size()));
+  runtime.heap.reserve(need);
+
+  Value *result;
+  if (err.empty()) {
+    result = claim_result(runtime.heap, true, claim_unit(runtime.heap));
+  } else {
+    result = claim_result(runtime.heap, false, String::claim(runtime.heap, err));
+  }
+
+  cont->resume(runtime, result);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// PRIMTYPE and PRIMFN
+// ---------------------------------------------------------------------------
+
+static PRIMTYPE(type_write_wakebox_spec) {
+  TypeVar result;
+  Data::typeResult.clone(result);
+  result[0].unify(Data::typeUnit);
+  result[1].unify(Data::typeString);
+  // arg0 is WakeboxSpec — any record type; Wake's type checker enforces the exact type
+  // at the call site via the typed wrapper function in runner.wake.
+  TypeVar spec_type;
+  spec_type.setDOB();  // default TypeVar ctor leaves var_dob=0; do_unify asserts it non-zero
+  return args.size() == 3 && args[0]->unify(spec_type) && args[1]->unify(Data::typeInteger) &&
+         args[2]->unify(Data::typeString) && out->unify(result);
+}
+
+static PRIMFN(prim_write_wakebox_spec) {
+  EXPECT(3);
+  RECORD(spec, 0);
+  INTEGER_MPZ(indent_mpz, 1);
+  STRING(filepath, 2);
+
+  int indent = mpz_fits_sint_p(indent_mpz) ? mpz_get_si(indent_mpz) : 0;
+  if (indent < 0) indent = 0;
+
+  // Reserve space for WriteWakeboxJson + the fulfiller continuation.
+  runtime.heap.reserve(WriteWakeboxJson::reserve() + Tuple::fulfiller_pads);
+
+  Continuation *fulfiller = scope->claim_fulfiller(runtime, output);
+  WriteWakeboxJson *wbj = WriteWakeboxJson::claim(runtime.heap, spec, filepath, fulfiller, indent);
+  wbj->execute(runtime);
+}
+
+void prim_register_wakebox(PrimMap &pmap) {
+  prim_register(pmap, "write_wakebox_spec", prim_write_wakebox_spec, type_write_wakebox_spec,
+                PRIM_IMPURE);
+}

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -41,21 +41,22 @@
 // WakeboxSpec field layout (must match the tuple declaration order in Wake):
 //
 //   WakeboxSpec =
-//     [0]  Command          : List String
-//     [1]  Environment      : List String
-//     [2]  Visible          : List Path
-//     [3]  Directory        : String
-//     [4]  Stdin            : String
-//     [5]  CasDir           : String
-//     [6]  IsolateNetwork   : Boolean
-//     [7]  IsolatePids      : Boolean
-//     [8]  MountOps         : List WakeboxMountOp
-//     [9]  Hostname         : String
-//     [10] Domainname       : String
-//     [11] UserId           : Option Integer
-//     [12] GroupId          : Option Integer
-//     [13] CommandTimeout   : Option Integer
-//     [14] Runner           : String
+//     [0]  Label            : String
+//     [1]  Command          : List String
+//     [2]  Environment      : List String
+//     [3]  Visible          : List Path
+//     [4]  Directory        : String
+//     [5]  Stdin            : String
+//     [6]  CasDir           : String
+//     [7]  IsolateNetwork   : Boolean
+//     [8]  IsolatePids      : Boolean
+//     [9]  MountOps         : List WakeboxMountOp
+//     [10] Hostname         : String
+//     [11] Domainname       : String
+//     [12] UserId           : Option Integer
+//     [13] GroupId          : Option Integer
+//     [14] CommandTimeout   : Option Integer
+//     [15] Runner           : String
 //
 //   Path (from io.wake / path.wake) =
 //     [0] Name    : String
@@ -106,6 +107,7 @@ struct SpecData {
   // collect_spec returns nullptr in this case — callers must check this field.
   std::string error;
 
+  std::string label;
   std::vector<std::string> command;
   std::vector<std::string> environment;
   std::vector<VisEntry> visible;
@@ -179,16 +181,17 @@ static Promise *collect_spec(Record *spec, SpecData &data) {
     if (broken) return broken; \
   } while (0)
 
-  TRY(rh::string_list(spec, 0, data.command));
-  TRY(rh::string_list(spec, 1, data.environment));
+  TRY(rh::string(spec, 0, data.label));
+  TRY(rh::string_list(spec, 1, data.command));
+  TRY(rh::string_list(spec, 2, data.environment));
 
-  // Field 2: Visible — List Path
+  // Field 3: Visible — List Path
   // Path layout: [0]=Name:String, [1]=Type:PathType, [2]=Hash:String,
   //              [3]=Mode:Integer, [4]=MtimeNs:Integer
   {
-    Promise *p2 = spec->at(2);
-    if (!*p2) return p2;
-    Record *list = p2->coerce<Record>();
+    Promise *p3 = spec->at(3);
+    if (!*p3) return p3;
+    Record *list = p3->coerce<Record>();
     while (list->cons == &List->members[1]) {  // Cons
       Promise *head = list->at(0);
       if (!*head) return head;
@@ -212,17 +215,17 @@ static Promise *collect_spec(Record *spec, SpecData &data) {
     }
   }
 
-  TRY(rh::string(spec, 3, data.directory));
-  TRY(rh::string(spec, 4, data.stdin_str));
-  TRY(rh::string(spec, 5, data.cas_dir));
-  TRY(rh::boolean(spec, 6, data.isolate_network));
-  TRY(rh::boolean(spec, 7, data.isolate_pids));
+  TRY(rh::string(spec, 4, data.directory));
+  TRY(rh::string(spec, 5, data.stdin_str));
+  TRY(rh::string(spec, 6, data.cas_dir));
+  TRY(rh::boolean(spec, 7, data.isolate_network));
+  TRY(rh::boolean(spec, 8, data.isolate_pids));
 
-  // Field 8: MountOps — List WakeboxMountOp
+  // Field 9: MountOps — List WakeboxMountOp
   {
-    Promise *p8 = spec->at(8);
-    if (!*p8) return p8;
-    Record *list = p8->coerce<Record>();
+    Promise *p9 = spec->at(9);
+    if (!*p9) return p9;
+    Record *list = p9->coerce<Record>();
     while (list->cons == &List->members[1]) {  // Cons
       Promise *head = list->at(0);
       if (!*head) return head;
@@ -241,12 +244,12 @@ static Promise *collect_spec(Record *spec, SpecData &data) {
     }
   }
 
-  TRY(rh::string(spec, 9, data.hostname));
-  TRY(rh::string(spec, 10, data.domainname));
-  TRY(rh::opt_integer(spec, 11, data.has_user_id, data.user_id));
-  TRY(rh::opt_integer(spec, 12, data.has_group_id, data.group_id));
-  TRY(rh::opt_integer(spec, 13, data.has_command_timeout, data.command_timeout));
-  TRY(rh::string(spec, 14, data.runner));
+  TRY(rh::string(spec, 10, data.hostname));
+  TRY(rh::string(spec, 11, data.domainname));
+  TRY(rh::opt_integer(spec, 12, data.has_user_id, data.user_id));
+  TRY(rh::opt_integer(spec, 13, data.has_group_id, data.group_id));
+  TRY(rh::opt_integer(spec, 14, data.has_command_timeout, data.command_timeout));
+  TRY(rh::string(spec, 15, data.runner));
 
 #undef TRY
 
@@ -299,6 +302,8 @@ static void write_jast_pretty(std::ostream &os, const JAST &jast, int indent, in
 // Returns an empty string on success, or an error message.
 static std::string write_spec_json(const SpecData &d, const char *filepath, int indent) {
   JAST root(JSON_OBJECT);
+
+  root.add("label", d.label);
 
   JAST &cmd = root.add("command", JSON_ARRAY);
   for (const auto &s : d.command) cmd.add(s);

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -42,19 +42,20 @@
 //     [0]  Label            : Option String
 //     [1]  Command          : List String
 //     [2]  Environment      : List String
-//     [3]  Visible          : List Path
+//     [3]  Stdin            : String
 //     [4]  Directory        : String
-//     [5]  Stdin            : String
-//     [6]  CasDir           : String
-//     [7]  IsolateNetwork   : Boolean
-//     [8]  IsolatePids      : Boolean
-//     [9]  MountOps         : List WakeboxMountOp
-//     [10] Hostname         : Option String
-//     [11] DomainName       : Option String
-//     [12] UserId           : Option Integer
-//     [13] GroupId          : Option Integer
-//     [14] CommandTimeout   : Option Integer
-//     [15] Runner           : Option String
+//     [5]  CommandTimeout   : Option Integer
+//     [6]  IsolateNetwork   : Boolean
+//     [7]  IsolatePids      : Boolean
+//     [8]  Hostname         : Option String
+//     [9]  DomainName       : Option String
+//     [10] UserId           : Option Integer
+//     [11] GroupId          : Option Integer
+//     [12] Version          : Option String
+//     [13] Runner           : Option String
+//     [14] CasDir           : String
+//     [15] MountOps         : List WakeboxMountOp
+//     [16] Visible          : List Path
 //
 //   Path (from io.wake / path.wake) =
 //     [0] Name    : String
@@ -99,22 +100,23 @@ enum FieldKind {
 
 static Promise *check_spec_ready(Record *spec) {
   static const FieldKind kFields[] = {
-      FK_OPTION,      // Label            : Option String
-      FK_LIST_STR,    // Command          : List String
-      FK_LIST_STR,    // Environment      : List String
-      FK_LIST_PATH,   // Visible          : List Path
-      FK_SCALAR,      // Directory        : String
-      FK_SCALAR,      // Stdin            : String
-      FK_SCALAR,      // CasDir           : String
-      FK_SCALAR,      // IsolateNetwork   : Boolean
-      FK_SCALAR,      // IsolatePids      : Boolean
-      FK_LIST_MOUNT,  // MountOps         : List WakeboxMountOp
-      FK_OPTION,      // Hostname         : Option String
-      FK_OPTION,      // DomainName       : Option String
-      FK_OPTION,      // UserId           : Option Integer
-      FK_OPTION,      // GroupId          : Option Integer
-      FK_OPTION,      // CommandTimeout   : Option Integer
-      FK_OPTION,      // Runner           : Option String
+      FK_OPTION,      // [0]  Label            : Option String
+      FK_LIST_STR,    // [1]  Command          : List String
+      FK_LIST_STR,    // [2]  Environment      : List String
+      FK_SCALAR,      // [3]  Stdin            : String
+      FK_SCALAR,      // [4]  Directory        : String
+      FK_OPTION,      // [5]  CommandTimeout   : Option Integer
+      FK_SCALAR,      // [6]  IsolateNetwork   : Boolean
+      FK_SCALAR,      // [7]  IsolatePids      : Boolean
+      FK_OPTION,      // [8]  Hostname         : Option String
+      FK_OPTION,      // [9]  DomainName       : Option String
+      FK_OPTION,      // [10] UserId           : Option Integer
+      FK_OPTION,      // [11] GroupId          : Option Integer
+      FK_OPTION,      // [12] Version          : Option String
+      FK_OPTION,      // [13] Runner           : Option String
+      FK_SCALAR,      // [14] CasDir           : String
+      FK_LIST_MOUNT,  // [15] MountOps         : List WakeboxMountOp
+      FK_LIST_PATH,   // [16] Visible          : List Path
   };
 
   for (int i = 0; i < (int)(sizeof(kFields) / sizeof(*kFields)); ++i) {
@@ -283,6 +285,103 @@ static std::string stream_spec_json(Record *spec, const char *filepath, int inde
   js.key("environment");
   write_str_array(js, spec->at(2)->coerce<Record>());
 
+  // directory, stdin, cas-dir
+  sep();
+  js.key("directory");
+  js.str(spec->at(4)->coerce<String>()->as_str());
+  sep();
+  js.key("stdin");
+  js.str(spec->at(3)->coerce<String>()->as_str());
+  sep();
+  js.key("cas-dir");
+  js.str(spec->at(14)->coerce<String>()->as_str());
+
+  // isolate-network, isolate-pids
+  bool iso_net = (spec->at(6)->coerce<Record>()->cons == &Boolean->members[0]);
+  bool iso_pid = (spec->at(7)->coerce<Record>()->cons == &Boolean->members[0]);
+  sep();
+  js.key("isolate-network");
+  out << (iso_net ? "true" : "false");
+  sep();
+  js.key("isolate-pids");
+  out << (iso_pid ? "true" : "false");
+
+  opt_str("hostname", 8);
+  opt_str("domainname", 9);
+
+  // Optional integer fields
+  auto opt_int = [&](const char *k, int f) {
+    Record *opt = spec->at(f)->coerce<Record>();
+    if (opt->cons->index == 0) {  // Some
+      mpz_t v = {opt->at(0)->coerce<Integer>()->wrap()};
+      sep();
+      js.key(k);
+      out << mpz_get_si(v);
+    }
+  };
+  opt_int("user-id", 10);
+  opt_int("group-id", 11);
+  opt_int("command-timeout", 5);
+
+  opt_str("version", 12);
+  opt_str("runner", 13);
+
+  // mount-ops
+  sep();
+  js.key("mount-ops");
+  out << '[';
+  {
+    ++js.depth;
+    bool first = true;
+    Record *list = spec->at(15)->coerce<Record>();
+    while (list->cons == &List->members[1]) {
+      if (!first) out << ',';
+      first = false;
+      js.nl();
+
+      Record *entry = list->at(0)->coerce<Record>();
+      int idx = entry->cons->index;
+
+      out << '{';
+      ++js.depth;
+      bool mf = false;
+      auto mk = [&]() {
+        if (mf) out << ',';
+        mf = true;
+        js.nl();
+      };
+      mk();
+      js.key("type");
+      out << '"' << k_mount_type_strings[idx] << '"';
+      if (idx == 0 || idx == 1) {  // bind or squashfs — have source + destination
+        mk();
+        js.key("source");
+        js.str(entry->at(0)->coerce<String>()->as_str());
+        mk();
+        js.key("destination");
+        js.str(entry->at(1)->coerce<String>()->as_str());
+        if (idx == 0) {  // bind also has read_only
+          bool ro = (entry->at(2)->coerce<Record>()->cons == &Boolean->members[0]);
+          mk();
+          js.key("read_only");
+          out << (ro ? "true" : "false");
+        }
+      } else {  // tmpfs, create-dir, create-file, workspace — destination only
+        mk();
+        js.key("destination");
+        js.str(entry->at(0)->coerce<String>()->as_str());
+      }
+      --js.depth;
+      js.nl();
+      out << '}';
+
+      list = list->at(1)->coerce<Record>();
+    }
+    --js.depth;
+    if (!first) js.nl();
+    out << ']';
+  }
+
   // visible
   sep();
   js.key("visible");
@@ -290,7 +389,7 @@ static std::string stream_spec_json(Record *spec, const char *filepath, int inde
   {
     ++js.depth;
     bool first = true;
-    Record *list = spec->at(3)->coerce<Record>();
+    Record *list = spec->at(16)->coerce<Record>();
     while (list->cons == &List->members[1]) {
       if (!first) out << ',';
       first = false;
@@ -342,102 +441,6 @@ static std::string stream_spec_json(Record *spec, const char *filepath, int inde
     if (!first) js.nl();
     out << ']';
   }
-
-  // directory, stdin, cas-dir
-  sep();
-  js.key("directory");
-  js.str(spec->at(4)->coerce<String>()->as_str());
-  sep();
-  js.key("stdin");
-  js.str(spec->at(5)->coerce<String>()->as_str());
-  sep();
-  js.key("cas-dir");
-  js.str(spec->at(6)->coerce<String>()->as_str());
-
-  // isolate-network, isolate-pids
-  bool iso_net = (spec->at(7)->coerce<Record>()->cons == &Boolean->members[0]);
-  bool iso_pid = (spec->at(8)->coerce<Record>()->cons == &Boolean->members[0]);
-  sep();
-  js.key("isolate-network");
-  out << (iso_net ? "true" : "false");
-  sep();
-  js.key("isolate-pids");
-  out << (iso_pid ? "true" : "false");
-
-  // mount-ops
-  sep();
-  js.key("mount-ops");
-  out << '[';
-  {
-    ++js.depth;
-    bool first = true;
-    Record *list = spec->at(9)->coerce<Record>();
-    while (list->cons == &List->members[1]) {
-      if (!first) out << ',';
-      first = false;
-      js.nl();
-
-      Record *entry = list->at(0)->coerce<Record>();
-      int idx = entry->cons->index;
-
-      out << '{';
-      ++js.depth;
-      bool mf = false;
-      auto mk = [&]() {
-        if (mf) out << ',';
-        mf = true;
-        js.nl();
-      };
-      mk();
-      js.key("type");
-      out << '"' << k_mount_type_strings[idx] << '"';
-      if (idx == 0 || idx == 1) {  // bind or squashfs — have source + destination
-        mk();
-        js.key("source");
-        js.str(entry->at(0)->coerce<String>()->as_str());
-        mk();
-        js.key("destination");
-        js.str(entry->at(1)->coerce<String>()->as_str());
-        if (idx == 0) {  // bind also has read_only
-          bool ro = (entry->at(2)->coerce<Record>()->cons == &Boolean->members[0]);
-          mk();
-          js.key("read_only");
-          out << (ro ? "true" : "false");
-        }
-      } else {  // tmpfs, create-dir, create-file, workspace — destination only
-        mk();
-        js.key("destination");
-        js.str(entry->at(0)->coerce<String>()->as_str());
-      }
-      --js.depth;
-      js.nl();
-      out << '}';
-
-      list = list->at(1)->coerce<Record>();
-    }
-    --js.depth;
-    if (!first) js.nl();
-    out << ']';
-  }
-
-  opt_str("hostname", 10);
-  opt_str("domainname", 11);
-
-  // Optional integer fields
-  auto opt_int = [&](const char *k, int f) {
-    Record *opt = spec->at(f)->coerce<Record>();
-    if (opt->cons->index == 0) {  // Some
-      mpz_t v = {opt->at(0)->coerce<Integer>()->wrap()};
-      sep();
-      js.key(k);
-      out << mpz_get_si(v);
-    }
-  };
-  opt_int("user-id", 12);
-  opt_int("group-id", 13);
-  opt_int("command-timeout", 14);
-
-  opt_str("runner", 15);
 
   --js.depth;
   js.nl();

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -74,11 +74,13 @@
 //     5 = PathTypeSymlink      -> "symlink"
 //     6 = PathTypeSocket          (unsupported by wakebox)
 //
-//   WakeboxMountOp =
-//     [0] Type     : MountOpType  (0=Bind,1=CreateDir,2=CreateFile,3=Squashfs,4=Tmpfs,5=Workspace)
-//     [1] Source   : String
-//     [2] Dest     : String
-//     [3] ReadOnly : Boolean
+//   WakeboxMountOp constructor indices (declaration order in runner.wake):
+//     0 = WakeboxBindOp(source:String, dest:String, readonly:Boolean)
+//     1 = WakeboxSquashfsOp(source:String, dest:String)
+//     2 = WakeboxTmpfsOp(dest:String)
+//     3 = WakeboxCreateDirOp(dest:String)
+//     4 = WakeboxCreateFileOp(dest:String)
+//     5 = WakeboxFuseWorkspaceOp(dest:String)
 // ---------------------------------------------------------------------------
 
 namespace {
@@ -97,9 +99,10 @@ struct VisEntry {
 
 struct MountEntry {
   std::string type;
-  std::string source;
+  std::string source;       // empty = omit from JSON
   std::string dest;
-  bool read_only;
+  bool read_only = false;
+  bool has_read_only = false;  // only WakeboxBindOp carries readonly
 };
 
 struct SpecData {
@@ -128,17 +131,38 @@ struct SpecData {
   long command_timeout = 0;
 };
 
-// Map a MountOpType ADT value to its wakebox JSON string.
-// MountOpType constructor indices (runner.wake declaration order):
-//   0=MountBind, 1=MountCreateDir, 2=MountCreateFile,
-//   3=MountSquashfs, 4=MountTmpfs, 5=MountWorkspace
-static Promise *get_mount_op_type_string(Record *mount_rec, std::string &out) {
-  Promise *p = mount_rec->at(0);  // Type field
-  if (!*p) return p;
-  static const char *strings[] = {"bind", "create-dir", "create-file",
-                                  "squashfs", "tmpfs", "workspace"};
-  int idx = p->coerce<Record>()->cons->index;
-  if (idx >= 0 && idx < 6) out = strings[idx];
+// Collect all fields from a WakeboxMountOp ADT value into a MountEntry.
+// WakeboxMountOp constructor indices (runner.wake declaration order):
+//   0=WakeboxBindOp(source,dest,readonly), 1=WakeboxSquashfsOp(source,dest),
+//   2=WakeboxTmpfsOp(dest), 3=WakeboxCreateDirOp(dest),
+//   4=WakeboxCreateFileOp(dest), 5=WakeboxFuseWorkspaceOp(dest)
+static Promise *collect_mount_entry(Record *entry, MountEntry &me) {
+  static const char *strings[] = {"bind", "squashfs", "tmpfs",
+                                  "create-dir", "create-file", "workspace"};
+  int idx = entry->cons->index;
+  if (idx < 0 || idx >= 6) return nullptr;
+  me.type = strings[idx];
+
+  Promise *p;
+  switch (idx) {
+    case 0: {  // WakeboxBindOp(source, dest, readonly)
+      p = entry->at(0); if (!*p) return p; me.source = p->coerce<String>()->as_str();
+      p = entry->at(1); if (!*p) return p; me.dest = p->coerce<String>()->as_str();
+      p = entry->at(2); if (!*p) return p;
+      me.read_only = (p->coerce<Record>()->cons == &Boolean->members[0]);
+      me.has_read_only = true;
+      break;
+    }
+    case 1: {  // WakeboxSquashfsOp(source, dest)
+      p = entry->at(0); if (!*p) return p; me.source = p->coerce<String>()->as_str();
+      p = entry->at(1); if (!*p) return p; me.dest = p->coerce<String>()->as_str();
+      break;
+    }
+    default: {  // TmpfsOp, CreateDirOp, CreateFileOp, FuseWorkspaceOp — only dest
+      p = entry->at(0); if (!*p) return p; me.dest = p->coerce<String>()->as_str();
+      break;
+    }
+  }
   return nullptr;
 }
 
@@ -232,10 +256,7 @@ static Promise *collect_spec(Record *spec, SpecData &data) {
       Record *entry = head->coerce<Record>();
 
       MountEntry me;
-      TRY(get_mount_op_type_string(entry, me.type));
-      TRY(rh::string(entry, 1, me.source));
-      TRY(rh::string(entry, 2, me.dest));
-      TRY(rh::boolean(entry, 3, me.read_only));
+      TRY(collect_mount_entry(entry, me));
       data.mounts.push_back(std::move(me));
 
       Promise *tail = list->at(1);
@@ -333,7 +354,7 @@ static std::string write_spec_json(const SpecData &d, const char *filepath, int 
     obj.add("type", me.type);
     if (!me.source.empty()) obj.add("source", me.source);
     obj.add("destination", me.dest);
-    obj.add_bool("read_only", me.read_only);
+    if (me.has_read_only) obj.add_bool("read_only", me.read_only);
   }
 
   if (!d.hostname.empty()) root.add("hostname", d.hostname);

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -105,14 +105,24 @@ struct SpecData {
   // collect_spec returns nullptr in this case — callers must check this field.
   std::string error;
 
-  std::vector<std::string> command, environment;
+  std::vector<std::string> command;
+  std::vector<std::string> environment;
   std::vector<VisEntry> visible;
-  std::string directory, stdin_str, cas_dir;
-  bool isolate_network, isolate_pids;
+  std::string directory;
+  std::string stdin_str;
+  std::string cas_dir;
+  bool isolate_network;
+  bool isolate_pids;
   std::vector<MountEntry> mounts;
-  std::string hostname, domainname, runner;
-  bool has_user_id = false, has_group_id = false, has_command_timeout = false;
-  long user_id = 0, group_id = 0, command_timeout = 0;
+  std::string hostname;
+  std::string domainname;
+  std::string runner;
+  bool has_user_id = false;
+  bool has_group_id = false;
+  bool has_command_timeout = false;
+  long user_id = 0;
+  long group_id = 0;
+  long command_timeout = 0;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -90,31 +90,31 @@ namespace {
 // ---------------------------------------------------------------------------
 
 enum FieldKind {
-  FK_SCALAR,     // String / Boolean / Integer — check the top-level Promise only
-  FK_OPTION,     // Option T — check outer Promise; if Some, check the inner Promise
-  FK_LIST_STR,   // List String — walk nodes, check head and tail Promises
-  FK_LIST_PATH,  // List Path — walk nodes, check head + all 5 Path field Promises
-  FK_LIST_MOUNT, // List WakeboxMountOp — walk nodes, check head + variable field count
+  FK_SCALAR,      // String / Boolean / Integer — check the top-level Promise only
+  FK_OPTION,      // Option T — check outer Promise; if Some, check the inner Promise
+  FK_LIST_STR,    // List String — walk nodes, check head and tail Promises
+  FK_LIST_PATH,   // List Path — walk nodes, check head + all 5 Path field Promises
+  FK_LIST_MOUNT,  // List WakeboxMountOp — walk nodes, check head + variable field count
 };
 
 static Promise *check_spec_ready(Record *spec) {
   static const FieldKind kFields[] = {
-    FK_OPTION,     // Label            : Option String
-    FK_LIST_STR,   // Command          : List String
-    FK_LIST_STR,   // Environment      : List String
-    FK_LIST_PATH,  // Visible          : List Path
-    FK_SCALAR,     // Directory        : String
-    FK_SCALAR,     // Stdin            : String
-    FK_SCALAR,     // CasDir           : String
-    FK_SCALAR,     // IsolateNetwork   : Boolean
-    FK_SCALAR,     // IsolatePids      : Boolean
-    FK_LIST_MOUNT, // MountOps         : List WakeboxMountOp
-    FK_OPTION,     // Hostname         : Option String
-    FK_OPTION,     // DomainName       : Option String
-    FK_OPTION,     // UserId           : Option Integer
-    FK_OPTION,     // GroupId          : Option Integer
-    FK_OPTION,     // CommandTimeout   : Option Integer
-    FK_OPTION,     // Runner           : Option String
+      FK_OPTION,      // Label            : Option String
+      FK_LIST_STR,    // Command          : List String
+      FK_LIST_STR,    // Environment      : List String
+      FK_LIST_PATH,   // Visible          : List Path
+      FK_SCALAR,      // Directory        : String
+      FK_SCALAR,      // Stdin            : String
+      FK_SCALAR,      // CasDir           : String
+      FK_SCALAR,      // IsolateNetwork   : Boolean
+      FK_SCALAR,      // IsolatePids      : Boolean
+      FK_LIST_MOUNT,  // MountOps         : List WakeboxMountOp
+      FK_OPTION,      // Hostname         : Option String
+      FK_OPTION,      // DomainName       : Option String
+      FK_OPTION,      // UserId           : Option Integer
+      FK_OPTION,      // GroupId          : Option Integer
+      FK_OPTION,      // CommandTimeout   : Option Integer
+      FK_OPTION,      // Runner           : Option String
   };
 
   for (int i = 0; i < (int)(sizeof(kFields) / sizeof(*kFields)); ++i) {
@@ -202,9 +202,7 @@ struct JStream {
     for (int i = 0; i < depth * indent; ++i) os << ' ';
   }
 
-  void key(const char *k) {
-    os << '"' << k << (indent > 0 ? "\": " : "\":");
-  }
+  void key(const char *k) { os << '"' << k << (indent > 0 ? "\": " : "\":"); }
 
   void str(const std::string &s) { os << '"' << json_escape(s) << '"'; }
 };
@@ -227,23 +225,23 @@ static void write_str_array(JStream &js, Record *list) {
 
 // PathType constructor indices (io.wake declaration order):
 static const char *k_path_type_strings[] = {
-    "file",        // 0 PathTypeRegularFile
-    "directory",   // 1 PathTypeDirectory
-    nullptr,       // 2 PathTypeCharDevice   (unsupported)
-    nullptr,       // 3 PathTypeBlockDevice  (unsupported)
-    nullptr,       // 4 PathTypeFifo         (unsupported)
-    "symlink",     // 5 PathTypeSymlink
-    nullptr,       // 6 PathTypeSocket       (unsupported)
+    "file",       // 0 PathTypeRegularFile
+    "directory",  // 1 PathTypeDirectory
+    nullptr,      // 2 PathTypeCharDevice   (unsupported)
+    nullptr,      // 3 PathTypeBlockDevice  (unsupported)
+    nullptr,      // 4 PathTypeFifo         (unsupported)
+    "symlink",    // 5 PathTypeSymlink
+    nullptr,      // 6 PathTypeSocket       (unsupported)
 };
 
 // WakeboxMountOp constructor indices (runner.wake declaration order):
 static const char *k_mount_type_strings[] = {
-    "bind",        // 0 WakeboxBindOp
-    "squashfs",    // 1 WakeboxSquashfsOp
-    "tmpfs",       // 2 WakeboxTmpfsOp
-    "create-dir",  // 3 WakeboxCreateDirOp
-    "create-file", // 4 WakeboxCreateFileOp
-    "workspace",   // 5 WakeboxFuseWorkspaceOp
+    "bind",         // 0 WakeboxBindOp
+    "squashfs",     // 1 WakeboxSquashfsOp
+    "tmpfs",        // 2 WakeboxTmpfsOp
+    "create-dir",   // 3 WakeboxCreateDirOp
+    "create-file",  // 4 WakeboxCreateFileOp
+    "workspace",    // 5 WakeboxFuseWorkspaceOp
 };
 
 // Stream spec JSON directly to filepath without an intermediate SpecData or
@@ -304,8 +302,8 @@ static std::string stream_spec_json(Record *spec, const char *filepath, int inde
       if (pt_idx < 0 || pt_idx >= 7 || k_path_type_strings[pt_idx] == nullptr) {
         out.close();
         (void)unlink(filepath);
-        return std::string("write_wakebox_spec: unsupported path type '") +
-               pt->cons->ast.name + "' for wakebox (only file, directory, symlink are valid)";
+        return std::string("write_wakebox_spec: unsupported path type '") + pt->cons->ast.name +
+               "' for wakebox (only file, directory, symlink are valid)";
       }
 
       mpz_t mv = {path->at(3)->coerce<Integer>()->wrap()};
@@ -319,11 +317,21 @@ static std::string stream_spec_json(Record *spec, const char *filepath, int inde
         pf = true;
         js.nl();
       };
-      pk(); js.key("path"); js.str(path->at(0)->coerce<String>()->as_str());
-      pk(); js.key("type"); out << '"' << k_path_type_strings[pt_idx] << '"';
-      pk(); js.key("hash"); js.str(path->at(2)->coerce<String>()->as_str());
-      pk(); js.key("mode"); out << mpz_get_si(mv);
-      pk(); js.key("mtime"); out << mpz_get_si(tv);
+      pk();
+      js.key("path");
+      js.str(path->at(0)->coerce<String>()->as_str());
+      pk();
+      js.key("type");
+      out << '"' << k_path_type_strings[pt_idx] << '"';
+      pk();
+      js.key("hash");
+      js.str(path->at(2)->coerce<String>()->as_str());
+      pk();
+      js.key("mode");
+      out << mpz_get_si(mv);
+      pk();
+      js.key("mtime");
+      out << mpz_get_si(tv);
       --js.depth;
       js.nl();
       out << '}';
@@ -336,15 +344,25 @@ static std::string stream_spec_json(Record *spec, const char *filepath, int inde
   }
 
   // directory, stdin, cas-dir
-  sep(); js.key("directory"); js.str(spec->at(4)->coerce<String>()->as_str());
-  sep(); js.key("stdin");     js.str(spec->at(5)->coerce<String>()->as_str());
-  sep(); js.key("cas-dir");   js.str(spec->at(6)->coerce<String>()->as_str());
+  sep();
+  js.key("directory");
+  js.str(spec->at(4)->coerce<String>()->as_str());
+  sep();
+  js.key("stdin");
+  js.str(spec->at(5)->coerce<String>()->as_str());
+  sep();
+  js.key("cas-dir");
+  js.str(spec->at(6)->coerce<String>()->as_str());
 
   // isolate-network, isolate-pids
   bool iso_net = (spec->at(7)->coerce<Record>()->cons == &Boolean->members[0]);
   bool iso_pid = (spec->at(8)->coerce<Record>()->cons == &Boolean->members[0]);
-  sep(); js.key("isolate-network"); out << (iso_net ? "true" : "false");
-  sep(); js.key("isolate-pids");    out << (iso_pid ? "true" : "false");
+  sep();
+  js.key("isolate-network");
+  out << (iso_net ? "true" : "false");
+  sep();
+  js.key("isolate-pids");
+  out << (iso_pid ? "true" : "false");
 
   // mount-ops
   sep();
@@ -370,16 +388,26 @@ static std::string stream_spec_json(Record *spec, const char *filepath, int inde
         mf = true;
         js.nl();
       };
-      mk(); js.key("type"); out << '"' << k_mount_type_strings[idx] << '"';
+      mk();
+      js.key("type");
+      out << '"' << k_mount_type_strings[idx] << '"';
       if (idx == 0 || idx == 1) {  // bind or squashfs — have source + destination
-        mk(); js.key("source");      js.str(entry->at(0)->coerce<String>()->as_str());
-        mk(); js.key("destination"); js.str(entry->at(1)->coerce<String>()->as_str());
+        mk();
+        js.key("source");
+        js.str(entry->at(0)->coerce<String>()->as_str());
+        mk();
+        js.key("destination");
+        js.str(entry->at(1)->coerce<String>()->as_str());
         if (idx == 0) {  // bind also has read_only
           bool ro = (entry->at(2)->coerce<Record>()->cons == &Boolean->members[0]);
-          mk(); js.key("read_only"); out << (ro ? "true" : "false");
+          mk();
+          js.key("read_only");
+          out << (ro ? "true" : "false");
         }
       } else {  // tmpfs, create-dir, create-file, workspace — destination only
-        mk(); js.key("destination"); js.str(entry->at(0)->coerce<String>()->as_str());
+        mk();
+        js.key("destination");
+        js.str(entry->at(0)->coerce<String>()->as_str());
       }
       --js.depth;
       js.nl();
@@ -502,7 +530,8 @@ static PRIMFN(prim_write_wakebox_spec) {
   INTEGER_MPZ(indent_mpz, 1);
   STRING(filepath, 2);
 
-  int indent = (mpz_fits_sint_p(indent_mpz) && mpz_get_si(indent_mpz) > 0) ? mpz_get_si(indent_mpz) : 0;
+  int indent =
+      (mpz_fits_sint_p(indent_mpz) && mpz_get_si(indent_mpz) > 0) ? mpz_get_si(indent_mpz) : 0;
 
   // Reserve space for WriteWakeboxJson + the fulfiller continuation.
   runtime.heap.reserve(WriteWakeboxJson::reserve() + Tuple::fulfiller_pads);

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -246,8 +246,7 @@ static const char *k_mount_type_strings[] = {
     "workspace",    // 5 WakeboxFuseWorkspaceOp
 };
 
-// Stream spec JSON directly to filepath without an intermediate SpecData or
-// JAST tree. All Promises must be fulfilled (call check_spec_ready first).
+// Stream spec JSON directly to filepath All Promises must be fulfilled.
 // Returns an empty string on success, or an error message on failure.
 static std::string stream_spec_json(Record *spec, const char *filepath, int indent) {
   (void)unlink(filepath);

--- a/src/runtime/wakebox_prim.cpp
+++ b/src/runtime/wakebox_prim.cpp
@@ -99,7 +99,7 @@ struct VisEntry {
 
 struct MountEntry {
   std::string type;
-  std::string source;       // empty = omit from JSON
+  std::string source;  // empty = omit from JSON
   std::string dest;
   bool read_only = false;
   bool has_read_only = false;  // only WakeboxBindOp carries readonly
@@ -137,7 +137,7 @@ struct SpecData {
 //   2=WakeboxTmpfsOp(dest), 3=WakeboxCreateDirOp(dest),
 //   4=WakeboxCreateFileOp(dest), 5=WakeboxFuseWorkspaceOp(dest)
 static Promise *collect_mount_entry(Record *entry, MountEntry &me) {
-  static const char *strings[] = {"bind", "squashfs", "tmpfs",
+  static const char *strings[] = {"bind",       "squashfs",    "tmpfs",
                                   "create-dir", "create-file", "workspace"};
   int idx = entry->cons->index;
   if (idx < 0 || idx >= 6) return nullptr;
@@ -146,20 +146,31 @@ static Promise *collect_mount_entry(Record *entry, MountEntry &me) {
   Promise *p;
   switch (idx) {
     case 0: {  // WakeboxBindOp(source, dest, readonly)
-      p = entry->at(0); if (!*p) return p; me.source = p->coerce<String>()->as_str();
-      p = entry->at(1); if (!*p) return p; me.dest = p->coerce<String>()->as_str();
-      p = entry->at(2); if (!*p) return p;
+      p = entry->at(0);
+      if (!*p) return p;
+      me.source = p->coerce<String>()->as_str();
+      p = entry->at(1);
+      if (!*p) return p;
+      me.dest = p->coerce<String>()->as_str();
+      p = entry->at(2);
+      if (!*p) return p;
       me.read_only = (p->coerce<Record>()->cons == &Boolean->members[0]);
       me.has_read_only = true;
       break;
     }
     case 1: {  // WakeboxSquashfsOp(source, dest)
-      p = entry->at(0); if (!*p) return p; me.source = p->coerce<String>()->as_str();
-      p = entry->at(1); if (!*p) return p; me.dest = p->coerce<String>()->as_str();
+      p = entry->at(0);
+      if (!*p) return p;
+      me.source = p->coerce<String>()->as_str();
+      p = entry->at(1);
+      if (!*p) return p;
+      me.dest = p->coerce<String>()->as_str();
       break;
     }
     default: {  // TmpfsOp, CreateDirOp, CreateFileOp, FuseWorkspaceOp — only dest
-      p = entry->at(0); if (!*p) return p; me.dest = p->coerce<String>()->as_str();
+      p = entry->at(0);
+      if (!*p) return p;
+      me.dest = p->coerce<String>()->as_str();
       break;
     }
   }
@@ -190,7 +201,6 @@ static Promise *get_path_type_string(Record *path_rec, std::string &out, std::st
   out = strings[idx];
   return nullptr;
 }
-
 
 // Try to collect all values from the WakeboxSpec record into plain C++ data.
 // Returns nullptr if everything is fulfilled, or the first unfulfilled Promise.

--- a/src/runtime/wakebox_prim.h
+++ b/src/runtime/wakebox_prim.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WAKEBOX_PRIM_H
+#define WAKEBOX_PRIM_H
+
+#include "types/primfn.h"
+
+void prim_register_wakebox(PrimMap &pmap);
+
+#endif

--- a/tests/standard-library/wakebox-spec/.wakeroot
+++ b/tests/standard-library/wakebox-spec/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/standard-library/wakebox-spec/pass.sh
+++ b/tests/standard-library/wakebox-spec/pass.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+set -e
+WAKE="${1:+$1/wake}"
+
+rm -f wake.db wake.log output-minimal.json output-compact.json output-full.json
+
+"${WAKE:-wake}" --stdout=warning,report testWriteMinimal
+diff -u reference-minimal.json output-minimal.json
+
+"${WAKE:-wake}" --stdout=warning,report testWriteCompact
+diff -u reference-compact.json output-compact.json
+
+"${WAKE:-wake}" --stdout=warning,report testWriteFull
+diff -u reference-full.json output-full.json

--- a/tests/standard-library/wakebox-spec/reference-compact.json
+++ b/tests/standard-library/wakebox-spec/reference-compact.json
@@ -1,0 +1,1 @@
+{"command":["true"],"environment":[],"directory":".","stdin":"","cas-dir":"/tmp/cas","isolate-network":false,"isolate-pids":false,"mount-ops":[],"visible":[]}

--- a/tests/standard-library/wakebox-spec/reference-full.json
+++ b/tests/standard-library/wakebox-spec/reference-full.json
@@ -1,0 +1,59 @@
+{
+  "label": "my-label",
+  "command": [
+    "cmd",
+    "--flag"
+  ],
+  "environment": [
+    "HOME=/home/user",
+    "PATH=/bin"
+  ],
+  "directory": ".",
+  "stdin": "",
+  "cas-dir": "/cas",
+  "isolate-network": true,
+  "isolate-pids": true,
+  "hostname": "myhost",
+  "domainname": "example.com",
+  "user-id": 1000,
+  "group-id": 1001,
+  "command-timeout": 3600,
+  "version": "1.0",
+  "runner": "/bin/runner",
+  "mount-ops": [
+    {
+      "type": "bind",
+      "source": "/src",
+      "destination": "/dst",
+      "read_only": false
+    },
+    {
+      "type": "bind",
+      "source": "/rsrc",
+      "destination": "/rdst",
+      "read_only": true
+    },
+    {
+      "type": "squashfs",
+      "source": "/sq.img",
+      "destination": "/mnt"
+    },
+    {
+      "type": "tmpfs",
+      "destination": "/tmp"
+    },
+    {
+      "type": "create-dir",
+      "destination": "/newdir"
+    },
+    {
+      "type": "create-file",
+      "destination": "/newfile"
+    },
+    {
+      "type": "workspace",
+      "destination": "."
+    }
+  ],
+  "visible": []
+}

--- a/tests/standard-library/wakebox-spec/reference-minimal.json
+++ b/tests/standard-library/wakebox-spec/reference-minimal.json
@@ -1,0 +1,13 @@
+{
+  "command": [
+    "true"
+  ],
+  "environment": [],
+  "directory": ".",
+  "stdin": "",
+  "cas-dir": "/tmp/cas",
+  "isolate-network": false,
+  "isolate-pids": false,
+  "mount-ops": [],
+  "visible": []
+}

--- a/tests/standard-library/wakebox-spec/test.wake
+++ b/tests/standard-library/wakebox-spec/test.wake
@@ -1,0 +1,87 @@
+# Tests for WakeboxSpec JSON serialization (writeWakeboxSpec / write_wakebox_spec prim).
+# Each test writes to an output-*.json file; pass.sh diffs against the committed references.
+
+package test_wake
+
+from wake import _
+
+# WakeboxSpec field order (must match runner.wake / wakebox_prim.cpp):
+#   [0]  Label          : Option String
+#   [1]  Command        : List String
+#   [2]  Environment    : List String
+#   [3]  Stdin          : String
+#   [4]  Directory      : String
+#   [5]  CommandTimeout : Option Integer
+#   [6]  IsolateNetwork : Boolean
+#   [7]  IsolatePids    : Boolean
+#   [8]  Hostname       : Option String
+#   [9]  DomainName     : Option String
+#   [10] UserId         : Option Integer
+#   [11] GroupId        : Option Integer
+#   [12] Version        : Option String
+#   [13] Runner         : Option String
+#   [14] CasDir         : String
+#   [15] MountOps       : List WakeboxMountOp
+#   [16] Visible        : List Path
+
+def baseSpec: WakeboxSpec =
+    WakeboxSpec
+    None           # Label
+    ("true", Nil)  # Command
+    Nil            # Environment
+    ""             # Stdin
+    "."            # Directory
+    None           # CommandTimeout
+    False          # IsolateNetwork
+    False          # IsolatePids
+    None           # Hostname
+    None           # DomainName
+    None           # UserId
+    None           # GroupId
+    None           # Version
+    None           # Runner
+    "/tmp/cas"     # CasDir
+    Nil            # MountOps
+    Nil            # Visible
+
+def fullSpec: WakeboxSpec =
+    def ops =
+        WakeboxBindOp "/src" "/dst" False,
+        WakeboxBindOp "/rsrc" "/rdst" True,
+        WakeboxSquashfsOp "/sq.img" "/mnt",
+        WakeboxTmpfsOp "/tmp",
+        WakeboxCreateDirOp "/newdir",
+        WakeboxCreateFileOp "/newfile",
+        WakeboxFuseWorkspaceOp ".",
+        Nil
+
+    WakeboxSpec
+    (Some "my-label")                         # Label
+    ("cmd", "--flag", Nil)                    # Command
+    ("HOME=/home/user", "PATH=/bin", Nil)     # Environment
+    ""                                         # Stdin
+    "."                                        # Directory
+    (Some 3600)                               # CommandTimeout
+    True                                       # IsolateNetwork
+    True                                       # IsolatePids
+    (Some "myhost")                           # Hostname
+    (Some "example.com")                      # DomainName
+    (Some 1000)                               # UserId
+    (Some 1001)                               # GroupId
+    (Some "1.0")                              # Version
+    (Some "/bin/runner")                      # Runner
+    "/cas"                                     # CasDir
+    ops                                        # MountOps
+    Nil                                        # Visible
+
+# Writes the minimal spec as pretty-printed JSON.
+export def testWriteMinimal _: Result Unit Error =
+    writeWakeboxSpec baseSpec 2 "output-minimal.json"
+
+# Writes the minimal spec as compact (no-whitespace) JSON.
+export def testWriteCompact _: Result Unit Error =
+    writeWakeboxSpec baseSpec 0 "output-compact.json"
+
+# Writes a spec exercising all optional fields and all mount-op variants.
+export def testWriteFull _: Result Unit Error =
+    writeWakeboxSpec fullSpec 2 "output-full.json"


### PR DESCRIPTION
* Create wakebox write_wakebox_spec prim
* Create wakebox runner input tuple
* update makeJSONRunner to use new prim and tuple

Creation of the wakebox json in wakeLang has observed to be very compute expensive when scaling up, especially with large Visible file lists. The foldr in the [doFormat](https://github.com/sifiveinc/wake/blob/66c3aa1feafe388cf1d6b181ba5286a83308142d/share/wake/lib/core/json.wake#L82) looks to be the source of a lot of this. 

Basically our current flow requires taking our tuples -> converting them to Jvalue -> Converting them to a string -> writing to a file. Since the write is a job, wake will add this to the work to heap. This will remain there until the runtime interpreter finishes and we can run the job scheduler to launch the jobs. 

This is an enhancement to avoid the problem by just taking an explicit tuple and doing all that work in a single prim so we can dump it out disk ASAP. 