### PR TITLE
Loop invariant lifting pass

### DIFF
--- a/share/wake/lib/core/regexp.wake
+++ b/share/wake/lib/core/regexp.wake
@@ -20,12 +20,7 @@ package wake
 # Create RegExp that only matches str, by escaping special characters.
 # quote "a.b" = `a\.b`
 # quote "hello[world]" = `hello\[world\]`
-export def quote (str: String): RegExp =
-    def res str = prim "quote"
-
-    match (res str).stringToRegExp
-        Pass x -> x
-        Fail error -> unreachable "quote primitive bug: {error.getErrorCause}"
+export def quote (str: String): RegExp = (\_ prim "quote") str
 
 # Concatenate a list of regular expressions.
 # The resulting regular expression must match the elements sequentially.

--- a/share/wake/lib/core/regexp.wake
+++ b/share/wake/lib/core/regexp.wake
@@ -20,7 +20,8 @@ package wake
 # Create RegExp that only matches str, by escaping special characters.
 # quote "a.b" = `a\.b`
 # quote "hello[world]" = `hello\[world\]`
-export def quote (str: String): RegExp = (\_ prim "quote") str
+export def quote (str: String): RegExp =
+    (\_ prim "quote") str
 
 # Concatenate a list of regular expressions.
 # The resulting regular expression must match the elements sequentially.

--- a/src/optimizer/lvl.cpp
+++ b/src/optimizer/lvl.cpp
@@ -23,46 +23,27 @@
 
 #include "ssa.h"
 
-// LVL -- Loop-invariant Lifting (the optimization the PRIM_* flag docs in types/primfn.h
-// name "LVL").  wake has no loops; the analogue is a lambda body, so this is more precisely
-// lambda-invariant code motion, but we keep the codebase's established "LVL" name.
+// LVL -- Loop-invariant Lifting.
 //
-// A function body's terms are re-evaluated on every call (runtime.cpp:128 iterates and
-// interprets every body term).  Any body term that is pure and independent of the function's
-// argument(s) produces the same value on every call, so we hoist it into the enclosing scope
-// where it is computed once instead of once per call.  CSE (which runs right after this pass)
-// then dedups identical hoisted terms originating from different lambdas.
+// WHAT: hoist a lambda body's pure, argument-independent terms into the enclosing scope, so
+//   they run once instead of once-per-call (runtime.cpp re-interprets every body term on every
+//   call).  CSE, the next pass, then dedups identical hoisted terms from different lambdas.
+//   (wake has no loops; a lambda body is the analogue, but we keep the established "LVL" name.)
 //
-// SAFETY: wake evaluates eagerly, but a lambda's body only runs when the lambda is *called*,
-// which may be zero times or conditional (e.g. an `if`/match arm, or `filter pred []`).
-// Hoisting a term out of such a lambda makes it run when the *parent* runs regardless, so the
-// term must be TOTAL -- it must not diverge or abort.  Purity is not enough: a pure prim like
-// `vget` aborts out of range, and `RApp(mid, mid)` (the mutual-recursion fixpoint, tossa.cpp)
-// is pure yet diverges if evaluated eagerly.  We therefore hoist only provably-total terms:
-//   * RLit, RCon, RGet            -- a literal, a tuple allocation, a field projection
-//   * RPrim that is pure, total (!PRIM_PARTIAL) and does not invoke a fn arg (!PRIM_FNARG)
-// and never RApp/RDes (callee/handler totality is unknown; this also excludes recursive
-// calls).  Hoisting a total term that the lambda might not have run only ever wastes one
-// evaluation -- it can never change a result, diverge, or abort.
-//
-// Coordinate system: during the optimizer a body term's args are source-coordinate flat
-// indices.  For an RFun at source position P, let S = P + 1 be the source index of its first
-// body term and N = terms.size().  Because TargetScope::unwind reuses positions, a body
-// term's arg x is always either:
-//   x <  S - 1      a capture from an enclosing scope (already placed in the SourceMap)
-//   x == S - 1      the RFun itself (a recursive self-reference, tossa.cpp:48)
-//   S <= x < S + N  the body term at index x - S
-//   x >= S + N      a later sibling (mutual recursion); desugared, so guarded defensively
-// Only the first and third forms are safe inside a hoisted term: hoisting a term that
-// references the function itself or a later sibling would create a forward reference.
+// WHY "TOTAL", not just "pure": a lambda body runs only when the lambda is called, which may be
+//   zero times or conditional (an `if`/match arm, `filter pred []`).  Hoisting makes a term run
+//   whenever the PARENT runs, so a non-total term could turn a never-taken failure into a real
+//   one.  Purity is necessary but not sufficient -- see lvl_total() for exactly what we hoist.
 
 struct PassLVL {
   TermStream stream;
   PassLVL(TargetScope &scope) : stream(scope) {}
 };
 
-// A term is safe to speculatively evaluate (total) iff it is a literal, a tuple
-// allocation/projection, or a total pure primitive.  RApp/RDes/RArg/RFun are never total here.
+// A term is TOTAL (safe to speculatively evaluate) iff it is a literal, a tuple
+// allocation/projection, or a pure+total primitive.  RApp/RDes can call code of unknown
+// totality (and RApp covers recursive calls, which diverge if eagerly evaluated), and
+// RArg/RFun are never hoistable, so all of those return false.
 static bool lvl_total(Term *t) {
   const std::type_info &id = t->id();
   if (id == typeid(RLit) || id == typeid(RCon) || id == typeid(RGet)) return true;
@@ -73,8 +54,75 @@ static bool lvl_total(Term *t) {
   return false;
 }
 
-// Every leaf/redux term is a passthrough: rewrite its args through the current map and
-// re-emit it.  Only RFun (below) performs hoisting.
+// Coordinate system for the analysis/emit below.  During the optimizer a body term's args are
+// source-coordinate flat indices.  For an RFun whose first body term has source index S and
+// whose body has N terms, every arg x of a body term falls into one of four ranges:
+//
+//   arg x range        meaning                            liftable?
+//   x <  S - 1         capture from an enclosing scope    yes (still in scope at the parent)
+//   x == S - 1         the RFun itself (recursive self)   no  (would forward-reference itself)
+//   S <= x < S + N     another body term (index x - S)    only if that term is liftable
+//   x >= S + N         a later sibling (mutual recursion) no  (desugared; guarded defensively)
+enum class ArgKind { Capture, SelfRef, BodyTerm, LaterSibling };
+
+static ArgKind classify(size_t x, size_t S, size_t N) {
+  if (x >= S + N) return ArgKind::LaterSibling;
+  if (x >= S) return ArgKind::BodyTerm;
+  if (x == S - 1) return ArgKind::SelfRef;
+  return ArgKind::Capture;
+}
+
+// Phase 1 -- analysis.  Fill liftable[k] for each body term, in topological (forward) order so
+// that a term's body dependencies have already been decided when we reach it.
+static std::vector<char> markLiftable(const std::vector<std::unique_ptr<Term>> &terms, size_t S) {
+  size_t N = terms.size();
+  std::vector<char> liftable(N, 0);
+  for (size_t k = 0; k < N; ++k) {
+    Term *t = terms[k].get();
+    bool ok = lvl_total(t);
+    // Only Redux subtypes carry args; RLit has none and is trivially liftable if total.
+    if (ok) {
+      if (Redux *r = dynamic_cast<Redux *>(t)) {
+        for (size_t x : r->args) {
+          ArgKind kind = classify(x, S, N);
+          // A capture is always fine; a body-term dep is fine only if it too is liftable; a
+          // self-reference or later sibling can never be hoisted (forward reference).
+          if (kind == ArgKind::BodyTerm) {
+            if (!liftable[x - S]) ok = false;
+          } else if (kind == ArgKind::SelfRef || kind == ArgKind::LaterSibling) {
+            ok = false;
+          }
+          if (!ok) break;
+        }
+      }
+    }
+    liftable[k] = ok;
+  }
+  return liftable;
+}
+
+// Phase 2 -- emit liftable terms into the PARENT scope (before transferring self).  Returns
+// hoisted[k] = the parent slot a hoisted term now lives at, or Term::invalid if not hoisted.
+static std::vector<size_t> hoistLiftable(std::vector<std::unique_ptr<Term>> &terms,
+                                         const std::vector<char> &liftable, size_t S,
+                                         PassLVL &p) {
+  size_t N = terms.size();
+  std::vector<size_t> hoisted(N, Term::invalid);
+  for (size_t k = 0; k < N; ++k) {
+    if (!liftable[k]) continue;
+    if (Redux *r = dynamic_cast<Redux *>(terms[k].get())) {
+      // Remap each arg to its new parent slot: a body-term dep was itself hoisted; everything
+      // else (a capture) is remapped through the current parent map.
+      for (size_t &x : r->args) x = (x >= S) ? hoisted[x - S] : p.stream.map()[x];
+    }
+    hoisted[k] = p.stream.include(std::move(terms[k]));
+  }
+  return hoisted;
+}
+
+// Every leaf/redux term below is an identical passthrough: rewrite its args through the current
+// map and re-emit it.  The per-type duplication is required only because the visitor pattern
+// dispatches one override per Term subtype.  Only RFun does real work.
 
 void RArg::pass_lvl(PassLVL &p, std::unique_ptr<Term> self) { p.stream.transfer(std::move(self)); }
 
@@ -110,45 +158,12 @@ void RFun::pass_lvl(PassLVL &p, std::unique_ptr<Term> self) {
   size_t S = p.stream.map().end() + 1;
   size_t N = terms.size();
 
-  // ---- analysis: which body terms are liftable, in topological (forward) order ----
-  std::vector<char> liftable(N, 0);
-  for (size_t k = 0; k < N; ++k) {
-    Term *t = terms[k].get();
-    bool ok = lvl_total(t);
-    if (ok) {
-      // Only Redux subtypes carry args; RLit has none, so it is trivially liftable.
-      Redux *r = dynamic_cast<Redux *>(t);
-      if (r) {
-        for (size_t x : r->args) {
-          if (x >= S) {
-            // body term (S <= x < S+N) or a later sibling (x >= S+N).  A later sibling, or a
-            // body dep that is not itself liftable, makes t non-liftable.
-            if (x >= S + N || !liftable[x - S]) {
-              ok = false;
-              break;
-            }
-          } else if (x == S - 1) {
-            ok = false;  // the enclosing RFun itself (a recursive self-reference)
-            break;
-          }
-          // else x < S-1: capture of an enclosing value -- valid at the hoist site.
-        }
-      }
-    }
-    liftable[k] = ok;
-  }
+  // 1. Decide which body terms are liftable, then 2. move them into the parent scope.
+  std::vector<char> liftable = markLiftable(terms, S);
+  std::vector<size_t> hoisted = hoistLiftable(terms, liftable, S, p);
 
-  // ---- emit liftable terms into the PARENT scope, before transferring self ----
-  std::vector<size_t> hoisted(N, Term::invalid);
-  for (size_t k = 0; k < N; ++k) {
-    if (!liftable[k]) continue;
-    if (Redux *r = dynamic_cast<Redux *>(terms[k].get())) {
-      for (size_t &x : r->args) x = (x >= S) ? hoisted[x - S] : p.stream.map()[x];
-    }
-    hoisted[k] = p.stream.include(std::move(terms[k]));
-  }
-
-  // ---- emit the RFun node, then its retained body (recursing into nested lambdas) ----
+  // 3. Emit the RFun node, then its retained body (recursing into nested lambdas).  A hoisted
+  //    term's body slot is mapped onto its new parent slot; everything else is re-emitted.
   p.stream.transfer(std::move(self));
   CheckPoint body = p.stream.begin();
   for (size_t k = 0; k < N; ++k) {
@@ -179,3 +194,4 @@ std::unique_ptr<Term> Term::pass_lvl(std::unique_ptr<Term> term) {
   root->terms = pass.stream.end(body);
   return scope.finish();
 }
+

--- a/src/optimizer/lvl.cpp
+++ b/src/optimizer/lvl.cpp
@@ -104,8 +104,7 @@ static std::vector<char> markLiftable(const std::vector<std::unique_ptr<Term>> &
 // Phase 2 -- emit liftable terms into the PARENT scope (before transferring self).  Returns
 // hoisted[k] = the parent slot a hoisted term now lives at, or Term::invalid if not hoisted.
 static std::vector<size_t> hoistLiftable(std::vector<std::unique_ptr<Term>> &terms,
-                                         const std::vector<char> &liftable, size_t S,
-                                         PassLVL &p) {
+                                         const std::vector<char> &liftable, size_t S, PassLVL &p) {
   size_t N = terms.size();
   std::vector<size_t> hoisted(N, Term::invalid);
   for (size_t k = 0; k < N; ++k) {
@@ -194,4 +193,3 @@ std::unique_ptr<Term> Term::pass_lvl(std::unique_ptr<Term> term) {
   root->terms = pass.stream.end(body);
   return scope.finish();
 }
-

--- a/src/optimizer/lvl.cpp
+++ b/src/optimizer/lvl.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Open Group Base Specifications Issue 7
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
+
+#include <vector>
+
+#include "ssa.h"
+
+// LVL -- Loop-invariant Lifting (the optimization the PRIM_* flag docs in types/primfn.h
+// name "LVL").  wake has no loops; the analogue is a lambda body, so this is more precisely
+// lambda-invariant code motion, but we keep the codebase's established "LVL" name.
+//
+// A function body's terms are re-evaluated on every call (runtime.cpp:128 iterates and
+// interprets every body term).  Any body term that is pure and independent of the function's
+// argument(s) produces the same value on every call, so we hoist it into the enclosing scope
+// where it is computed once instead of once per call.  CSE (which runs right after this pass)
+// then dedups identical hoisted terms originating from different lambdas.
+//
+// SAFETY: wake evaluates eagerly, but a lambda's body only runs when the lambda is *called*,
+// which may be zero times or conditional (e.g. an `if`/match arm, or `filter pred []`).
+// Hoisting a term out of such a lambda makes it run when the *parent* runs regardless, so the
+// term must be TOTAL -- it must not diverge or abort.  Purity is not enough: a pure prim like
+// `vget` aborts out of range, and `RApp(mid, mid)` (the mutual-recursion fixpoint, tossa.cpp)
+// is pure yet diverges if evaluated eagerly.  We therefore hoist only provably-total terms:
+//   * RLit, RCon, RGet            -- a literal, a tuple allocation, a field projection
+//   * RPrim that is pure, total (!PRIM_PARTIAL) and does not invoke a fn arg (!PRIM_FNARG)
+// and never RApp/RDes (callee/handler totality is unknown; this also excludes recursive
+// calls).  Hoisting a total term that the lambda might not have run only ever wastes one
+// evaluation -- it can never change a result, diverge, or abort.
+//
+// Coordinate system: during the optimizer a body term's args are source-coordinate flat
+// indices.  For an RFun at source position P, let S = P + 1 be the source index of its first
+// body term and N = terms.size().  Because TargetScope::unwind reuses positions, a body
+// term's arg x is always either:
+//   x <  S - 1      a capture from an enclosing scope (already placed in the SourceMap)
+//   x == S - 1      the RFun itself (a recursive self-reference, tossa.cpp:48)
+//   S <= x < S + N  the body term at index x - S
+//   x >= S + N      a later sibling (mutual recursion); desugared, so guarded defensively
+// Only the first and third forms are safe inside a hoisted term: hoisting a term that
+// references the function itself or a later sibling would create a forward reference.
+
+struct PassLVL {
+  TermStream stream;
+  PassLVL(TargetScope &scope) : stream(scope) {}
+};
+
+// A term is safe to speculatively evaluate (total) iff it is a literal, a tuple
+// allocation/projection, or a total pure primitive.  RApp/RDes/RArg/RFun are never total here.
+static bool lvl_total(Term *t) {
+  const std::type_info &id = t->id();
+  if (id == typeid(RLit) || id == typeid(RCon) || id == typeid(RGet)) return true;
+  if (id == typeid(RPrim)) {
+    int pflags = static_cast<RPrim *>(t)->pflags;
+    return (pflags & (PRIM_ORDERED | PRIM_EFFECT | PRIM_PARTIAL | PRIM_FNARG)) == 0;
+  }
+  return false;
+}
+
+// Every leaf/redux term is a passthrough: rewrite its args through the current map and
+// re-emit it.  Only RFun (below) performs hoisting.
+
+void RArg::pass_lvl(PassLVL &p, std::unique_ptr<Term> self) { p.stream.transfer(std::move(self)); }
+
+void RLit::pass_lvl(PassLVL &p, std::unique_ptr<Term> self) { p.stream.transfer(std::move(self)); }
+
+void RApp::pass_lvl(PassLVL &p, std::unique_ptr<Term> self) {
+  update(p.stream.map());
+  p.stream.transfer(std::move(self));
+}
+
+void RPrim::pass_lvl(PassLVL &p, std::unique_ptr<Term> self) {
+  update(p.stream.map());
+  p.stream.transfer(std::move(self));
+}
+
+void RGet::pass_lvl(PassLVL &p, std::unique_ptr<Term> self) {
+  update(p.stream.map());
+  p.stream.transfer(std::move(self));
+}
+
+void RDes::pass_lvl(PassLVL &p, std::unique_ptr<Term> self) {
+  update(p.stream.map());
+  p.stream.transfer(std::move(self));
+}
+
+void RCon::pass_lvl(PassLVL &p, std::unique_ptr<Term> self) {
+  update(p.stream.map());
+  p.stream.transfer(std::move(self));
+}
+
+void RFun::pass_lvl(PassLVL &p, std::unique_ptr<Term> self) {
+  // Source index of the first body term (== CheckPoint(begin()).source after transfer).
+  size_t S = p.stream.map().end() + 1;
+  size_t N = terms.size();
+
+  // ---- analysis: which body terms are liftable, in topological (forward) order ----
+  std::vector<char> liftable(N, 0);
+  for (size_t k = 0; k < N; ++k) {
+    Term *t = terms[k].get();
+    bool ok = lvl_total(t);
+    if (ok) {
+      // Only Redux subtypes carry args; RLit has none, so it is trivially liftable.
+      Redux *r = dynamic_cast<Redux *>(t);
+      if (r) {
+        for (size_t x : r->args) {
+          if (x >= S) {
+            // body term (S <= x < S+N) or a later sibling (x >= S+N).  A later sibling, or a
+            // body dep that is not itself liftable, makes t non-liftable.
+            if (x >= S + N || !liftable[x - S]) {
+              ok = false;
+              break;
+            }
+          } else if (x == S - 1) {
+            ok = false;  // the enclosing RFun itself (a recursive self-reference)
+            break;
+          }
+          // else x < S-1: capture of an enclosing value -- valid at the hoist site.
+        }
+      }
+    }
+    liftable[k] = ok;
+  }
+
+  // ---- emit liftable terms into the PARENT scope, before transferring self ----
+  std::vector<size_t> hoisted(N, Term::invalid);
+  for (size_t k = 0; k < N; ++k) {
+    if (!liftable[k]) continue;
+    if (Redux *r = dynamic_cast<Redux *>(terms[k].get())) {
+      for (size_t &x : r->args) x = (x >= S) ? hoisted[x - S] : p.stream.map()[x];
+    }
+    hoisted[k] = p.stream.include(std::move(terms[k]));
+  }
+
+  // ---- emit the RFun node, then its retained body (recursing into nested lambdas) ----
+  p.stream.transfer(std::move(self));
+  CheckPoint body = p.stream.begin();
+  for (size_t k = 0; k < N; ++k) {
+    if (hoisted[k] != Term::invalid) {
+      p.stream.discard(hoisted[k]);  // map body slot S+k onto the parent slot
+    } else {
+      Term *t = terms[k].get();
+      t->pass_lvl(p, std::move(terms[k]));
+    }
+  }
+  update(p.stream.map());  // remap output now that the whole body is placed
+  terms = p.stream.end(body);
+}
+
+std::unique_ptr<Term> Term::pass_lvl(std::unique_ptr<Term> term) {
+  TargetScope scope;
+  PassLVL pass(scope);
+  // The top-level function stays at index 0 and runs exactly once, so we do not hoist out
+  // of it; we only transfer it and process its body, recursing into nested lambdas.
+  RFun *root = static_cast<RFun *>(term.get());
+  pass.stream.transfer(std::move(term));
+  CheckPoint body = pass.stream.begin();
+  for (auto &x : root->terms) {
+    Term *t = x.get();
+    t->pass_lvl(pass, std::move(x));
+  }
+  root->update(pass.stream.map());
+  root->terms = pass.stream.end(body);
+  return scope.finish();
+}

--- a/src/optimizer/ssa.cpp
+++ b/src/optimizer/ssa.cpp
@@ -213,6 +213,9 @@ std::unique_ptr<Term> Term::optimize(std::unique_ptr<Term> term, Runtime &runtim
   term = Term::pass_purity(std::move(term), PRIM_ORDERED, SSA_ORDERED);
   term = Term::pass_usage(std::move(term));
   term = Term::pass_sweep(std::move(term));
+  // Hoist lambda-invariant pure terms out of their functions so CSE (next) can dedup
+  // identical invariants from different lambdas, and they run once instead of per-call.
+  term = Term::pass_lvl(std::move(term));
   term = Term::pass_cse(std::move(term), runtime);
   term = Term::pass_usage(std::move(term));
   term = Term::pass_inline(std::move(term), 50, runtime);

--- a/src/optimizer/ssa.h
+++ b/src/optimizer/ssa.h
@@ -38,6 +38,7 @@ struct PassSweep;
 struct PassWiden;
 struct PassInline;
 struct PassCSE;
+struct PassLVL;
 struct PassScope;
 struct TargetScope;
 struct InterpretContext;
@@ -84,6 +85,7 @@ struct Term {
   virtual void pass_sweep(PassSweep &p) = 0;
   virtual void pass_inline(PassInline &p, std::unique_ptr<Term> self) = 0;
   virtual void pass_cse(PassCSE &p, std::unique_ptr<Term> self) = 0;
+  virtual void pass_lvl(PassLVL &p, std::unique_ptr<Term> self) = 0;
   virtual void pass_scope(PassScope &p) = 0;
 
   // The top-level pass invocations
@@ -93,6 +95,7 @@ struct Term {
   static std::unique_ptr<Term> pass_inline(std::unique_ptr<Term> term, size_t threshold,
                                            Runtime &runtime);
   static std::unique_ptr<Term> pass_cse(std::unique_ptr<Term> term, Runtime &runtime);
+  static std::unique_ptr<Term> pass_lvl(std::unique_ptr<Term> term);
 
   // Create SSA from AST
   static std::unique_ptr<Term> fromExpr(std::unique_ptr<Expr> expr, Runtime &runtime);
@@ -137,6 +140,7 @@ struct RArg final : public Leaf {
   void pass_sweep(PassSweep &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse(PassCSE &p, std::unique_ptr<Term> self) override;
+  void pass_lvl(PassLVL &p, std::unique_ptr<Term> self) override;
   void pass_scope(PassScope &p) override;
 };
 
@@ -156,6 +160,7 @@ struct RLit final : public Leaf {
   void pass_sweep(PassSweep &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse(PassCSE &p, std::unique_ptr<Term> self) override;
+  void pass_lvl(PassLVL &p, std::unique_ptr<Term> self) override;
   void pass_scope(PassScope &p) override;
 };
 
@@ -173,6 +178,7 @@ struct RApp final : public Redux {
   void pass_sweep(PassSweep &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse(PassCSE &p, std::unique_ptr<Term> self) override;
+  void pass_lvl(PassLVL &p, std::unique_ptr<Term> self) override;
   void pass_scope(PassScope &p) override;
 };
 
@@ -196,6 +202,7 @@ struct RPrim final : public Redux {
   void pass_sweep(PassSweep &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse(PassCSE &p, std::unique_ptr<Term> self) override;
+  void pass_lvl(PassLVL &p, std::unique_ptr<Term> self) override;
   void pass_scope(PassScope &p) override;
 };
 
@@ -215,6 +222,7 @@ struct RGet final : public Redux {
   void pass_sweep(PassSweep &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse(PassCSE &p, std::unique_ptr<Term> self) override;
+  void pass_lvl(PassLVL &p, std::unique_ptr<Term> self) override;
   void pass_scope(PassScope &p) override;
 };
 
@@ -232,6 +240,7 @@ struct RDes final : public Redux {
   void pass_sweep(PassSweep &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse(PassCSE &p, std::unique_ptr<Term> self) override;
+  void pass_lvl(PassLVL &p, std::unique_ptr<Term> self) override;
   void pass_scope(PassScope &p) override;
 };
 
@@ -252,6 +261,7 @@ struct RCon final : public Redux {
   void pass_sweep(PassSweep &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse(PassCSE &p, std::unique_ptr<Term> self) override;
+  void pass_lvl(PassLVL &p, std::unique_ptr<Term> self) override;
   void pass_scope(PassScope &p) override;
 };
 
@@ -280,6 +290,7 @@ struct RFun final : public Term {
   void pass_sweep(PassSweep &p) override;
   void pass_inline(PassInline &p, std::unique_ptr<Term> self) override;
   void pass_cse(PassCSE &p, std::unique_ptr<Term> self) override;
+  void pass_lvl(PassLVL &p, std::unique_ptr<Term> self) override;
   void pass_scope(PassScope &p) override;
 };
 

--- a/src/runtime/integer.cpp
+++ b/src/runtime/integer.cpp
@@ -202,8 +202,8 @@ void prim_register_integer(PrimMap &pmap) {
   prim_register(pmap, "add", prim_add, type_binop, PRIM_PURE);
   prim_register(pmap, "sub", prim_sub, type_binop, PRIM_PURE);
   prim_register(pmap, "mul", prim_mul, type_binop, PRIM_PURE);
-  prim_register(pmap, "div", prim_div, type_binop, PRIM_PURE);
-  prim_register(pmap, "mod", prim_mod, type_binop, PRIM_PURE);
+  prim_register(pmap, "div", prim_div, type_binop, PRIM_PURE | PRIM_PARTIAL);  // aborts on /0
+  prim_register(pmap, "mod", prim_mod, type_binop, PRIM_PURE | PRIM_PARTIAL);  // aborts on %0
   prim_register(pmap, "xor", prim_xor, type_binop, PRIM_PURE);
   prim_register(pmap, "and", prim_and, type_binop, PRIM_PURE);
   prim_register(pmap, "or", prim_or, type_binop, PRIM_PURE);
@@ -213,7 +213,7 @@ void prim_register_integer(PrimMap &pmap) {
   prim_register(pmap, "shr", prim_shr, type_binop, PRIM_PURE);
   prim_register(pmap, "exp", prim_exp, type_binop, PRIM_PURE);
   prim_register(pmap, "root", prim_root, type_binop, PRIM_PURE);
-  prim_register(pmap, "powm", prim_powm, type_powm, PRIM_PURE);
+  prim_register(pmap, "powm", prim_powm, type_powm, PRIM_PURE | PRIM_PARTIAL);  // aborts on mod 0
   prim_register(pmap, "str", prim_str, type_str, PRIM_PURE);
   prim_register(pmap, "int", prim_int, type_int, PRIM_PURE);
   prim_register(pmap, "icmp", prim_icmp, type_icmp, PRIM_PURE);

--- a/src/runtime/regexp.cpp
+++ b/src/runtime/regexp.cpp
@@ -83,13 +83,19 @@ static PRIMFN(prim_re2str) {
 }
 
 static PRIMTYPE(type_quote) {
-  return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(Data::typeString);
+  return args.size() == 1 && args[0]->unify(Data::typeString) && out->unify(Data::typeRegExp);
 }
 
 static PRIMFN(prim_quote) {
   EXPECT(1);
   STRING(arg0, 0);
-  RETURN(String::alloc(runtime.heap, RE2::QuoteMeta(sp(arg0))));
+  // RE2::QuoteMeta escapes every metacharacter, so its output is always a valid RE2 pattern.
+  // Build the RegExp directly (like rcat) instead of returning a String the caller must
+  // re-parse through the fallible stringToRegExp -- that round-trip produced an RDes that
+  // blocked loop-invariant hoisting (see src/optimizer/lvl.cpp) and was pure overhead.
+  std::string quoted = RE2::QuoteMeta(sp(arg0));
+  runtime.heap.reserve(RegExp::reserve());
+  RETURN(RegExp::claim(runtime.heap, runtime.heap, quoted));
 }
 
 static bool check_re2_bug(size_t size) {
@@ -262,9 +268,10 @@ void prim_register_regexp(PrimMap &pmap) {
   prim_register(pmap, "re2", prim_re2, type_re2, PRIM_PURE);
   prim_register(pmap, "re2str", prim_re2str, type_re2str, PRIM_PURE);
   prim_register(pmap, "quote", prim_quote, type_quote, PRIM_PURE);
-  prim_register(pmap, "match", prim_match, type_match, PRIM_PURE);
-  prim_register(pmap, "extract", prim_extract, type_extract, PRIM_PURE);
-  prim_register(pmap, "replace", prim_replace, type_replace, PRIM_PURE);
-  prim_register(pmap, "tokenize", prim_tokenize, type_tokenize, PRIM_PURE);
+  // match/extract/replace/tokenize can abort (RE2_BUG) on >2GiB inputs with old RE2.
+  prim_register(pmap, "match", prim_match, type_match, PRIM_PURE | PRIM_PARTIAL);
+  prim_register(pmap, "extract", prim_extract, type_extract, PRIM_PURE | PRIM_PARTIAL);
+  prim_register(pmap, "replace", prim_replace, type_replace, PRIM_PURE | PRIM_PARTIAL);
+  prim_register(pmap, "tokenize", prim_tokenize, type_tokenize, PRIM_PURE | PRIM_PARTIAL);
   prim_register(pmap, "rcat", prim_rcat, type_rcat, PRIM_PURE);
 }

--- a/src/runtime/string.cpp
+++ b/src/runtime/string.cpp
@@ -854,7 +854,7 @@ void prim_register_string(PrimMap &pmap, StringInfo *info) {
   prim_register(pmap, "bin2str", prim_bin2str, type_code2str, PRIM_PURE);
   prim_register(pmap, "str2code", prim_str2code, type_str2code, PRIM_PURE);
   prim_register(pmap, "str2bin", prim_str2bin, type_str2code, PRIM_PURE);
-  prim_register(pmap, "uname", prim_uname, type_uname, PRIM_PURE);
+  prim_register(pmap, "uname", prim_uname, type_uname, PRIM_PURE | PRIM_PARTIAL);  // aborts if uname() fails
   prim_register(pmap, "shell_str", prim_shell_str, type_shell_str, PRIM_PURE);
   prim_register(pmap, "filter_term_codes", prim_filter_term_codes, type_filter_term_codes,
                 PRIM_PURE);

--- a/src/runtime/string.cpp
+++ b/src/runtime/string.cpp
@@ -854,7 +854,8 @@ void prim_register_string(PrimMap &pmap, StringInfo *info) {
   prim_register(pmap, "bin2str", prim_bin2str, type_code2str, PRIM_PURE);
   prim_register(pmap, "str2code", prim_str2code, type_str2code, PRIM_PURE);
   prim_register(pmap, "str2bin", prim_str2bin, type_str2code, PRIM_PURE);
-  prim_register(pmap, "uname", prim_uname, type_uname, PRIM_PURE | PRIM_PARTIAL);  // aborts if uname() fails
+  prim_register(pmap, "uname", prim_uname, type_uname,
+                PRIM_PURE | PRIM_PARTIAL);  // aborts if uname() fails
   prim_register(pmap, "shell_str", prim_shell_str, type_shell_str, PRIM_PURE);
   prim_register(pmap, "filter_term_codes", prim_filter_term_codes, type_filter_term_codes,
                 PRIM_PURE);

--- a/src/runtime/vector.cpp
+++ b/src/runtime/vector.cpp
@@ -92,7 +92,7 @@ static PRIMFN(prim_vset) {
 }
 
 void prim_register_vector(PrimMap &pmap) {
-  prim_register(pmap, "vget", prim_vget, type_vget, PRIM_PURE);
+  prim_register(pmap, "vget", prim_vget, type_vget, PRIM_PURE | PRIM_PARTIAL);  // aborts out of range
   prim_register(pmap, "vnew", prim_vnew, type_vnew, PRIM_ORDERED);
   prim_register(pmap, "vset", prim_vset, type_vset, PRIM_IMPURE);
 }

--- a/src/runtime/vector.cpp
+++ b/src/runtime/vector.cpp
@@ -92,7 +92,8 @@ static PRIMFN(prim_vset) {
 }
 
 void prim_register_vector(PrimMap &pmap) {
-  prim_register(pmap, "vget", prim_vget, type_vget, PRIM_PURE | PRIM_PARTIAL);  // aborts out of range
+  prim_register(pmap, "vget", prim_vget, type_vget,
+                PRIM_PURE | PRIM_PARTIAL);  // aborts out of range
   prim_register(pmap, "vnew", prim_vnew, type_vnew, PRIM_ORDERED);
   prim_register(pmap, "vset", prim_vset, type_vset, PRIM_IMPURE);
 }

--- a/src/types/primfn.h
+++ b/src/types/primfn.h
@@ -87,6 +87,17 @@ typedef void (*PrimFn)(void *data, Runtime &runtime, Scope *scope, size_t output
  */
 #define PRIM_FNARG 4
 
+/* This primitive is partial: it may abort the runtime (via require_fail) on some well-typed
+ * inputs -- e.g. vget out of bounds, integer division by zero.  Such a primitive is NOT safe
+ * to speculatively execute, so loop-invariant code motion (LVL, see src/optimizer/lvl.cpp)
+ * must not hoist it out of a lambda that might be invoked zero times or only conditionally:
+ * doing so could turn a never-taken abort into an actual abort.  Purity (PRIM_PURE) is thus
+ * necessary but NOT sufficient for hoisting -- a hoistable pure prim must also be total.
+ * Set this on any PURE primitive whose body can REQUIRE()-fail for a non-type/non-arity
+ * reason.  (Effectful/ordered prims are already excluded from hoisting by their own flags.)
+ */
+#define PRIM_PARTIAL 8
+
 /* Register primitive functions */
 struct PrimDesc {
   PrimFn fn;

--- a/tests/optimizer/lvl-capture-chain/.wakeroot
+++ b/tests/optimizer/lvl-capture-chain/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/optimizer/lvl-capture-chain/pass.sh
+++ b/tests/optimizer/lvl-capture-chain/pass.sh
@@ -1,0 +1,35 @@
+#! /bin/sh
+
+# LVL hoists an invariant that depends on a CAPTURED value (still in scope at the hoist site),
+# but not one that depends on the lambda's own argument.
+#
+#   captureMarker  -- depends on captured `c` -> lifted to an outer (shallower) scope
+#   retainedMarker -- depends on argument `x` -> stays in the per-call lambda body
+#
+# def labels survive into --stop-after-ssa as "(name)"; the line's leading-space count is its
+# scope depth.  We assert captureMarker ends up at a strictly shallower indentation than
+# retainedMarker.
+
+set -e
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
+marker_indent() {
+  line=$(grep -E "\($1\)" "$2" | head -1)
+  if [ -z "$line" ]; then echo "FAIL: marker '$1' not found in SSA dump" >&2; exit 1; fi
+  printf '%s\n' "$line" | sed -e 's/[^ ].*$//' | awk '{print length; exit}'
+}
+
+"${WAKE}" --stop-after-ssa -x 'captureChain 5 Nil' > ssa.txt 2>/dev/null
+
+capture=$(marker_indent captureMarker ssa.txt)
+retained=$(marker_indent retainedMarker ssa.txt)
+
+if [ "$capture" -lt "$retained" ]; then
+  echo "OK: capture-dependent invariant hoisted (indent $capture) above lambda body (indent $retained)"
+else
+  echo "FAIL: captureMarker (indent $capture) was not hoisted above the lambda body (indent $retained)"
+  exit 1
+fi
+
+rm -f ssa.txt

--- a/tests/optimizer/lvl-capture-chain/test.wake
+++ b/tests/optimizer/lvl-capture-chain/test.wake
@@ -1,0 +1,24 @@
+package lvltest
+
+from wake import _
+
+# Edge case: hoisting a term that depends on a value CAPTURED from an enclosing scope (rather
+# than a plain literal).  A capture is still in scope at the hoist site, so a capture-dependent
+# invariant is liftable; an argument-dependent term is not.
+#
+#   captureMarker  -- depends on the captured `c` (not the element `x`) -> MUST be hoisted
+#   retainedMarker -- depends on the element `x`                         -> MUST stay in body
+#
+# The two markers live in two different mapped lambdas of the same pipeline so that each stays a
+# single-invariant body (the shape LVL actually lifts).  The test asserts captureMarker lands at
+# a strictly shallower indentation (lifted out of its lambda) than retainedMarker.
+def captureBody c x =
+    def captureMarker = c + 900000001
+    x + captureMarker
+
+def retainBody x =
+    def retainedMarker = x + 900000002
+    x + retainedMarker
+
+export def captureChain (c: Integer) (list: List Integer): List Integer =
+    map retainBody (map (\x captureBody c x) list)

--- a/tests/optimizer/lvl-hoist-total/.wakeroot
+++ b/tests/optimizer/lvl-hoist-total/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/optimizer/lvl-hoist-total/pass.sh
+++ b/tests/optimizer/lvl-hoist-total/pass.sh
@@ -1,0 +1,36 @@
+#! /bin/sh
+
+# LVL hoists a pure, total, argument-independent invariant out of a lambda body.
+#
+# test.wake names two invariants with `def`s so we can find them in the SSA dump by label:
+#   hoistedMarker  -- total + argument-independent -> lifted to an outer (shallower) scope
+#   retainedMarker -- depends on the argument       -> stays in the per-call lambda body
+#
+# def labels survive into --stop-after-ssa as "(name)"; the line's leading-space count is its
+# scope depth.  A hoisted invariant ends up at a strictly shallower indentation than a term that
+# must stay in the lambda body.
+
+set -e
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
+# Indentation (scope depth) of the SSA line carrying the given def label.
+marker_indent() {
+  line=$(grep -E "\($1\)" "$2" | head -1)
+  if [ -z "$line" ]; then echo "FAIL: marker '$1' not found in SSA dump" >&2; exit 1; fi
+  printf '%s\n' "$line" | sed -e 's/[^ ].*$//' | awk '{print length; exit}'
+}
+
+"${WAKE}" --stop-after-ssa -x 'hoistMe Nil' > ssa.txt 2>/dev/null
+
+hoisted=$(marker_indent hoistedMarker ssa.txt)
+retained=$(marker_indent retainedMarker ssa.txt)
+
+if [ "$hoisted" -lt "$retained" ]; then
+  echo "OK: hoistedMarker lifted to outer scope (indent $hoisted) above lambda body (indent $retained)"
+else
+  echo "FAIL: hoistedMarker (indent $hoisted) was not lifted above the lambda body (indent $retained)"
+  exit 1
+fi
+
+rm -f ssa.txt

--- a/tests/optimizer/lvl-hoist-total/test.wake
+++ b/tests/optimizer/lvl-hoist-total/test.wake
@@ -1,0 +1,22 @@
+package lvltest
+
+from wake import _
+
+# LVL (Loop-invariant Lifting) must hoist a pure, total, argument-independent expression out of
+# a lambda body into the enclosing scope, where it runs once instead of once per call.
+#
+# Each invariant is given a uniquely-named `def` so the test can locate the exact term in the
+# `--stop-after-ssa` dump by its label (def names survive into the SSA; comments do not).
+#
+#   hoistedMarker  -- pure + TOTAL + argument-independent -> MUST be hoisted (run shallower)
+#   retainedMarker -- references the argument `x`          -> MUST stay in the lambda body
+#
+# The test asserts hoistedMarker ends up at a strictly shallower indentation (an outer scope)
+# than retainedMarker, which marks the per-call lambda body.
+def body x =
+    def hoistedMarker = 900000001 + 900000002
+    def retainedMarker = x + 900000003
+    hoistedMarker + retainedMarker
+
+export def hoistMe (list: List Integer): List Integer =
+    map body list

--- a/tests/optimizer/lvl-nested-lambda/.wakeroot
+++ b/tests/optimizer/lvl-nested-lambda/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/optimizer/lvl-nested-lambda/pass.sh
+++ b/tests/optimizer/lvl-nested-lambda/pass.sh
@@ -1,0 +1,35 @@
+#! /bin/sh
+
+# LVL through nested lambdas.  An invariant independent of both lambda arguments must be hoisted
+# out past both lambdas; a term depending on the inner argument stays deep in the inner body.
+#
+#   hoistedMarker  -- independent of x and y -> lifted to the outermost scope
+#   retainedMarker -- depends on inner arg y -> stays in the inner lambda body
+#
+# def labels survive into --stop-after-ssa as "(name)"; the line's leading-space count is its
+# scope depth.  We assert hoistedMarker ends up at a strictly shallower indentation than
+# retainedMarker.
+
+set -e
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
+marker_indent() {
+  line=$(grep -E "\($1\)" "$2" | head -1)
+  if [ -z "$line" ]; then echo "FAIL: marker '$1' not found in SSA dump" >&2; exit 1; fi
+  printf '%s\n' "$line" | sed -e 's/[^ ].*$//' | awk '{print length; exit}'
+}
+
+"${WAKE}" --stop-after-ssa -x 'nested Nil Nil' > ssa.txt 2>/dev/null
+
+hoisted=$(marker_indent hoistedMarker ssa.txt)
+retained=$(marker_indent retainedMarker ssa.txt)
+
+if [ "$hoisted" -lt "$retained" ]; then
+  echo "OK: invariant hoisted out of nested lambdas (indent $hoisted) above inner body (indent $retained)"
+else
+  echo "FAIL: hoistedMarker (indent $hoisted) was not lifted above the inner lambda body (indent $retained)"
+  exit 1
+fi
+
+rm -f ssa.txt

--- a/tests/optimizer/lvl-nested-lambda/test.wake
+++ b/tests/optimizer/lvl-nested-lambda/test.wake
@@ -1,0 +1,18 @@
+package lvltest
+
+from wake import _
+
+# Nested lambdas.  LVL descends recursively into nested function bodies.
+#
+#   hoistedMarker  -- independent of BOTH `x` and `y` -> lifted out past both lambdas
+#   retainedMarker -- depends on the inner argument `y` -> stays deep in the inner lambda body
+#
+# The test asserts hoistedMarker ends up at a strictly shallower indentation than retainedMarker
+# (in fact it is lifted all the way to the outermost scope, while retainedMarker stays nested).
+def innerBody x y =
+    def hoistedMarker = 900000001 + 900000002
+    def retainedMarker = y + 900000003
+    x + y + hoistedMarker + retainedMarker
+
+export def nested (xs: List Integer) (ys: List Integer): List (List Integer) =
+    map (\x map (innerBody x) ys) xs

--- a/tests/optimizer/lvl-partial-not-hoisted/.wakeroot
+++ b/tests/optimizer/lvl-partial-not-hoisted/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/optimizer/lvl-partial-not-hoisted/pass.sh
+++ b/tests/optimizer/lvl-partial-not-hoisted/pass.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+
+# LVL safety: a PURE but PARTIAL primitive (integer division, which aborts on a zero divisor)
+# must NOT be hoisted out of a lambda body, because the lambda may run zero times.  A total `+`
+# over different literals is the control: it MUST still hoist, so a regression in either
+# direction is caught.
+#
+# def labels survive into --stop-after-ssa as "(name)"; the line's leading-space count is its
+# scope depth.  We assert the total hoistedMarker ends up at a strictly shallower indentation
+# (an outer scope) than the partialMarker, which must remain inside the lambda body.
+
+set -e
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
+marker_indent() {
+  line=$(grep -E "\($1\)" "$2" | head -1)
+  if [ -z "$line" ]; then echo "FAIL: marker '$1' not found in SSA dump" >&2; exit 1; fi
+  printf '%s\n' "$line" | sed -e 's/[^ ].*$//' | awk '{print length; exit}'
+}
+
+"${WAKE}" --stop-after-ssa -x 'dontHoist Nil' > ssa.txt 2>/dev/null
+
+partial=$(marker_indent partialMarker ssa.txt)
+hoisted=$(marker_indent hoistedMarker ssa.txt)
+
+if [ "$hoisted" -lt "$partial" ]; then
+  echo "OK: partialMarker stayed in lambda body (indent $partial); total control hoisted (indent $hoisted)"
+else
+  echo "FAIL: partialMarker (indent $partial) was hoisted out of the lambda (control indent $hoisted)"
+  exit 1
+fi
+
+rm -f ssa.txt

--- a/tests/optimizer/lvl-partial-not-hoisted/test.wake
+++ b/tests/optimizer/lvl-partial-not-hoisted/test.wake
@@ -1,0 +1,22 @@
+package lvltest
+
+from wake import _
+
+# This is the core safety property of LVL.
+#
+# A lambda body runs only when the lambda is invoked, which may be zero times (e.g. `map f Nil`).
+# Hoisting a PARTIAL operation (one that can abort) out of such a lambda would run it
+# unconditionally in the parent scope, turning a never-taken abort into a real one.  So:
+#
+#   partialMarker -- pure but PARTIAL (integer divide, aborts on /0) -> MUST stay in the lambda
+#   hoistedMarker -- pure + TOTAL, argument-independent              -> MUST be hoisted (control)
+#
+# The control proves the test would notice a regression in the other direction too.  The test
+# asserts hoistedMarker lands at a strictly shallower indentation than partialMarker.
+def body x =
+    def partialMarker = 900000001 / 900000002
+    def hoistedMarker = 900000004 + 900000005
+    x + partialMarker + hoistedMarker
+
+export def dontHoist (list: List Integer): List Integer =
+    map body list

--- a/tests/optimizer/lvl-recursion/.wakeroot
+++ b/tests/optimizer/lvl-recursion/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/optimizer/lvl-recursion/pass.sh
+++ b/tests/optimizer/lvl-recursion/pass.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+
+# LVL must not hoist recursive calls (RApp is never total).  Were it to do so, these recursions
+# would run unconditionally -- diverging or, for the list build, exhausting memory.  We bound
+# each run with a timeout so a regression manifests as a failure rather than a hang.
+
+set -e
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
+run() {
+  # Prefer a hard timeout if available so a hoisting regression fails fast instead of hanging.
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 60 "$@"
+  else
+    "$@"
+  fi
+}
+
+# Plain numeric recursion must terminate and return 0.
+out=$(run "${WAKE}" -x 'countdown 200000' 2>&1)
+if [ "$out" != "0" ]; then
+  echo "FAIL: countdown did not terminate cleanly with 0 (got: $out)"
+  exit 1
+fi
+echo "OK: numeric recursion terminates (recursive call not hoisted)"
+
+# List-building recursion must terminate; check it produced the right number of elements.
+len=$(run "${WAKE}" -x 'len (buildList 50000)' 2>&1)
+if [ "$len" != "50000" ]; then
+  echo "FAIL: buildList did not terminate with expected length 50000 (got: $len)"
+  exit 1
+fi
+echo "OK: allocation-shaped recursion terminates without memory blowup"

--- a/tests/optimizer/lvl-recursion/test.wake
+++ b/tests/optimizer/lvl-recursion/test.wake
@@ -1,0 +1,21 @@
+package lvltest
+
+from wake import _
+
+# A recursive call is pure but NOT total: evaluating it eagerly diverges (and, when the
+# recursion builds data, blows up memory).  LVL must never hoist an RApp out of a lambda, both
+# because callee totality is unknown and because the recursive self-reference would become a
+# forward reference / unconditional eager evaluation.
+#
+# If the recursive call were hoisted, `countdown` would recurse unconditionally regardless of
+# the `n <= 0` base case and never terminate.  Termination here is the observable proof that
+# the recursive application stayed inside the conditional branch.
+export def countdown (n: Integer): Integer =
+    if n <= 0 then 0
+    else countdown (n - 1)
+
+# A larger, allocation-shaped recursion: building a list. If the recursive build were eagerly
+# hoisted it would attempt to construct an infinite list and exhaust memory.
+export def buildList (n: Integer): List Integer =
+    if n <= 0 then Nil
+    else n, buildList (n - 1)

--- a/tests/optimizer/lvl-regex-quote/.wakeroot
+++ b/tests/optimizer/lvl-regex-quote/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/optimizer/lvl-regex-quote/pass.sh
+++ b/tests/optimizer/lvl-regex-quote/pass.sh
@@ -1,0 +1,36 @@
+#! /bin/sh
+
+# A regex/quote memory-blowup scenario.
+#
+#   quoteMarker -- `quote` builds a RegExp from a constant string; pure + TOTAL -> MUST be
+#                  hoisted, so the pattern is compiled once and shared.
+#   matchMarker -- `matches` uses the PRIM_PARTIAL `match` prim (can abort on huge inputs);
+#                  even with constant arguments it MUST stay inside the lambda body.
+#
+# def labels survive into --stop-after-ssa as "(name)"; the line's leading-space count is its
+# scope depth.  We assert quoteMarker ends up at a strictly shallower indentation (an outer
+# scope) than matchMarker, which must remain in the per-call lambda body.
+
+set -e
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
+marker_indent() {
+  line=$(grep -E "\($1\)" "$2" | head -1)
+  if [ -z "$line" ]; then echo "FAIL: marker '$1' not found in SSA dump" >&2; exit 1; fi
+  printf '%s\n' "$line" | sed -e 's/[^ ].*$//' | awk '{print length; exit}'
+}
+
+"${WAKE}" --stop-after-ssa -x 'regexCase Nil' > ssa.txt 2>/dev/null
+
+quote=$(marker_indent quoteMarker ssa.txt)
+match=$(marker_indent matchMarker ssa.txt)
+
+if [ "$quote" -lt "$match" ]; then
+  echo "OK: quote regex hoisted/shared (indent $quote); partial match kept in lambda (indent $match)"
+else
+  echo "FAIL: quoteMarker (indent $quote) was not hoisted above the partial match (indent $match)"
+  exit 1
+fi
+
+rm -f ssa.txt

--- a/tests/optimizer/lvl-regex-quote/test.wake
+++ b/tests/optimizer/lvl-regex-quote/test.wake
@@ -1,0 +1,31 @@
+package lvltest
+
+from wake import _
+
+# A regex/quote memory-blowup scenario.
+#
+# Applying the same regular expression to every element of a large list, where the pattern is
+# rebuilt from a string on every call, re-creates (and re-allocates) the compiled RE2 program
+# once per element, blowing up memory.  The fix has two halves, both checked here:
+#
+#   quoteMarker -- `quote` compiles a RegExp from a constant String.  It is pure and TOTAL, so
+#                  LVL MUST hoist it: the regex is compiled once and shared, not per element.
+#                  (Previously `quote` round-tripped through a fallible stringToRegExp, producing
+#                  an RDes that blocked hoisting; it is now a directly-hoistable pure prim.)
+#
+#   matchMarker -- `matches` uses the `match` prim, which is PRIM_PARTIAL (it can abort on
+#                  >2GiB inputs with old RE2).  Even though its arguments are constant and
+#                  argument-independent, it MUST NOT be hoisted out of a lambda that may run
+#                  zero times -- the same safety rule that keeps a partial op conditional.
+#
+# The test asserts quoteMarker is lifted to a strictly shallower scope than matchMarker.
+def quoteBody (x: String): RegExp =
+    def quoteMarker = quote "constant.literal"
+    quoteMarker
+
+def matchBody (x: String): Boolean =
+    def matchMarker = matches `constant.*` "constant-subject-string"
+    matchMarker
+
+export def regexCase (list: List String): Pair (List RegExp) (List Boolean) =
+    Pair (map quoteBody list) (map matchBody list)

--- a/tests/optimizer/lvl-runtime-safety/.wakeroot
+++ b/tests/optimizer/lvl-runtime-safety/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/optimizer/lvl-runtime-safety/pass.sh
+++ b/tests/optimizer/lvl-runtime-safety/pass.sh
@@ -1,0 +1,31 @@
+#! /bin/sh
+
+# Runtime safety of LVL.  A partial op (`x / n`) captured inside a lambda must stay inside it,
+# so that for an empty list (lambda never invoked) the division never runs.
+#
+#   scaleAll 0 Nil       -> lambda never runs -> must SUCCEED (no division-by-zero)
+#   scaleAll 0 (1, Nil)  -> lambda runs once  -> division-by-zero -> must FAIL
+#
+# The second case is a negative control: it proves the division really is partial, so the
+# first case is a meaningful test rather than a no-op.
+
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
+# Case 1: uncalled lambda must not abort.
+if ! "${WAKE}" -x 'scaleAll 0 Nil' >out1.txt 2>&1; then
+  echo "FAIL: 'scaleAll 0 Nil' aborted -- partial division was wrongly hoisted/evaluated"
+  cat out1.txt
+  exit 1
+fi
+echo "OK: uncalled lambda with partial division did not abort"
+
+# Case 2: called lambda must abort on division by zero (sanity control).
+if "${WAKE}" -x 'scaleAll 0 (1, Nil)' >out2.txt 2>&1; then
+  echo "FAIL: 'scaleAll 0 (1, Nil)' unexpectedly succeeded -- division is not actually partial"
+  cat out2.txt
+  exit 1
+fi
+echo "OK: invoked lambda aborts on division by zero (control)"
+
+rm -f out1.txt out2.txt

--- a/tests/optimizer/lvl-runtime-safety/test.wake
+++ b/tests/optimizer/lvl-runtime-safety/test.wake
@@ -1,0 +1,14 @@
+package lvltest
+
+from wake import _
+
+# Runtime-observable safety property of LVL.
+#
+# `100 / n` is a PARTIAL operation: it aborts the runtime when n == 0.  It is also entirely
+# argument-independent within the lambda (it does not mention `x`), so it is exactly the shape
+# a naive loop-invariant lifter would hoist out of the lambda and run unconditionally.  But the
+# lambda passed to `map` runs zero times on an empty list, so for `scaleAll 0 Nil` the division
+# must NEVER execute.  If LVL incorrectly hoisted it, this evaluation would abort with a
+# division-by-zero -- the same "evaluate work that should have stayed conditional" bug.
+export def scaleAll (n: Integer) (xs: List Integer): List Integer =
+    map (\x x + (100 / n)) xs


### PR DESCRIPTION
### Problem
Wake currently does not evaluate regular expressions (or any pure expressions) inside a lambda body call efficiently, with these expressions being re-evaluated every call to the lambda which can be extremely expensive and blow up heap memory usage (`RegExp` GC object, and allocating that in each recursive call can blow up live heap).

Wake's compiler should be able to be smarter, and detect what expressions can be 'hoisted' or 'lifted' into the parent enclosing scope so these computations are evaluated once. Hence this PR implements the `Loop Invariant Lifting` (LVL) (or also known as Loop-Invariant Code Motion) Pass. 

Three pieces work together:
1. **The LVL pass (src/optimizer/lvl.cpp)** — analyzes each lambda body and hoists only provably-total terms (literals, tuple alloc/projection, and pure+total prims), never RApp/RDes, never recursive self-references.
2. **A new PRIM_PARTIAL flag** (src/types/primfn.h) — marks pure primitives that can still abort (e.g. div/mod/vget out of bounds, as well as regex match/extract/replace/tokenize). These are excluded from hoisting: a lambda may run zero times, so hoisting a partial op could turn a never-taken abort into a real one.
3. **quote made directly hoistable** (src/runtime/regexp.cpp) — previously quote round-tripped through a fallible stringToRegExp, producing an RDes that blocked hoisting. It now builds the RegExp directly as a pure prim, so the compiled regex hoists out of the loop and is built once and shared — the core fix for the memory blowup.


### Example SSA of the issue that causes memory blow up
```
# The same regex is rebuilt from a string for every element of the list.
export def filterMatching (pattern: String) (lines: List String): List String =
    filter (\line matches (quote pattern) line) lines
```
    
**Before LVL — quote is recompiled inside the loop body**
```
  305 [-,1] = "x"
  306 (filter@wake.anon.loop) [R,2] = Fun(.../list.wake:628):
    returns: 310
    307 (_ 1) [E,1] = <arg>
    308 (filter@wake.anon.loop) [-,1] = Fun(.../list.wake:628):
      returns: 7
      309 (_ tuple_case) [E,0] = <arg>
    309 (filter@wake.anon.loop) [-,1] = Fun(.../list.wake:627):
      returns: 318
      310 (_ tuple_case) [E,2] = <arg>
      311 (_ a1) [-,2] = Get:0(310)
      312 (_ a2) [-,1] = Get:1(310)
      313 (sub) [-,2] = App(306 312)
      314 [-,1] = quote(305)            <-- rebuilt on every element
      315 (_ a0) [-,1] = match(314 311)
      ...
```
quote(305) (slot 314) lives inside the recursive loop body, so the regex is recompiled and re-allocated once per element.


**After LVL — quote is hoisted out; only match stays in the loop**
```
  372 [-,1] = "x"
  373 [-,1] = quote(372)                <-- hoisted out; compiled once, shared
  374 (filter@wake.anon.loop) [R,2] = Fun(.../list.wake:628):
    returns: 378
    375 (_ 1) [E,1] = <arg>
    376 (filter@wake.anon.loop) [-,1] = Fun(.../list.wake:628):
      returns: 7
      377 (_ tuple_case) [E,0] = <arg>
    377 (filter@wake.anon.loop) [-,1] = Fun(.../list.wake:627):
      returns: 386
      378 (_ tuple_case) [E,2] = <arg>
      379 (_ a1) [-,2] = Get:0(378)
      380 (_ a2) [-,1] = Get:1(378)
      381 (sub) [-,2] = App(374 380)
      382 (_ a0) [-,1] = match(373 379) <-- partial match stays in the loop
      ...
```
quote(372) (slot 373) is now lifted into the enclosing scope and computed once, with the loop body referencing it. 