### PR TITLE
Allow input directories to be accessable (if mode allows)

### DIFF
--- a/tests/wakebox/visible-dir-writable/input.json
+++ b/tests/wakebox/visible-dir-writable/input.json
@@ -1,0 +1,30 @@
+{
+  "command": [
+    "/bin/sh",
+    "-c",
+    "test -w foo && echo WRITABLE || echo NOTWRITABLE\necho hi > foo/new.txt && echo CREATE_OK\ncat foo/new.txt"
+  ],
+  "environment": [
+    "USER=root",
+    "HOME=/root",
+    "PATH=/usr/bin:/bin:/usr/sbin:/sbin"
+  ],
+  "directory": ".",
+  "stdin": "",
+  "user-id": 0,
+  "group-id": 0,
+  "mount-ops": [
+    {
+      "type": "workspace",
+      "destination": "."
+    }
+  ],
+  "visible": [
+    {
+      "path": "foo",
+      "type": "directory",
+      "mode": 493,
+      "mtime": 0
+    }
+  ]
+}

--- a/tests/wakebox/visible-dir-writable/pass.sh
+++ b/tests/wakebox/visible-dir-writable/pass.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Regression test: access(W_OK) on a visible directory must agree with actual writability
+# (pre-fix, it always denied W_OK even though creating files there worked).
+#
+# Verifies that:
+# 1. `test -w foo` reports WRITABLE (access(2) no longer lies)
+# 2. a new file can actually be created under the visible dir (CREATE_OK)
+# 3. the created file is captured in staging_files
+set -eu
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+
+STATS_FILE=$(mktemp)
+trap 'rm -f "$STATS_FILE"' EXIT
+
+OUTPUT=$(${1}/wakebox -o "$STATS_FILE" -p input.json 2>&1)
+
+# Anchored: must be "WRITABLE", not the "NOTWRITABLE" that the pre-fix code produced.
+echo "$OUTPUT" | grep -qx "WRITABLE"  || { echo "FAIL: visible dir not reported writable"; echo "$OUTPUT"; exit 1; }
+echo "$OUTPUT" | grep -qx "CREATE_OK" || { echo "FAIL: could not create file in visible dir"; echo "$OUTPUT"; exit 1; }
+echo "$OUTPUT" | grep -qx "hi"        || { echo "FAIL: created file content missing"; echo "$OUTPUT"; exit 1; }
+
+grep -q '"foo/new.txt"' "$STATS_FILE" || { echo "FAIL: foo/new.txt missing from staging_files"; cat "$STATS_FILE"; exit 1; }
+
+echo "PASS"

--- a/tests/wakebox/visible-dir-writable/pass.sh
+++ b/tests/wakebox/visible-dir-writable/pass.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 # Regression test: access(W_OK) on a visible directory must agree with actual writability
-# (pre-fix, it always denied W_OK even though creating files there worked).
 #
 # Verifies that:
-# 1. `test -w foo` reports WRITABLE (access(2) no longer lies)
+# 1. `test -w foo` reports WRITABLE
 # 2. a new file can actually be created under the visible dir (CREATE_OK)
 # 3. the created file is captured in staging_files
 set -eu

--- a/tools/fuse-waked/main.cpp
+++ b/tools/fuse-waked/main.cpp
@@ -898,7 +898,11 @@ static int wakefuse_access(const char *path, int mask) {
     if (visible_it != it->second.visible_entries.end()) {
       const std::string &type = visible_it->second.type;
       if (type == "directory") {
-        if (mask & W_OK) return -EACCES;
+        // Match access() to getattr()'s mode bits; real writes are still gated by
+        // is_writeable() in unlink/rename/etc.
+        mode_t mode = visible_mode_or(visible_it->second, 0755);
+        if ((mask & W_OK) && !(mode & (S_IWUSR | S_IWGRP | S_IWOTH))) return -EACCES;
+        if ((mask & X_OK) && !(mode & (S_IXUSR | S_IXGRP | S_IXOTH))) return -EACCES;
         return 0;
       }
       if (type == "symlink") {


### PR DESCRIPTION
Previously, we would deny access to all visible input directories so they would report that they couldn't be written into (even if they could, `access` would just misreport). This is incorrect behavior, and should match for whatever mode is set for that directory. Visible input files are still guarded and are not modifiable.