### PR TITLE
Add fix to stop materializng source and claim during cached run

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -264,6 +264,11 @@ def finalizeJob job inputs outputs cleanable reality runnerError =
     (\_ primJobFinish job inputs.implode preparedOutputStrings.implode cleanable.implode reality)
     clResult
 
+def isSourceOrClaimJob (cmd: List String): Boolean = match cmd
+    prefix, _ if prefix ==* sourceJobCommandPrefix -> True
+    prefix, _ if prefix ==* claimJobCommandPrefix -> True
+    _ -> False
+
 def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo stdout stderr label isatty: Job =
     def hash = jobSignature cmd res finputs foutputs keep
 
@@ -331,10 +336,14 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
         | map parseCachedPathInfo
 
     match cache
-        Pair (job, _) _ -> match (materializeCachedOutputs cachedOutputs)
-            Pass _ -> job
-            Fail err ->
-                panic "Failed to materialize outputs for {str job.getJobId} '{job.getJobDescription}': {err.getErrorCause}"
+        Pair (job, _) _ ->
+            # Keep source and claim files unchanged on cache hits.
+            if isSourceOrClaimJob cmd then
+                job
+            else match (materializeCachedOutputs cachedOutputs)
+                Pass _ -> job
+                Fail err ->
+                    panic "Failed to materialize outputs for {str job.getJobId} '{job.getJobDescription}': {err.getErrorCause}"
         # Cache miss, or -c mode (TODO: determine checking is needed, compare output paths!)
         Pair Nil _ -> build Unit
 

--- a/share/wake/lib/system/sources.wake
+++ b/share/wake/lib/system/sources.wake
@@ -22,6 +22,12 @@ package wake
 # Anything published to this topic will be returned by calls to `sources`.
 export topic source: String
 
+def sourceJobCommandPrefix: String =
+    "<source>"
+
+def claimJobCommandPrefix: String =
+    "<claim>"
+
 # Private implementation of global sources
 def add_sources str =
     prim "add_sources"
@@ -45,7 +51,7 @@ def raw_source file =
     if time == -1 then
         failWithError "{file}: source does not exist. Did you delete it or move it without telling git?"
     else
-        makeExecPlan ("<source>", str time, file, Nil) Nil
+        makeExecPlan (sourceJobCommandPrefix, str time, file, Nil) Nil
         | setPlanLabel "source: {file}"
         | setPlanShare False
         | setPlanEcho logDebug
@@ -99,7 +105,7 @@ export def claim (file: String): Result Path Error =
         else
             # Its important that the command here is distinct from what `source` would use
             # so that claim and source do not overlap.
-            makeExecPlan ("<claim>", str time, file, Nil) Nil
+            makeExecPlan (claimJobCommandPrefix, str time, file, Nil) Nil
             | setPlanLabel "claim: {file}"
             | setPlanShare False
             | setPlanEcho logDebug

--- a/tests/runtime/cached-source-and-claim-preserve-workspace/pass.sh
+++ b/tests/runtime/cached-source-and-claim-preserve-workspace/pass.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Checks that `source` and `claim` cache hits preserve existing files, including their inode, mode,
+# and edited contents when the original mtime is retained.
+
+set -eu
+
+WAKE="${1:+$1/wake}"
+WAKE="${WAKE:-wake}"
+
+rm -rf wake.db* wake.log .wake .build src.txt claimed.txt ref-src.txt ref-claimed.txt
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+echo original-src > src.txt
+echo original-claimed > claimed.txt
+# Give claimed.txt a distinct, arbitrary-but-fixed mtime unrelated to `touch -r`'s "now" default,
+# so we can restore it exactly after mutating content.
+touch -d '2020-01-01 00:00:00 UTC' src.txt
+touch -d '2020-06-01 00:00:00 UTC' claimed.txt
+cp -p src.txt ref-src.txt
+cp -p claimed.txt ref-claimed.txt
+
+echo "=== Run 1: record source and claim ==="
+"${WAKE}" -q --no-tty -x 'useSource Unit'
+"${WAKE}" -q --no-tty -x 'useClaim Unit'
+
+src_inode_before=$(ls -i src.txt | awk '{print $1}')
+claim_inode_before=$(ls -i claimed.txt | awk '{print $1}')
+chmod 0755 src.txt claimed.txt
+
+echo "=== Run 2: matching cache hits leave source and claim inodes and modes unchanged ==="
+"${WAKE}" -q --no-tty -x 'useSource Unit'
+"${WAKE}" -q --no-tty -x 'useClaim Unit'
+
+test "$src_inode_before" = "$(ls -i src.txt | awk '{print $1}')" ||
+    fail "matching source cache hit changed its inode"
+test "$claim_inode_before" = "$(ls -i claimed.txt | awk '{print $1}')" ||
+    fail "matching claim cache hit changed its inode"
+test "$(stat -c %a src.txt)" = 755 ||
+    fail "matching source cache hit reset its mode"
+test "$(stat -c %a claimed.txt)" = 755 ||
+    fail "matching claim cache hit reset its mode"
+
+# Mutate both files, but restore their exact original mtimes (nanosecond-preserving `cp -p`
+# references) so their Keep virtual-job keys still select the historical cache records.
+echo replacement-src > src.txt
+echo replacement-claimed > claimed.txt
+touch -r ref-src.txt src.txt
+touch -r ref-claimed.txt claimed.txt
+
+echo "=== Run 3: same mtime, different bytes -- cache hits must not rewrite either file ==="
+"${WAKE}" -q --no-tty -x 'useSource Unit'
+"${WAKE}" -q --no-tty -x 'useClaim Unit'
+
+test "$(cat src.txt)" = "replacement-src" || fail "source bytes were rehydrated from stale cache"
+test "$(cat claimed.txt)" = "replacement-claimed" || fail "claim bytes were rehydrated from stale cache"
+
+echo "PASS: source and claim cache hits preserved workspace files" >&2
+
+rm -rf wake.db* wake.log .wake .build src.txt claimed.txt ref-src.txt ref-claimed.txt

--- a/tests/runtime/cached-source-and-claim-preserve-workspace/test.wake
+++ b/tests/runtime/cached-source-and-claim-preserve-workspace/test.wake
@@ -1,0 +1,23 @@
+# Tell Wake that `src.txt` is a source file for this test.
+publish source =
+    "src.txt", Nil
+
+# Reads the source file. Exercised twice per invocation to prove it still deduplicates multiple
+# uses of the same source within a single build.
+export def useSource Unit =
+    require Pass a = source "src.txt"
+    require Pass b = source "src.txt"
+
+    def dedup = a.getPathHash ==* b.getPathHash
+
+    Pass "{a.getPathName}={read a | getWhenFail "ERROR"} dedup={format dedup}"
+
+# Claims a workspace-local file that was produced by a previous (untracked-by-this-run) step.
+# Exercised twice per invocation to prove it still deduplicates within a single build.
+export def useClaim Unit =
+    require Pass a = claim "claimed.txt"
+    require Pass b = claim "claimed.txt"
+
+    def dedup = a.getPathHash ==* b.getPathHash
+
+    Pass "{a.getPathName}={read a | getWhenFail "ERROR"} dedup={format dedup}"


### PR DESCRIPTION
This PR fixes an issue where we observed source files getting modified and affecting git: during materialization we would `rename` over the destination which replaces the inode, and any inode replacement updates ctime. Git's index caches `(ctime, ino, mtime, size)` per entry, so a changed ino/ctime invalidates the stat cache for every source file on every wake run — `git status` / `git diff` degrade to full content re-reads across the tree. This problem is addressed by gating materialization for `source` and `claim` jobs.

Our current strategy for output files is to continue materialize all output files during a cached run - as a file equivalence check is expensive (through hashing) and using only an lstat does not work for our purposes (multiple wake runs can modify a workspace path) - the workspace is no longer the source of truth either way in the CAS world and therefore not critical to maintain correctness. This PR does not address the situation where an output files becomes elevated to a source file between runs (whenever a user calls `git add` to an output), and therefore that file will continue to materialize - we can address this situation in the future.