### PR TITLE
Staging dir runner

### DIFF
--- a/share/wake/lib/system/cas.wake
+++ b/share/wake/lib/system/cas.wake
@@ -27,6 +27,20 @@ export def primCasBlobAbsPathStr (hash: String): Result String Error =
     raw hash
     | rmapError makeError
 
+# Allocate a private per-job directory beneath the CAS staging root.
+export def casAllocStagingDir (prefix: String): Result String Error =
+    def raw prefix = prim "cas_alloc_staging_dir"
+
+    raw prefix
+    | rmapError makeError
+
+# Remove a directory previously returned by casAllocStagingDir.
+export def casRemoveStagingDir (path: String): Result Unit Error =
+    def raw path = prim "cas_remove_staging_dir"
+
+    raw path
+    | rmapError makeError
+
 # Materialize an item from CAS to workspace.
 def primCasMaterializeItem (destPath: String) (itemType: String) (hashOrTarget: String) (mode: Integer) (mtimeSec: Integer) (mtimeNsec: Integer): Result Unit Error =
     def raw destPath itemType hashOrTarget mode mtimeSec mtimeNsec = prim "cas_materialize_item"

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -432,25 +432,32 @@ export def stagingDirNsRunner: Runner =
     def fuse = "{wakePath}/wakebox"
 
     def run (job: Job) (input: RunnerInput): RunnerOutput =
-        def stagingDirResult = casAllocStagingDir "job.{input.getRunnerInputPrefix}"
+        def stagingDirResult = casAllocStagingDir "job-{input.getRunnerInputPrefix}"
 
         require Pass stagingDir = stagingDirResult
         else
-            def err = stagingDirResult | getWhenPass "Failed to allocate staging directory".makeError
+            def err = match stagingDirResult
+                Fail e -> e
+                Pass _ -> unreachable "require Pass else guarantees Fail here"
             def _ = markJobSetupFailure job err
 
             RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some err)
 
         def cleanup _ =
-            def _ = casRemoveStagingDir stagingDir
+            match (casRemoveStagingDir stagingDir)
+                Pass _ -> Unit
+                Fail err ->
+                    def _ = printlnLevel logWarning "Failed to remove staging dir {stagingDir}: {err.getErrorCause}"
 
-            Unit
+                    Unit
 
         def stageResult = stageVisibleInputs stagingDir input.getRunnerInputVisible
 
         require Pass _ = stageResult
         else
-            def err = stageResult | getWhenPass "Failed to stage visible inputs".makeError
+            def err = match stageResult
+                Fail e -> e
+                Pass _ -> unreachable "require Pass else guarantees Fail here"
             def _ = cleanup Unit
             def _ = markJobSetupFailure job err
 
@@ -487,7 +494,9 @@ export def stagingDirNsRunner: Runner =
 
         require Pass (Pair stagedOutputs cleanableOutputs) = stagingResult
         else
-            def err = stagingResult | getWhenPass "Failed to stage declared outputs".makeError
+            def err = match stagingResult
+                Fail e -> e
+                Pass _ -> unreachable "require Pass else guarantees Fail here"
             def _ = cleanup Unit
 
             innerOutput
@@ -545,7 +554,9 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
 
         require Pass mountOps = mountOpsResult
         else
-            def runnerError = mountOpsResult | getWhenPass "Failed to create wakebox mount operations".makeError
+            def runnerError = match mountOpsResult
+                Fail e -> e
+                Pass _ -> unreachable "require Pass else guarantees Fail here"
             def _ = markJobSetupFailure job runnerError
 
             RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some runnerError)

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -423,6 +423,11 @@ def stageVisibleInputs (stagingDir: String) (visibles: List Path): Result Unit E
 
 # Runs a job in a private copy of its declared inputs, then stages declared outputs directly
 # from that private tree. This avoids a FUSE daemon and keeps concurrent Wake runs isolated.
+#
+# Only explicit/constant `FnOutputs` (e.g. `setPlanFnOutputs`) is supported. `setPlanFilterOutputs`
+# silently returns no outputs here (`filter f Nil = Nil`), and since the staging root is deleted
+# after finalization, undeclared outputs are lost, not just unpublished. Use `workspaceRunner`/
+# `fuseRunner` for filter-based `FnOutputs`.
 export def stagingDirNsRunner: Runner =
     def fuse = "{wakePath}/wakebox"
 
@@ -451,13 +456,24 @@ export def stagingDirNsRunner: Runner =
 
             RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some err)
 
+        # This runner disables FUSE tracking, so `jsonInputs` is always empty; conservatively
+        # report every visible as an input instead (like `localRunner`) to avoid unconditional
+        # cache hits. Pass `identity` inward as `FnInputs` (no-op) and call the caller's real
+        # `FnInputs` exactly once out here against the full visible set.
+        def visiblePaths = input.getRunnerInputVisible | map getPathName
         def declaredOutputs = input.getRunnerInputFnOutputs Nil
-        def innerInput = input | setRunnerInputFnOutputs (\_ Nil)
+        def innerInput =
+            input
+            | setRunnerInputFnOutputs (\_ Nil)
+            | setRunnerInputFnInputs identity
         def plan =
             makeJSONRunnerPlan fuse
             | setJSONRunnerPlanMkMountOps (stagingMountOps stagingDir)
         def (Runner _ innerRun) = makeJSONRunner plan
-        def innerOutput = innerRun job innerInput
+        def reportedInputs = input.getRunnerInputFnInputs visiblePaths
+        def innerOutput =
+            innerRun job innerInput
+            | setRunnerOutputInputs reportedInputs
 
         require None = innerOutput.getRunnerOutputRunnerError
         else

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -413,10 +413,14 @@ export def writeWakeboxSpec (spec: WakeboxSpec) (indent: Integer) (filePath: Str
     f spec indent filePath
     | rmapError makeError
 
-def stagingMountOps (stagingDir: String) (_input: RunnerInput): Result (List WakeboxMountOp) Error =
+# Produces the sandbox mount ops for a staging-dir based runner: just a single
+# bind mount of `stagingDir` onto the sandbox root (".")
+export def stagingMountOps (stagingDir: String) (_input: RunnerInput): Result (List WakeboxMountOp) Error =
     Pass (WakeboxBindOp stagingDir "." False, Nil)
 
-def stageVisibleInputs (stagingDir: String) (visibles: List Path): Result Unit Error =
+# Copies each visible input `Path` into `stagingDir`, preserving its relative
+# workspace path, so a job can run against a private snapshot of its inputs.
+export def stageVisibleInputs (stagingDir: String) (visibles: List Path): Result Unit Error =
     def raw workspace stagingDir relPaths = prim "stage_visible_inputs"
 
     raw workspace stagingDir (visibles | map getPathName | catWith "\n")

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -238,15 +238,11 @@ def stageWorkspaceOutputsImpl (inPlace: Boolean) (stageFromDir: String) (allOutp
         require True = subset scmp normAllOutputPaths stagedOutputPaths
         else failWithError "Missing staged metadata for workspace outputs"
 
-        def cleanableOutputs =
-            if inPlace then
-                (baseCleanableOutputs ++ stagedOutputPaths)
-                | distinctBy scmp
-            else
-                (baseCleanableOutputs ++ stagedOutputPaths ++ (stagingRoot, Nil))
-                | distinctBy scmp
-
         def stagingRootOpt = if inPlace then None else Some stagingRoot
+
+        def cleanableOutputs =
+            (baseCleanableOutputs ++ stagedOutputPaths ++ optionToList stagingRootOpt)
+            | distinctBy scmp
 
         Pass (
             Pair
@@ -427,49 +423,48 @@ export def stageVisibleInputs (stagingDir: String) (visibles: List Path): Result
     | rmapError makeError
     | addErrorContext "Failed to stage visible inputs into {stagingDir}: "
 
-# Runs a job in a private copy of its declared inputs, then stages declared outputs directly
-# from that private tree. This avoids a FUSE daemon and keeps concurrent Wake runs isolated.
+# Runs a job in a private copy of its declared inputs, then stages declared outputs in place from
+# that private tree (without workspaceRunner's extra safety copy). Outputs still go through CAS
+# ingestion and workspace materialization. The job does not go through
+# FUSE workspace tracking, and keeps concurrent Wake runs isolated.
 #
-# Only explicit/constant `FnOutputs` (e.g. `setPlanFnOutputs`) is supported. `setPlanFilterOutputs`
-# silently returns no outputs here (`filter f Nil = Nil`), and since the staging root is deleted
-# after finalization, undeclared outputs are lost, not just unpublished. Use `workspaceRunner`/
-# `fuseRunner` for filter-based `FnOutputs`.
-export def stagingDirNsRunner: Runner =
-    def fuse = "{wakePath}/wakebox"
+# This runner does not detect files created by the job, so `FnOutputs` starts with an empty list.
+# Add every output that should be materialized to the workspace explicitly. `setPlanFilterOutputs`
+# alone therefore selects no outputs (`filter f Nil = Nil`). To retain unhashed side-effect files,
+# explicitly add them before applying any output filter; files not selected are discarded when the
+# private staging tree is removed.
+export def stagingDirRunner: Runner =
+    def wakebox = "{wakePath}/wakebox"
 
     def run (job: Job) (input: RunnerInput): RunnerOutput =
-        def stagingDirResult = casAllocStagingDir "job-{input.getRunnerInputPrefix}"
+        def getFailure result =
+            require Some err = result.getFail
+            else unreachable "getFailure requires a failed result"
 
-        require Pass stagingDir = stagingDirResult
-        else
-            def err = match stagingDirResult
-                Fail e -> e
-                Pass _ -> unreachable "require Pass else guarantees Fail here"
+            err
 
+        def setupFailure err =
             def _ = markJobSetupFailure job err
 
             RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some err)
 
+        def stagingDirResult = casAllocStagingDir "job-{input.getRunnerInputPrefix}"
+
+        require Pass stagingDir = stagingDirResult
+        else setupFailure (getFailure stagingDirResult)
+
         def cleanup _ = match (casRemoveStagingDir stagingDir)
             Pass _ -> Unit
             Fail err ->
-                def _ =
-                    printlnLevel logWarning "Failed to remove staging dir {stagingDir}: {err.getErrorCause}"
-
-                Unit
+                printlnLevel logWarning "Failed to remove staging dir {stagingDir}: {err.getErrorCause}"
 
         def stageResult = stageVisibleInputs stagingDir input.getRunnerInputVisible
 
         require Pass _ = stageResult
         else
-            def err = match stageResult
-                Fail e -> e
-                Pass _ -> unreachable "require Pass else guarantees Fail here"
-
             def _ = cleanup Unit
-            def _ = markJobSetupFailure job err
 
-            RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some err)
+            setupFailure (getFailure stageResult)
 
         # This runner disables FUSE tracking, so `jsonInputs` is always empty; conservatively
         # report every visible as an input instead (like `localRunner`) to avoid unconditional
@@ -487,7 +482,7 @@ export def stagingDirNsRunner: Runner =
             | setRunnerInputFnInputs identity
 
         def plan =
-            makeJSONRunnerPlan fuse
+            makeJSONRunnerPlan wakebox
             | setJSONRunnerPlanMkMountOps (stagingMountOps stagingDir)
 
         def (Runner _ innerRun) = makeJSONRunner plan
@@ -510,28 +505,22 @@ export def stagingDirNsRunner: Runner =
 
         require Pass (Pair stagedOutputs cleanableOutputs) = stagingResult
         else
-            def err = match stagingResult
-                Fail e -> e
-                Pass _ -> unreachable "require Pass else guarantees Fail here"
-
             def _ = cleanup Unit
 
             innerOutput
-            | setRunnerOutputRunnerError (Some err)
+            | setRunnerOutputRunnerError (Some (getFailure stagingResult))
 
-        def existingPostFinalize = stagedOutputs.getStagedOutputsPostFinalize
-
-        def postFinalize preparedItems =
+        def postFinalize existingPostFinalize preparedItems =
             def _ = existingPostFinalize preparedItems
             def _ = cleanup Unit
 
             Unit
 
         innerOutput
-        | setRunnerOutputOutputs (stagedOutputs | setStagedOutputsPostFinalize postFinalize)
+        | setRunnerOutputOutputs (stagedOutputs | editStagedOutputsPostFinalize postFinalize)
         | setRunnerOutputCleanableOutputs cleanableOutputs
 
-    makeRunner "staging-dir-ns" run
+    makeRunner "staging-dir" run
 
 export def defaultJSONRunnerMkMountOps (_input: RunnerInput): Result (List WakeboxMountOp) Error =
     Pass (WakeboxFuseWorkspaceOp ".", Nil)

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -240,9 +240,11 @@ def stageWorkspaceOutputsImpl (inPlace: Boolean) (stageFromDir: String) (allOutp
 
         def cleanableOutputs =
             if inPlace then
-                (baseCleanableOutputs ++ stagedOutputPaths) | distinctBy scmp
+                (baseCleanableOutputs ++ stagedOutputPaths)
+                | distinctBy scmp
             else
-                (baseCleanableOutputs ++ stagedOutputPaths ++ (stagingRoot, Nil)) | distinctBy scmp
+                (baseCleanableOutputs ++ stagedOutputPaths ++ (stagingRoot, Nil))
+                | distinctBy scmp
 
         def stagingRootOpt = if inPlace then None else Some stagingRoot
 
@@ -439,17 +441,18 @@ export def stagingDirNsRunner: Runner =
             def err = match stagingDirResult
                 Fail e -> e
                 Pass _ -> unreachable "require Pass else guarantees Fail here"
+
             def _ = markJobSetupFailure job err
 
             RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some err)
 
-        def cleanup _ =
-            match (casRemoveStagingDir stagingDir)
-                Pass _ -> Unit
-                Fail err ->
-                    def _ = printlnLevel logWarning "Failed to remove staging dir {stagingDir}: {err.getErrorCause}"
+        def cleanup _ = match (casRemoveStagingDir stagingDir)
+            Pass _ -> Unit
+            Fail err ->
+                def _ =
+                    printlnLevel logWarning "Failed to remove staging dir {stagingDir}: {err.getErrorCause}"
 
-                    Unit
+                Unit
 
         def stageResult = stageVisibleInputs stagingDir input.getRunnerInputVisible
 
@@ -458,6 +461,7 @@ export def stagingDirNsRunner: Runner =
             def err = match stageResult
                 Fail e -> e
                 Pass _ -> unreachable "require Pass else guarantees Fail here"
+
             def _ = cleanup Unit
             def _ = markJobSetupFailure job err
 
@@ -467,17 +471,24 @@ export def stagingDirNsRunner: Runner =
         # report every visible as an input instead (like `localRunner`) to avoid unconditional
         # cache hits. Pass `identity` inward as `FnInputs` (no-op) and call the caller's real
         # `FnInputs` exactly once out here against the full visible set.
-        def visiblePaths = input.getRunnerInputVisible | map getPathName
+        def visiblePaths =
+            input.getRunnerInputVisible
+            | map getPathName
+
         def declaredOutputs = input.getRunnerInputFnOutputs Nil
+
         def innerInput =
             input
             | setRunnerInputFnOutputs (\_ Nil)
             | setRunnerInputFnInputs identity
+
         def plan =
             makeJSONRunnerPlan fuse
             | setJSONRunnerPlanMkMountOps (stagingMountOps stagingDir)
+
         def (Runner _ innerRun) = makeJSONRunner plan
         def reportedInputs = input.getRunnerInputFnInputs visiblePaths
+
         def innerOutput =
             innerRun job innerInput
             | setRunnerOutputInputs reportedInputs
@@ -489,6 +500,7 @@ export def stagingDirNsRunner: Runner =
             innerOutput
 
         def innerCleanable = innerOutput.getRunnerOutputCleanableOutputs
+
         def stagingResult =
             stageWorkspaceOutputsInPlace stagingDir declaredOutputs declaredOutputs innerCleanable
 
@@ -497,12 +509,14 @@ export def stagingDirNsRunner: Runner =
             def err = match stagingResult
                 Fail e -> e
                 Pass _ -> unreachable "require Pass else guarantees Fail here"
+
             def _ = cleanup Unit
 
             innerOutput
             | setRunnerOutputRunnerError (Some err)
 
         def existingPostFinalize = stagedOutputs.getStagedOutputsPostFinalize
+
         def postFinalize preparedItems =
             def _ = existingPostFinalize preparedItems
             def _ = cleanup Unit
@@ -550,13 +564,28 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
             RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some runnerError)
 
         def mountOpsResult =
-            mkMountOps (RunnerInput label command visible environment directory stdin res prefix record isatty fnInputs fnOutputs)
+            mkMountOps (
+                RunnerInput
+                label
+                command
+                visible
+                environment
+                directory
+                stdin
+                res
+                prefix
+                record
+                isatty
+                fnInputs
+                fnOutputs
+            )
 
         require Pass mountOps = mountOpsResult
         else
             def runnerError = match mountOpsResult
                 Fail e -> e
                 Pass _ -> unreachable "require Pass else guarantees Fail here"
+
             def _ = markJobSetupFailure job runnerError
 
             RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some runnerError)

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -180,22 +180,12 @@ export def localRunner: Runner =
 def workspaceStageBase =
     ".build/staging/{str wakePid}"
 
-# Stages a declared workspace-output list and returns the full staged output metadata
-# plus any helper paths that should be cleaned later.
-#
-# Assumes all outputs already exist at their final workspace paths (e.g. produced by a local job
-# or written directly by the runner), so the returned StagedOutputs always has
-# NeedsWorkspaceMaterialization=False -- job finalization will hash/ingest them but not move them.
-#
-# allOutputPaths: every output path to stage (hashed and optionally CAS-ingested)
-# filteredOutputPaths: the published subset of allOutputPaths, i.e. those exposed via getJobOutputs
-# baseCleanableOutputs: additional paths (beyond staging artifacts) to include in the cleanup list,
-export def stageWorkspaceOutputs (allOutputPaths: List String) (filteredOutputPaths: List String) (baseCleanableOutputs: List String): Result (Pair StagedOutputs (List String)) Error =
+def stageWorkspaceOutputsImpl (inPlace: Boolean) (stageFromDir: String) (allOutputPaths: List String) (filteredOutputPaths: List String) (baseCleanableOutputs: List String): Result (Pair StagedOutputs (List String)) Error =
     # Snapshots each listed workspace output (reflink/copy for files, readlink for symlinks,
     # mode capture for directories) into a fresh stage.XXXXXX/ subdirectory of stagingBase and
     # returns (stagingRoot, list of (destPath, type, stagingPathOrTarget, mode, mtimeSec, mtimeNsec)).
     # On any failure the staging directory is cleaned up before returning Fail.
-    def stage_outputs_prim pathsLines stagingBase = prim "stage_outputs"
+    def stage_outputs_prim pathsLines stagingBase stageFromDir = prim "stage_outputs"
 
     # Normalize paths so string comparisons and prim path lookups are consistent
     def normAllOutputPaths = map simplify allOutputPaths
@@ -208,7 +198,7 @@ export def stageWorkspaceOutputs (allOutputPaths: List String) (filteredOutputPa
         failWithError "Published outputs not present in staged workspace outputs: {catWith ", " missing}"
 
     if empty normAllOutputPaths then
-        Pass (Pair (StagedOutputs normFilteredOutputPaths False Nil None (\_ Unit)) baseCleanableOutputs)
+        Pass (Pair (StagedOutputs normFilteredOutputPaths inPlace Nil None (\_ Unit)) baseCleanableOutputs)
     else
         # Convert one flat tuple (destPath, type, stagingPathOrTarget, mode, mtimeSec, mtimeNsec)
         # back into the StagingItem ADT.
@@ -228,8 +218,10 @@ export def stageWorkspaceOutputs (allOutputPaths: List String) (filteredOutputPa
                     Pass (StagingDirectory (StagingDirectoryOutput destPath mode mtimeSec mtimeNsec))
                 t -> failWithError "Unknown staging entry type from stage_outputs prim: {t}"
 
+        def stagingBase = if inPlace then "" else workspaceStageBase
+
         require Pass (Pair stagingRoot rawEntries) =
-            stage_outputs_prim (catWith "\n" normAllOutputPaths) workspaceStageBase
+            stage_outputs_prim (catWith "\n" normAllOutputPaths) stagingBase stageFromDir
             | rmapFail (\msg failWithError "workspace staging failed: {msg}")
 
         require Pass stagingItems =
@@ -247,14 +239,25 @@ export def stageWorkspaceOutputs (allOutputPaths: List String) (filteredOutputPa
         else failWithError "Missing staged metadata for workspace outputs"
 
         def cleanableOutputs =
-            (baseCleanableOutputs ++ stagedOutputPaths ++ (stagingRoot, Nil))
-            | distinctBy scmp
+            if inPlace then
+                (baseCleanableOutputs ++ stagedOutputPaths) | distinctBy scmp
+            else
+                (baseCleanableOutputs ++ stagedOutputPaths ++ (stagingRoot, Nil)) | distinctBy scmp
+
+        def stagingRootOpt = if inPlace then None else Some stagingRoot
 
         Pass (
             Pair
-            (StagedOutputs normFilteredOutputPaths False stagingItems (Some stagingRoot) (\_ Unit))
+            (StagedOutputs normFilteredOutputPaths inPlace stagingItems stagingRootOpt (\_ Unit))
             cleanableOutputs
         )
+
+export def stageWorkspaceOutputsInPlace (stageFromDir: String) (allOutputPaths: List String) (filteredOutputPaths: List String) (baseCleanableOutputs: List String): Result (Pair StagedOutputs (List String)) Error =
+    stageWorkspaceOutputsImpl True stageFromDir allOutputPaths filteredOutputPaths baseCleanableOutputs
+
+# Stages workspace outputs into a separate snapshot before finalization.
+export def stageWorkspaceOutputs (allOutputPaths: List String) (filteredOutputPaths: List String) (baseCleanableOutputs: List String): Result (Pair StagedOutputs (List String)) Error =
+    stageWorkspaceOutputsImpl False "" allOutputPaths filteredOutputPaths baseCleanableOutputs
 
 # workspaceRunner: execute a normal workspace job, then stage its published outputs into a
 # per-invocation staging root for job finalization. Staging isolates outputs so they cannot
@@ -408,6 +411,88 @@ export def writeWakeboxSpec (spec: WakeboxSpec) (indent: Integer) (filePath: Str
     f spec indent filePath
     | rmapError makeError
 
+def stagingMountOps (stagingDir: String) (_input: RunnerInput): Result (List WakeboxMountOp) Error =
+    Pass (WakeboxBindOp stagingDir "." False, Nil)
+
+def stageVisibleInputs (stagingDir: String) (visibles: List Path): Result Unit Error =
+    def raw workspace stagingDir relPaths = prim "stage_visible_inputs"
+
+    raw workspace stagingDir (visibles | map getPathName | catWith "\n")
+    | rmapError makeError
+    | addErrorContext "Failed to stage visible inputs into {stagingDir}: "
+
+# Runs a job in a private copy of its declared inputs, then stages declared outputs directly
+# from that private tree. This avoids a FUSE daemon and keeps concurrent Wake runs isolated.
+export def stagingDirNsRunner: Runner =
+    def fuse = "{wakePath}/wakebox"
+
+    def run (job: Job) (input: RunnerInput): RunnerOutput =
+        def stagingDirResult = casAllocStagingDir "job.{input.getRunnerInputPrefix}"
+
+        require Pass stagingDir = stagingDirResult
+        else
+            def err = stagingDirResult | getWhenPass "Failed to allocate staging directory".makeError
+            def _ = markJobSetupFailure job err
+
+            RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some err)
+
+        def cleanup _ =
+            def _ = casRemoveStagingDir stagingDir
+
+            Unit
+
+        def stageResult = stageVisibleInputs stagingDir input.getRunnerInputVisible
+
+        require Pass _ = stageResult
+        else
+            def err = stageResult | getWhenPass "Failed to stage visible inputs".makeError
+            def _ = cleanup Unit
+            def _ = markJobSetupFailure job err
+
+            RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some err)
+
+        def declaredOutputs = input.getRunnerInputFnOutputs Nil
+        def innerInput = input | setRunnerInputFnOutputs (\_ Nil)
+        def plan =
+            makeJSONRunnerPlan fuse
+            | setJSONRunnerPlanMkMountOps (stagingMountOps stagingDir)
+        def (Runner _ innerRun) = makeJSONRunner plan
+        def innerOutput = innerRun job innerInput
+
+        require None = innerOutput.getRunnerOutputRunnerError
+        else
+            def _ = cleanup Unit
+
+            innerOutput
+
+        def innerCleanable = innerOutput.getRunnerOutputCleanableOutputs
+        def stagingResult =
+            stageWorkspaceOutputsInPlace stagingDir declaredOutputs declaredOutputs innerCleanable
+
+        require Pass (Pair stagedOutputs cleanableOutputs) = stagingResult
+        else
+            def err = stagingResult | getWhenPass "Failed to stage declared outputs".makeError
+            def _ = cleanup Unit
+
+            innerOutput
+            | setRunnerOutputRunnerError (Some err)
+
+        def existingPostFinalize = stagedOutputs.getStagedOutputsPostFinalize
+        def postFinalize preparedItems =
+            def _ = existingPostFinalize preparedItems
+            def _ = cleanup Unit
+
+            Unit
+
+        innerOutput
+        | setRunnerOutputOutputs (stagedOutputs | setStagedOutputsPostFinalize postFinalize)
+        | setRunnerOutputCleanableOutputs cleanableOutputs
+
+    makeRunner "staging-dir-ns" run
+
+export def defaultJSONRunnerMkMountOps (_input: RunnerInput): Result (List WakeboxMountOp) Error =
+    Pass (WakeboxFuseWorkspaceOp ".", Nil)
+
 # A plan describing how to construct a JSONRunner
 # RawScript: the path to the script to run jobs with
 # ExtraArgs: extra arguments to pass to ``RawScript``
@@ -418,22 +503,33 @@ tuple JSONRunnerPlan =
     export ExtraArgs: List String
     export ExtraEnv: List String
     export Estimate: Usage => Usage
+    export MkMountOps: RunnerInput => Result (List WakeboxMountOp) Error
 
 # make a ``JSONRunnerPlan`` with ``Nil`` and ``(_)`` as defaults for ``ExtraArgs`` and ``Estimate`` respectively
 # rawScript: String; the path to the script to run jobs with
 export def makeJSONRunnerPlan (rawScript: String): JSONRunnerPlan =
-    JSONRunnerPlan rawScript Nil Nil (_)
+    JSONRunnerPlan rawScript Nil Nil (_) defaultJSONRunnerMkMountOps
 
 # Make a Runner that runs a named script to run jobs
 # plan: JSONRunnerPlan; a tuple containing the arguments for this function
-export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate): JSONRunnerPlan): Runner =
+export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate mkMountOps): JSONRunnerPlan): Runner =
     def script = which (simplify rawScript)
     def executeOk = access script xOK
 
-    def run (job: Job) ((RunnerInput label command visible environment directory stdin _ prefix record isatty fnInputs fnOutputs): RunnerInput): RunnerOutput =
+    def run (job: Job) ((RunnerInput label command visible environment directory stdin res prefix record isatty fnInputs fnOutputs): RunnerInput): RunnerOutput =
         require True = executeOk
         else
             def runnerError = "Runner {script} is not executable".makeError
+            def _ = markJobSetupFailure job runnerError
+
+            RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some runnerError)
+
+        def mountOpsResult =
+            mkMountOps (RunnerInput label command visible environment directory stdin res prefix record isatty fnInputs fnOutputs)
+
+        require Pass mountOps = mountOpsResult
+        else
+            def runnerError = mountOpsResult | getWhenPass "Failed to create wakebox mount operations".makeError
             def _ = markJobSetupFailure job runnerError
 
             RunnerOutput Nil emptyStagedOutputs Nil emptyUsage (Some runnerError)
@@ -459,7 +555,7 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
             (Some version)
             (Some script)
             primCasDir
-            (WakeboxFuseWorkspaceOp ".", Nil)
+            mountOps
             visible
 
         def writeResult =

--- a/src/cas/cas.cpp
+++ b/src/cas/cas.cpp
@@ -41,6 +41,25 @@ static_assert(SHARD_LEN < HASH_HEX_LEN, "hash length must be longer than shard l
 
 // Global counter for unique temp file names when ingesting files.
 static std::atomic<uint64_t> g_store_counter{0};
+static std::atomic<uint64_t> g_alloc_staging_counter{0};
+
+static std::string sanitize_staging_prefix(const std::string& prefix) {
+  static constexpr size_t kMaxPrefixLen = 64;
+  std::string out;
+  out.reserve(prefix.size());
+  for (char c : prefix) {
+    if (c == '/' || c == '\\' || c == '\0' || c == '.') {
+      out.push_back('_');
+    } else if (c >= 0x20 && c < 0x7f) {
+      out.push_back(c);
+    } else {
+      out.push_back('_');
+    }
+    if (out.size() >= kMaxPrefixLen) break;
+  }
+  if (out.empty()) out = "job";
+  return out;
+}
 // Helper functions for hash-based directory sharding
 static std::string hash_prefix(const ContentHash& hash) {
   std::string hex = hash.to_hex();
@@ -339,6 +358,39 @@ std::optional<CASError> Cas::remove_blob(const ContentHash& hash) {
   if (!fs::remove(blob, ec)) return CASError::NotFound;
   if (ec) return CASError::IOError;
   return std::nullopt;
+}
+
+wcl::result<std::string, CASError> Cas::alloc_staging_dir(const std::string& prefix) const {
+  std::string name = sanitize_staging_prefix(prefix) + "." + std::to_string(getpid()) + "." +
+                     std::to_string(g_alloc_staging_counter.fetch_add(1));
+  std::string path = (fs::path(staging_dir_) / name).string();
+  std::error_code ec;
+  if (!fs::create_directory(path, ec) || ec) {
+    return wcl::make_error<std::string, CASError>(CASError::IOError);
+  }
+  if (chmod(path.c_str(), 0755) != 0) {
+    fs::remove_all(path, ec);
+    return wcl::make_error<std::string, CASError>(CASError::IOError);
+  }
+  return wcl::make_result<std::string, CASError>(std::move(path));
+}
+
+wcl::result<bool, CASError> Cas::remove_staging_dir(const std::string& path) const {
+  std::error_code ec;
+  fs::path target = fs::weakly_canonical(fs::path(path), ec);
+  if (ec) return wcl::make_error<bool, CASError>(CASError::IOError);
+  fs::path root = fs::weakly_canonical(fs::path(staging_dir_), ec);
+  if (ec) return wcl::make_error<bool, CASError>(CASError::IOError);
+
+  auto relative = fs::relative(target, root, ec);
+  if (ec || relative.empty() || relative == fs::path(".") ||
+      relative.native().rfind("..", 0) == 0) {
+    return wcl::make_error<bool, CASError>(CASError::InvalidHash);
+  }
+
+  fs::remove_all(target, ec);
+  if (ec) return wcl::make_error<bool, CASError>(CASError::IOError);
+  return wcl::make_result<bool, CASError>(true);
 }
 
 }  // namespace cas

--- a/src/cas/cas.h
+++ b/src/cas/cas.h
@@ -88,6 +88,9 @@ class Cas {
   // Remove blob from CAS.  Be careful.
   std::optional<CASError> remove_blob(const ContentHash& hash);
 
+  wcl::result<std::string, CASError> alloc_staging_dir(const std::string& prefix) const;
+  wcl::result<bool, CASError> remove_staging_dir(const std::string& path) const;
+
  private:
   std::string root_;
   std::string blobs_dir_;

--- a/src/runtime/cas_prim.cpp
+++ b/src/runtime/cas_prim.cpp
@@ -588,8 +588,8 @@ static PRIMFN(prim_cas_alloc_staging_dir) {
   }
   auto result = store->alloc_staging_dir(prefix->c_str());
   if (!result) {
-    std::string msg = "Failed to allocate CAS staging directory: " +
-                      cas::cas_error_to_string(result.error());
+    std::string msg =
+        "Failed to allocate CAS staging directory: " + cas::cas_error_to_string(result.error());
     runtime.heap.reserve(reserve_result() + String::reserve(msg.size()));
     RETURN(claim_result(runtime.heap, false, String::claim(runtime.heap, msg)));
   }
@@ -617,8 +617,8 @@ static PRIMFN(prim_cas_remove_staging_dir) {
   }
   auto result = store->remove_staging_dir(path->c_str());
   if (!result) {
-    std::string msg = "Failed to remove CAS staging directory: " +
-                      cas::cas_error_to_string(result.error());
+    std::string msg =
+        "Failed to remove CAS staging directory: " + cas::cas_error_to_string(result.error());
     runtime.heap.reserve(reserve_result() + String::reserve(msg.size()));
     RETURN(claim_result(runtime.heap, false, String::claim(runtime.heap, msg)));
   }

--- a/src/runtime/cas_prim.cpp
+++ b/src/runtime/cas_prim.cpp
@@ -568,6 +568,64 @@ static PRIMFN(prim_cas_blob_abs_path) {
   RETURN(claim_result(runtime.heap, true, String::claim(runtime.heap, path)));
 }
 
+static PRIMTYPE(type_cas_alloc_staging_dir) {
+  TypeVar result;
+  Data::typeResult.clone(result);
+  result[0].unify(Data::typeString);
+  result[1].unify(Data::typeString);
+  return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(result);
+}
+
+static PRIMFN(prim_cas_alloc_staging_dir) {
+  CASContext* ctx = static_cast<CASContext*>(data);
+  EXPECT(1);
+  STRING(prefix, 0);
+  cas::Cas* store = ctx->get_store();
+  if (!store) {
+    std::string msg = "CAS store not initialized";
+    runtime.heap.reserve(reserve_result() + String::reserve(msg.size()));
+    RETURN(claim_result(runtime.heap, false, String::claim(runtime.heap, msg)));
+  }
+  auto result = store->alloc_staging_dir(prefix->c_str());
+  if (!result) {
+    std::string msg = "Failed to allocate CAS staging directory: " +
+                      cas::cas_error_to_string(result.error());
+    runtime.heap.reserve(reserve_result() + String::reserve(msg.size()));
+    RETURN(claim_result(runtime.heap, false, String::claim(runtime.heap, msg)));
+  }
+  runtime.heap.reserve(reserve_result() + String::reserve(result->size()));
+  RETURN(claim_result(runtime.heap, true, String::claim(runtime.heap, *result)));
+}
+
+static PRIMTYPE(type_cas_remove_staging_dir) {
+  TypeVar result;
+  Data::typeResult.clone(result);
+  result[0].unify(Data::typeUnit);
+  result[1].unify(Data::typeString);
+  return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(result);
+}
+
+static PRIMFN(prim_cas_remove_staging_dir) {
+  CASContext* ctx = static_cast<CASContext*>(data);
+  EXPECT(1);
+  STRING(path, 0);
+  cas::Cas* store = ctx->get_store();
+  if (!store) {
+    std::string msg = "CAS store not initialized";
+    runtime.heap.reserve(reserve_result() + String::reserve(msg.size()));
+    RETURN(claim_result(runtime.heap, false, String::claim(runtime.heap, msg)));
+  }
+  auto result = store->remove_staging_dir(path->c_str());
+  if (!result) {
+    std::string msg = "Failed to remove CAS staging directory: " +
+                      cas::cas_error_to_string(result.error());
+    runtime.heap.reserve(reserve_result() + String::reserve(msg.size()));
+    RETURN(claim_result(runtime.heap, false, String::claim(runtime.heap, msg)));
+  }
+  runtime.heap.reserve(reserve_result() + reserve_unit());
+  RETURN(claim_result(runtime.heap, true, claim_unit(runtime.heap)));
+}
+
 // ============================================================================
 // Primitive Registration
 // ============================================================================
@@ -576,6 +634,10 @@ void prim_register_cas(CASContext* ctx, PrimMap& pmap) {
   prim_register(pmap, "cas_dir", prim_cas_dir, type_cas_dir, PRIM_PURE, ctx);
   prim_register(pmap, "cas_blob_abs_path", prim_cas_blob_abs_path, type_cas_blob_abs_path,
                 PRIM_PURE, ctx);
+  prim_register(pmap, "cas_alloc_staging_dir", prim_cas_alloc_staging_dir,
+                type_cas_alloc_staging_dir, PRIM_IMPURE, ctx);
+  prim_register(pmap, "cas_remove_staging_dir", prim_cas_remove_staging_dir,
+                type_cas_remove_staging_dir, PRIM_IMPURE, ctx);
   prim_register(pmap, "cas_materialize_item", prim_cas_materialize_item, type_cas_materialize_item,
                 PRIM_IMPURE, ctx);
   prim_register(pmap, "materialize_staged_workspace_item", prim_materialize_staged_workspace_item,

--- a/src/runtime/stage_prim.cpp
+++ b/src/runtime/stage_prim.cpp
@@ -126,8 +126,15 @@ wcl::result<std::string, std::string> create_stage_root(const std::string& stagi
   return wcl::result_value<std::string>(std::string(created));
 }
 
+static std::string resolve_source_path(const std::string& stage_from_dir,
+                                       const std::string& dest_path) {
+  if (stage_from_dir.empty()) return dest_path;
+  return stage_from_dir + "/" + dest_path;
+}
+
 wcl::result<std::vector<StageEntry>, std::string> stage_outputs(
-    const std::vector<std::string>& output_paths, const std::string& stage_root) {
+    const std::vector<std::string>& output_paths, const std::string& stage_root,
+    const std::string& stage_from_dir, bool in_place) {
   std::vector<StageEntry> entries;
   size_t next_stage_id = 0;
 
@@ -137,19 +144,27 @@ wcl::result<std::vector<StageEntry>, std::string> stage_outputs(
                                                         dest_path);
     }
 
+    const std::string source_path = resolve_source_path(stage_from_dir, dest_path);
+
     struct stat st;
-    if (lstat(dest_path.c_str(), &st) != 0) {
-      return wcl::result_error<std::vector<StageEntry>>("lstat(" + dest_path +
+    if (lstat(source_path.c_str(), &st) != 0) {
+      return wcl::result_error<std::vector<StageEntry>>("lstat(" + source_path +
                                                         "): " + strerror(errno));
     }
 
     if (S_ISREG(st.st_mode)) {
-      std::string staging_path = stage_root + "/" + std::to_string(next_stage_id++);
-      auto copy_result = wcl::reflink_or_copy_file(dest_path, staging_path,
-                                                   static_cast<mode_t>(st.st_mode & 07777));
-      if (!copy_result) {
-        return wcl::result_error<std::vector<StageEntry>>("failed to stage file " + dest_path +
-                                                          ": " + strerror(copy_result.error()));
+      // In-place mode: hash directly from `source_path`; CAS ingest will atomically
+      // rename the source into blobs/. Skip the per-output reflink. Used by runners
+      // whose source tree is private and ephemeral (e.g. stagingDirNsRunner).
+      std::string staging_path =
+          in_place ? source_path : stage_root + "/" + std::to_string(next_stage_id++);
+      if (!in_place) {
+        auto copy_result = wcl::reflink_or_copy_file(source_path, staging_path,
+                                                     static_cast<mode_t>(st.st_mode & 07777));
+        if (!copy_result) {
+          return wcl::result_error<std::vector<StageEntry>>("failed to stage file " + source_path +
+                                                            ": " + strerror(copy_result.error()));
+        }
       }
 
       entries.push_back(StageEntry{
@@ -160,7 +175,7 @@ wcl::result<std::vector<StageEntry>, std::string> stage_outputs(
           st.st_mtim,
       });
     } else if (S_ISLNK(st.st_mode)) {
-      auto target_result = read_symlink_target(dest_path);
+      auto target_result = read_symlink_target(source_path);
       if (!target_result) {
         return wcl::make_error<std::vector<StageEntry>, std::string>(target_result.error());
       }
@@ -181,7 +196,8 @@ wcl::result<std::vector<StageEntry>, std::string> stage_outputs(
           st.st_mtim,
       });
     } else {
-      return wcl::result_error<std::vector<StageEntry>>("unsupported output type for " + dest_path);
+      return wcl::result_error<std::vector<StageEntry>>("unsupported output type for " +
+                                                        source_path);
     }
   }
 
@@ -209,10 +225,26 @@ inline size_t reserve_tuple6() { return reserve_tuple2() + reserve_tuple5(); }
 
 }  // namespace
 
-// prim "stage_outputs" pathsLines stagingBase -> Result (Pair String (List Entry)) String
+// prim "stage_outputs" pathsLines stagingBase stageFromDir -> Result (Pair String (List Entry)) String
+//
+// WHEN:    Post-exec. Runners (workspaceRunner, fuseRunner, stagingDirNsRunner) call this
+//          after a job finishes to snapshot declared outputs for hashing + CAS ingest.
+// LAYOUT:  Produces a FLAT staging tree — `stage.XXXXXX/{0,1,2,...}` numbered slots, one
+//          per output, in declaration order. Flatness decouples hashing from path nesting.
+//          IN-PLACE MODE: pass empty stagingBase to skip the flat staging step; the
+//          returned `staging_path` for each file points at its original source location
+//          (under stage_from_dir). CAS ingest then atomically renames sources straight
+//          into blobs/. Safe only when the source tree is private and ephemeral
+//          (e.g. stagingDirNsRunner) — otherwise renaming files away from a shared
+//          workspace would be visible to concurrent readers.
+//
 // where Entry = (destPath, type, stagingPathOrTarget, mode, mtimeSec, mtimeNsec)
-// pathsLines: newline-separated workspace-relative output paths.
+// pathsLines:  newline-separated workspace-relative output paths.
 // stagingBase: directory under which a fresh `stage.XXXXXX/` is created (mkdtemp).
+//              Empty triggers in-place mode; the returned outer Pair's first element
+//              is then "" (no flat staging root was created).
+// stageFromDir: source-side base each output path is read from. Empty = wake's cwd
+//               (the workspace); non-empty = a sandboxed runner's private staging tree.
 // On any failure the staging directory (if created) is removed via CleanupRoot's destructor.
 static PRIMTYPE(type_stage_outputs) {
   // Entry tuple: 6 nested Pairs.
@@ -247,14 +279,15 @@ static PRIMTYPE(type_stage_outputs) {
   result[0].unify(outerPair);
   result[1].unify(Data::typeString);
 
-  return args.size() == 2 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeString) &&
-         out->unify(result);
+  return args.size() == 3 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeString) &&
+         args[2]->unify(Data::typeString) && out->unify(result);
 }
 
 static PRIMFN(prim_stage_outputs) {
-  EXPECT(2);
+  EXPECT(3);
   STRING(paths_arg, 0);
   STRING(staging_base_arg, 1);
+  STRING(stage_from_dir_arg, 2);
 
   auto fail = [&](const std::string& msg) {
     runtime.heap.reserve(reserve_result() + String::reserve(msg.size()));
@@ -265,8 +298,14 @@ static PRIMFN(prim_stage_outputs) {
   std::stringstream paths_stream(std::string(paths_arg->c_str(), paths_arg->size()));
   std::vector<std::string> output_paths = read_input_paths(paths_stream);
 
+  // In-place mode: caller signals "no flat slot needed; hash directly from source paths"
+  // by passing an empty stagingBase. CAS ingest will atomically rename the source files
+  // out of stage_from_dir into the blobs/ tree. Used by stagingDirNsRunner whose
+  // stage_from_dir is a private per-job tree that gets wiped at PostFinalize anyway.
+  const bool in_place = (staging_base_arg->size() == 0);
+
   CleanupRoot cleanup;
-  if (!output_paths.empty()) {
+  if (!in_place && !output_paths.empty()) {
     auto root_result = create_stage_root(staging_base_arg->c_str());
     if (!root_result) {
       fail(root_result.error());
@@ -275,7 +314,8 @@ static PRIMFN(prim_stage_outputs) {
     cleanup.root = *root_result;
   }
 
-  auto entries_result = stage_outputs(output_paths, cleanup.root.string());
+  auto entries_result = stage_outputs(output_paths, cleanup.root.string(),
+                                      std::string(stage_from_dir_arg->c_str()), in_place);
   if (!entries_result) {
     fail(entries_result.error());
     return;
@@ -314,6 +354,106 @@ static PRIMFN(prim_stage_outputs) {
   RETURN(claim_result(runtime.heap, true, outer));
 }
 
+// Materialize a Job's visible files, symlinks, and directories into `dest` staging directory
+static wcl::result<bool, std::string> stage_visible_entry(const std::string& src,
+                                                          const std::string& dest) {
+  struct stat st;
+  if (lstat(src.c_str(), &st) != 0) {
+    return wcl::make_error<bool, std::string>("lstat(" + src + "): " + strerror(errno));
+  }
+
+  if (S_ISREG(st.st_mode)) {
+    auto copy_result =
+        wcl::reflink_or_copy_file(src, dest, static_cast<mode_t>(st.st_mode & 07777));
+    if (!copy_result) {
+      return wcl::make_error<bool, std::string>("reflink/copy " + src + " -> " + dest + ": " +
+                                                strerror(copy_result.error()));
+    }
+    return wcl::make_result<bool, std::string>(true);
+  }
+
+  if (S_ISLNK(st.st_mode)) {
+    auto target = read_symlink_target(src);
+    if (!target) return wcl::make_error<bool, std::string>(target.error());
+    if (symlink(target->c_str(), dest.c_str()) != 0) {
+      return wcl::make_error<bool, std::string>("symlink(" + dest + " -> " + *target +
+                                                "): " + strerror(errno));
+    }
+    return wcl::make_result<bool, std::string>(true);
+  }
+
+  if (S_ISDIR(st.st_mode)) {
+    if (mkdir(dest.c_str(), static_cast<mode_t>(st.st_mode & 07777)) != 0 && errno != EEXIST) {
+      return wcl::make_error<bool, std::string>("mkdir(" + dest + "): " + strerror(errno));
+    }
+    return wcl::make_result<bool, std::string>(true);
+  }
+
+  return wcl::make_error<bool, std::string>("unsupported source type for " + src);
+}
+
+// prim "stage_visible_inputs" workspaceDir stagingDir relPathsLines -> Result Unit String
+//
+// workspaceDir:   absolute path to wake's workspace root.
+// stagingDir:     absolute path to the per-job stagingDir.
+// relPathsLines:  newline-separated workspace-relative path of each visible.
+//
+// Prim utilized by stagingDirRunners to stage a Job's visible input list into a staging
+// directory hierarchically (mirroring the workspace), before a job (wakebox) runs.
+static PRIMTYPE(type_stage_visible_inputs) {
+  TypeVar result;
+  Data::typeResult.clone(result);
+  result[0].unify(Data::typeUnit);
+  result[1].unify(Data::typeString);
+  return args.size() == 3 && args[0]->unify(Data::typeString) &&
+         args[1]->unify(Data::typeString) && args[2]->unify(Data::typeString) &&
+         out->unify(result);
+}
+
+static PRIMFN(prim_stage_visible_inputs) {
+  EXPECT(3);
+  STRING(workspace_arg, 0);
+  STRING(staging_dir_arg, 1);
+  STRING(rel_paths_arg, 2);
+
+  auto fail = [&](const std::string& msg) {
+    runtime.heap.reserve(reserve_result() + String::reserve(msg.size()));
+    auto err = String::claim(runtime.heap, msg);
+    RETURN(claim_result(runtime.heap, false, err));
+  };
+
+  std::string workspace(workspace_arg->c_str(), workspace_arg->size());
+  std::string staging_dir(staging_dir_arg->c_str(), staging_dir_arg->size());
+
+  std::stringstream rel_stream(std::string(rel_paths_arg->c_str(), rel_paths_arg->size()));
+  std::vector<std::string> rel_paths = read_input_paths(rel_stream);
+
+  for (const auto& rel : rel_paths) {
+    std::string src = workspace + "/" + rel;
+    std::string dest = staging_dir + "/" + rel;
+
+    fs::path parent = fs::path(dest).parent_path();
+    if (!parent.empty()) {
+      int err = mkdir_with_parents(parent.string(), 0755);
+      if (err != 0) {
+        fail("mkdir parents for " + dest + ": " + strerror(err));
+        return;
+      }
+    }
+
+    auto result = stage_visible_entry(src, dest);
+    if (!result) {
+      fail(result.error());
+      return;
+    }
+  }
+
+  runtime.heap.reserve(reserve_result() + reserve_unit());
+  RETURN(claim_result(runtime.heap, true, claim_unit(runtime.heap)));
+}
+
 void prim_register_stage(PrimMap& pmap) {
   prim_register(pmap, "stage_outputs", prim_stage_outputs, type_stage_outputs, PRIM_IMPURE);
+  prim_register(pmap, "stage_visible_inputs", prim_stage_visible_inputs,
+                type_stage_visible_inputs, PRIM_IMPURE);
 }

--- a/src/runtime/stage_prim.cpp
+++ b/src/runtime/stage_prim.cpp
@@ -155,7 +155,7 @@ wcl::result<std::vector<StageEntry>, std::string> stage_outputs(
     if (S_ISREG(st.st_mode)) {
       // In-place mode: hash directly from `source_path`; CAS ingest will atomically
       // rename the source into blobs/. Skip the per-output reflink. Used by runners
-      // whose source tree is private and ephemeral (e.g. stagingDirNsRunner).
+      // whose source tree is private and ephemeral (e.g. stagingDirRunner).
       std::string staging_path =
           in_place ? source_path : stage_root + "/" + std::to_string(next_stage_id++);
       if (!in_place) {
@@ -228,7 +228,7 @@ inline size_t reserve_tuple6() { return reserve_tuple2() + reserve_tuple5(); }
 // prim "stage_outputs" pathsLines stagingBase stageFromDir -> Result (Pair String (List Entry))
 // String
 //
-// WHEN:    Post-exec. Runners (workspaceRunner, fuseRunner, stagingDirNsRunner) call this
+// WHEN:    Post-exec. Runners (workspaceRunner, fuseRunner, stagingDirRunner) call this
 //          after a job finishes to snapshot declared outputs for hashing + CAS ingest.
 // LAYOUT:  Produces a FLAT staging tree — `stage.XXXXXX/{0,1,2,...}` numbered slots, one
 //          per output, in declaration order. Flatness decouples hashing from path nesting.
@@ -236,7 +236,7 @@ inline size_t reserve_tuple6() { return reserve_tuple2() + reserve_tuple5(); }
 //          returned `staging_path` for each file points at its original source location
 //          (under stage_from_dir). CAS ingest then atomically renames sources straight
 //          into blobs/. Safe only when the source tree is private and ephemeral
-//          (e.g. stagingDirNsRunner) — otherwise renaming files away from a shared
+//          (e.g. stagingDirRunner) — otherwise renaming files away from a shared
 //          workspace would be visible to concurrent readers.
 //
 // where Entry = (destPath, type, stagingPathOrTarget, mode, mtimeSec, mtimeNsec)
@@ -301,7 +301,7 @@ static PRIMFN(prim_stage_outputs) {
 
   // In-place mode: caller signals "no flat slot needed; hash directly from source paths"
   // by passing an empty stagingBase. CAS ingest will atomically rename the source files
-  // out of stage_from_dir into the blobs/ tree. Used by stagingDirNsRunner whose
+  // out of stage_from_dir into the blobs/ tree. Used by stagingDirRunner whose
   // stage_from_dir is a private per-job tree that gets wiped at PostFinalize anyway.
   const bool in_place = (staging_base_arg->size() == 0);
 

--- a/src/runtime/stage_prim.cpp
+++ b/src/runtime/stage_prim.cpp
@@ -225,7 +225,8 @@ inline size_t reserve_tuple6() { return reserve_tuple2() + reserve_tuple5(); }
 
 }  // namespace
 
-// prim "stage_outputs" pathsLines stagingBase stageFromDir -> Result (Pair String (List Entry)) String
+// prim "stage_outputs" pathsLines stagingBase stageFromDir -> Result (Pair String (List Entry))
+// String
 //
 // WHEN:    Post-exec. Runners (workspaceRunner, fuseRunner, stagingDirNsRunner) call this
 //          after a job finishes to snapshot declared outputs for hashing + CAS ingest.
@@ -405,9 +406,8 @@ static PRIMTYPE(type_stage_visible_inputs) {
   Data::typeResult.clone(result);
   result[0].unify(Data::typeUnit);
   result[1].unify(Data::typeString);
-  return args.size() == 3 && args[0]->unify(Data::typeString) &&
-         args[1]->unify(Data::typeString) && args[2]->unify(Data::typeString) &&
-         out->unify(result);
+  return args.size() == 3 && args[0]->unify(Data::typeString) && args[1]->unify(Data::typeString) &&
+         args[2]->unify(Data::typeString) && out->unify(result);
 }
 
 static PRIMFN(prim_stage_visible_inputs) {
@@ -454,6 +454,6 @@ static PRIMFN(prim_stage_visible_inputs) {
 
 void prim_register_stage(PrimMap& pmap) {
   prim_register(pmap, "stage_outputs", prim_stage_outputs, type_stage_outputs, PRIM_IMPURE);
-  prim_register(pmap, "stage_visible_inputs", prim_stage_visible_inputs,
-                type_stage_visible_inputs, PRIM_IMPURE);
+  prim_register(pmap, "stage_visible_inputs", prim_stage_visible_inputs, type_stage_visible_inputs,
+                PRIM_IMPURE);
 }

--- a/tests/runtime/staging-dir-runner/.wakeroot
+++ b/tests/runtime/staging-dir-runner/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/runtime/staging-dir-runner/pass.sh
+++ b/tests/runtime/staging-dir-runner/pass.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Exercises stagingDirNsRunner: a job runner that runs jobs against a private copy of
+# their declared visible inputs (no FUSE) and stages declared outputs directly out of
+# that private tree.
+
+set -eu
+
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
+
+ARTIFACTS="basic-in.txt basic-out.txt \
+    symlink-in.txt symlink-out.link \
+    nested-out \
+    isolation-secret.txt isolation-out.txt \
+    filter-a.txt filter-b.txt filter-out.txt \
+    failing-out.txt \
+    does-not-exist.txt \
+    filter-declared.txt"
+
+cleanup() {
+    rm -rf .build wake.db* wake.log $ARTIFACTS
+}
+trap cleanup EXIT
+cleanup
+
+"${WAKE}" -x 'test Unit'
+
+# Rerun to check that staged outputs are stable enough for wake's normal cache-hit
+# machinery: every successful job from the first run should be a pure cache hit (not
+# re-executed) on an unchanged rerun. The one job that intentionally fails
+# ("failing-with-output") is never cached and is expected to run again every time.
+"${WAKE}" -x 'test Unit'
+
+reexecuted=$("${WAKE}" --last-executed --simple | grep '^# staging-dir-runner:' || true)
+
+unexpected=$(echo "$reexecuted" | grep -v '^# staging-dir-runner: failing-with-output' || true)
+
+if [ -n "$unexpected" ]; then
+    echo "FAIL: expected only 'failing-with-output' to re-execute on an unchanged rerun, but got:" >&2
+    echo "$unexpected" >&2
+    exit 1
+fi
+
+if ! echo "$reexecuted" | grep -q '^# staging-dir-runner: failing-with-output'; then
+    echo "FAIL: expected 'failing-with-output' to re-execute (failed jobs are never cached)" >&2
+    exit 1
+fi

--- a/tests/runtime/staging-dir-runner/pass.sh
+++ b/tests/runtime/staging-dir-runner/pass.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Exercises stagingDirNsRunner: a job runner that runs jobs against a private copy of
+# Exercises stagingDirRunner: a job runner that runs jobs against a private copy of
 # their declared visible inputs (no FUSE) and stages declared outputs directly out of
 # that private tree.
 

--- a/tests/runtime/staging-dir-runner/stdout
+++ b/tests/runtime/staging-dir-runner/stdout
@@ -1,0 +1,2 @@
+Pass 0
+Pass 0

--- a/tests/runtime/staging-dir-runner/test.wake
+++ b/tests/runtime/staging-dir-runner/test.wake
@@ -1,0 +1,264 @@
+# Tests for `stagingDirNsRunner`: runs a job against a private copy of its declared
+# visible inputs (no FUSE daemon), then stages declared outputs directly out of that
+# private tree.
+#
+# Coverage:
+#  - basic file output round-trip (content + hash stability across cache hit)
+#  - symlink output staging
+#  - directory input round-trip
+#  - isolation: files not declared `Visible` are not observable by the job
+#  - `FnInputs` filtering is honored (only reported inputs affect rerun tracking)
+#  - outputs are staged even when the job itself fails (getJobFailedOutputs)
+#  - a declared output that the job never produces is a hard failure
+#  - a job with no declared outputs and `getJobOutputs`/`getJobOutput` fail as expected
+#  - `setPlanFilterOutputs`-declared (non-constant) outputs are silently dropped
+#    (documented limitation of this runner)
+#  - workspace-escaping declared output paths ("../x") are rejected
+#  - no leftover staging directories survive under `.build/cas/staging` after
+#    success, expected failure, or setup failure
+
+export def writeContent (path: String) (content: String) =
+    write path content
+
+# --- basic file round trip ---
+
+export def basicOutput Unit =
+    require Pass inFile = writeContent "basic-in.txt" "hello"
+    makeExecPlan ("sh", "-c", "cat basic-in.txt > basic-out.txt", Nil) (inFile, Nil)
+    | setPlanLabel "staging-dir-runner: basic"
+    | setPlanFnOutputs (\_ "basic-out.txt", Nil)
+    | runJobWith stagingDirNsRunner
+    | getJobOutput
+
+export def testBasicOutput _: Result Unit Error =
+    require Pass out = basicOutput Unit
+    require Pass content = read out
+    require True = content ==* "hello"
+    else failWithError "expected 'hello', got '{content}'"
+    Pass Unit
+    | addErrorContext "basic-output"
+
+# --- symlink output ---
+
+export def symlinkOutput Unit =
+    require Pass inFile = writeContent "symlink-in.txt" "target contents"
+    makeExecPlan ("sh", "-c", "ln -s symlink-in.txt symlink-out.link", Nil) (inFile, Nil)
+    | setPlanLabel "staging-dir-runner: symlink"
+    | setPlanFnOutputs (\_ "symlink-out.link", Nil)
+    | runJobWith stagingDirNsRunner
+    | getJobOutput
+
+export def testSymlinkOutput _: Result Unit Error =
+    require Pass out = symlinkOutput Unit
+    require PathTypeSymlink = out.getPathType
+    else failWithError "expected symlink output, got {format out.getPathType}"
+    Pass Unit
+    | addErrorContext "symlink-output"
+
+# --- directory input, nested file output ---
+
+export def nestedOutput Unit =
+    makeExecPlan
+    ("sh", "-c", "mkdir -p nested-out/dir && echo deep > nested-out/dir/deep.txt", Nil)
+    Nil
+    | setPlanLabel "staging-dir-runner: nested-output"
+    | setPlanFnOutputs (\_ "nested-out/dir/deep.txt", Nil)
+    | runJobWith stagingDirNsRunner
+    | getJobOutput
+
+export def testNestedOutput _: Result Unit Error =
+    require Pass out = nestedOutput Unit
+    require Pass content = read out
+    require True = content ==* "deep\n"
+    else failWithError "expected 'deep\\n', got '{content}'"
+    Pass Unit
+    | addErrorContext "nested-output"
+
+# --- isolation: undeclared workspace files must not be visible to the job ---
+
+export def isolationCheck Unit =
+    require Pass _secret = writeContent "isolation-secret.txt" "top secret"
+    makeExecPlan
+    ("sh", "-c", "test -f isolation-secret.txt && echo FOUND > isolation-out.txt || echo NOTFOUND > isolation-out.txt", Nil)
+    Nil
+    | setPlanLabel "staging-dir-runner: isolation"
+    | setPlanFnOutputs (\_ "isolation-out.txt", Nil)
+    | runJobWith stagingDirNsRunner
+    | getJobOutput
+
+export def testIsolation _: Result Unit Error =
+    require Pass out = isolationCheck Unit
+    require Pass content = read out
+    require True = content ==* "NOTFOUND\n"
+    else failWithError "expected job to not see undeclared file, got '{content}'"
+    Pass Unit
+    | addErrorContext "isolation"
+
+# --- FnInputs filtering must be honored by the wrapper ---
+
+export def filterInputs Unit =
+    require Pass a = writeContent "filter-a.txt" "aaa"
+    require Pass b = writeContent "filter-b.txt" "bbb"
+    makeExecPlan ("sh", "-c", "cat filter-a.txt filter-b.txt > filter-out.txt", Nil) (a, b, Nil)
+    | setPlanLabel "staging-dir-runner: filter-inputs"
+    | editPlanFnInputs (\_ (\files filter (matches `.*filter-a\.txt` _) files))
+    | setPlanFnOutputs (\_ "filter-out.txt", Nil)
+    | runJobWith stagingDirNsRunner
+    | getJobInputs
+
+export def testFilterInputs _: Result Unit Error =
+    require Pass inputs = filterInputs Unit
+    require i, Nil = inputs
+    else failWithError "expected exactly one reported input, got {format inputs}"
+    require True = i.getPathName ==* "filter-a.txt"
+    else failWithError "expected reported input 'filter-a.txt', got '{i.getPathName}'"
+    Pass Unit
+    | addErrorContext "filter-inputs"
+
+# --- outputs are staged even when the job fails, and are reachable via getJobFailedOutputs ---
+
+export def failingJobWithOutput Unit =
+    makeExecPlan ("sh", "-c", "echo partial > failing-out.txt; exit 3", Nil) Nil
+    | setPlanLabel "staging-dir-runner: failing-with-output"
+    | setPlanFnOutputs (\_ "failing-out.txt", Nil)
+    | runJobWith stagingDirNsRunner
+
+export def testFailingJobOutputStillStaged _: Result Unit Error =
+    def job = failingJobWithOutput Unit
+
+    require Exited 3 = job.getJobStatus
+    else failWithError "expected job to exit 3, got {format job.getJobStatus}"
+
+    require Fail _ = job.getJobOutputs
+    else failWithError "expected getJobOutputs to fail for a failed job"
+
+    require Pass outs = job.getJobFailedOutputs
+    require out, Nil = outs
+    else failWithError "expected exactly one failed output, got {format outs}"
+
+    require Pass content = read out
+    require True = content ==* "partial\n"
+    else failWithError "expected 'partial\\n', got '{content}'"
+
+    Pass Unit
+    | addErrorContext "failing-job-output-still-staged"
+
+# --- a declared output the job never produces is a hard failure, and never partially applies ---
+
+export def missingDeclaredOutput Unit =
+    makeExecPlan ("sh", "-c", "true # missing-declared-output", Nil) Nil
+    | setPlanLabel "staging-dir-runner: missing-declared-output"
+    | setPlanFnOutputs (\_ "does-not-exist.txt", Nil)
+    | setPlanShare False
+    | runJobWith stagingDirNsRunner
+    | getJobOutput
+
+export def testMissingDeclaredOutput _: Result Unit Error =
+    require Fail _ = missingDeclaredOutput Unit
+    else failWithError "expected a Fail for a declared output the job never wrote"
+
+    require False = access "does-not-exist.txt" 0
+    else failWithError "does-not-exist.txt should not exist in the workspace"
+
+    Pass Unit
+    | addErrorContext "missing-declared-output"
+
+# --- no declared outputs: getJobOutputs/getJobOutput both fail cleanly ---
+
+export def noOutputsJob Unit =
+    makeExecPlan ("sh", "-c", "true # no-outputs", Nil) Nil
+    | setPlanLabel "staging-dir-runner: no-outputs"
+    | setPlanFnOutputs (\_ Nil)
+    | setPlanShare False
+    | runJobWith stagingDirNsRunner
+
+export def testNoOutputs _: Result Unit Error =
+    def job = noOutputsJob Unit
+
+    require Pass Nil = job.getJobOutputs
+    else failWithError "expected getJobOutputs to succeed with an empty list"
+
+    require Fail _ = job.getJobOutput
+    else failWithError "expected getJobOutput to fail when there are no outputs"
+
+    Pass Unit
+    | addErrorContext "no-outputs"
+
+# --- setPlanFilterOutputs (a non-constant FnOutputs) is documented to silently
+# yield no outputs under this runner, since `filter f Nil = Nil` regardless of `f`. ---
+
+export def filterOutputsUnsupported Unit =
+    makeExecPlan ("sh", "-c", "echo unseen > filter-declared.txt", Nil) Nil
+    | setPlanLabel "staging-dir-runner: filter-outputs-unsupported"
+    | setPlanFilterOutputs (matches `.*\.txt`)
+    | runJobWith stagingDirNsRunner
+
+export def testFilterOutputsUnsupported _: Result Unit Error =
+    def job = filterOutputsUnsupported Unit
+
+    require True = job.isJobOk
+    else failWithError "expected the underlying job to succeed"
+
+    require Pass Nil = job.getJobOutputs
+    else failWithError "expected setPlanFilterOutputs to yield no outputs under this runner"
+
+    Pass Unit
+    | addErrorContext "filter-outputs-unsupported"
+
+# --- declared output paths that escape the workspace are rejected ---
+
+export def outsideWorkspaceOutput Unit =
+    makeExecPlan ("sh", "-c", "true # outside-workspace", Nil) Nil
+    | setPlanLabel "staging-dir-runner: outside-workspace"
+    | setPlanFnOutputs (\_ "../escape.txt", Nil)
+    | setPlanShare False
+    | runJobWith stagingDirNsRunner
+    | getJobOutput
+
+export def testOutsideWorkspaceOutput _: Result Unit Error =
+    require Fail _ = outsideWorkspaceOutput Unit
+    else failWithError "expected a workspace-escaping output path to be rejected"
+
+    Pass Unit
+    | addErrorContext "outside-workspace-output"
+
+# --- no leftover per-job staging directories after success, job failure, or setup failure ---
+
+def stagingRoot = ".build/cas/staging"
+
+export def leftoverStagingDirs Unit =
+    require True = access stagingRoot 0
+    else Pass Nil
+
+    sources stagingRoot `.*`
+
+export def testNoLeftoverStagingDirs _: Result Unit Error =
+    # Exercise success, job-failure, and setup-failure (missing declared output) paths.
+    def _ = basicOutput Unit
+    def _ = failingJobWithOutput Unit
+    def _ = missingDeclaredOutput Unit
+
+    require Pass leftovers = leftoverStagingDirs Unit
+
+    require Nil = leftovers
+    else
+        failWithError
+        "expected no leftover staging directories, found: {catWith ", " (map getPathName leftovers)}"
+
+    Pass Unit
+    | addErrorContext "no-leftover-staging-dirs"
+
+export def test _ =
+    require Pass Unit = testBasicOutput Unit
+    require Pass Unit = testSymlinkOutput Unit
+    require Pass Unit = testNestedOutput Unit
+    require Pass Unit = testIsolation Unit
+    require Pass Unit = testFilterInputs Unit
+    require Pass Unit = testFailingJobOutputStillStaged Unit
+    require Pass Unit = testMissingDeclaredOutput Unit
+    require Pass Unit = testNoOutputs Unit
+    require Pass Unit = testFilterOutputsUnsupported Unit
+    require Pass Unit = testOutsideWorkspaceOutput Unit
+    require Pass Unit = testNoLeftoverStagingDirs Unit
+
+    Pass 0

--- a/tests/runtime/staging-dir-runner/test.wake
+++ b/tests/runtime/staging-dir-runner/test.wake
@@ -1,4 +1,4 @@
-# Tests for `stagingDirNsRunner`: runs a job against a private copy of its declared
+# Tests for `stagingDirRunner`: runs a job against a private copy of its declared
 # visible inputs (no FUSE daemon), then stages declared outputs directly out of that
 # private tree.
 #
@@ -27,7 +27,7 @@ export def basicOutput Unit =
     makeExecPlan ("sh", "-c", "cat basic-in.txt > basic-out.txt", Nil) (inFile, Nil)
     | setPlanLabel "staging-dir-runner: basic"
     | setPlanFnOutputs (\_ "basic-out.txt", Nil)
-    | runJobWith stagingDirNsRunner
+    | runJobWith stagingDirRunner
     | getJobOutput
 
 export def testBasicOutput _: Result Unit Error =
@@ -45,7 +45,7 @@ export def symlinkOutput Unit =
     makeExecPlan ("sh", "-c", "ln -s symlink-in.txt symlink-out.link", Nil) (inFile, Nil)
     | setPlanLabel "staging-dir-runner: symlink"
     | setPlanFnOutputs (\_ "symlink-out.link", Nil)
-    | runJobWith stagingDirNsRunner
+    | runJobWith stagingDirRunner
     | getJobOutput
 
 export def testSymlinkOutput _: Result Unit Error =
@@ -63,7 +63,7 @@ export def nestedOutput Unit =
     Nil
     | setPlanLabel "staging-dir-runner: nested-output"
     | setPlanFnOutputs (\_ "nested-out/dir/deep.txt", Nil)
-    | runJobWith stagingDirNsRunner
+    | runJobWith stagingDirRunner
     | getJobOutput
 
 export def testNestedOutput _: Result Unit Error =
@@ -83,7 +83,7 @@ export def isolationCheck Unit =
     Nil
     | setPlanLabel "staging-dir-runner: isolation"
     | setPlanFnOutputs (\_ "isolation-out.txt", Nil)
-    | runJobWith stagingDirNsRunner
+    | runJobWith stagingDirRunner
     | getJobOutput
 
 export def testIsolation _: Result Unit Error =
@@ -103,7 +103,7 @@ export def filterInputs Unit =
     | setPlanLabel "staging-dir-runner: filter-inputs"
     | editPlanFnInputs (\_ (\files filter (matches `.*filter-a\.txt` _) files))
     | setPlanFnOutputs (\_ "filter-out.txt", Nil)
-    | runJobWith stagingDirNsRunner
+    | runJobWith stagingDirRunner
     | getJobInputs
 
 export def testFilterInputs _: Result Unit Error =
@@ -121,7 +121,7 @@ export def failingJobWithOutput Unit =
     makeExecPlan ("sh", "-c", "echo partial > failing-out.txt; exit 3", Nil) Nil
     | setPlanLabel "staging-dir-runner: failing-with-output"
     | setPlanFnOutputs (\_ "failing-out.txt", Nil)
-    | runJobWith stagingDirNsRunner
+    | runJobWith stagingDirRunner
 
 export def testFailingJobOutputStillStaged _: Result Unit Error =
     def job = failingJobWithOutput Unit
@@ -150,7 +150,7 @@ export def missingDeclaredOutput Unit =
     | setPlanLabel "staging-dir-runner: missing-declared-output"
     | setPlanFnOutputs (\_ "does-not-exist.txt", Nil)
     | setPlanShare False
-    | runJobWith stagingDirNsRunner
+    | runJobWith stagingDirRunner
     | getJobOutput
 
 export def testMissingDeclaredOutput _: Result Unit Error =
@@ -170,7 +170,7 @@ export def noOutputsJob Unit =
     | setPlanLabel "staging-dir-runner: no-outputs"
     | setPlanFnOutputs (\_ Nil)
     | setPlanShare False
-    | runJobWith stagingDirNsRunner
+    | runJobWith stagingDirRunner
 
 export def testNoOutputs _: Result Unit Error =
     def job = noOutputsJob Unit
@@ -191,7 +191,7 @@ export def filterOutputsUnsupported Unit =
     makeExecPlan ("sh", "-c", "echo unseen > filter-declared.txt", Nil) Nil
     | setPlanLabel "staging-dir-runner: filter-outputs-unsupported"
     | setPlanFilterOutputs (matches `.*\.txt`)
-    | runJobWith stagingDirNsRunner
+    | runJobWith stagingDirRunner
 
 export def testFilterOutputsUnsupported _: Result Unit Error =
     def job = filterOutputsUnsupported Unit
@@ -212,7 +212,7 @@ export def outsideWorkspaceOutput Unit =
     | setPlanLabel "staging-dir-runner: outside-workspace"
     | setPlanFnOutputs (\_ "../escape.txt", Nil)
     | setPlanShare False
-    | runJobWith stagingDirNsRunner
+    | runJobWith stagingDirRunner
     | getJobOutput
 
 export def testOutsideWorkspaceOutput _: Result Unit Error =


### PR DESCRIPTION
Adds stagingDirNsRunner, a non-FUSE runner that executes each job directly inside a private per-job staging directory, then feeds its outputs through the CAS pipeline.

- Allocates a fresh per-job staging directory under {cas_dir}/staging/.
- Materializes the job's visible inputs into that directory at their workspace-relative paths.
- Bind-mounts the directory read-write as . inside a wakebox user/mount namespace and runs the job there 
- After the job exits, harvests the declared outputs (fnOutputs) directly from the staging tree and hands them to job finalization for hashing + CAS ingest, then materializes them into the workspace.
- Cleans up the staging directory via a PostFinalize hook (after CAS ingest completes).