### PR TITLE
switch doFormat implementation to foldL

### DIFF
--- a/share/wake/lib/core/json.wake
+++ b/share/wake/lib/core/json.wake
@@ -108,18 +108,22 @@ def doFormat (fmt: JSONFormat) (lhs: JValue): List String =
             JArray list ->
                 def helper acc value = ",{tabbeder}", rec acc deeper value
 
-                if list.empty then
-                    '[]', rhs
-                else
-                    "[{tabbeder}", foldl helper ("{tabbed}]", rhs) list.reverse | tail
+                # For 0- or 1-element lists the fold direction is irrelevant, so skip
+                # the reverse entirely — this keeps deep, narrow structures (single-element
+                # arrays nested many levels) cheap.
+                match list
+                    Nil -> '[]', rhs
+                    single, Nil -> "[{tabbeder}", rec ("{tabbed}]", rhs) deeper single
+                    _ -> "[{tabbeder}", foldl helper ("{tabbed}]", rhs) list.reverse | tail
             JObject list ->
                 def helper acc (Pair key value) =
                     ",{tabbeder}", '"', jsonEscape key, ("\":{space}", rec acc deeper value)
 
-                if list.empty then
-                    '{}', rhs
-                else
-                    "\{{tabbeder}", foldl helper ("{tabbed}\}", rhs) list.reverse | tail
+                match list
+                    Nil -> '{}', rhs
+                    (Pair key value), Nil ->
+                        "\{{tabbeder}", '"', jsonEscape key, ("\":{space}", rec ("{tabbed}\}", rhs) deeper value)
+                    _ -> "\{{tabbeder}", foldl helper ("{tabbed}\}", rhs) list.reverse | tail
 
     rec Nil (if indent > 0 then Some "" else None) lhs
 

--- a/share/wake/lib/core/json.wake
+++ b/share/wake/lib/core/json.wake
@@ -106,20 +106,20 @@ def doFormat (fmt: JSONFormat) (lhs: JValue): List String =
             JBoolean False -> "false", rhs
             JNull -> "null", rhs
             JArray list ->
-                def helper value acc = ",{tabbeder}", rec acc deeper value
+                def helper acc value = ",{tabbeder}", rec acc deeper value
 
                 if list.empty then
                     '[]', rhs
                 else
-                    "[{tabbeder}", foldr helper ("{tabbed}]", rhs) list | tail
+                    "[{tabbeder}", foldl helper ("{tabbed}]", rhs) list.reverse | tail
             JObject list ->
-                def helper (Pair key value) acc =
+                def helper acc (Pair key value) =
                     ",{tabbeder}", '"', jsonEscape key, ("\":{space}", rec acc deeper value)
 
                 if list.empty then
                     '{}', rhs
                 else
-                    "\{{tabbeder}", foldr helper ("{tabbed}\}", rhs) list | tail
+                    "\{{tabbeder}", foldl helper ("{tabbed}\}", rhs) list.reverse | tail
 
     rec Nil (if indent > 0 then Some "" else None) lhs
 


### PR DESCRIPTION
Currently doFormat uses foldR as its implementation, which has an expensive cost in the heap as it is not tail recursive (the memory is not reclaimable until the recursion bottoms out). Our JSON objects can have extremely long lists of strings (as seen by the compounding memory allocations for the wakebox visible list issue), which makes this ineffective. 

Changing doFormat to use foldL will solve this heap allocation issue (since it is tail recursive), at some cost of time complexity as it needs to reverse the list. This will more so benefit for wide arrays in the JSON (similar to the visible list length), rather than super deeply nested JSON's (which I don't believe we have a use case for)