### PR TITLE
Make staging file always owner readable

### DIFF
--- a/tests/runtime/chmod-unreadable-output/.wakeroot
+++ b/tests/runtime/chmod-unreadable-output/.wakeroot
@@ -1,0 +1,1 @@
+{"log_header":"", "log_header_source_width":0}

--- a/tests/runtime/chmod-unreadable-output/pass.sh
+++ b/tests/runtime/chmod-unreadable-output/pass.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+# A job creates an output and chmods it write-only (0200).
+#
+# The build must succeed: the staging file is opened for reading to hash it and to copy
+# it into CAS, so without a S_IRUSR floor in wakefuse_chmod that read fails. The
+# materialized workspace file must still have the 0200 the job asked for -- the floor
+# applies only to the staging file, never to what wake records or materializes.
+
+set -eu
+
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
+rm -rf .build .fuse wake.db* wake.log output.txt
+
+"${WAKE}" -q --no-tty -x 'test Unit'
+
+echo "mode=$(ls -l output.txt | cut -c1-10)"
+
+# Re-run from cache to confirm the blob was ingested and materializes the same way.
+rm -f output.txt
+"${WAKE}" -q --no-tty -x 'test Unit'
+
+echo "cached mode=$(ls -l output.txt | cut -c1-10)"

--- a/tests/runtime/chmod-unreadable-output/pass.sh
+++ b/tests/runtime/chmod-unreadable-output/pass.sh
@@ -11,6 +11,9 @@ set -eu
 WAKE="${1:+$1/wake}"
 WAKE="${WAKE:-wake}"
 
+# output.txt should be removed since its mode 0200
+trap 'rm -f output.txt' EXIT
+
 rm -rf .build .fuse wake.db* wake.log output.txt
 
 "${WAKE}" -q --no-tty -x 'test Unit'

--- a/tests/runtime/chmod-unreadable-output/stdout
+++ b/tests/runtime/chmod-unreadable-output/stdout
@@ -1,0 +1,2 @@
+mode=--w-------
+cached mode=--w-------

--- a/tests/runtime/chmod-unreadable-output/test.wake
+++ b/tests/runtime/chmod-unreadable-output/test.wake
@@ -1,0 +1,17 @@
+# A job that chmods its own output write-only must still produce a usable output.
+#
+# The fuse daemon keeps the on-disk staging file's permissions in sync with chmod
+# (wakefuse_chmod), but wake-hash and CAS ingestion both open that staging file for
+# reading afterwards. Without a S_IRUSR floor, mode 0200 makes it unopenable, and the
+# build fails with "wake-hash: read(...): Permission denied" / "No outputs available"
+# after the job itself has already succeeded.
+#
+# The mode the job asked for must still be what lands in the workspace, so the
+# floor must not be observable outside the staging directory.
+
+export def test Unit =
+    makeExecPlan ("sh", "-c", "echo contents > output.txt; chmod 0200 output.txt", Nil) Nil
+    | setPlanLabel "produce write-only output"
+    | setPlanFnOutputs (\_ "output.txt", Nil)
+    | runJobWith fuseRunner
+    | getJobOutput

--- a/tests/wakebox/chmod-staging-mode/input.json
+++ b/tests/wakebox/chmod-staging-mode/input.json
@@ -1,0 +1,23 @@
+{
+  "command": [
+    "/bin/sh",
+    "-c",
+    "set -e\ninstall -m 0200 /dev/null restrictive.txt\nprintf 'chmod-test' > restrictive.txt\nchmod 0644 restrictive.txt\ncat restrictive.txt\ninstall -m 0200 /dev/null stays_write_only.txt\nprintf 'still-here' > stays_write_only.txt\n"
+  ],
+  "environment": [
+    "USER=root",
+    "HOME=/root",
+    "PATH=/usr/bin:/bin:/usr/sbin:/sbin"
+  ],
+  "directory": ".",
+  "stdin": "",
+  "user-id": 0,
+  "group-id": 0,
+  "mount-ops": [
+    {
+      "type": "workspace",
+      "destination": "."
+    }
+  ],
+  "visible": []
+}

--- a/tests/wakebox/chmod-staging-mode/pass.sh
+++ b/tests/wakebox/chmod-staging-mode/pass.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Regression test: wakefuse_chmod must apply the mode to the on-disk staging file, not
+# just track it in memory. Readers that bypass the FUSE daemon -- access(R_OK), wake-hash,
+# CAS ingestion -- open that file directly and fail with Permission denied otherwise.
+#
+# The job in input.json creates two files with no read bit at all (install -m 0200):
+#   restrictive.txt      then chmod'd 0644 -> staging file must end up 0644 on disk
+#   stays_write_only.txt left at 0200      -> staging file must STILL be readable (the
+#                                             S_IRUSR floor), while the mode wake tracks
+#                                             and reports stays 0200
+#
+set -eu
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+
+STATS_FILE=$(mktemp)
+trap 'rm -f restrictive.txt stays_write_only.txt "$STATS_FILE"' EXIT
+
+${1}/wakebox -o "$STATS_FILE" -p input.json
+
+# Pull each file's staging_path out of the stats JSON.
+staging_path_of() {
+  tr ',' '\n' < "$STATS_FILE" \
+    | grep -A2 "\"$1\"" \
+    | grep -o '"staging_path":"[^"]*"' \
+    | head -1 \
+    | sed 's/.*:"//; s/"$//'
+}
+
+# chmod 0644 must have reached the on-disk staging file. Assert the exact mode.
+rp=$(staging_path_of restrictive.txt)
+[ -n "$rp" ] || { echo "FAIL: no staging_path for restrictive.txt"; cat "$STATS_FILE"; exit 1; }
+rmode=$(stat -c '%a' "$rp")
+echo "restrictive.txt staging mode=$rmode"
+[ "$rmode" = "644" ] || { echo "FAIL: chmod 0644 did not reach staging file (got $rmode)"; exit 1; }
+
+# The still-write-only file's staging file must be readable, even though the mode wake
+# tracks and reports for it has no read bit. 0200 | S_IRUSR = 0600.
+wp=$(staging_path_of stays_write_only.txt)
+[ -n "$wp" ] || { echo "FAIL: no staging_path for stays_write_only.txt"; cat "$STATS_FILE"; exit 1; }
+wmode=$(stat -c '%a' "$wp")
+echo "stays_write_only.txt staging mode=$wmode"
+[ -r "$wp" ] || { echo "FAIL: staging file $wp is not readable (S_IRUSR floor missing)"; exit 1; }
+
+# ...and the tracked mode must still be the 0200 the job asked for (128 decimal),
+# proving the floor is not leaking into what wake records.
+grep -q '"mode":128' "$STATS_FILE" || { echo "FAIL: tracked mode for a 0200 file is not 128"; cat "$STATS_FILE"; exit 1; }
+
+echo "PASS"

--- a/tools/fuse-waked/main.cpp
+++ b/tools/fuse-waked/main.cpp
@@ -1673,21 +1673,18 @@ static int wakefuse_chmod(const char *path, mode_t mode) {
 
   // Update mode in staged file if present
   if (StagedItem *sf = g_staged_files.find(key.first, key.second)) {
-    sf->set_mode(mode);
-    // Keep the on-disk backing object's permissions in sync with the tracked mode. The on-disk
-    // staging file was created with the create() mode and is read directly (bypassing this daemon)
-    // by access(R_OK) and by anything that copies staged outputs back out (e.g. rsync in salloc
-    // jobs). Without this, a job that creates a file with a restrictive mode (e.g. 0200) and later
-    // chmod's it open leaves the staging file unreadable on disk, even though getattr/dump report
-    // the chmod'd mode. Mirrors wakefuse_utimens, which already applies to the staging file.
+    // Apply the mode to the backing file too, not just our metadata: access(R_OK) and the
+    // hashing/CAS steps after the job read that file directly. Keep it owner-readable so a
+    // job that chmods its own output write-only doesn't make it unreadable to them; getattr
+    // still reports the mode set below, so the extra bit isn't visible to the job.
     if (auto spath = sf->staging_path()) {
-      // File/hardlink: apply to backing (staging) file directly.
-      if (chmod(spath->data(), mode & 07777) == -1) return -errno;
+      if (chmod(spath->data(), (mode & 07777) | S_IRUSR) == -1) return -errno;
     } else if (auto *s = std::get_if<StagedSpecialData>(&sf->data)) {
       // Special nodes (sockets/fifos/devices) have a real backing node; keep its actual
       // permissions in sync so access()/bind()/connect() agree with what getattr reports.
       if (chmod(s->real_path.c_str(), mode & 07777) == -1) return -errno;
     }
+    sf->set_mode(mode);  // after chmod, so a failure can't leave mode and disk diverged
     return 0;
   }
   // TODO: Remove workspace writes once backwards compatibility is no longer needed

--- a/tools/fuse-waked/main.cpp
+++ b/tools/fuse-waked/main.cpp
@@ -1674,9 +1674,18 @@ static int wakefuse_chmod(const char *path, mode_t mode) {
   // Update mode in staged file if present
   if (StagedItem *sf = g_staged_files.find(key.first, key.second)) {
     sf->set_mode(mode);
-    // Special nodes (sockets/fifos/devices) have a real backing node; keep its actual
-    // permissions in sync so access()/bind()/connect() agree with what getattr reports.
-    if (auto *s = std::get_if<StagedSpecialData>(&sf->data)) {
+    // Keep the on-disk backing object's permissions in sync with the tracked mode. The on-disk
+    // staging file was created with the create() mode and is read directly (bypassing this daemon)
+    // by access(R_OK) and by anything that copies staged outputs back out (e.g. rsync in salloc
+    // jobs). Without this, a job that creates a file with a restrictive mode (e.g. 0200) and later
+    // chmod's it open leaves the staging file unreadable on disk, even though getattr/dump report
+    // the chmod'd mode. Mirrors wakefuse_utimens, which already applies to the staging file.
+    if (auto spath = sf->staging_path()) {
+      // File/hardlink: apply to backing (staging) file directly.
+      if (chmod(spath->data(), mode & 07777) == -1) return -errno;
+    } else if (auto *s = std::get_if<StagedSpecialData>(&sf->data)) {
+      // Special nodes (sockets/fifos/devices) have a real backing node; keep its actual
+      // permissions in sync so access()/bind()/connect() agree with what getattr reports.
       if (chmod(s->real_path.c_str(), mode & 07777) == -1) return -errno;
     }
     return 0;

--- a/tools/fuse-waked/main.cpp
+++ b/tools/fuse-waked/main.cpp
@@ -1106,7 +1106,10 @@ static int wakefuse_mknod(const char *path, mode_t mode, dev_t rdev) {
     // Stage a regular file (like create(), but without keeping an open fd). wakebox will hash and
     // store it in CAS after the job completes.
     std::string staging_path = create_unique_staging_path();
-    mode_t perm_bits = mode & 07777;
+    // Keep the staging file owner-readable regardless of the requested mode: the hashing and
+    // CAS steps after the job open it directly. The tracked mode below is what getattr reports
+    // and what lands in the workspace, so the extra bit isn't visible to the job.
+    mode_t perm_bits = (mode & 07777) | S_IRUSR;
     int fd = open(staging_path.c_str(), O_CREAT | O_EXCL | O_WRONLY, perm_bits);
     if (fd == -1) return -errno;
     (void)close(fd);
@@ -1218,7 +1221,10 @@ static int wakefuse_create(const char *path, mode_t mode, struct fuse_file_info 
   }
 
   std::string staging_path = create_unique_staging_path();
-  mode_t perm_bits = mode & 07777;
+  // Keep the staging file owner-readable regardless of the requested mode: the hashing and CAS
+  // steps after the job open it directly. The tracked mode below is what getattr reports and
+  // what lands in the workspace, so the extra bit isn't visible to the job.
+  mode_t perm_bits = (mode & 07777) | S_IRUSR;
   int fd = open(staging_path.c_str(), O_CREAT | O_RDWR | O_TRUNC, perm_bits);
   if (fd == -1) return -errno;
 


### PR DESCRIPTION
`chmod` would not propagate to the backing staging file, which would cause issues in hashing or external tools trying to read the file if the staged file had 0200 permissions. We should propagate the `chmod` to the staged file, and make sure that it stays readable to the user always (including create() and mknod() calls)