### PR TITLE
Rsc batch blob downloads

### DIFF
--- a/share/wake/lib/core/string.wake
+++ b/share/wake/lib/core/string.wake
@@ -49,13 +49,13 @@ export def catWith (separator: String) (strings: List String): String =
     | tail
     | cat
 
-# shellEscape: quote a String so it is safe to embed as a single argument in a shell command.
+# shellQuote: quote a String so it is safe to embed as a single argument in a shell command.
 #
-#   shellEscape "foo"        = "foo"
-#   shellEscape "foo bar"    = "'foo bar'"
-#   shellEscape "it's"       = "'it'\\''s'"
-#   shellEscape ""           = "''"
-export def shellEscape (string: String): String =
+#   shellQuote "foo"        = "foo"
+#   shellQuote "foo bar"    = "'foo bar'"
+#   shellQuote "it's"       = "'it'\\''s'"
+#   shellQuote ""           = "''"
+export def shellQuote (string: String): String =
     def p s = prim "shell_str"
 
     p string

--- a/share/wake/lib/core/string.wake
+++ b/share/wake/lib/core/string.wake
@@ -49,6 +49,17 @@ export def catWith (separator: String) (strings: List String): String =
     | tail
     | cat
 
+# shellEscape: quote a String so it is safe to embed as a single argument in a shell command.
+#
+#   shellEscape "foo"        = "foo"
+#   shellEscape "foo bar"    = "'foo bar'"
+#   shellEscape "it's"       = "'it'\\''s'"
+#   shellEscape ""           = "''"
+export def shellEscape (string: String): String =
+    def p s = prim "shell_str"
+
+    p string
+
 # explode: split a String up into Unicode code points
 # This is rarely useful; consider using a RegExp instead.
 #

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -510,29 +510,6 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
 
     require Pass configPath = writeTempFile "curl.batch.config" configBody
 
-    # Force-remove then touch each destination before downloading so that a failed transfer still
-    # yields a file (wake-hash can't hash a non-existent file). Mirrors makeBinaryRequest's cleanup semantics.
-    def cleanupScript =
-        destinations
-        | map (\d "rm -f \"{d}\"\ntouch \"{d}\"")
-        | catWith "\n"
-
-    def cleanupJob =
-        makeShellPlan cleanupScript (httpDirPath, Nil)
-        | setPlanLabel "http: batch cleanup ({str specs.len} files)"
-        | setPlanStdout logNever
-        | setPlanStderr logNever
-        | setPlanPersistence Once
-        | setPlanFnOutputs (\_ Nil)
-        | setPlanUsage (Usage 0 0.0 0.002 0 0 0)
-        | setPlanEcho logDebug
-        | runJobWith localRunner
-        | setJobTag "http.cleanup" "batch"
-        | setJobInspectVisibilityHidden
-
-    require True = cleanupJob.isJobOk
-    else failWithError "Unable to remove binary files before redownloading them"
-
     # Only pass --parallel on curl that supports it (>= 7.66.0). On older curl (el8's 7.61.1) the
     # batch runs sequentially, which is still one process + one wake job + connection reuse.
     def parallelFlags =
@@ -541,21 +518,34 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
         else
             Nil
 
-    def cmd =
-        "curl",
-        (
-            parallelFlags ++
-            (
-                # Exit non-zero on any HTTP error so the batch fails all-or-nothing.
-                "--fail",
-                "--config",
-                configPath.getPathName,
-                Nil
-            )
-        )
+    # All destinations quoted for a single-pass shell arg list.
+    def quotedDests =
+        destinations
+        | map (\d "\"{d}\"")
+        | catWith " "
+
+    # The curl invocation. `--create-dirs` makes any missing parent directories so we don't need a
+    # separate mkdir fan-out; `--fail` exits non-zero on any HTTP error (all-or-nothing batch).
+    def curlLine =
+        def flags = parallelFlags ++ ("--create-dirs", "--fail", Nil)
+
+        "curl {catWith " " flags} --config \"{configPath.getPathName}\""
+
+    # Do the cleanup in the same job as curl. One `rm -f` clears any write-protected leftovers,
+    # curl downloads, then one `touch` ensures every declared output exists even if its transfer
+    # failed (wake-hash can't hash a missing file). curl's exit status is preserved so the job
+    # still fails as a whole when any transfer fails.
+    def batchScript =
+        """
+        rm -f %{quotedDests}
+        %{curlLine}
+        curl_status=$?
+        touch %{quotedDests}
+        exit $curl_status
+        """
 
     def job =
-        makeExecPlan cmd (configPath, Nil)
+        makeShellPlan batchScript (configPath, httpDirPath, Nil)
         | setPlanLabel "http: batch GET ({str specs.len} files)"
         | setPlanStdout logNever
         # Curl dumps download stats to stderr

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -425,9 +425,12 @@ export tuple BatchDownloadSpec =
     # The local path the downloaded bytes should be written to
     export Output: String
 
-# The default maximum number of concurrent transfers curl performs within a single batch job.
-# This is the real concurrency knob: it bounds process/connection churn independent of how many
-# transfers are in the batch.
+export def downloadUsageCpu: Double =
+    0.25
+
+# The maximum number of concurrent transfers curl performs within a single batch job, used ONLY as
+# the `--parallel-max` value on curl >= 7.66.0 (feature-detected). Older curl (e.g. el8's 7.61.1)
+# runs the batch sequentially and ignores this.
 export def downloadParallelMax: Integer =
     8
 
@@ -436,13 +439,50 @@ export def downloadParallelMax: Integer =
 export def downloadBatchSize: Integer =
     256
 
-# makeBinaryRequests: Downloads many urls to their destination paths in a single curl process using
-# `curl --parallel`. Returns all destination paths on success, or a single Fail for the whole batch.
+# Feature-detects whether the curl on this image supports `--parallel` (added in curl 7.66.0).
+export target curlSupportsParallel Unit: Boolean =
+    def job =
+        makeExecPlan ("curl", "--version", Nil) Nil
+        | setPlanLabel "http: detect curl --parallel support"
+        | setPlanStdout logNever
+        | setPlanStderr logNever
+        | setPlanPersistence ReRun
+        | setPlanFnOutputs (\_ Nil)
+        | setPlanUsage (Usage 0 0.0 0.002 0 0 0)
+        | setPlanEcho logDebug
+        | runJobWith localRunner
+        | setJobInspectVisibilityHidden
+
+    require True = job.isJobOk
+    else False
+
+    require Pass stdout = job.getJobStdout
+    else False
+
+    # First line looks like: "curl 7.61.1 (x86_64-redhat-linux-gnu) libcurl/7.61.1 ..."
+    require Some firstLine = head (tokenize `\n` stdout)
+    else False
+
+    require (majStr, minStr, _rest, Nil) = extract `curl (\d+)\.(\d+)\.(.*)` firstLine
+    else False
+
+    require Some major = int majStr
+    else False
+
+    require Some minor = int minStr
+    else False
+
+    # --parallel requires curl >= 7.66.0
+    major > 7 || (major == 7 && minor >= 66)
+
+# makeBinaryRequests: Downloads many urls to their destination paths in a single curl process,
+# returning all destination paths on success or a single Fail for the whole batch.
 #
 # This is the batched analogue of makeBinaryRequest. Instead of one curl process per transfer it
 # writes a curl `--config` file listing one url/output stanza per input and runs a single curl job
-# with `--parallel --parallel-max <downloadParallelMax>`, reusing connections within the batch and
-# bounding concurrency explicitly.
+# that transfers them **sequentially** over a reused connection. On curl >= 7.66.0 (feature-detected)
+# it additionally passes `--parallel --parallel-max <downloadParallelMax>` for within-batch
+# concurrency; older curl (el8's 7.61.1) runs sequentially since `--parallel` is unsupported there.
 #
 # Failure is all-or-nothing: `--fail` makes curl exit non-zero on any HTTP error, so any failed
 # transfer fails the whole batch. Callers that need per-blob isolation should not use this.
@@ -493,16 +533,26 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
     require True = cleanupJob.isJobOk
     else failWithError "Unable to remove binary files before redownloading them"
 
+    # Only pass --parallel on curl that supports it (>= 7.66.0). On older curl (el8's 7.61.1) the
+    # batch runs sequentially, which is still one process + one wake job + connection reuse.
+    def parallelFlags =
+        if curlSupportsParallel Unit then
+            "--parallel", "--parallel-max", str downloadParallelMax, Nil
+        else
+            Nil
+
     def cmd =
         "curl",
-        "--parallel",
-        "--parallel-max",
-        str downloadParallelMax,
-        # Exit non-zero on any HTTP error so the batch fails all-or-nothing.
-        "--fail",
-        "--config",
-        configPath.getPathName,
-        Nil
+        (
+            parallelFlags ++
+            (
+                # Exit non-zero on any HTTP error so the batch fails all-or-nothing.
+                "--fail",
+                "--config",
+                configPath.getPathName,
+                Nil
+            )
+        )
 
     def job =
         makeExecPlan cmd (configPath, Nil)
@@ -512,9 +562,9 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
         | setPlanStderr logInfo
         | setPlanPersistence Once
         | setPlanFnOutputs (\_ destinations)
-        # Reflect the real concurrency of the batch so wake doesn't also run many of these jobs at
-        # once and re-create the fan-out storm at a coarser granularity.
-        | setPlanUsage (Usage 0 0.0 (dint (min specs.len downloadParallelMax) *. 0.1) 0 0 0)
+        # Flat per-batch CPU claim (NOT scaled by batch size): a sequential batch is only ever one
+        # concurrent transfer, so this bounds concurrent batch processes to ~cores / downloadUsageCpu.
+        | setPlanUsage (Usage 0 0.0 downloadUsageCpu 0 0 0)
         | setPlanEcho logDebug
         | runJobWith workspaceRunner
         | setJobTag "http.method" "GET"

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -429,7 +429,7 @@ export def downloadUsageCpu: Double =
     0.25
 
 # The maximum number of concurrent transfers curl performs within a single batch job, used ONLY as
-# the `--parallel-max` value on curl >= 7.66.0 (feature-detected). Older curl versions
+# the `--parallel-max` value on curl >= 7.66.0. Older curl versions
 # runs the batch sequentially and ignores this.
 export def downloadParallelMax: Integer =
     8
@@ -439,7 +439,7 @@ export def downloadParallelMax: Integer =
 export def downloadBatchSize: Integer =
     256
 
-# Feature-detects whether the curl on this image supports `--parallel` (added in curl 7.66.0).
+# Checks whether the curl on this image supports `--parallel` (added in curl 7.66.0).
 export target curlSupportsParallel Unit: Boolean =
     def job =
         makeExecPlan ("curl", "--version", Nil) Nil
@@ -448,13 +448,10 @@ export target curlSupportsParallel Unit: Boolean =
         | setPlanStderr logNever
         | setPlanPersistence ReRun
         | setPlanFnOutputs (\_ Nil)
-        | setPlanUsage (Usage 0 0.0 0.002 0 0 0)
+        | setPlanUsage (Usage 0 0.0 0.01 0 0 0)
         | setPlanEcho logDebug
         | runJobWith localRunner
         | setJobInspectVisibilityHidden
-
-    require True = job.isJobOk
-    else False
 
     require Pass stdout = job.getJobStdout
     else False
@@ -474,6 +471,30 @@ export target curlSupportsParallel Unit: Boolean =
 
     # --parallel requires curl >= 7.66.0
     major > 7 || (major == 7 && minor >= 66)
+
+# curlConfigQuote: quote a value for use in a curl `--config` file, returning a double-quoted
+# string with the escape sequences curl recognizes there. Per the curl manual, within double
+# quotes only `\\`, `\"`, `\t`, `\n`, `\r` and `\v` are understood, so we escape backslash and
+# double-quote (to survive the quoting) and the C0 whitespace bytes curl would otherwise mangle;
+# any other byte is emitted verbatim. This keeps urls/outputs containing spaces, quotes, or
+# backslashes intact.
+def curlConfigQuote (value: String): String =
+    def escapeCodePoint (c: String): String = match c
+        "\\" -> "\\\\"
+        "\"" -> "\\\""
+        "\t" -> "\\t"
+        "\n" -> "\\n"
+        "\r" -> "\\r"
+        # \v (vertical tab, U+000B): no wake string escape for it, match by code point.
+        _ -> if c ==* integerToUnicode 11 then "\\v" else c
+
+    def escaped =
+        value
+        | explode
+        | map escapeCodePoint
+        | cat
+
+    "\"{escaped}\""
 
 # makeBinaryRequests: Downloads many urls to their destination paths in a single curl process,
 # returning all destination paths on success or a single Fail for the whole batch.
@@ -501,11 +522,12 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
         specs
         | map getBatchDownloadSpecOutput
 
-    # Build the curl config file. Each stanza is a url/output pair. Quoting each value avoids
-    # command-line length limits and shell-escaping issues, mirroring the long-body path above.
+    # Build the curl config file: one url/output stanza per transfer, avoiding arg-length limits.
+    # curlConfigQuote quotes each value per curl's config-file grammar so paths/urls with spaces or
+    # special characters aren't truncated or misparsed.
     def configBody =
         specs
-        | map (\(BatchDownloadSpec url output) "url = \"{url}\"\noutput = \"{output}\"")
+        | map (\(BatchDownloadSpec url output) "url = {curlConfigQuote url}\noutput = {curlConfigQuote output}")
         | catWith "\n"
 
     require Pass configPath = writeTempFile "curl.batch.config" configBody
@@ -517,24 +539,23 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
         else
             Nil
 
-    # All destinations quoted for a single-pass shell arg list.
+    # All destinations shell-escaped for a single-pass shell arg list.
     def quotedDests =
         destinations
-        | map (\d "\"{d}\"")
+        | map shellEscape
         | catWith " "
 
     def curlLine =
         def flags = parallelFlags ++ ("--create-dirs", "--fail", Nil)
 
-        "curl {catWith " " flags} --config \"{configPath.getPathName}\""
+        "curl {catWith " " flags} --config {shellEscape configPath.getPathName}"
 
-    # Do the cleanup in the same job as curl. One `rm -f` clears any write-protected leftovers,
-    # curl downloads, then one `touch` ensures every declared output exists even if its transfer
-    # failed (wake-hash can't hash a missing file). curl's exit status is preserved so the job
-    # still fails as a whole when any transfer fails.
+    # curl downloads all transfers, then one `touch` ensures every declared output exists even if
+    # its transfer failed (wake-hash can't hash a missing declared output). `exit $curl_status`
+    # preserves curl's status so the job — and thus the whole batch — still fails on any transfer
+    # error.
     def batchScript =
         """
-        rm -f %{quotedDests}
         %{curlLine}
         curl_status=$?
         touch %{quotedDests}
@@ -556,7 +577,5 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
         | setJobTag "http.batch" (str specs.len)
         | setJobInspectVisibilityHidden
 
-    require True = job.isJobOk
-    else failWithError "Failed attempting to batch download {str specs.len} binary files"
-
     job.getJobOutputs
+    | addErrorContext "Failed attempting to batch download {str specs.len} binary files"

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -486,7 +486,11 @@ def curlConfigQuote (value: String): String =
         "\n" -> "\\n"
         "\r" -> "\\r"
         # \v (vertical tab, U+000B): no wake string escape for it, match by code point.
-        _ -> if c ==* integerToUnicode 11 then "\\v" else c
+        _ ->
+            if c ==* integerToUnicode 11 then
+                "\\v"
+            else
+                c
 
     def escaped =
         value

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -546,13 +546,13 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
     # All destinations shell-escaped for a single-pass shell arg list.
     def quotedDests =
         destinations
-        | map shellEscape
+        | map shellQuote
         | catWith " "
 
     def curlLine =
         def flags = parallelFlags ++ ("--create-dirs", "--fail", Nil)
 
-        "curl {catWith " " flags} --config {shellEscape configPath.getPathName}"
+        "curl {catWith " " flags} --config {shellQuote configPath.getPathName}"
 
     # curl downloads all transfers, then one `touch` ensures every declared output exists even if
     # its transfer failed (wake-hash can't hash a missing declared output). `exit $curl_status`

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -429,7 +429,7 @@ export def downloadUsageCpu: Double =
     0.25
 
 # The maximum number of concurrent transfers curl performs within a single batch job, used ONLY as
-# the `--parallel-max` value on curl >= 7.66.0 (feature-detected). Older curl (e.g. el8's 7.61.1)
+# the `--parallel-max` value on curl >= 7.66.0 (feature-detected). Older curl versions
 # runs the batch sequentially and ignores this.
 export def downloadParallelMax: Integer =
     8
@@ -482,7 +482,7 @@ export target curlSupportsParallel Unit: Boolean =
 # writes a curl `--config` file listing one url/output stanza per input and runs a single curl job
 # that transfers them **sequentially** over a reused connection. On curl >= 7.66.0 (feature-detected)
 # it additionally passes `--parallel --parallel-max <downloadParallelMax>` for within-batch
-# concurrency; older curl (el8's 7.61.1) runs sequentially since `--parallel` is unsupported there.
+# concurrency; older curl runs sequentially since `--parallel` is unsupported there.
 #
 # Failure is all-or-nothing: `--fail` makes curl exit non-zero on any HTTP error, so any failed
 # transfer fails the whole batch. Callers that need per-blob isolation should not use this.
@@ -502,7 +502,7 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
         | map getBatchDownloadSpecOutput
 
     # Build the curl config file. Each stanza is a url/output pair. Quoting each value avoids
-    # command-line length limits and shell-escaping headaches, mirroring the long-body path above.
+    # command-line length limits and shell-escaping issues, mirroring the long-body path above.
     def configBody =
         specs
         | map (\(BatchDownloadSpec url output) "url = \"{url}\"\noutput = \"{output}\"")
@@ -510,8 +510,7 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
 
     require Pass configPath = writeTempFile "curl.batch.config" configBody
 
-    # Only pass --parallel on curl that supports it (>= 7.66.0). On older curl (el8's 7.61.1) the
-    # batch runs sequentially, which is still one process + one wake job + connection reuse.
+    # Only pass --parallel on curl that supports it.
     def parallelFlags =
         if curlSupportsParallel Unit then
             "--parallel", "--parallel-max", str downloadParallelMax, Nil
@@ -524,8 +523,6 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
         | map (\d "\"{d}\"")
         | catWith " "
 
-    # The curl invocation. `--create-dirs` makes any missing parent directories so we don't need a
-    # separate mkdir fan-out; `--fail` exits non-zero on any HTTP error (all-or-nothing batch).
     def curlLine =
         def flags = parallelFlags ++ ("--create-dirs", "--fail", Nil)
 
@@ -552,8 +549,6 @@ export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path
         | setPlanStderr logInfo
         | setPlanPersistence Once
         | setPlanFnOutputs (\_ destinations)
-        # Flat per-batch CPU claim (NOT scaled by batch size): a sequential batch is only ever one
-        # concurrent transfer, so this bounds concurrent batch processes to ~cores / downloadUsageCpu.
         | setPlanUsage (Usage 0 0.0 downloadUsageCpu 0 0 0)
         | setPlanEcho logDebug
         | runJobWith workspaceRunner

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -416,3 +416,112 @@ export def makeBinaryRequest (request: HttpRequest): Result Path Error =
     else failWithError "Job resolved with the incorrect number of outputs. This should not be possible."
 
     Pass path
+
+# A single transfer within a batched binary download: a source url and the destination path to
+# write its bytes to.
+export tuple BatchDownloadSpec =
+    # The url to download from
+    export Url: String
+    # The local path the downloaded bytes should be written to
+    export Output: String
+
+# The default maximum number of concurrent transfers curl performs within a single batch job.
+# This is the real concurrency knob: it bounds process/connection churn independent of how many
+# transfers are in the batch.
+export def downloadParallelMax: Integer =
+    8
+
+# The default maximum number of transfers to place in a single batch curl job. This bounds the
+# curl config file size and per-job output count, mirroring the upload side's blobUploadBatchSize.
+export def downloadBatchSize: Integer =
+    256
+
+# makeBinaryRequests: Downloads many urls to their destination paths in a single curl process using
+# `curl --parallel`. Returns all destination paths on success, or a single Fail for the whole batch.
+#
+# This is the batched analogue of makeBinaryRequest. Instead of one curl process per transfer it
+# writes a curl `--config` file listing one url/output stanza per input and runs a single curl job
+# with `--parallel --parallel-max <downloadParallelMax>`, reusing connections within the batch and
+# bounding concurrency explicitly.
+#
+# Failure is all-or-nothing: `--fail` makes curl exit non-zero on any HTTP error, so any failed
+# transfer fails the whole batch. Callers that need per-blob isolation should not use this.
+#
+# WARNING: This function will likely break the sandbox and make your build unreliable
+export def makeBinaryRequests (specs: List BatchDownloadSpec): Result (List Path) Error =
+    require False = specs.empty
+    else Pass Nil
+
+    def wakePid: Integer = prim "pid"
+    def httpDir = ".build/wake-{str wakePid}/stdlib/http"
+
+    require Pass httpDirPath = mkdir httpDir
+
+    def destinations =
+        specs
+        | map getBatchDownloadSpecOutput
+
+    # Build the curl config file. Each stanza is a url/output pair. Quoting each value avoids
+    # command-line length limits and shell-escaping headaches, mirroring the long-body path above.
+    def configBody =
+        specs
+        | map (\(BatchDownloadSpec url output) "url = \"{url}\"\noutput = \"{output}\"")
+        | catWith "\n"
+
+    require Pass configPath = writeTempFile "curl.batch.config" configBody
+
+    # Force-remove then touch each destination before downloading so that a failed transfer still
+    # yields a file (wake-hash can't hash a non-existent file). Mirrors makeBinaryRequest's cleanup semantics.
+    def cleanupScript =
+        destinations
+        | map (\d "rm -f \"{d}\"\ntouch \"{d}\"")
+        | catWith "\n"
+
+    def cleanupJob =
+        makeShellPlan cleanupScript (httpDirPath, Nil)
+        | setPlanLabel "http: batch cleanup ({str specs.len} files)"
+        | setPlanStdout logNever
+        | setPlanStderr logNever
+        | setPlanPersistence Once
+        | setPlanFnOutputs (\_ Nil)
+        | setPlanUsage (Usage 0 0.0 0.002 0 0 0)
+        | setPlanEcho logDebug
+        | runJobWith localRunner
+        | setJobTag "http.cleanup" "batch"
+        | setJobInspectVisibilityHidden
+
+    require True = cleanupJob.isJobOk
+    else failWithError "Unable to remove binary files before redownloading them"
+
+    def cmd =
+        "curl",
+        "--parallel",
+        "--parallel-max",
+        str downloadParallelMax,
+        # Exit non-zero on any HTTP error so the batch fails all-or-nothing.
+        "--fail",
+        "--config",
+        configPath.getPathName,
+        Nil
+
+    def job =
+        makeExecPlan cmd (configPath, Nil)
+        | setPlanLabel "http: batch GET ({str specs.len} files)"
+        | setPlanStdout logNever
+        # Curl dumps download stats to stderr
+        | setPlanStderr logInfo
+        | setPlanPersistence Once
+        | setPlanFnOutputs (\_ destinations)
+        # Reflect the real concurrency of the batch so wake doesn't also run many of these jobs at
+        # once and re-create the fan-out storm at a coarser granularity.
+        | setPlanUsage (Usage 0 0.0 (dint (min specs.len downloadParallelMax) *. 0.1) 0 0 0)
+        | setPlanEcho logDebug
+        | runJobWith workspaceRunner
+        | setJobTag "http.method" "GET"
+        | setJobTag "http.batch" (str specs.len)
+        | setJobInspectVisibilityHidden
+
+    require True = job.isJobOk
+    else failWithError "Failed attempting to batch download {str specs.len} binary files"
+
+    job.getJobOutputs

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -644,9 +644,8 @@ def chunkList (n: Integer) (xs: List a): List (List a) =
     head, chunkList n tail
 
 # resolveBlobsToPaths: Resolves many blobs to local file paths holding their bytes. db-scheme blobs
-# are decoded inline (no network); file/http(s) blobs are downloaded via few batched curl jobs
-# (chunked by downloadBatchSize, bounded concurrency via downloadParallelMax). Blobs are deduped by
-# id so shared content is only fetched once. Returns an assoc list of (blobId -> Path).
+# are decoded inline (no network); file/http(s) blobs are downloaded via few batched curl jobs. Blobs
+# are deduped by id so shared content is only fetched once. Returns an assoc list of (blobId -> Path).
 def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String Path)) Error =
     # Dedupe by blob id: identical ids resolve to identical bytes, so fetch each once.
     def uniqueBlobs =
@@ -656,7 +655,8 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
     # Parse + validate each blob's URI exactly once, pairing the blob with its (scheme, path).
     # Fails loudly on an unsupported scheme or malformed URI, mirroring the old resolveUriResponse.
     def parseBlob (blob: CacheSearchBlob): Result (Pair CacheSearchBlob (Pair String String)) Error =
-        require (scheme, path, Nil) = extract `([a-zA-Z][a-zA-Z0-9+.-]*)://(.*)` blob.getCacheSearchBlobUri
+        require (scheme, path, Nil) =
+            extract `([a-zA-Z][a-zA-Z0-9+.-]*)://(.*)` blob.getCacheSearchBlobUri
         else failWithError "rsc: uri has unexpected format: '{blob.getCacheSearchBlobUri}'"
 
         match scheme
@@ -729,10 +729,11 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
             | listToMap scmp
 
         sortedChunk
-        | map (\b match (mlookup (destForBlob b) pathByName)
-            Some p -> Pass (Pair b.getCacheSearchBlobId p)
-            None ->
-                failWithError "rsc: batched download did not produce output for blob {b.getCacheSearchBlobId}"
+        | map (
+            \b match (mlookup (destForBlob b) pathByName)
+                Some p -> Pass (Pair b.getCacheSearchBlobId p)
+                None ->
+                    failWithError "rsc: batched download did not produce output for blob {b.getCacheSearchBlobId}"
         )
         | findFail
 
@@ -745,8 +746,7 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
 
     Pass (dbResolved ++ networkResolved)
 
-# rscApiGetStringBlobs: Batched analogue of rscApiGetStringBlob. Downloads many blobs (partitioning
-# db-scheme blobs onto the inline path and network blobs into few batched curl jobs), verifies each
+# rscApiGetStringBlobs: Batched analogue of rscApiGetStringBlob. Downloads many blobs, verifies each
 # blob's content hash, and returns the contents in the same order as the input.
 export def rscApiGetStringBlobs (blobs: List CacheSearchBlob): Result (List String) Error =
     require Pass resolved = resolveBlobsToPaths blobs
@@ -784,10 +784,9 @@ export def rscApiGetStringBlob (blob: CacheSearchBlob): Result String Error =
 
     Pass content
 
-# rscApiGetBlobsToCas: Batched analogue of rscApiGetFileBlobToCas. Downloads many file blobs
-# (db-scheme inline, network blobs via few batched curl jobs), verifies each blob's hash, and
-# ingests each into CAS. Returns the PreparedStagingItems (in input order) so the caller can
-# materialize them later, after every blob for a job has been verified.
+# rscApiGetBlobsToCas: Batched analogue of rscApiGetFileBlobToCas. Downloads many file blobs,
+# verifies each blob's hash, and ingests each into CAS. Returns the PreparedStagingItems
+# (in input order) so the caller can materialize them later, after every blob for a job has been verified.
 export def rscApiGetBlobsToCas (entries: List (Pair CacheSearchBlob (Pair String Integer))): Result (List PreparedStagingItem) Error =
     def blobs =
         entries

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -694,16 +694,30 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
         networkParsed
         | map getPairFirst
 
-    # Batched download of the network blobs. Each blob gets a unique destination keyed by its id.
+    # Batched download of the network blobs.
     def wakePid: Integer = prim "pid"
     def httpDir = ".build/wake-{str wakePid}/stdlib/http"
 
-    def destForBlob (blob: CacheSearchBlob): String =
-        "{httpDir}/rsc.blob.{blob.getCacheSearchBlobId}"
-
     def downloadChunk (chunk: List CacheSearchBlob): Result (List (Pair String Path)) Error =
-        def specs =
+        # Sort the chunk deterministically by blob id so that two batches with the same blob set
+        # produce byte-identical curl jobs (which wake then dedups to a single job / single writer).
+        def sortedChunk =
             chunk
+            | sortBy (\a \b scmp a.getCacheSearchBlobId b.getCacheSearchBlobId)
+
+        # Key output filenames by the batch's blob-id set so distinct batches sharing a blob write
+        # to different paths (no concurrent-write race) while identical batches dedup to one writer.
+        def batchKey =
+            sortedChunk
+            | map getCacheSearchBlobId
+            | catWith "\n"
+            | hashString
+
+        def destForBlob (blob: CacheSearchBlob): String =
+            "{httpDir}/rsc.blob.{batchKey}.{blob.getCacheSearchBlobId}"
+
+        def specs =
+            sortedChunk
             | map (\b BatchDownloadSpec b.getCacheSearchBlobUri (destForBlob b))
 
         require Pass paths = makeBinaryRequests specs
@@ -714,7 +728,7 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
             | map (\p p.getPathName :-> p)
             | listToMap scmp
 
-        chunk
+        sortedChunk
         | map (\b match (mlookup (destForBlob b) pathByName)
             Some p -> Pass (Pair b.getCacheSearchBlobId p)
             None ->

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -614,23 +614,6 @@ def resolveDbScheme _scheme path =
     | cat
     | Pass
 
-# Dispatches the content resolution for uri based on its scheme
-def resolveUriResponse (dbSchemeFn: (String => String => Result a Error)) (fileSchemeFn: (String => String => Result a Error)) (uri: String) =
-    require scheme, path, Nil = extract `([a-zA-Z][a-zA-Z0-9+.-]*)://(.*)` uri
-    else failWithError "rsc: uri has unexpected format: '{uri}'"
-
-    def unsupportedSchemeFn s p =
-        failWithError "rsc: scheme '{scheme}' from uri '{uri}' is not supported"
-
-    def schemeFn = match scheme
-        "db" -> dbSchemeFn
-        "file" -> fileSchemeFn
-        "http" -> fileSchemeFn
-        "https" -> fileSchemeFn
-        _ -> unsupportedSchemeFn
-
-    schemeFn scheme path
-
 # Verifies that the actual hash matches the expected content hash
 def verifyBlobHash (blobId: String) (actualHash: String) (contentHash: String): Result Unit Error =
     require True = actualHash ==* contentHash
@@ -647,31 +630,185 @@ def verifyBlobHash (blobId: String) (actualHash: String) (contentHash: String): 
 
     Pass Unit
 
+# chunkList: Splits a list into consecutive sublists of at most *n* elements.
+#
+# ```
+#  chunkList 2 (1, 2, 3, 4, 5, Nil) = ((1, 2, Nil), (3, 4, Nil), (5, Nil), Nil)
+# ```
+def chunkList (n: Integer) (xs: List a): List (List a) =
+    require False = xs.empty
+    else Nil
+
+    def Pair head tail = splitAt n xs
+
+    head, chunkList n tail
+
+# resolveBlobsToPaths: Resolves many blobs to local file paths holding their bytes. db-scheme blobs
+# are decoded inline (no network); file/http(s) blobs are downloaded via few batched curl jobs
+# (chunked by downloadBatchSize, bounded concurrency via downloadParallelMax). Blobs are deduped by
+# id so shared content is only fetched once. Returns an assoc list of (blobId -> Path).
+def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String Path)) Error =
+    # Dedupe by blob id: identical ids resolve to identical bytes, so fetch each once.
+    def uniqueBlobs =
+        blobs
+        | distinctBy (\a \b scmp a.getCacheSearchBlobId b.getCacheSearchBlobId)
+
+    # Parse + validate each blob's URI exactly once, pairing the blob with its (scheme, path).
+    # Fails loudly on an unsupported scheme or malformed URI, mirroring the old resolveUriResponse.
+    def parseBlob (blob: CacheSearchBlob): Result (Pair CacheSearchBlob (Pair String String)) Error =
+        require (scheme, path, Nil) = extract `([a-zA-Z][a-zA-Z0-9+.-]*)://(.*)` blob.getCacheSearchBlobUri
+        else failWithError "rsc: uri has unexpected format: '{blob.getCacheSearchBlobUri}'"
+
+        match scheme
+            "db" -> Pass (Pair blob (Pair scheme path))
+            "file" -> Pass (Pair blob (Pair scheme path))
+            "http" -> Pass (Pair blob (Pair scheme path))
+            "https" -> Pass (Pair blob (Pair scheme path))
+            _ ->
+                failWithError "rsc: scheme '{scheme}' from uri '{blob.getCacheSearchBlobUri}' is not supported"
+
+    require Pass parsedBlobs =
+        uniqueBlobs
+        | map parseBlob
+        | findFail
+
+    # db-scheme blobs stay on the inline path; file/http(s) blobs are curled.
+    def Pair networkParsed dbParsed =
+        parsedBlobs
+        | splitBy (\(Pair _ (Pair scheme _)) scheme !=* "db")
+
+    # Resolve db-scheme blobs inline to temp files (no curl), reusing the already-parsed scheme/path.
+    def resolveDbBlob ((Pair blob (Pair scheme path)): Pair CacheSearchBlob (Pair String String)): Result (Pair String Path) Error =
+        require Pass tmp =
+            resolveDbScheme scheme path
+            |> writeTempFile "rsc.blob.{blob.getCacheSearchBlobId}"
+
+        Pass (Pair blob.getCacheSearchBlobId tmp)
+
+    require Pass dbResolved =
+        dbParsed
+        | map resolveDbBlob
+        | findFail
+
+    def networkBlobs =
+        networkParsed
+        | map getPairFirst
+
+    # Batched download of the network blobs. Each blob gets a unique destination keyed by its id.
+    def wakePid: Integer = prim "pid"
+    def httpDir = ".build/wake-{str wakePid}/stdlib/http"
+
+    def destForBlob (blob: CacheSearchBlob): String =
+        "{httpDir}/rsc.blob.{blob.getCacheSearchBlobId}"
+
+    def downloadChunk (chunk: List CacheSearchBlob): Result (List (Pair String Path)) Error =
+        def specs =
+            chunk
+            | map (\b BatchDownloadSpec b.getCacheSearchBlobUri (destForBlob b))
+
+        require Pass paths = makeBinaryRequests specs
+
+        # Map returned paths back to blob ids by path name rather than relying on wire/output order.
+        def pathByName =
+            paths
+            | map (\p p.getPathName :-> p)
+            | listToMap scmp
+
+        chunk
+        | map (\b match (mlookup (destForBlob b) pathByName)
+            Some p -> Pass (Pair b.getCacheSearchBlobId p)
+            None ->
+                failWithError "rsc: batched download did not produce output for blob {b.getCacheSearchBlobId}"
+        )
+        | findFail
+
+    require Pass networkResolved =
+        networkBlobs
+        | chunkList downloadBatchSize
+        | map downloadChunk
+        | findFail
+        |< flatten
+
+    Pass (dbResolved ++ networkResolved)
+
+# rscApiGetStringBlobs: Batched analogue of rscApiGetStringBlob. Downloads many blobs (partitioning
+# db-scheme blobs onto the inline path and network blobs into few batched curl jobs), verifies each
+# blob's content hash, and returns the contents in the same order as the input.
+export def rscApiGetStringBlobs (blobs: List CacheSearchBlob): Result (List String) Error =
+    require Pass resolved = resolveBlobsToPaths blobs
+
+    def pathById =
+        resolved
+        | listToMap scmp
+
+    def resolveOne ((CacheSearchBlob blobId _uri contentHash): CacheSearchBlob): Result String Error =
+        require Some blobPath = mlookup blobId pathById
+        else failWithError "rsc: no downloaded bytes found for blob {blobId}"
+
+        require Pass content = read blobPath
+
+        def actualHash = hashString content
+
+        require Pass _ = verifyBlobHash blobId actualHash contentHash
+
+        Pass content
+
+    blobs
+    | map resolveOne
+    | findFail
+
 # rscApiGetStringBlob: Downloads a blob and returns the contents as a string
 #
 # ```
 #  rscApiGetStringBlob (RemoteCacheBlob "asdf" "https://...") = Pass "foo\nbar\nbat"
 # ```
-export def rscApiGetStringBlob ((CacheSearchBlob blobId uri contentHash): CacheSearchBlob): Result String Error =
-    def resolveStringFileScheme scheme path =
-        def blobUrl = "{scheme}://{path}"
+export def rscApiGetStringBlob (blob: CacheSearchBlob): Result String Error =
+    require Pass contents = rscApiGetStringBlobs (blob, Nil)
 
-        require Pass binaryPath =
-            buildHttpRequest blobUrl
-            | setMethod HttpMethodGet
-            | makeBinaryRequest
-
-        read binaryPath
-
-    require Pass content =
-        uri
-        | resolveUriResponse resolveDbScheme resolveStringFileScheme
-
-    def actualHash = hashString content
-
-    require Pass _ = verifyBlobHash blobId actualHash contentHash
+    require (content, Nil) = contents
+    else failWithError "rsc: expected exactly one blob result for {blob.getCacheSearchBlobId}"
 
     Pass content
+
+# rscApiGetBlobsToCas: Batched analogue of rscApiGetFileBlobToCas. Downloads many file blobs
+# (db-scheme inline, network blobs via few batched curl jobs), verifies each blob's hash, and
+# ingests each into CAS. Returns the PreparedStagingItems (in input order) so the caller can
+# materialize them later, after every blob for a job has been verified.
+export def rscApiGetBlobsToCas (entries: List (Pair CacheSearchBlob (Pair String Integer))): Result (List PreparedStagingItem) Error =
+    def blobs =
+        entries
+        | map getPairFirst
+
+    require Pass resolved = resolveBlobsToPaths blobs
+
+    def pathById =
+        resolved
+        | listToMap scmp
+
+    def prepareOne ((Pair (CacheSearchBlob blobId _uri contentHash) (Pair path mode)): Pair CacheSearchBlob (Pair String Integer)): Result PreparedStagingItem Error =
+        require Some blobPath = mlookup blobId pathById
+        else failWithError "rsc: no downloaded bytes found for blob {blobId}"
+
+        def actualHash = blobPath.getPathHash
+
+        require Pass _ = verifyBlobHash blobId actualHash contentHash
+
+        # Build a synthetic PreparedStagingItem from the staging path under ".build/wake-{pid}/...".
+        # That path will be ingested and reflink/copy'd into CAS.
+        def preparedItem =
+            PreparedStagingItem
+            (StagingFile (StagingFileOutput path blobPath.getPathName mode 0 0)) # use 0 for mtime; This will be set to the current time on materialization.
+            contentHash
+
+        require Pass _ =
+            ingestPreparedStagingItemIntoCas preparedItem
+            | addErrorContext "rsc: Failed to ingest blob {blobId} into CAS for {path}"
+
+        Pass preparedItem
+
+    entries
+    | map prepareOne
+    | findFail
 
 # rscApiGetFileBlobToCas: Downloads a blob, verifies its hash, and ingests it into CAS without
 # writing anything back to the workspace path. Returns the PreparedStagingItem describing the
@@ -681,33 +818,11 @@ export def rscApiGetStringBlob ((CacheSearchBlob blobId uri contentHash): CacheS
 # ```
 #  rscApiGetFileBlobToCas (RemoteCacheBlob "asdf" "https://...") "foo/bar" 0644 = Pass (PreparedStagingItem ...)
 # ```
-export def rscApiGetFileBlobToCas ((CacheSearchBlob blobId uri contentHash): CacheSearchBlob) (path: String) (mode: Integer): Result PreparedStagingItem Error =
-    def resolveDbSchemeToFile scheme path =
-        resolveDbScheme scheme path
-        |> writeTempFile "rsc.output_file.blob.{blobId}"
+export def rscApiGetFileBlobToCas (blob: CacheSearchBlob) (path: String) (mode: Integer): Result PreparedStagingItem Error =
+    require Pass preparedItems = rscApiGetBlobsToCas (Pair blob (Pair path mode), Nil)
 
-    def resolveBlobFileScheme scheme path =
-        buildHttpRequest "{scheme}://{path}"
-        | setMethod HttpMethodGet
-        | makeBinaryRequest
-
-    require Pass blobPath = (uri | resolveUriResponse resolveDbSchemeToFile resolveBlobFileScheme)
-
-    # Verify content hash if provided
-    def actualHash = blobPath.getPathHash
-
-    require Pass _ = verifyBlobHash blobId actualHash contentHash
-
-    # Build a synthetic PreparedStagingItem from the staging path under ".build/wake-{pid}/...".
-    # That path will be ingested and reflink/copy'd into CAS.
-    def preparedItem =
-        PreparedStagingItem
-        (StagingFile (StagingFileOutput path blobPath.getPathName mode 0 0)) # use 0 for mtime; This will be set to the current time on materialization.
-        contentHash
-
-    require Pass _ =
-        ingestPreparedStagingItemIntoCas preparedItem
-        | addErrorContext "rsc: Failed to ingest blob {blobId} into CAS for {path}"
+    require (preparedItem, Nil) = preparedItems
+    else failWithError "rsc: expected exactly one blob result for {blob.getCacheSearchBlobId}"
 
     Pass preparedItem
 

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -673,9 +673,9 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
         | findFail
 
     # db-scheme blobs stay on the inline path; file/http(s) blobs are curled.
-    def Pair networkParsed dbParsed =
+    def Pair dbParsed networkParsed =
         parsedBlobs
-        | splitBy (\(Pair _ (Pair scheme _)) scheme !=* "db")
+        | splitBy (\(Pair _ (Pair scheme _)) scheme ==* "db")
 
     # Resolve db-scheme blobs inline to temp files (no curl), reusing the already-parsed scheme/path.
     def resolveDbBlob ((Pair blob (Pair scheme path)): Pair CacheSearchBlob (Pair String String)): Result (Pair String Path) Error =

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -183,10 +183,12 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
             | findFail
             | addErrorContext "rsc: Failed to ingest a symlink"
 
-        require Pass (stdout, stderr, Nil) =
+        require Pass stdStrings =
             stdStringsDownload
             | addErrorContext "rsc: Failed to download stdout/stderr for '{label}'"
-        else failWithError "rsc: Failed to download stdout/stderr for '{label}'"
+
+        require (stdout, stderr, Nil) = stdStrings
+        else failWithError "rsc: expected exactly stdout+stderr for '{label}'"
 
         # Everything is now verified, and in the CAS. We can now materialize.
         def materializeItem preparedItem =

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -105,7 +105,9 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
             outputDirs
             | map makeDirectoryPreparedItem
 
-        # Files: download + verify + ingest into CAS in a single (few) batched curl job.
+        # Files: every blob is downloaded, verified, and ingested into CAS in a single (few) batched
+        # curl job. This does NOT skip blobs already in the local CAS — every file is (re)downloaded.
+        # TODO: partition on CAS presence and only curl the misses.
         def fileDownloadEntries =
             outputFiles
             | map (\(CacheSearchOutputFile path mode blob) Pair blob (Pair path mode))

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -92,9 +92,8 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
             obytes
         ) = details
 
-        # Start these downloads now since they aren't written to disk
-        def stdoutDownload = rscApiGetStringBlob stdoutBlob
-        def stderrDownload = rscApiGetStringBlob stderrBlob
+        # Batch stdout+stderr into a single (few) curl job rather than one process each.
+        def stdStringsDownload = rscApiGetStringBlobs (stdoutBlob, stderrBlob, Nil)
 
         # Since RSC doesn't store mtimes, set the mtime as (0,0) so materialization
         # can set the mtime at creation for files, symlinks, and directories.
@@ -106,9 +105,10 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
             outputDirs
             | map makeDirectoryPreparedItem
 
-        # Files: download + verify + ingest into CAS. Returns the item to materialize.
-        def doDownloadFileToCas (CacheSearchOutputFile path mode blob) =
-            rscApiGetFileBlobToCas blob path mode
+        # Files: download + verify + ingest into CAS in a single (few) batched curl job.
+        def fileDownloadEntries =
+            outputFiles
+            | map (\(CacheSearchOutputFile path mode blob) Pair blob (Pair path mode))
 
         # Symlinks: target is inline. Ingest into CAS. Returns the item to materialize.
         def doIngestSymlink (CacheSearchOutputSymlink symlinkTarget symlinkPath hash) =
@@ -120,10 +120,6 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
                 | addErrorContext "rsc: Failed to ingest symlink {symlinkPath} into CAS"
 
             Pass preparedItem
-
-        def fileIngests =
-            outputFiles
-            | map doDownloadFileToCas
 
         def symlinkIngests =
             outputSymlinks
@@ -179,8 +175,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
         # First download + verify + ingest every blob into CAS before writing
         # anything to the workspace.
         require Pass filePreparedItems =
-            fileIngests
-            | findFail
+            rscApiGetBlobsToCas fileDownloadEntries
             | addErrorContext "rsc: Failed to download a blob"
 
         require Pass symlinkPreparedItems =
@@ -188,13 +183,10 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
             | findFail
             | addErrorContext "rsc: Failed to ingest a symlink"
 
-        require Pass stdout =
-            stdoutDownload
-            | addErrorContext "rsc: Failed to download stdout for '{label}'"
-
-        require Pass stderr =
-            stderrDownload
-            | addErrorContext "rsc: Failed to download stderr for '{label}'"
+        require Pass (stdout, stderr, Nil) =
+            stdStringsDownload
+            | addErrorContext "rsc: Failed to download stdout/stderr for '{label}'"
+        else failWithError "rsc: Failed to download stdout/stderr for '{label}'"
 
         # Everything is now verified, and in the CAS. We can now materialize.
         def materializeItem preparedItem =


### PR DESCRIPTION
This PR significantly improves the RSC client's performance in the RSC hit job path. Previously, the client would spin up a wake process to handle a curl download per job output file, which would lead to timeouts on builds for machines with smaller amount of cores due to resource exhaustion of so many concurrent curl jobs (especially since `setPlanUsage` was set to 0.1).

This PR solves this issue by batching the curl GET requests from the nfs blob store for each job, so that we now have fewer (up to a ~100x less total) curl processes. This PR also adds support for the `--parallel` curl flag for machines that support it (version ≥ 7.66) which allows for many parallel concurrent transfers within a single process. 

The next thing to implement (not on this PR) would be to batch job uploads.