### PR TITLE
Add missing `--rm -r dir/` -> `dir` normalization

### DIFF
--- a/tests/clean/rm/safety-checks/pass.sh
+++ b/tests/clean/rm/safety-checks/pass.sh
@@ -40,6 +40,12 @@ cd ..
 "${WAKE}" --rm .build/other 2>&1 || fail "should *not* reject '.build/other'"
 test -f .build/other && fail ".build/other still exists"
 
+# Test 7: Normalize trailing slashes (subdir/ should work like subdir)
+"${WAKE}" -q -x 'mkdir "test-dir"' 2>&1 || fail "could not create test-dir/"
+test -d test-dir || fail "test-dir/ not created"
+"${WAKE}" --rm -r test-dir/ 2>&1 || fail "should accept 'test-dir/' (trailing slash should be normalized)"
+rmdir test-dir 2>/dev/null && fail "test-dir/ should have been removed"
+
 echo "PASS: safety checks" >&2
 
 # Clean up

--- a/tools/wake/clean.cpp
+++ b/tools/wake/clean.cpp
@@ -61,6 +61,11 @@ int remove_paths(Database &db, CASContext &cas_ctx, const std::vector<std::strin
       workspace_path = std::filesystem::relative(workspace_path, workspace_root);
     }
 
+    // Strip trailing slashes to match the DB representation of directories.
+    if (!workspace_path.has_filename() && workspace_path.has_parent_path()) {
+      workspace_path = workspace_path.parent_path();
+    }
+
     // Reject dangerous paths
     if (workspace_path == ".") {
       std::cerr << "wake --rm: cannot remove the workspace root: '" << path << "'" << std::endl;


### PR DESCRIPTION
I had assumed this was getting normalized in one direction or the other automatically (and since it was working in cases without trailing slashes, that it was normalized to remove them), but apparently `dir/` and `dir` are indeed represented differently and need explicit unification.